### PR TITLE
fix(image): require exact files.slack.com host before attaching auth

### DIFF
--- a/internal/image/auth_url_test.go
+++ b/internal/image/auth_url_test.go
@@ -1,0 +1,77 @@
+package image
+
+import "testing"
+
+// TestTeamIDFromFilesURL_HostCheck verifies that team-ID extraction
+// requires the URL host to be exactly files.slack.com. A previous
+// implementation used strings.Contains, which let hostile URLs that
+// merely embedded "files.slack.com/files-pri/..." in their path or
+// query trigger auth attachment, leaking the workspace's xoxc Bearer
+// and 'd' cookie to the attacker.
+func TestTeamIDFromFilesURL_HostCheck(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+		want string
+	}{
+		// Legitimate Slack file URLs — must keep working.
+		{
+			name: "files-pri canonical",
+			url:  "https://files.slack.com/files-pri/T01ABCDEF-F0123/foo.png",
+			want: "T01ABCDEF",
+		},
+		{
+			name: "files-tmb canonical",
+			url:  "https://files.slack.com/files-tmb/T01ABCDEF-F0123/foo_360.png",
+			want: "T01ABCDEF",
+		},
+		{
+			name: "files canonical (no team-suffix split)",
+			url:  "https://files.slack.com/files/T01ABCDEF/foo.png",
+			want: "T01ABCDEF",
+		},
+		{
+			name: "with query string",
+			url:  "https://files.slack.com/files-pri/T01ABCDEF-F0123/foo.png?t=abc",
+			want: "T01ABCDEF",
+		},
+
+		// Spoofing vectors — must NOT extract a team ID.
+		{
+			name: "attacker host with files.slack.com in path",
+			url:  "https://attacker.com/files.slack.com/files-pri/T01ABCDEF/x.png",
+			want: "",
+		},
+		{
+			name: "attacker host with files.slack.com in query",
+			url:  "https://attacker.com/x?u=https://files.slack.com/files-pri/T01ABCDEF/x.png",
+			want: "",
+		},
+		{
+			name: "subdomain spoof",
+			url:  "https://files.slack.com.attacker.com/files-pri/T01ABCDEF/x.png",
+			want: "",
+		},
+		{
+			name: "userinfo spoof",
+			url:  "https://files.slack.com@attacker.com/files-pri/T01ABCDEF/x.png",
+			want: "",
+		},
+
+		// Non-matches that should remain non-matches.
+		{name: "empty", url: "", want: ""},
+		{name: "garbage", url: "::not a url::", want: ""},
+		{name: "unrelated host", url: "https://example.com/files-pri/T01ABCDEF/x.png", want: ""},
+		{name: "slack.com root, not files.", url: "https://slack.com/files-pri/T01ABCDEF/x.png", want: ""},
+		{name: "files.slack.com but unknown path prefix", url: "https://files.slack.com/api/foo", want: ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := teamIDFromFilesURL(tc.url)
+			if got != tc.want {
+				t.Errorf("teamIDFromFilesURL(%q) = %q, want %q", tc.url, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/image/fetcher.go
+++ b/internal/image/fetcher.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -453,21 +454,21 @@ func (f *Fetcher) tryDownload(ctx context.Context, url string, auth TeamAuth) ([
 // teamIDFromFilesURL extracts the team ID embedded in a Slack file URL.
 // Returns "" for URLs that aren't on files.slack.com or don't match a
 // recognized path pattern.
+//
+// The host check uses url.Parse + exact equality rather than substring
+// matching: a substring check would accept hostile URLs like
+// https://attacker.com/files.slack.com/files-pri/T01ABCDEF/x.png and
+// authsForURL would then attach the workspace's xoxc Bearer + 'd' cookie
+// to the request, leaking the session to the attacker.
 func teamIDFromFilesURL(rawURL string) string {
-	// Cheap host check before fully parsing.
-	if !strings.Contains(rawURL, "files.slack.com") {
+	u, err := url.Parse(rawURL)
+	if err != nil {
 		return ""
 	}
-	// Find the path portion. We don't need full url.Parse for this.
-	i := strings.Index(rawURL, "files.slack.com")
-	if i < 0 {
+	if u.Host != "files.slack.com" {
 		return ""
 	}
-	rest := rawURL[i+len("files.slack.com"):]
-	// Strip any query string for cleanliness.
-	if q := strings.IndexByte(rest, '?'); q >= 0 {
-		rest = rest[:q]
-	}
+	rest := u.Path
 	for _, prefix := range []string{"/files-tmb/", "/files-pri/", "/files/"} {
 		if !strings.HasPrefix(rest, prefix) {
 			continue


### PR DESCRIPTION
## Summary

`teamIDFromFilesURL` decides whether to attach a workspace's `xoxc` Bearer token and `d` cookie to an outbound image fetch. The current check is `strings.Contains(rawURL, "files.slack.com")` plus a path-prefix scan, so a URL whose path or query merely embeds `files.slack.com/files-pri/...` satisfies the gate while still resolving to an attacker-controlled host.

Concretely:

```
https://attacker.com/files.slack.com/files-pri/T01ABCDEF/x.png
https://attacker.com/x?u=https://files.slack.com/files-pri/T01ABCDEF/x.png
https://files.slack.com.attacker.com/files-pri/T01ABCDEF/x.png
https://files.slack.com@attacker.com/files-pri/T01ABCDEF/x.png
```

All four pass the existing check. `authsForURL` then returns the matching team's auth (or, on a foreign team, walks the full fallback list of every configured workspace), and `tryDownload` adds:

```
Authorization: Bearer xoxc-...
Cookie: d=...
```

…to the request to attacker.com. Both halves of the browser-session credential leak in a single fetch.

### Delivery path

`internal/ui/messages/blockkit/image.go` passes the raw block URL straight into the fetcher, so anything that can post a Block Kit `ImageBlock` or attachment `image_url` into a channel the user views can trigger the leak — most realistically a malicious app/bot the workspace has installed, or a hostile peer in a Slack Connect channel.

## Fix

Parse with `net/url` and require `u.Host == "files.slack.com"` before returning a team ID. Path-prefix logic is unchanged. Behavior on canonical URLs is identical; the spoofing shapes now return `""` and the fetch goes out unauthenticated.

## Test plan

- [x] `go test ./internal/image/ -run TestTeamIDFromFilesURL -v` — 13 subcases pass, covering canonical `/files-pri/`, `/files-tmb/`, `/files/` shapes, query-string variants, and the four spoofing vectors above plus empty/garbage/unrelated-host inputs.
- [x] `go test ./...` — full suite passes, no regressions.
- [x] `go vet ./...` — no new warnings.