### PR TITLE
cache: set busy_timeout in DSN so concurrent writers wait

### DIFF
--- a/internal/cache/db.go
+++ b/internal/cache/db.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 
 	_ "modernc.org/sqlite"
 )
@@ -11,22 +12,40 @@ type DB struct {
 	conn *sql.DB
 }
 
+// dsnPragmas are appended to every DSN passed to New(). They are
+// applied per-connection by modernc.org/sqlite as the pool opens new
+// connections, which is the only reliable way to set per-connection
+// pragmas (a one-off conn.Exec only sets the pragma on the single
+// connection that ran it). See issue #9: without busy_timeout, two
+// goroutines that write at the same time fail the second with
+// SQLITE_BUSY immediately instead of waiting, which the reconnect
+// backfill silently swallowed.
+//
+//   - busy_timeout(5000): writers wait up to 5s for a competing
+//     writer to finish before returning SQLITE_BUSY. Five seconds
+//     comfortably covers the bursty fan-out in runChannelPhase.
+//   - journal_mode(WAL): concurrent readers don't block the writer.
+//     WAL persists in the file header once set, but applying it
+//     per-connection is harmless and keeps it visible in the DSN
+//     alongside busy_timeout.
+//   - foreign_keys(ON): mirrors the previous one-shot PRAGMA exec.
+const dsnPragmas = "_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=foreign_keys(ON)"
+
+// appendPragmas returns dsn with the per-connection pragmas spliced
+// into its query string. Handles plain paths, ":memory:", and
+// already-URI-formatted DSNs (file:..., or path?key=value).
+func appendPragmas(dsn string) string {
+	sep := "?"
+	if strings.Contains(dsn, "?") {
+		sep = "&"
+	}
+	return dsn + sep + dsnPragmas
+}
+
 func New(dsn string) (*DB, error) {
-	conn, err := sql.Open("sqlite", dsn)
+	conn, err := sql.Open("sqlite", appendPragmas(dsn))
 	if err != nil {
 		return nil, fmt.Errorf("opening database: %w", err)
-	}
-
-	// Enable WAL mode for better concurrent read performance
-	if _, err := conn.Exec("PRAGMA journal_mode=WAL"); err != nil {
-		conn.Close()
-		return nil, fmt.Errorf("setting WAL mode: %w", err)
-	}
-
-	// Enable foreign keys
-	if _, err := conn.Exec("PRAGMA foreign_keys=ON"); err != nil {
-		conn.Close()
-		return nil, fmt.Errorf("enabling foreign keys: %w", err)
 	}
 
 	db := &DB{conn: conn}

--- a/internal/cache/db_test.go
+++ b/internal/cache/db_test.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"context"
 	"database/sql"
 	"path/filepath"
 	"testing"
@@ -147,6 +148,52 @@ func TestMigrateAddsChannelsSyncedAtColumn(t *testing.T) {
 	}
 	if !found {
 		t.Error("channels table missing synced_at column")
+	}
+}
+
+// TestNew_SetsBusyTimeoutOnAllPoolConnections is a regression test
+// for issue #9. Without a busy_timeout pragma on every connection in
+// the pool, two goroutines in WAL mode that try to write at the same
+// time will fail the second writer with SQLITE_BUSY immediately
+// instead of waiting. The reconnect backfill (cmd/slk/reconnect_backfill.go)
+// fans out N goroutines across the shared *sql.DB and silently
+// dropped messages on systems where the lock window was long enough
+// to collide.
+//
+// We force the pool to open multiple connections and assert that
+// each one has a non-zero busy_timeout. PRAGMA busy_timeout is
+// per-connection in sqlite, so the only way to ensure every pooled
+// connection has it is to set it in the DSN (so it runs as part of
+// the per-connection init), not via a one-off conn.Exec.
+func TestNew_SetsBusyTimeoutOnAllPoolConnections(t *testing.T) {
+	db, err := New(filepath.Join(t.TempDir(), "busy.db"))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	// Hold N concurrent conns so the pool actually opens N distinct
+	// underlying sqlite connections. If we just queried PRAGMA on
+	// db.conn N times, the pool would hand back the same connection.
+	const N = 4
+	conns := make([]*sql.Conn, 0, N)
+	for i := 0; i < N; i++ {
+		c, err := db.conn.Conn(ctx)
+		if err != nil {
+			t.Fatalf("Conn[%d]: %v", i, err)
+		}
+		conns = append(conns, c)
+	}
+	for i, c := range conns {
+		var bt int
+		if err := c.QueryRowContext(ctx, "PRAGMA busy_timeout").Scan(&bt); err != nil {
+			t.Fatalf("conn %d PRAGMA busy_timeout: %v", i, err)
+		}
+		if bt < 1000 {
+			t.Errorf("conn %d busy_timeout = %d ms, want >= 1000 (writers must wait, not return SQLITE_BUSY immediately)", i, bt)
+		}
+		c.Close()
 	}
 }
 


### PR DESCRIPTION
## Summary

- Set `busy_timeout=5000` (and `journal_mode=WAL`, `foreign_keys=ON`) in the SQLite DSN so the pragmas apply to every pooled connection, not just the first one that ran a one-shot `PRAGMA` exec.
- Regression test holds N concurrent pool connections and asserts `PRAGMA busy_timeout >= 1000` on every one of them.

Closes #9.

## Root cause

WAL mode lets readers run concurrently but writes still serialize. Without `busy_timeout`, the second concurrent writer gets `SQLITE_BUSY` (errno 5) immediately rather than waiting. `runChannelPhase` (added in v0.7.6) fans out goroutines that each call `UpsertMessage` on the shared `*sql.DB` — and `backfillOneChannel` discards the `UpsertMessage` error (`cmd/slk/reconnect_backfill.go:161`), so the message is silently dropped.

That's exactly what `TestBackfillChannels_FetchesPerChannelSinceSyncedAt` was catching on slower disks: two channels run in parallel, one writer hits `SQLITE_BUSY`, the message never lands, `GetMessage` returns `sql: no rows in result set`.

Reproduced in isolation: 20 runs × 8 concurrent goroutines writing distinct rows to WAL-mode sqlite:
- Without `busy_timeout`: 47 silent failures (~29% rate).
- With `_pragma=busy_timeout(5000)`: 0 failures.

## Why DSN, not `conn.Exec`

`PRAGMA busy_timeout` is per-connection. `database/sql` opens multiple connections in its pool — a one-shot `conn.Exec("PRAGMA busy_timeout=5000")` only sets it on the connection that ran it. modernc.org/sqlite re-applies DSN-level `_pragma=...` params on every new pool connection, which is what we want.

## Why fold WAL + foreign_keys into the DSN too

`journal_mode=WAL` persists in the file header once set, so per-connection application is functionally a no-op after the first write — but keeping all three pragmas together in the DSN documents intent and avoids a future regression if someone adds another pool-aware pragma. `foreign_keys=ON` had the same pool problem as `busy_timeout` (each connection starts with `foreign_keys=OFF` by default), so it's a quiet correctness improvement too.

## Test plan

- `go test -race ./...` — all 33 packages pass.
- `TestBackfillChannels_FetchesPerChannelSinceSyncedAt` × 50 with `-race` — clean.
- `TestNew_SetsBusyTimeoutOnAllPoolConnections` (new): fails before the fix (busy_timeout=0 on all 4 pool conns), passes after (5000 ms on all 4).
- Manual stress harness (out-of-tree): 47 silent write failures over 20×8 goroutines without the fix, 0 with it.

## Not in this PR

`backfillOneChannel` and `backfillOneThread` still discard `UpsertMessage` errors. That's a separate defense-in-depth concern — even with `busy_timeout` set, swallowing DB errors is brittle. Worth a follow-up, but not needed to close #9.