### PR TITLE
Read-state sync rewrite: single SQLite source of truth + wake detection

### DIFF
--- a/cmd/slk/event_handler_marked_test.go
+++ b/cmd/slk/event_handler_marked_test.go
@@ -38,6 +38,31 @@ func TestOnChannelMarked_WritesReadState(t *testing.T) {
 	}
 }
 
+func TestOnChannelMarked_InactiveWorkspace_StillWritesDB(t *testing.T) {
+	db := newTestDB(t)
+	if err := db.UpsertChannel(cache.Channel{ID: "C1", WorkspaceID: "T1", Name: "general", Type: "channel"}); err != nil {
+		t.Fatalf("UpsertChannel: %v", err)
+	}
+	if err := db.UpdateChannelReadState("C1", "1.0000", true); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	h := &rtmEventHandler{
+		db:          db,
+		wsCtx:       &WorkspaceContext{},
+		isActive:    func() bool { return false }, // inactive workspace
+		program:     nil,
+		workspaceID: "T1",
+	}
+	h.OnChannelMarked("C1", "1.0050", 0)
+	s, _ := db.GetChannelReadState("C1")
+	if s.HasUnread {
+		t.Errorf("HasUnread should be false even for inactive-workspace channel_marked")
+	}
+	if s.LastReadTS != "1.0050" {
+		t.Errorf("LastReadTS = %q, want %q", s.LastReadTS, "1.0050")
+	}
+}
+
 func TestMarkChannelReadAsync_UpdatesReadState(t *testing.T) {
 	// markChannelReadAsync runs its work in a goroutine and calls
 	// client.MarkChannel on a *slackclient.Client, which requires real

--- a/cmd/slk/event_handler_marked_test.go
+++ b/cmd/slk/event_handler_marked_test.go
@@ -63,6 +63,69 @@ func TestOnChannelMarked_InactiveWorkspace_StillWritesDB(t *testing.T) {
 	}
 }
 
+func TestOnChannelMarked_RemoteMarkUnread_SetsHasUnread(t *testing.T) {
+	// When the user marks a message unread on another client (phone,
+	// official desktop client), Slack sends `channel_marked` with the
+	// new (older) last_read AND unread_count_display>0. Our handler
+	// must use the count to set has_unread=true; previously it hardcoded
+	// false, silently swallowing every remote mark-unread.
+	db := newTestDB(t)
+	if err := db.UpsertChannel(cache.Channel{ID: "C1", WorkspaceID: "T1", Name: "general", Type: "channel"}); err != nil {
+		t.Fatalf("UpsertChannel: %v", err)
+	}
+	// Channel currently read in slk's cache.
+	if err := db.UpdateChannelReadState("C1", "1.0100", false); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	h := &rtmEventHandler{
+		db:          db,
+		wsCtx:       &WorkspaceContext{},
+		isActive:    func() bool { return true },
+		program:     nil,
+		workspaceID: "T1",
+	}
+	// User marks message at ts=1.0050 unread on phone. Slack rolls the
+	// last_read back to 1.0050 and reports unread_count=1.
+	h.OnChannelMarked("C1", "1.0050", 1)
+
+	state, err := db.GetChannelReadState("C1")
+	if err != nil {
+		t.Fatalf("GetChannelReadState: %v", err)
+	}
+	if !state.HasUnread {
+		t.Errorf("HasUnread = false after remote mark-unread; want true (unread_count was 1)")
+	}
+	if state.LastReadTS != "1.0050" {
+		t.Errorf("LastReadTS = %q, want %q", state.LastReadTS, "1.0050")
+	}
+}
+
+func TestOnChannelMarked_ZeroUnreadCount_ClearsHasUnread(t *testing.T) {
+	// Companion to RemoteMarkUnread: when unread_count is 0 (the normal
+	// "read" case), has_unread must clear. This pins down the
+	// unread_count > 0 contract.
+	db := newTestDB(t)
+	if err := db.UpsertChannel(cache.Channel{ID: "C1", WorkspaceID: "T1", Name: "general", Type: "channel"}); err != nil {
+		t.Fatalf("UpsertChannel: %v", err)
+	}
+	if err := db.UpdateChannelReadState("C1", "1.0000", true); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	h := &rtmEventHandler{
+		db:          db,
+		wsCtx:       &WorkspaceContext{},
+		isActive:    func() bool { return true },
+		program:     nil,
+		workspaceID: "T1",
+	}
+	h.OnChannelMarked("C1", "1.0050", 0)
+
+	state, _ := db.GetChannelReadState("C1")
+	if state.HasUnread {
+		t.Errorf("HasUnread = true after channel_marked with unread_count=0; want false")
+	}
+}
+
 func TestMarkChannelReadAsync_UpdatesReadState(t *testing.T) {
 	// markChannelReadAsync runs its work in a goroutine and calls
 	// client.MarkChannel on a *slackclient.Client, which requires real

--- a/cmd/slk/event_handler_marked_test.go
+++ b/cmd/slk/event_handler_marked_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gammons/slk/internal/cache"
+)
+
+func TestOnChannelMarked_WritesReadState(t *testing.T) {
+	db := newTestDB(t)
+	if err := db.UpsertChannel(cache.Channel{ID: "C1", WorkspaceID: "T1", Name: "general", Type: "channel"}); err != nil {
+		t.Fatalf("UpsertChannel: %v", err)
+	}
+	// Pre-seed unread to verify the marked event clears it.
+	if err := db.UpdateChannelReadState("C1", "1.0000", true); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	wctx := &WorkspaceContext{}
+	h := &rtmEventHandler{
+		db:       db,
+		wsCtx:    wctx,
+		isActive: func() bool { return true },
+		program:  nil, // exercise the no-program path
+	}
+
+	h.OnChannelMarked("C1", "1.0050", 0)
+
+	state, err := db.GetChannelReadState("C1")
+	if err != nil {
+		t.Fatalf("GetChannelReadState: %v", err)
+	}
+	if state.LastReadTS != "1.0050" {
+		t.Errorf("LastReadTS = %q, want %q", state.LastReadTS, "1.0050")
+	}
+	if state.HasUnread {
+		t.Errorf("HasUnread should be false after channel_marked")
+	}
+}

--- a/cmd/slk/event_handler_marked_test.go
+++ b/cmd/slk/event_handler_marked_test.go
@@ -37,3 +37,15 @@ func TestOnChannelMarked_WritesReadState(t *testing.T) {
 		t.Errorf("HasUnread should be false after channel_marked")
 	}
 }
+
+func TestMarkChannelReadAsync_UpdatesReadState(t *testing.T) {
+	// markChannelReadAsync runs its work in a goroutine and calls
+	// client.MarkChannel on a *slackclient.Client, which requires real
+	// HTTP/Slack wiring (or a fake) to construct. The function body is
+	// otherwise a thin wrapper over db.UpdateChannelReadState (covered by
+	// cache-level tests) plus a tea.Program send. Wiring a fake Client
+	// would require introducing an interface seam we don't otherwise need.
+	// The reconnect-backfill integration test in Task 20 exercises this
+	// path end-to-end.
+	t.Skip("markChannelReadAsync requires a real *slackclient.Client; covered by Task 20 integration test")
+}

--- a/cmd/slk/event_handler_test.go
+++ b/cmd/slk/event_handler_test.go
@@ -50,16 +50,22 @@ func TestOnConversationOpened_AppendsAndSends(t *testing.T) {
 }
 
 // TestOnConversationOpened_DedupesByID verifies that a re-delivered event for
-// an already-known channel updates the descriptive fields (Name) but preserves
-// live unread state (UnreadCount, LastReadTS). Same-ID Slack events arrive
-// duplicated in practice (e.g. im_open followed by im_created on first DM).
+// an already-known channel updates the descriptive fields (Name) in place
+// instead of double-adding the row. Same-ID Slack events arrive duplicated
+// in practice (e.g. im_open followed by im_created on first DM).
+//
+// Read state used to be mirrored on ChannelItem (UnreadCount, LastReadTS)
+// and required explicit preservation across this upsert. Those fields are
+// gone -- the read-state DB is the single source of truth -- so there's
+// nothing left to assert on that axis here. The descriptive-field
+// overwrite and FinderItems dedupe are the only behaviors that remain.
 func TestOnConversationOpened_DedupesByID(t *testing.T) {
 	wctx := &WorkspaceContext{
 		BotUserIDs:        map[string]bool{},
 		UserNames:         map[string]string{},
 		UserNamesByHandle: map[string]string{"alice": "Alice", "bob": "Bob"},
 		Channels: []sidebar.ChannelItem{
-			{ID: "G1", Name: "old", Type: "group_dm", UnreadCount: 5, LastReadTS: "1700000000.000000"},
+			{ID: "G1", Name: "old", Type: "group_dm"},
 		},
 		// Seed FinderItems so we can assert dedupe doesn't double-add.
 		FinderItems: []channelfinder.Item{
@@ -83,12 +89,6 @@ func TestOnConversationOpened_DedupesByID(t *testing.T) {
 
 	if len(wctx.Channels) != 1 {
 		t.Errorf("len(Channels) = %d, want 1 (deduped on ID)", len(wctx.Channels))
-	}
-	if wctx.Channels[0].UnreadCount != 5 {
-		t.Errorf("UnreadCount = %d, want 5 (preserved across update)", wctx.Channels[0].UnreadCount)
-	}
-	if wctx.Channels[0].LastReadTS != "1700000000.000000" {
-		t.Errorf("LastReadTS = %q, want preserved", wctx.Channels[0].LastReadTS)
 	}
 	if wctx.Channels[0].Name != "Alice, Bob" {
 		t.Errorf("Name = %q, want %q (updated descriptive field)", wctx.Channels[0].Name, "Alice, Bob")

--- a/cmd/slk/event_handler_test.go
+++ b/cmd/slk/event_handler_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"testing"
 
+	"github.com/gammons/slk/internal/cache"
 	"github.com/gammons/slk/internal/config"
 	"github.com/gammons/slk/internal/ui/channelfinder"
 	"github.com/gammons/slk/internal/ui/sidebar"
@@ -137,67 +138,97 @@ func TestOnConversationOpened_InactiveWorkspace_PersistsContext(t *testing.T) {
 	}
 }
 
-func TestOnMessage_InactiveWorkspace_BumpsChannelUnreadCount(t *testing.T) {
-	wctx := &WorkspaceContext{
-		BotUserIDs: map[string]bool{},
-		UserNames:  map[string]string{},
-		Channels: []sidebar.ChannelItem{
-			{ID: "D1", Name: "alice", Type: "dm", UnreadCount: 0},
-			{ID: "C1", Name: "general", Type: "channel"},
-		},
-	}
-	h := &rtmEventHandler{
-		wsCtx:        wctx,
-		workspaceID:  "T1",
-		channelNames: map[string]string{"D1": "alice", "C1": "general"},
-		channelTypes: map[string]string{"D1": "dm", "C1": "channel"},
-		isActive:     func() bool { return false },
-		// db, program, notifier left nil — handler must guard.
-	}
-	h.OnMessage("D1", "U2", "1700000001.000000", "hi", "", "", false, nil, slack.Blocks{}, nil)
+// The OnMessage read-state matrix below replaces the pre-Task-10 trio
+// (InactiveWorkspace_BumpsChannelUnreadCount, ...ThreadReplyDoesNotBumpChannel,
+// ...ThreadBroadcastBumpsChannel), which asserted against the now-removed
+// wctx.Channels[i].UnreadCount in-memory bump. The DB-backed assertions
+// here exercise the actual contract (UpdateChannelReadState writes) and
+// also cover the new active-channel suppression dimension.
 
-	for _, ch := range wctx.Channels {
-		if ch.ID == "D1" && ch.UnreadCount != 1 {
-			t.Errorf("D1 UnreadCount = %d, want 1", ch.UnreadCount)
-		}
+func TestOnMessage_InactiveChannel_SetsHasUnread(t *testing.T) {
+	db := newTestDB(t)
+	_ = db.UpsertChannel(cache.Channel{ID: "C1", WorkspaceID: "T1", Name: "general", Type: "channel"})
+	h := &rtmEventHandler{
+		db:              db,
+		wsCtx:           &WorkspaceContext{},
+		isActive:        func() bool { return true },
+		activeChannelID: func() string { return "C2" }, // viewing a different channel
+	}
+	h.OnMessage("C1", "U1", "1.001", "hi", "", "", false, nil, slack.Blocks{}, nil)
+
+	s, _ := db.GetChannelReadState("C1")
+	if !s.HasUnread {
+		t.Errorf("HasUnread = false, want true for inactive-channel message")
 	}
 }
 
-func TestOnMessage_InactiveWorkspace_ThreadReplyDoesNotBumpChannel(t *testing.T) {
-	wctx := &WorkspaceContext{
-		Channels: []sidebar.ChannelItem{{ID: "C1", Name: "general", Type: "channel"}},
-	}
+func TestOnMessage_ActiveChannel_DoesNotSetHasUnread(t *testing.T) {
+	db := newTestDB(t)
+	_ = db.UpsertChannel(cache.Channel{ID: "C1", WorkspaceID: "T1", Name: "general", Type: "channel"})
 	h := &rtmEventHandler{
-		wsCtx:        wctx,
-		workspaceID:  "T1",
-		channelNames: map[string]string{"C1": "general"},
-		channelTypes: map[string]string{"C1": "channel"},
-		isActive:     func() bool { return false },
+		db:              db,
+		wsCtx:           &WorkspaceContext{},
+		isActive:        func() bool { return true },
+		activeChannelID: func() string { return "C1" }, // viewing the same channel
 	}
-	// thread_ts != ts and subtype != "thread_broadcast" → reply, must not bump.
-	h.OnMessage("C1", "U2", "1700000002.000000", "reply", "1700000001.000000", "", false, nil, slack.Blocks{}, nil)
+	h.OnMessage("C1", "U1", "1.001", "hi", "", "", false, nil, slack.Blocks{}, nil)
 
-	if wctx.Channels[0].UnreadCount != 0 {
-		t.Errorf("thread reply bumped channel unread; got %d", wctx.Channels[0].UnreadCount)
+	s, _ := db.GetChannelReadState("C1")
+	if s.HasUnread {
+		t.Errorf("HasUnread = true, want false (active-channel suppression)")
 	}
 }
 
-func TestOnMessage_InactiveWorkspace_ThreadBroadcastBumpsChannel(t *testing.T) {
-	wctx := &WorkspaceContext{
-		Channels: []sidebar.ChannelItem{{ID: "C1", Name: "general", Type: "channel"}},
-	}
+func TestOnMessage_InactiveWorkspace_StillSetsHasUnread(t *testing.T) {
+	db := newTestDB(t)
+	_ = db.UpsertChannel(cache.Channel{ID: "C1", WorkspaceID: "T1", Name: "general", Type: "channel"})
 	h := &rtmEventHandler{
-		wsCtx:        wctx,
-		workspaceID:  "T1",
-		channelNames: map[string]string{"C1": "general"},
-		channelTypes: map[string]string{"C1": "channel"},
-		isActive:     func() bool { return false },
+		db:              db,
+		wsCtx:           &WorkspaceContext{},
+		isActive:        func() bool { return false },
+		activeChannelID: func() string { return "" },
+		workspaceID:     "T1",
 	}
-	// thread_broadcast bumps the channel even though it's a reply.
-	h.OnMessage("C1", "U2", "1700000002.000000", "broadcast", "1700000001.000000", "thread_broadcast", false, nil, slack.Blocks{}, nil)
+	h.OnMessage("C1", "U1", "1.001", "hi", "", "", false, nil, slack.Blocks{}, nil)
 
-	if wctx.Channels[0].UnreadCount != 1 {
-		t.Errorf("thread_broadcast did not bump channel unread; got %d", wctx.Channels[0].UnreadCount)
+	s, _ := db.GetChannelReadState("C1")
+	if !s.HasUnread {
+		t.Errorf("HasUnread = false, want true (inactive workspace)")
+	}
+}
+
+func TestOnMessage_ThreadReply_DoesNotSetHasUnread(t *testing.T) {
+	db := newTestDB(t)
+	_ = db.UpsertChannel(cache.Channel{ID: "C1", WorkspaceID: "T1", Name: "general", Type: "channel"})
+	h := &rtmEventHandler{
+		db:              db,
+		wsCtx:           &WorkspaceContext{},
+		isActive:        func() bool { return true },
+		activeChannelID: func() string { return "C2" },
+	}
+	// threadTS != ts and not a broadcast subtype = non-broadcast thread reply.
+	h.OnMessage("C1", "U1", "1.002", "reply", "1.001", "", false, nil, slack.Blocks{}, nil)
+
+	s, _ := db.GetChannelReadState("C1")
+	if s.HasUnread {
+		t.Errorf("HasUnread = true, want false (non-broadcast thread reply)")
+	}
+}
+
+func TestOnMessage_ThreadBroadcast_SetsHasUnread(t *testing.T) {
+	db := newTestDB(t)
+	_ = db.UpsertChannel(cache.Channel{ID: "C1", WorkspaceID: "T1", Name: "general", Type: "channel"})
+	h := &rtmEventHandler{
+		db:              db,
+		wsCtx:           &WorkspaceContext{},
+		isActive:        func() bool { return true },
+		activeChannelID: func() string { return "C2" },
+	}
+	h.OnMessage("C1", "U1", "1.002", "ALL", "1.001", "thread_broadcast", false, nil, slack.Blocks{}, nil)
+
+	s, _ := db.GetChannelReadState("C1")
+	if !s.HasUnread {
+		t.Errorf("HasUnread = false, want true (thread_broadcast bumps channel)")
 	}
 }
 

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -1598,22 +1598,17 @@ func connectWorkspace(ctx context.Context, token slackclient.Token, db *cache.DB
 		debuglog.Cache("workspace_unread_bootstrap: team=%s GetUnreadCounts failed: %v", token.TeamName, ucErr)
 	}
 	wctx.ThreadsHasUnreads = threadsAgg.HasUnreads
-	unreadMap := make(map[string]int)
-	for _, u := range unreadCounts {
-		if u.HasUnread {
-			unreadMap[u.ChannelID] = u.Count
+	if ucErr == nil && len(unreadCounts) > 0 {
+		updates := make([]cache.ChannelReadStateUpdate, 0, len(unreadCounts))
+		for _, u := range unreadCounts {
+			updates = append(updates, cache.ChannelReadStateUpdate{
+				ChannelID:  u.ChannelID,
+				LastReadTS: u.LastRead, // may be ""; BatchUpdate preserves existing in that case
+				HasUnread:  u.HasUnread,
+			})
 		}
-		if u.LastRead != "" {
-			wctx.LastReadMap[u.ChannelID] = u.LastRead
-			_ = db.UpdateLastReadTS(u.ChannelID, u.LastRead)
-		}
-	}
-	for i := range wctx.Channels {
-		if count, ok := unreadMap[wctx.Channels[i].ID]; ok {
-			wctx.Channels[i].UnreadCount = count
-		}
-		if lr, ok := wctx.LastReadMap[wctx.Channels[i].ID]; ok {
-			wctx.Channels[i].LastReadTS = lr
+		if err := db.BatchUpdateChannelReadState(updates); err != nil {
+			log.Printf("Warning: bootstrap BatchUpdateChannelReadState for team=%s: %v", token.TeamName, err)
 		}
 	}
 	mutedItemCount := 0

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -1645,33 +1645,23 @@ func connectWorkspace(ctx context.Context, token slackclient.Token, db *cache.DB
 	}
 	log.Printf("workspace %s: %d/%d channel items marked IsMuted after build", token.TeamName, mutedItemCount, len(wctx.Channels))
 
-	// Bootstrap-time unread/mute summary so a user can grep
-	// `[cache] workspace_unread_bootstrap` after launch and see what
-	// slk learned from client.counts vs. what the official Slack
-	// desktop client shows. Only per-channel-detail-log the unread
-	// ones; the muted-vs-unread aggregates are sufficient baseline
-	// for everything else.
+	// Bootstrap-time mute summary so a user can grep
+	// `[cache] workspace_unread_bootstrap` after launch and see how
+	// many channels are muted in this workspace. The per-channel
+	// unread detail log that used to live here was driven by
+	// ChannelItem.UnreadCount, which no longer exists -- unread state
+	// is now sourced exclusively from the read-state DB (see
+	// db.GetChannelReadState) and any equivalent dump would live
+	// alongside the DB write path in updateReadStateFromCounts.
 	if debuglog.Enabled() {
-		var unreadChans, mutedChans, unreadAndUnmuted int
+		var mutedChans int
 		for _, ch := range wctx.Channels {
-			if ch.UnreadCount > 0 {
-				unreadChans++
-				if !ch.IsMuted {
-					unreadAndUnmuted++
-				}
-			}
 			if ch.IsMuted {
 				mutedChans++
 			}
 		}
-		debuglog.Cache("workspace_unread_bootstrap: team=%s total=%d unread_count_>0=%d muted=%d unread_unmuted=%d threads_has_unreads=%v threads_unread=%d",
-			token.TeamName, len(wctx.Channels), unreadChans, mutedChans, unreadAndUnmuted, threadsAgg.HasUnreads, threadsAgg.UnreadCount)
-		for _, ch := range wctx.Channels {
-			if ch.UnreadCount > 0 {
-				debuglog.Cache("workspace_unread_bootstrap: team=%s channel=%s name=%q type=%s unread=%d last_read=%s muted=%v",
-					token.TeamName, ch.ID, ch.Name, ch.Type, ch.UnreadCount, ch.LastReadTS, ch.IsMuted)
-			}
-		}
+		debuglog.Cache("workspace_unread_bootstrap: team=%s total=%d muted=%d threads_has_unreads=%v threads_unread=%d",
+			token.TeamName, len(wctx.Channels), mutedChans, threadsAgg.HasUnreads, threadsAgg.UnreadCount)
 	}
 
 	// Finder items are built alongside the sidebar items in the loop above
@@ -2992,12 +2982,12 @@ func (h *rtmEventHandler) OnConversationOpened(ch slack.Channel) {
 	// Persist in the workspace context so a workspace switch later
 	// shows the new conversation. De-dupe on ID — the same event can
 	// arrive twice (e.g. im_open followed by im_created on first DM).
+	// No read-state preservation is needed: those fields no longer
+	// live on ChannelItem; the read-state DB (per workspace) is the
+	// single source of truth and is unaffected by this in-memory upsert.
 	replaced := false
 	for i := range h.wsCtx.Channels {
 		if h.wsCtx.Channels[i].ID == item.ID {
-			// Preserve unread/last-read from the live context.
-			item.UnreadCount = h.wsCtx.Channels[i].UnreadCount
-			item.LastReadTS = h.wsCtx.Channels[i].LastReadTS
 			h.wsCtx.Channels[i] = item
 			replaced = true
 			break

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gammons/slk/internal/ui/styles"
 	"github.com/gammons/slk/internal/ui/themeswitcher"
 	"github.com/gammons/slk/internal/ui/workspace"
+	"github.com/gammons/slk/internal/wake"
 	emoji "github.com/kyokomi/emoji/v2"
 	"github.com/slack-go/slack"
 	"golang.design/x/clipboard"
@@ -1410,6 +1411,23 @@ func run() error {
 			}
 		}(ot.Token)
 	}
+
+	// Wake-from-sleep detector. The WS read deadline is 60 s; sleeps
+	// shorter than that don't tear down the TCP connection, so
+	// OnConnect never fires and the read-state catch-up in
+	// runChannelPhase doesn't run. The clock-jump heuristic catches
+	// these short sleeps and forces a backfill per workspace.
+	wakeCtx, wakeCancel := context.WithCancel(context.Background())
+	defer wakeCancel()
+	go wake.New(10*time.Second, 5*time.Second, func(elapsed time.Duration) {
+		debuglog.Backfill("wake detected: elapsed=%v — triggering catch-up across all workspaces", elapsed)
+		for _, wctx := range router.all {
+			if wctx == nil || wctx.RTMHandler == nil {
+				continue
+			}
+			wctx.RTMHandler.triggerBackfill("wake")
+		}
+	}).Run(wakeCtx)
 
 	_, err = p.Run()
 
@@ -2833,23 +2851,43 @@ func (h *rtmEventHandler) OnConnect() {
 	// synced_at for freshly-bootstrapped channels is current, so most
 	// GetHistorySince calls return zero messages quickly. The 4-wide
 	// concurrency cap bounds the cost.
-	if h.wsCtx != nil && h.db != nil && h.wsCtx.Client != nil {
-		if h.backfillGate.tryStart(time.Now()) {
-			wctx := h.wsCtx
-			workspaceID := h.workspaceID
-			program := h.program
-			db := h.db
-			go func() {
-				bf := newBackfiller(
-					wctx.Client, db, workspaceID, wctx.Client.UserID(), program, 4, 500,
-					func(available bool) { wctx.SubscriptionsAvailable = available },
-				)
-				_ = bf.run(context.Background())
-			}()
-		} else {
-			debuglog.Backfill("team=%s trigger=reconnect skipped reason=dedupe", h.workspaceID)
-		}
+	h.triggerBackfill("reconnect")
+}
+
+// triggerBackfill kicks off a reconnect-style backfill pass for this
+// workspace, subject to the per-handler 30 s dedupe gate. Called by
+// OnConnect on every WS reconnect AND by the wake detector when the
+// system wakes from sleep (where the WS may not have torn down — a
+// short sleep can survive within the 60 s WS read deadline, so
+// OnConnect never fires and no catch-up would happen without an
+// explicit trigger).
+//
+// The dedupe gate is shared with OnConnect, so a wake event that
+// happens to coincide with a real WS reconnect runs the backfill
+// exactly once.
+//
+// Returns true if the backfill was started, false if the gate
+// suppressed it.
+func (h *rtmEventHandler) triggerBackfill(trigger string) bool {
+	if h.wsCtx == nil || h.db == nil || h.wsCtx.Client == nil {
+		return false
 	}
+	if !h.backfillGate.tryStart(time.Now()) {
+		debuglog.Backfill("team=%s trigger=%s skipped reason=dedupe", h.workspaceID, trigger)
+		return false
+	}
+	wctx := h.wsCtx
+	workspaceID := h.workspaceID
+	program := h.program
+	db := h.db
+	go func() {
+		bf := newBackfiller(
+			wctx.Client, db, workspaceID, wctx.Client.UserID(), program, 4, 500,
+			func(available bool) { wctx.SubscriptionsAvailable = available },
+		)
+		_ = bf.run(context.Background())
+	}()
+	return true
 }
 
 func (h *rtmEventHandler) OnDisconnect() {

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -2876,11 +2876,8 @@ func (h *rtmEventHandler) OnDNDChange(enabled bool, endUnix int64) {
 func (h *rtmEventHandler) OnChannelMarked(channelID, ts string, unreadCount int) {
 	// Persist regardless of active workspace so the cache stays
 	// authoritative across workspace switches.
-	if err := h.db.UpdateLastReadTS(channelID, ts); err != nil {
-		log.Printf("Warning: failed to update last_read_ts on channel_marked %s/%s: %v", channelID, ts, err)
-	}
-	if h.wsCtx != nil && h.wsCtx.LastReadMap != nil {
-		h.wsCtx.LastReadMap[channelID] = ts
+	if err := h.db.UpdateChannelReadState(channelID, ts, false); err != nil {
+		log.Printf("Warning: failed to update read state on channel_marked %s/%s: %v", channelID, ts, err)
 	}
 	if h.isActive != nil && !h.isActive() {
 		// Inactive workspace: nothing to draw, but the persistence

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -2933,9 +2933,17 @@ func (h *rtmEventHandler) OnDNDChange(enabled bool, endUnix int64) {
 }
 
 func (h *rtmEventHandler) OnChannelMarked(channelID, ts string, unreadCount int) {
+	// Slack's *_marked events fire in BOTH directions: when the user
+	// reads a channel (unreadCount=0) AND when the user marks one
+	// unread (unreadCount>0). The event payload's
+	// `unread_count_display` tells us which case we're in. We must
+	// use it instead of always clearing the unread flag — the
+	// original spec hardcoded false here, which meant a remote
+	// mark-unread (via another client) silently cleared slk's dot.
+	hasUnread := unreadCount > 0
 	// Persist regardless of active workspace so the cache stays
 	// authoritative across workspace switches.
-	if err := h.db.UpdateChannelReadState(channelID, ts, false); err != nil {
+	if err := h.db.UpdateChannelReadState(channelID, ts, hasUnread); err != nil {
 		log.Printf("Warning: failed to update read state on channel_marked %s/%s: %v", channelID, ts, err)
 	}
 	if h.program != nil {

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -2900,9 +2900,17 @@ func (h *rtmEventHandler) OnChannelMarked(channelID, ts string, unreadCount int)
 	if err := h.db.UpdateChannelReadState(channelID, ts, false); err != nil {
 		log.Printf("Warning: failed to update read state on channel_marked %s/%s: %v", channelID, ts, err)
 	}
+	if h.program != nil {
+		// Always notify so the workspace rail can refresh, regardless
+		// of whether this workspace is active. The active-workspace
+		// sidebar refresh and toast come from ChannelMarkedRemoteMsg
+		// below; the rail refresh comes from ReadStateChangedMsg's
+		// App.Update handler.
+		h.program.Send(ui.ReadStateChangedMsg{WorkspaceID: h.workspaceID, ChannelID: channelID})
+	}
 	if h.isActive != nil && !h.isActive() {
-		// Inactive workspace: nothing to draw, but the persistence
-		// above already updated state for when the user switches in.
+		// Inactive workspace: persistence + rail refresh above are
+		// the only visible effects; no sidebar/toast to update.
 		return
 	}
 	if h.program == nil {

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -817,6 +817,19 @@ func run() error {
 			return wctx.LastReadMap[channelID]
 		})
 
+		app.SetReadStateReader(func() map[string]cache.ReadState {
+			wctx := router.Active()
+			if wctx == nil {
+				return nil
+			}
+			state, err := db.GetWorkspaceReadState(wctx.TeamID)
+			if err != nil {
+				log.Printf("Warning: GetWorkspaceReadState for %s: %v", wctx.TeamID, err)
+				return nil
+			}
+			return state
+		})
+
 		app.SetChannelVisitRecorder(func(channelID string) {
 			wctx := router.Active()
 			if wctx == nil {

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -961,7 +961,6 @@ func run() error {
 				return nil
 			}
 			client := wctx.Client
-			lastReadMap := wctx.LastReadMap
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 
@@ -969,10 +968,9 @@ func run() error {
 			if threadTS == "" {
 				err = client.MarkChannelUnread(ctx, channelID, boundaryTS)
 				if err == nil {
-					if dbErr := db.UpdateLastReadTS(channelID, boundaryTS); dbErr != nil {
-						log.Printf("Warning: failed to update last_read_ts %s/%s: %v", channelID, boundaryTS, dbErr)
+					if dbErr := db.UpdateChannelReadState(channelID, boundaryTS, true); dbErr != nil {
+						log.Printf("Warning: failed to update read state on mark-unread %s/%s: %v", channelID, boundaryTS, dbErr)
 					}
-					lastReadMap[channelID] = boundaryTS
 				} else {
 					log.Printf("Warning: failed to mark channel %s as unread (boundary %s): %v", channelID, boundaryTS, err)
 				}

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -830,6 +830,15 @@ func run() error {
 			return state
 		})
 
+		app.SetWorkspaceUnreadReader(func() []string {
+			ids, err := db.WorkspacesWithUnreads()
+			if err != nil {
+				log.Printf("Warning: WorkspacesWithUnreads: %v", err)
+				return nil
+			}
+			return ids
+		})
+
 		app.SetChannelVisitRecorder(func(channelID string) {
 			wctx := router.Active()
 			if wctx == nil {
@@ -2649,9 +2658,10 @@ func (h *rtmEventHandler) OnMessage(channelID, userID, ts, text, threadTS, subty
 
 	if h.isActive != nil && !h.isActive() {
 		// Inactive workspace — read state was already persisted above.
-		// The rail still needs to know an inactive workspace has new
-		// activity; that signal lives in WorkspaceUnreadMsg until the
-		// rail is rewired to derive from DB read state (Task 16).
+		// Fire a ReadStateChangedMsg so the workspace rail refreshes
+		// its dot from db.WorkspacesWithUnreads(). The sidebar's
+		// Invalidate is a no-op here because the active workspace's
+		// sidebar isn't showing this channel anyway.
 		if shouldMarkChannel {
 			debuglog.Cache("OnMessage: team=%s channel=%s ts=%s subtype=%q thread_ts=%s decision=inactive_workspace_persisted",
 				h.workspaceID, channelID, ts, subtype, threadTS)
@@ -2660,9 +2670,9 @@ func (h *rtmEventHandler) OnMessage(channelID, userID, ts, text, threadTS, subty
 				h.workspaceID, channelID, ts, subtype, threadTS)
 		}
 		if h.program != nil {
-			h.program.Send(ui.WorkspaceUnreadMsg{
-				TeamID:    h.workspaceID,
-				ChannelID: channelID,
+			h.program.Send(ui.ReadStateChangedMsg{
+				WorkspaceID: h.workspaceID,
+				ChannelID:   channelID,
 			})
 		}
 		return

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -2008,11 +2008,11 @@ func markChannelReadAsync(
 		return
 	}
 	client := wctx.Client
-	lastReadMap := wctx.LastReadMap
 	go func() {
 		_ = client.MarkChannel(ctx, channelID, ts)
-		_ = db.UpdateLastReadTS(channelID, ts)
-		lastReadMap[channelID] = ts
+		if err := db.UpdateChannelReadState(channelID, ts, false); err != nil {
+			log.Printf("Warning: failed to update read state in markChannelReadAsync %s/%s: %v", channelID, ts, err)
+		}
 		if p != nil {
 			p.Send(ui.ChannelMarkedReadMsg{ChannelID: channelID})
 		}

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -147,7 +147,6 @@ type WorkspaceContext struct {
 	// after a failed one. The UI uses it to decide whether to draw
 	// the "Threads list unavailable" banner.
 	SubscriptionsAvailable bool
-	LastReadMap       map[string]string
 	Channels    []sidebar.ChannelItem
 	// FinderItems is the merged list shown in the Ctrl+T finder. Initially
 	// contains only joined channels; the BrowseableChannelsLoadedMsg pipeline
@@ -805,7 +804,7 @@ func run() error {
 	// without any per-switch closure rebinding.
 	//
 	// Goroutines launched from inside a callback must capture
-	// workspace-scoped values (Client, LastReadMap, ...) into local
+	// workspace-scoped values (Client, UserNames, ...) into local
 	// vars BEFORE the `go func()` so they are not affected by a
 	// concurrent router.Set during the goroutine's lifetime.
 	wireCallbacks := func(router *workspaceRouter) {
@@ -814,7 +813,12 @@ func run() error {
 			if wctx == nil {
 				return ""
 			}
-			return wctx.LastReadMap[channelID]
+			state, err := db.GetChannelReadState(channelID)
+			if err != nil {
+				log.Printf("Warning: GetChannelReadState for %s: %v", channelID, err)
+				return ""
+			}
+			return state.LastReadTS
 		})
 
 		app.SetReadStateReader(func() map[string]cache.ReadState {
@@ -894,7 +898,8 @@ func run() error {
 			}
 			msgItems := fetchChannelMessages(wctx.Client, channelID, db, wctx.UserNames, tsFormat, avatarCache, router)
 
-			lastReadTS := wctx.LastReadMap[channelID]
+			state, _ := db.GetChannelReadState(channelID)
+			lastReadTS := state.LastReadTS
 
 			// Mark channel as read up to the latest message
 			if len(msgItems) > 0 {
@@ -1433,7 +1438,6 @@ func connectWorkspace(ctx context.Context, token slackclient.Token, db *cache.DB
 		AvatarURLs:           &sync.Map{},
 		UserNamesByHandle:    make(map[string]string),
 		BotUserIDs:           make(map[string]bool),
-		LastReadMap:          make(map[string]string),
 		CustomEmoji:          make(map[string]string),
 		LastVisitedByChannel: make(map[string]int64),
 	}

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -2614,30 +2614,39 @@ func (h *rtmEventHandler) OnMessage(channelID, userID, ts, text, threadTS, subty
 		}
 	}
 
+	// Read-state: mark the channel has_unread=true when a message
+	// arrives in a channel the user is NOT actively viewing. Mirrors
+	// Slack's channel-unread semantics — non-broadcast thread replies
+	// do not mark the parent channel unread (only top-level messages
+	// and thread_broadcast subtypes do). See internal/ui/app.go's
+	// thread-reply guard for the matching active-path treatment.
+	//
+	// This write runs for BOTH active and inactive workspaces; the
+	// active/inactive split below only governs the UI dispatch path,
+	// not durable read state. Task 10 of the read-state-sync plan
+	// consolidated the previously duplicated paths into this single
+	// gated write.
+	isThreadReply := threadTS != "" && threadTS != ts
+	isBroadcast := subtype == "thread_broadcast"
+	shouldMarkChannel := !isThreadReply || isBroadcast
+	activeChIDForRead := ""
+	if h.activeChannelID != nil {
+		activeChIDForRead = h.activeChannelID()
+	}
+	if h.db != nil && shouldMarkChannel && activeChIDForRead != channelID {
+		if err := h.db.UpdateChannelReadState(channelID, "", true); err != nil {
+			log.Printf("Warning: failed to set has_unread for %s: %v", channelID, err)
+		}
+	}
+
 	if h.isActive != nil && !h.isActive() {
-		// Inactive workspace — persist per-channel unread so a later
-		// workspace switch reflects the activity, then notify the rail.
-		//
-		// Skip thread replies that aren't broadcasts: per Slack's
-		// channel-unread semantics they don't mark the parent channel
-		// as unread (only top-level messages and thread_broadcast
-		// subtypes do). Mirrors the active-branch guard at
-		// internal/ui/app.go:1430-1431.
-		isThreadReply := threadTS != "" && threadTS != ts
-		isBroadcast := subtype == "thread_broadcast"
-		if !isThreadReply || isBroadcast {
-			countAfter := -1
-			if h.wsCtx != nil {
-				for i := range h.wsCtx.Channels {
-					if h.wsCtx.Channels[i].ID == channelID {
-						h.wsCtx.Channels[i].UnreadCount++
-						countAfter = h.wsCtx.Channels[i].UnreadCount
-						break
-					}
-				}
-			}
-			debuglog.Cache("OnMessage: team=%s channel=%s ts=%s subtype=%q thread_ts=%s decision=bumped_inactive_workspace count_after=%d",
-				h.workspaceID, channelID, ts, subtype, threadTS, countAfter)
+		// Inactive workspace — read state was already persisted above.
+		// The rail still needs to know an inactive workspace has new
+		// activity; that signal lives in WorkspaceUnreadMsg until the
+		// rail is rewired to derive from DB read state (Task 16).
+		if shouldMarkChannel {
+			debuglog.Cache("OnMessage: team=%s channel=%s ts=%s subtype=%q thread_ts=%s decision=inactive_workspace_persisted",
+				h.workspaceID, channelID, ts, subtype, threadTS)
 		} else {
 			debuglog.Cache("OnMessage: team=%s channel=%s ts=%s subtype=%q thread_ts=%s decision=skipped_thread_reply_inactive",
 				h.workspaceID, channelID, ts, subtype, threadTS)
@@ -2660,22 +2669,24 @@ func (h *rtmEventHandler) OnMessage(channelID, userID, ts, text, threadTS, subty
 	}
 	debuglog.Cache("OnMessage: team=%s channel=%s ts=%s subtype=%q thread_ts=%s decision=dispatched_to_app",
 		h.workspaceID, channelID, ts, subtype, threadTS)
-	h.program.Send(ui.NewMessageMsg{
-		ChannelID: channelID,
-		Message: messages.MessageItem{
-			TS:                ts,
-			UserID:            userID,
-			UserName:          userName,
-			Text:              text,
-			Timestamp:         formatTimestamp(ts, h.tsFormat),
-			ThreadTS:          threadTS,
-			Subtype:           subtype,
-			IsEdited:          edited,
-			Attachments:       extractAttachments(files),
-			Blocks:            extractBlocks(blocks),
-			LegacyAttachments: extractLegacyAttachments(attachments),
-		},
-	})
+	if h.program != nil {
+		h.program.Send(ui.NewMessageMsg{
+			ChannelID: channelID,
+			Message: messages.MessageItem{
+				TS:                ts,
+				UserID:            userID,
+				UserName:          userName,
+				Text:              text,
+				Timestamp:         formatTimestamp(ts, h.tsFormat),
+				ThreadTS:          threadTS,
+				Subtype:           subtype,
+				IsEdited:          edited,
+				Attachments:       extractAttachments(files),
+				Blocks:            extractBlocks(blocks),
+				LegacyAttachments: extractLegacyAttachments(attachments),
+			},
+		})
+	}
 }
 
 func (h *rtmEventHandler) OnMessageDeleted(channelID, ts string) {

--- a/cmd/slk/reconnect_backfill.go
+++ b/cmd/slk/reconnect_backfill.go
@@ -107,15 +107,29 @@ func newBackfiller(client historyFetcher, db *cache.DB, workspaceID, selfUserID 
 func (b *backfiller) runChannelPhase(ctx context.Context) error {
 	// Fetch the server's unread map first so we can include channels
 	// the user has never opened in slk (e.g., a brand-new DM that
-	// arrived during an offline window). Failures are non-fatal: we
-	// fall back to the cached-channels-only set.
+	// arrived during an offline window) AND so we can catch up the
+	// persistent read-state for channels the user has marked read in
+	// the official client during the offline window (Symptom 2).
+	// Failures are non-fatal: we fall back to the cached-channels-only
+	// set and skip the catch-up write.
 	var unreadIDs []string
 	if unreads, _, err := b.client.GetUnreadCounts(); err != nil {
 		debuglog.Backfill("team=%s GetUnreadCounts err=%v (falling back to cached-only)", b.workspaceID, err)
 	} else {
+		updates := make([]cache.ChannelReadStateUpdate, 0, len(unreads))
 		for _, u := range unreads {
+			updates = append(updates, cache.ChannelReadStateUpdate{
+				ChannelID:  u.ChannelID,
+				LastReadTS: u.LastRead,
+				HasUnread:  u.HasUnread,
+			})
 			if u.HasUnread {
 				unreadIDs = append(unreadIDs, u.ChannelID)
+			}
+		}
+		if len(updates) > 0 {
+			if err := b.db.BatchUpdateChannelReadState(updates); err != nil {
+				debuglog.Backfill("team=%s BatchUpdateChannelReadState err=%v", b.workspaceID, err)
 			}
 		}
 	}

--- a/cmd/slk/reconnect_backfill.go
+++ b/cmd/slk/reconnect_backfill.go
@@ -130,6 +130,11 @@ func (b *backfiller) runChannelPhase(ctx context.Context) error {
 		if len(updates) > 0 {
 			if err := b.db.BatchUpdateChannelReadState(updates); err != nil {
 				debuglog.Backfill("team=%s BatchUpdateChannelReadState err=%v", b.workspaceID, err)
+			} else if b.program != nil {
+				// Force the sidebar (and workspace rail, once wired in Task 16)
+				// to re-render with the freshly-caught-up read state. This is
+				// the catch-up notification for Symptom 2.
+				b.program.Send(ui.ReadStateChangedMsg{WorkspaceID: b.workspaceID})
 			}
 		}
 	}

--- a/cmd/slk/reconnect_backfill_test.go
+++ b/cmd/slk/reconnect_backfill_test.go
@@ -740,3 +740,49 @@ func makeBackfillMessages(base string, n int) []slack.Message {
 	}
 	return out
 }
+
+func TestRunChannelPhase_WritesReadStateForAllChannels(t *testing.T) {
+	db := newTestDB(t)
+	if err := db.UpsertChannel(cache.Channel{ID: "C1", WorkspaceID: "T1", Name: "a", Type: "channel", IsMember: true}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.UpsertChannel(cache.Channel{ID: "C2", WorkspaceID: "T1", Name: "b", Type: "channel", IsMember: true}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.UpsertChannel(cache.Channel{ID: "C3", WorkspaceID: "T1", Name: "c", Type: "channel", IsMember: true}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pre-seed C2 as unread, mirroring "user had unreads pre-suspend".
+	if err := db.UpdateChannelReadState("C2", "1.0000", true); err != nil {
+		t.Fatal(err)
+	}
+
+	fh := &fakeHistory{
+		unreads: []slackclient.UnreadInfo{
+			{ChannelID: "C1", HasUnread: true, LastRead: "1.0010"},
+			{ChannelID: "C2", HasUnread: false, LastRead: "1.0020"}, // user read it in official client
+			{ChannelID: "C3", HasUnread: false, LastRead: "1.0030"},
+		},
+	}
+	bf := newBackfiller(fh, db, "T1", "U_ME", nil, 4, 100, nil)
+	if err := bf.run(context.Background()); err != nil {
+		t.Fatalf("backfill run: %v", err)
+	}
+
+	s1, _ := db.GetChannelReadState("C1")
+	if !s1.HasUnread || s1.LastReadTS != "1.0010" {
+		t.Errorf("C1 = %+v, want {HasUnread:true LastReadTS:1.0010}", s1)
+	}
+	s2, _ := db.GetChannelReadState("C2")
+	if s2.HasUnread {
+		t.Errorf("C2 HasUnread still true after catch-up (Symptom 2 not fixed): %+v", s2)
+	}
+	if s2.LastReadTS != "1.0020" {
+		t.Errorf("C2 LastReadTS = %q, want %q", s2.LastReadTS, "1.0020")
+	}
+	s3, _ := db.GetChannelReadState("C3")
+	if s3.HasUnread || s3.LastReadTS != "1.0030" {
+		t.Errorf("C3 = %+v, want {HasUnread:false LastReadTS:1.0030}", s3)
+	}
+}

--- a/cmd/slk/reconnect_backfill_test.go
+++ b/cmd/slk/reconnect_backfill_test.go
@@ -638,6 +638,18 @@ func TestBackfill_OvernightSuspendScenario(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// D: a channel the user had unreads in pre-suspend, then read in the
+	// official Slack client during the offline window. The reconnect
+	// catch-up must reflect that — HasUnread=false and the newer LastRead.
+	// This is the regression test for Symptom 2 from the read-state-sync
+	// spec.
+	if err := db.UpsertChannel(cache.Channel{ID: "D", WorkspaceID: "T1", Name: "team-product", Type: "channel", IsMember: true}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.UpdateChannelReadState("D", "1700000050.000000", true); err != nil {
+		t.Fatal(err)
+	}
+
 	// --- Server state at wake-up ---
 
 	fh := &fakeHistory{
@@ -661,6 +673,10 @@ func TestBackfill_OvernightSuspendScenario(t *testing.T) {
 			// C is not in unreads → must still be backfilled because
 			// it's in the cached-channels set, even though the result
 			// will be empty.
+			// D was read in the official client during the offline window: server
+			// returns HasUnread=false and the new LastRead. Catch-up must clear
+			// slk's local has_unread and advance last_read_ts.
+			{ChannelID: "D", HasUnread: false, LastRead: "1700008600.000000"},
 		},
 	}
 
@@ -722,6 +738,21 @@ func TestBackfill_OvernightSuspendScenario(t *testing.T) {
 	// synced_at would still be 0 (never set by this test's setup).
 	if got := db.GetChannelSyncedAt("C"); got == 0 {
 		t.Errorf("C: synced_at not bumped — channel was skipped by candidate set, not visited")
+	}
+
+	// --- D assertions: Symptom 2 catch-up ---
+
+	// D had has_unread=true pre-suspend; the catch-up batch write should
+	// have cleared it because client.counts returned HasUnread=false.
+	sD, err := db.GetChannelReadState("D")
+	if err != nil {
+		t.Fatalf("GetChannelReadState D: %v", err)
+	}
+	if sD.HasUnread {
+		t.Errorf("D HasUnread = true after catch-up; Symptom 2 not fixed")
+	}
+	if sD.LastReadTS != "1700008600.000000" {
+		t.Errorf("D LastReadTS = %q, want %q", sD.LastReadTS, "1700008600.000000")
 	}
 }
 

--- a/docs/superpowers/plans/2026-05-17-read-state-sync.md
+++ b/docs/superpowers/plans/2026-05-17-read-state-sync.md
@@ -1,0 +1,2184 @@
+# Read-State Sync Rewrite Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Consolidate per-channel read state into a single SQLite source of truth, eliminate the three-store divergence, and add reconnect catch-up so channels stay in sync with the official Slack client.
+
+**Architecture:** SQLite is the only store for `last_read_ts` and a new boolean `has_unread`. All read-state writes flow through a single API (`UpdateChannelReadState` / `BatchUpdateChannelReadState`). All UI consumers read via `GetWorkspaceReadState` at render time. `WorkspaceContext.LastReadMap` and the per-channel `LastReadTS` / `UnreadCount` fields are removed. The integer unread count is replaced with a boolean; section aggregates become counts-of-channels-with-unreads.
+
+**Tech Stack:** Go 1.26, modernc.org/sqlite (WAL), bubbletea, lipgloss. Plain `testing.T` (no testify, no table-driven helpers). Tests use `cache.New(":memory:")` or `newTestDB(t)` from `cmd/slk/reconnect_backfill_test.go:133-145`.
+
+**Spec:** `docs/superpowers/specs/2026-05-17-read-state-sync-design.md`
+
+---
+
+## File structure
+
+**New files:**
+
+- `internal/cache/channels_read_state.go` — `ReadState`, `ChannelReadStateUpdate` types, `UpdateChannelReadState`, `BatchUpdateChannelReadState`, `GetChannelReadState`, `GetWorkspaceReadState`, `WorkspacesWithUnreads`.
+- `internal/cache/channels_read_state_test.go` — unit tests for the new API including the clobber-regression test.
+- `cmd/slk/event_handler_marked_test.go` — new tests for `OnChannelMarked` calling the new API.
+
+**Modified files:**
+
+- `internal/cache/db.go` — add `has_unread` column via `addColumnIfMissing`.
+- `internal/cache/channels.go` — fix `UpsertChannel` (drop `last_read_ts`/`unread_count` from `ON CONFLICT DO UPDATE`), remove `LastReadTS` and `UnreadCount` fields from `cache.Channel`, delete dead `UpdateUnreadCount`/`UpdateLastReadTS`/`GetLastReadTS`.
+- `internal/cache/channels_test.go` — remove tests for deleted functions; update `TestUpsertAndGetChannel` for the slimmer struct.
+- `internal/slack/client.go` — drop now-unused `Count` field on `UnreadInfo`? (Kept — see Task 14 note.)
+- `cmd/slk/main.go` — bootstrap migration to `BatchUpdateChannelReadState`; remove `LastReadMap`; route all read-state writes through the new API.
+- `cmd/slk/channelitem.go` — no behavioral change after the struct/upsert fix; the zero-value bootstrap clobber goes away automatically.
+- `cmd/slk/reconnect_backfill.go` — `runChannelPhase` now calls `BatchUpdateChannelReadState`.
+- `cmd/slk/reconnect_backfill_test.go` — new test asserting batch write; extend `TestBackfill_OvernightSuspendScenario` with channel D.
+- `cmd/slk/event_handler_test.go` — update existing tests for the new write path.
+- `internal/ui/app.go` — emit `ReadStateChangedMsg`; remove `MarkUnread`/`ClearUnread`/`SetUnreadCount` callers; route through DB API.
+- `internal/ui/sidebar/model.go` — delete `MarkUnread`/`ClearUnread`/`SetUnreadCount`; add `ReadStateReader` provider; `View()` consults DB; `ChannelItem` loses `UnreadCount`/`LastReadTS`; section aggregate counts channels.
+- `internal/ui/sidebar/model_test.go` — delete/rewrite tests for removed methods.
+- `internal/ui/workspace/model.go` — rail dot driven by `WorkspacesWithUnreads`.
+
+**Deprecated but kept:**
+
+- `unread_count` column on `channels` table — kept one release per spec, never read, never written.
+
+---
+
+## Phase 1: Cache layer foundation
+
+### Task 1: Add `has_unread` column migration
+
+**Files:**
+- Modify: `internal/cache/db.go:182-190`
+- Test: `internal/cache/db_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/cache/db_test.go`:
+
+```go
+func TestMigration_AddsHasUnreadColumn(t *testing.T) {
+	db, err := New(":memory:")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer db.Close()
+
+	rows, err := db.conn.Query("PRAGMA table_info(channels)")
+	if err != nil {
+		t.Fatalf("PRAGMA: %v", err)
+	}
+	defer rows.Close()
+
+	found := false
+	for rows.Next() {
+		var cid int
+		var name, ctype string
+		var notnull, pk int
+		var dflt sql.NullString
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if name == "has_unread" {
+			found = true
+			if ctype != "INTEGER" {
+				t.Errorf("has_unread type = %q, want INTEGER", ctype)
+			}
+			if notnull != 1 {
+				t.Errorf("has_unread NOT NULL = %d, want 1", notnull)
+			}
+			if !dflt.Valid || dflt.String != "0" {
+				t.Errorf("has_unread default = %v, want 0", dflt)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("has_unread column not added")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/cache/ -run TestMigration_AddsHasUnreadColumn -v`
+Expected: FAIL with `has_unread column not added`.
+
+- [ ] **Step 3: Add the migration**
+
+Edit `internal/cache/db.go` after line 189 (after `latest_synced_ts` block, before `return nil`):
+
+```go
+	if err := db.addColumnIfMissing("channels", "has_unread",
+		"ALTER TABLE channels ADD COLUMN has_unread INTEGER NOT NULL DEFAULT 0"); err != nil {
+		return err
+	}
+```
+
+Also add `has_unread INTEGER NOT NULL DEFAULT 0` to the inline `CREATE TABLE channels` schema at `db.go:86-98` so fresh databases get the column directly. Insert it after `unread_count INTEGER NOT NULL DEFAULT 0,` on line 95:
+
+```sql
+	CREATE TABLE IF NOT EXISTS channels (
+		id TEXT PRIMARY KEY,
+		workspace_id TEXT NOT NULL,
+		name TEXT NOT NULL,
+		type TEXT NOT NULL DEFAULT 'channel',
+		topic TEXT NOT NULL DEFAULT '',
+		is_member INTEGER NOT NULL DEFAULT 0,
+		is_starred INTEGER NOT NULL DEFAULT 0,
+		last_read_ts TEXT NOT NULL DEFAULT '',
+		unread_count INTEGER NOT NULL DEFAULT 0,
+		has_unread INTEGER NOT NULL DEFAULT 0,
+		updated_at INTEGER NOT NULL DEFAULT 0,
+		FOREIGN KEY (workspace_id) REFERENCES workspaces(id)
+	);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/cache/ -run TestMigration_AddsHasUnreadColumn -v`
+Expected: PASS.
+
+Run: `go test ./internal/cache/ -v` to confirm no other regressions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/cache/db.go internal/cache/db_test.go
+git commit -m "cache: add has_unread column to channels table"
+```
+
+---
+
+### Task 2: Add `ReadState` and `ChannelReadStateUpdate` types + skeleton functions
+
+**Files:**
+- Create: `internal/cache/channels_read_state.go`
+
+- [ ] **Step 1: Create the new file with type definitions and stub bodies**
+
+```go
+package cache
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+// ReadState captures the per-channel read-state values that drive the
+// unread dot and "new messages" line. It is the canonical type for
+// passing read state across package boundaries.
+type ReadState struct {
+	LastReadTS string
+	HasUnread  bool
+}
+
+// ChannelReadStateUpdate is one entry in a batched read-state write.
+// LastReadTS == "" means "preserve the existing last_read_ts" (used by
+// events that update has_unread only, e.g. new-message arrivals).
+type ChannelReadStateUpdate struct {
+	ChannelID  string
+	LastReadTS string
+	HasUnread  bool
+}
+
+// UpdateChannelReadState atomically updates the per-channel read state.
+// If lastReadTS == "", the existing last_read_ts is preserved. This is
+// the ONLY function permitted to modify read state after bootstrap.
+func (db *DB) UpdateChannelReadState(channelID, lastReadTS string, hasUnread bool) error {
+	return fmt.Errorf("not implemented")
+}
+
+// BatchUpdateChannelReadState writes multiple updates in a single
+// transaction. Used by bootstrap and reconnect catch-up paths.
+func (db *DB) BatchUpdateChannelReadState(updates []ChannelReadStateUpdate) error {
+	return fmt.Errorf("not implemented")
+}
+
+// GetChannelReadState returns the read state for a single channel.
+// A missing row yields a zero-valued ReadState and a nil error.
+func (db *DB) GetChannelReadState(channelID string) (ReadState, error) {
+	return ReadState{}, fmt.Errorf("not implemented")
+}
+
+// GetWorkspaceReadState returns channelID -> ReadState for every
+// channel in the workspace. Single batched query. Called by the
+// sidebar View() at render time.
+func (db *DB) GetWorkspaceReadState(workspaceID string) (map[string]ReadState, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// WorkspacesWithUnreads returns the set of workspace IDs with at least
+// one has_unread=true channel. Used by the workspace rail.
+func (db *DB) WorkspacesWithUnreads() ([]string, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+var _ = sql.ErrNoRows // keep sql import for later use
+```
+
+- [ ] **Step 2: Verify the package still builds**
+
+Run: `go build ./internal/cache/`
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/cache/channels_read_state.go
+git commit -m "cache: add read-state API skeleton"
+```
+
+---
+
+### Task 3: Implement `UpdateChannelReadState` (TDD)
+
+**Files:**
+- Modify: `internal/cache/channels_read_state.go`
+- Create: `internal/cache/channels_read_state_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/cache/channels_read_state_test.go`:
+
+```go
+package cache
+
+import (
+	"testing"
+)
+
+func newRSChannel(t *testing.T, db *DB, id, workspaceID string) {
+	t.Helper()
+	if err := db.UpsertWorkspace(Workspace{ID: workspaceID, Name: "ws"}); err != nil {
+		t.Fatalf("UpsertWorkspace: %v", err)
+	}
+	if err := db.UpsertChannel(Channel{ID: id, WorkspaceID: workspaceID, Name: id, Type: "channel"}); err != nil {
+		t.Fatalf("UpsertChannel: %v", err)
+	}
+}
+
+func TestUpdateChannelReadState_WritesBothColumns(t *testing.T) {
+	db, err := New(":memory:")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer db.Close()
+	newRSChannel(t, db, "C1", "T1")
+
+	if err := db.UpdateChannelReadState("C1", "1700000000.000001", true); err != nil {
+		t.Fatalf("UpdateChannelReadState: %v", err)
+	}
+	state, err := db.GetChannelReadState("C1")
+	if err != nil {
+		t.Fatalf("GetChannelReadState: %v", err)
+	}
+	if state.LastReadTS != "1700000000.000001" {
+		t.Errorf("LastReadTS = %q, want %q", state.LastReadTS, "1700000000.000001")
+	}
+	if !state.HasUnread {
+		t.Errorf("HasUnread = false, want true")
+	}
+}
+
+func TestUpdateChannelReadState_EmptyTSPreservesExisting(t *testing.T) {
+	db, err := New(":memory:")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer db.Close()
+	newRSChannel(t, db, "C1", "T1")
+
+	if err := db.UpdateChannelReadState("C1", "1700000000.000001", false); err != nil {
+		t.Fatalf("first update: %v", err)
+	}
+	if err := db.UpdateChannelReadState("C1", "", true); err != nil {
+		t.Fatalf("second update: %v", err)
+	}
+	state, err := db.GetChannelReadState("C1")
+	if err != nil {
+		t.Fatalf("GetChannelReadState: %v", err)
+	}
+	if state.LastReadTS != "1700000000.000001" {
+		t.Errorf("LastReadTS = %q, want preserved %q", state.LastReadTS, "1700000000.000001")
+	}
+	if !state.HasUnread {
+		t.Errorf("HasUnread = false, want true")
+	}
+}
+
+func TestUpdateChannelReadState_Idempotent(t *testing.T) {
+	db, err := New(":memory:")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer db.Close()
+	newRSChannel(t, db, "C1", "T1")
+
+	for i := 0; i < 3; i++ {
+		if err := db.UpdateChannelReadState("C1", "1700000000.000001", true); err != nil {
+			t.Fatalf("iter %d: %v", i, err)
+		}
+	}
+	state, _ := db.GetChannelReadState("C1")
+	if state.LastReadTS != "1700000000.000001" || !state.HasUnread {
+		t.Errorf("state = %+v after 3 writes", state)
+	}
+}
+```
+
+If `UpsertWorkspace` doesn't exist, use the actual constructor — check `internal/cache/workspaces.go`. The test helper may need to use a direct `db.conn.Exec("INSERT INTO workspaces ...")` instead.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/cache/ -run TestUpdateChannelReadState -v`
+Expected: FAIL with `not implemented` errors.
+
+- [ ] **Step 3: Implement the function**
+
+Replace the stub in `internal/cache/channels_read_state.go`:
+
+```go
+func (db *DB) UpdateChannelReadState(channelID, lastReadTS string, hasUnread bool) error {
+	var q string
+	var args []any
+	if lastReadTS == "" {
+		q = `UPDATE channels SET has_unread = ? WHERE id = ?`
+		args = []any{boolToInt(hasUnread), channelID}
+	} else {
+		q = `UPDATE channels SET last_read_ts = ?, has_unread = ? WHERE id = ?`
+		args = []any{lastReadTS, boolToInt(hasUnread), channelID}
+	}
+	if _, err := db.conn.Exec(q, args...); err != nil {
+		return fmt.Errorf("updating channel read state: %w", err)
+	}
+	return nil
+}
+
+func (db *DB) GetChannelReadState(channelID string) (ReadState, error) {
+	var lastReadTS string
+	var hasUnread int
+	err := db.conn.QueryRow(
+		`SELECT last_read_ts, has_unread FROM channels WHERE id = ?`,
+		channelID,
+	).Scan(&lastReadTS, &hasUnread)
+	if err == sql.ErrNoRows {
+		return ReadState{}, nil
+	}
+	if err != nil {
+		return ReadState{}, fmt.Errorf("getting channel read state: %w", err)
+	}
+	return ReadState{LastReadTS: lastReadTS, HasUnread: hasUnread == 1}, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/cache/ -run TestUpdateChannelReadState -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/cache/channels_read_state.go internal/cache/channels_read_state_test.go
+git commit -m "cache: implement UpdateChannelReadState and GetChannelReadState"
+```
+
+---
+
+### Task 4: Implement `BatchUpdateChannelReadState` (TDD)
+
+**Files:**
+- Modify: `internal/cache/channels_read_state.go`
+- Modify: `internal/cache/channels_read_state_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/cache/channels_read_state_test.go`:
+
+```go
+func TestBatchUpdateChannelReadState_WritesAll(t *testing.T) {
+	db, err := New(":memory:")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer db.Close()
+	newRSChannel(t, db, "C1", "T1")
+	newRSChannel(t, db, "C2", "T1")
+	newRSChannel(t, db, "C3", "T1")
+
+	updates := []ChannelReadStateUpdate{
+		{ChannelID: "C1", LastReadTS: "1.0001", HasUnread: true},
+		{ChannelID: "C2", LastReadTS: "1.0002", HasUnread: false},
+		{ChannelID: "C3", LastReadTS: "", HasUnread: true},
+	}
+	if err := db.BatchUpdateChannelReadState(updates); err != nil {
+		t.Fatalf("BatchUpdateChannelReadState: %v", err)
+	}
+	s1, _ := db.GetChannelReadState("C1")
+	if s1.LastReadTS != "1.0001" || !s1.HasUnread {
+		t.Errorf("C1 = %+v", s1)
+	}
+	s2, _ := db.GetChannelReadState("C2")
+	if s2.LastReadTS != "1.0002" || s2.HasUnread {
+		t.Errorf("C2 = %+v", s2)
+	}
+	s3, _ := db.GetChannelReadState("C3")
+	if s3.LastReadTS != "" || !s3.HasUnread {
+		t.Errorf("C3 = %+v (LastReadTS should be preserved empty)", s3)
+	}
+}
+
+func TestBatchUpdateChannelReadState_Transactional(t *testing.T) {
+	db, err := New(":memory:")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer db.Close()
+	newRSChannel(t, db, "C1", "T1")
+
+	// Seed C1
+	if err := db.UpdateChannelReadState("C1", "1.0", false); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Empty batch is a no-op and returns nil.
+	if err := db.BatchUpdateChannelReadState(nil); err != nil {
+		t.Errorf("nil batch: %v", err)
+	}
+	if err := db.BatchUpdateChannelReadState([]ChannelReadStateUpdate{}); err != nil {
+		t.Errorf("empty batch: %v", err)
+	}
+	// Original state untouched
+	s, _ := db.GetChannelReadState("C1")
+	if s.LastReadTS != "1.0" || s.HasUnread {
+		t.Errorf("after empty batch C1 = %+v", s)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/cache/ -run TestBatchUpdateChannelReadState -v`
+Expected: FAIL with `not implemented`.
+
+- [ ] **Step 3: Implement the function**
+
+Replace the stub in `internal/cache/channels_read_state.go`:
+
+```go
+func (db *DB) BatchUpdateChannelReadState(updates []ChannelReadStateUpdate) error {
+	if len(updates) == 0 {
+		return nil
+	}
+	tx, err := db.conn.Begin()
+	if err != nil {
+		return fmt.Errorf("begin batch read-state tx: %w", err)
+	}
+	stmtBoth, err := tx.Prepare(`UPDATE channels SET last_read_ts = ?, has_unread = ? WHERE id = ?`)
+	if err != nil {
+		tx.Rollback()
+		return fmt.Errorf("prepare both: %w", err)
+	}
+	defer stmtBoth.Close()
+	stmtFlag, err := tx.Prepare(`UPDATE channels SET has_unread = ? WHERE id = ?`)
+	if err != nil {
+		tx.Rollback()
+		return fmt.Errorf("prepare flag: %w", err)
+	}
+	defer stmtFlag.Close()
+
+	for _, u := range updates {
+		if u.LastReadTS == "" {
+			if _, err := stmtFlag.Exec(boolToInt(u.HasUnread), u.ChannelID); err != nil {
+				tx.Rollback()
+				return fmt.Errorf("batch flag for %s: %w", u.ChannelID, err)
+			}
+		} else {
+			if _, err := stmtBoth.Exec(u.LastReadTS, boolToInt(u.HasUnread), u.ChannelID); err != nil {
+				tx.Rollback()
+				return fmt.Errorf("batch both for %s: %w", u.ChannelID, err)
+			}
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit batch read-state: %w", err)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/cache/ -run TestBatchUpdateChannelReadState -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/cache/channels_read_state.go internal/cache/channels_read_state_test.go
+git commit -m "cache: implement BatchUpdateChannelReadState"
+```
+
+---
+
+### Task 5: Implement `GetWorkspaceReadState` and `WorkspacesWithUnreads` (TDD)
+
+**Files:**
+- Modify: `internal/cache/channels_read_state.go`
+- Modify: `internal/cache/channels_read_state_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/cache/channels_read_state_test.go`:
+
+```go
+func TestGetWorkspaceReadState_ReturnsAllChannels(t *testing.T) {
+	db, err := New(":memory:")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer db.Close()
+	newRSChannel(t, db, "C1", "T1")
+	newRSChannel(t, db, "C2", "T1")
+	newRSChannel(t, db, "C3", "T1")
+	newRSChannel(t, db, "C4", "T2") // different workspace
+
+	_ = db.UpdateChannelReadState("C1", "1.0001", true)
+	_ = db.UpdateChannelReadState("C2", "1.0002", false)
+	// C3 untouched — defaults
+
+	got, err := db.GetWorkspaceReadState("T1")
+	if err != nil {
+		t.Fatalf("GetWorkspaceReadState: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d entries, want 3 (C3 must be included with defaults): %+v", len(got), got)
+	}
+	if got["C1"].LastReadTS != "1.0001" || !got["C1"].HasUnread {
+		t.Errorf("C1 = %+v", got["C1"])
+	}
+	if got["C2"].LastReadTS != "1.0002" || got["C2"].HasUnread {
+		t.Errorf("C2 = %+v", got["C2"])
+	}
+	if got["C3"].LastReadTS != "" || got["C3"].HasUnread {
+		t.Errorf("C3 default = %+v", got["C3"])
+	}
+	if _, ok := got["C4"]; ok {
+		t.Errorf("C4 from other workspace should not be returned")
+	}
+}
+
+func TestWorkspacesWithUnreads(t *testing.T) {
+	db, err := New(":memory:")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer db.Close()
+	newRSChannel(t, db, "C1", "T1")
+	newRSChannel(t, db, "C2", "T2")
+	newRSChannel(t, db, "C3", "T3")
+
+	_ = db.UpdateChannelReadState("C1", "1.0", true)
+	_ = db.UpdateChannelReadState("C3", "1.0", true)
+	// C2/T2 has no unreads
+
+	got, err := db.WorkspacesWithUnreads()
+	if err != nil {
+		t.Fatalf("WorkspacesWithUnreads: %v", err)
+	}
+	want := map[string]bool{"T1": true, "T3": true}
+	if len(got) != 2 {
+		t.Fatalf("got %d ids, want 2: %v", len(got), got)
+	}
+	for _, id := range got {
+		if !want[id] {
+			t.Errorf("unexpected workspace %q", id)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/cache/ -run "TestGetWorkspaceReadState|TestWorkspacesWithUnreads" -v`
+Expected: FAIL with `not implemented`.
+
+- [ ] **Step 3: Implement the functions**
+
+Replace the stubs in `internal/cache/channels_read_state.go`:
+
+```go
+func (db *DB) GetWorkspaceReadState(workspaceID string) (map[string]ReadState, error) {
+	rows, err := db.conn.Query(
+		`SELECT id, last_read_ts, has_unread FROM channels WHERE workspace_id = ?`,
+		workspaceID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query workspace read state: %w", err)
+	}
+	defer rows.Close()
+	out := make(map[string]ReadState)
+	for rows.Next() {
+		var id, lastRead string
+		var hasUnread int
+		if err := rows.Scan(&id, &lastRead, &hasUnread); err != nil {
+			return nil, fmt.Errorf("scan workspace read state: %w", err)
+		}
+		out[id] = ReadState{LastReadTS: lastRead, HasUnread: hasUnread == 1}
+	}
+	return out, rows.Err()
+}
+
+func (db *DB) WorkspacesWithUnreads() ([]string, error) {
+	rows, err := db.conn.Query(
+		`SELECT DISTINCT workspace_id FROM channels WHERE has_unread = 1`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query workspaces with unreads: %w", err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan workspace id: %w", err)
+		}
+		out = append(out, id)
+	}
+	return out, rows.Err()
+}
+```
+
+Also remove the `var _ = sql.ErrNoRows` placeholder line — `sql` is now actually used.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/cache/ -v`
+Expected: ALL PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/cache/channels_read_state.go internal/cache/channels_read_state_test.go
+git commit -m "cache: implement GetWorkspaceReadState and WorkspacesWithUnreads"
+```
+
+---
+
+### Task 6: Fix `UpsertChannel` to never clobber read state + clobber-regression test
+
+**Files:**
+- Modify: `internal/cache/channels.go:21-41`
+- Modify: `internal/cache/channels_read_state_test.go`
+
+- [ ] **Step 1: Write the failing clobber-regression test**
+
+Append to `internal/cache/channels_read_state_test.go`:
+
+```go
+func TestUpsertChannel_DoesNotClobberReadState(t *testing.T) {
+	db, err := New(":memory:")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer db.Close()
+	newRSChannel(t, db, "C1", "T1")
+
+	// Set read state.
+	if err := db.UpdateChannelReadState("C1", "1700000000.000001", true); err != nil {
+		t.Fatalf("UpdateChannelReadState: %v", err)
+	}
+
+	// Re-upsert the channel with zero-value LastReadTS/UnreadCount.
+	// This mirrors what bootstrap (upsertChannelInDB) does today.
+	if err := db.UpsertChannel(Channel{
+		ID:          "C1",
+		WorkspaceID: "T1",
+		Name:        "renamed",
+		Type:        "channel",
+	}); err != nil {
+		t.Fatalf("re-upsert: %v", err)
+	}
+
+	state, err := db.GetChannelReadState("C1")
+	if err != nil {
+		t.Fatalf("GetChannelReadState: %v", err)
+	}
+	if state.LastReadTS != "1700000000.000001" {
+		t.Errorf("LastReadTS = %q, want preserved %q (clobber regression!)", state.LastReadTS, "1700000000.000001")
+	}
+	if !state.HasUnread {
+		t.Errorf("HasUnread = false after upsert (clobber regression!)")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/cache/ -run TestUpsertChannel_DoesNotClobberReadState -v`
+Expected: FAIL — `last_read_ts` reset to empty string.
+
+- [ ] **Step 3: Fix `UpsertChannel`**
+
+Edit `internal/cache/channels.go:21-41` — remove `last_read_ts` and `unread_count` from the `ON CONFLICT DO UPDATE SET` clause. The `INSERT` still writes them (for fresh rows the zero values are fine and the schema defaults would handle it anyway).
+
+```go
+func (db *DB) UpsertChannel(ch Channel) error {
+	_, err := db.conn.Exec(`
+		INSERT INTO channels (id, workspace_id, name, type, topic, is_member, is_starred, last_read_ts, unread_count, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			name=excluded.name,
+			type=excluded.type,
+			topic=excluded.topic,
+			is_member=excluded.is_member,
+			is_starred=excluded.is_starred,
+			updated_at=excluded.updated_at
+	`, ch.ID, ch.WorkspaceID, ch.Name, ch.Type, ch.Topic,
+		boolToInt(ch.IsMember), boolToInt(ch.IsStarred),
+		ch.LastReadTS, ch.UnreadCount, ch.UpdatedAt)
+	if err != nil {
+		return fmt.Errorf("upserting channel: %w", err)
+	}
+	return nil
+}
+```
+
+`has_unread` was never in the clause and must NEVER be added.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/cache/ -v`
+Expected: ALL PASS. The clobber test now passes; pre-existing `TestUpsertAndGetChannel` may still pass (it only checks insert path).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/cache/channels.go internal/cache/channels_read_state_test.go
+git commit -m "cache: stop UpsertChannel from clobbering read state on conflict"
+```
+
+---
+
+## Phase 2: Migrate write paths to the new API
+
+### Task 7: Migrate `OnChannelMarked` event handler
+
+**Files:**
+- Modify: `cmd/slk/main.go:2876-2898`
+- Create: `cmd/slk/event_handler_marked_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `cmd/slk/event_handler_marked_test.go`:
+
+```go
+package main
+
+import (
+	"testing"
+
+	"github.com/gammons/slk/internal/cache"
+)
+
+func TestOnChannelMarked_WritesReadState(t *testing.T) {
+	db := newTestDB(t)
+	if err := db.UpsertChannel(cache.Channel{ID: "C1", WorkspaceID: "T1", Name: "general", Type: "channel"}); err != nil {
+		t.Fatalf("UpsertChannel: %v", err)
+	}
+	// Pre-seed unread to verify the marked event clears it.
+	if err := db.UpdateChannelReadState("C1", "1.0000", true); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	wctx := &WorkspaceContext{}
+	h := &rtmEventHandler{
+		db:       db,
+		wsCtx:    wctx,
+		isActive: func() bool { return true },
+		program:  nil, // exercise the no-program path
+	}
+
+	h.OnChannelMarked("C1", "1.0050", 0)
+
+	state, err := db.GetChannelReadState("C1")
+	if err != nil {
+		t.Fatalf("GetChannelReadState: %v", err)
+	}
+	if state.LastReadTS != "1.0050" {
+		t.Errorf("LastReadTS = %q, want %q", state.LastReadTS, "1.0050")
+	}
+	if state.HasUnread {
+		t.Errorf("HasUnread should be false after channel_marked")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./cmd/slk/ -run TestOnChannelMarked_WritesReadState -v`
+Expected: FAIL — current handler only updates `last_read_ts`, never sets `has_unread=false`.
+
+- [ ] **Step 3: Update `OnChannelMarked`**
+
+Edit `cmd/slk/main.go:2876-2898`:
+
+```go
+func (h *rtmEventHandler) OnChannelMarked(channelID, ts string, unreadCount int) {
+	if err := h.db.UpdateChannelReadState(channelID, ts, false); err != nil {
+		log.Printf("Warning: failed to update read state on channel_marked %s/%s: %v", channelID, ts, err)
+	}
+	if h.isActive != nil && !h.isActive() {
+		return
+	}
+	if h.program == nil {
+		return
+	}
+	h.program.Send(ui.ChannelMarkedRemoteMsg{
+		ChannelID:   channelID,
+		TS:          ts,
+		UnreadCount: unreadCount,
+	})
+}
+```
+
+Note: removed the `h.wsCtx.LastReadMap[channelID] = ts` write. We will purge `LastReadMap` entirely in a later task.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./cmd/slk/ -run TestOnChannelMarked_WritesReadState -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/slk/main.go cmd/slk/event_handler_marked_test.go
+git commit -m "cmd/slk: route OnChannelMarked through UpdateChannelReadState"
+```
+
+---
+
+### Task 8: Migrate `markChannelReadAsync`
+
+**Files:**
+- Modify: `cmd/slk/main.go:1997-2020`
+
+- [ ] **Step 1: Add a test**
+
+Append to `cmd/slk/event_handler_marked_test.go`:
+
+```go
+import "context"
+
+type fakeReader struct{ called bool; ts string }
+func (f *fakeReader) MarkChannel(ctx context.Context, channelID, ts string) error {
+	f.called = true
+	f.ts = ts
+	return nil
+}
+
+// markChannelReadAsync calls client.MarkChannel via WorkspaceContext.Client which is
+// the real slackclient.Client; an integration-style test is heavy. Instead, exercise
+// the DB write path through a sibling helper if the production fn refuses extraction.
+// For this task we just assert the DB row after calling the function with a stubbed client.
+// The simplest way is to extract markChannelReadAsync into a form that accepts a small
+// interface; if extracting is too risky, defer this test and rely on Task 7's coverage.
+```
+
+(If extraction is too invasive, skip the unit test for this task and rely on integration-level coverage from the reconnect-backfill scenario test in Task 14.)
+
+- [ ] **Step 2: Edit `markChannelReadAsync`**
+
+Edit `cmd/slk/main.go:1997-2020`:
+
+```go
+func markChannelReadAsync(
+	ctx context.Context,
+	wctx *WorkspaceContext,
+	db *cache.DB,
+	p *tea.Program,
+	channelID, ts string,
+) {
+	if wctx == nil || ts == "" {
+		return
+	}
+	client := wctx.Client
+	go func() {
+		_ = client.MarkChannel(ctx, channelID, ts)
+		if err := db.UpdateChannelReadState(channelID, ts, false); err != nil {
+			log.Printf("Warning: failed to update read state in markChannelReadAsync %s/%s: %v", channelID, ts, err)
+		}
+		if p != nil {
+			p.Send(ui.ChannelMarkedReadMsg{ChannelID: channelID})
+		}
+	}()
+}
+```
+
+Removed: `_ = db.UpdateLastReadTS(channelID, ts)`, `lastReadMap[channelID] = ts`, and the `lastReadMap := wctx.LastReadMap` capture.
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `go build ./cmd/slk/`
+Expected: success.
+
+- [ ] **Step 4: Run all package tests**
+
+Run: `go test ./cmd/slk/ -v`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/slk/main.go
+git commit -m "cmd/slk: route markChannelReadAsync through UpdateChannelReadState"
+```
+
+---
+
+### Task 9: Migrate `SetMessageMarkUnreader` (user presses U)
+
+**Files:**
+- Modify: `cmd/slk/main.go:958-999`
+
+- [ ] **Step 1: Locate the existing callback**
+
+Read the existing `app.SetMessageMarkUnreader(func(...) tea.Msg {...})` registration at approximately `cmd/slk/main.go:958-999`. Identify the block that today does:
+
+```go
+err = client.MarkChannelUnread(ctx, channelID, boundaryTS)
+if err == nil {
+    if dbErr := db.UpdateLastReadTS(channelID, boundaryTS); dbErr != nil {
+        log.Printf("Warning: ...")
+    }
+    lastReadMap[channelID] = boundaryTS
+}
+```
+
+- [ ] **Step 2: Replace with the new API**
+
+Change the `if threadTS == ""` branch body to:
+
+```go
+err = client.MarkChannelUnread(ctx, channelID, boundaryTS)
+if err == nil {
+    if dbErr := db.UpdateChannelReadState(channelID, boundaryTS, true); dbErr != nil {
+        log.Printf("Warning: failed to update read state on mark-unread %s/%s: %v", channelID, boundaryTS, dbErr)
+    }
+}
+```
+
+Remove the `lastReadMap := wctx.LastReadMap` capture earlier in the closure (and any other `lastReadMap[...]` writes inside).
+
+- [ ] **Step 3: Verify build + tests**
+
+Run: `go build ./cmd/slk/ && go test ./cmd/slk/ -v`
+Expected: success.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/slk/main.go
+git commit -m "cmd/slk: route mark-unread through UpdateChannelReadState"
+```
+
+---
+
+### Task 10: Migrate `OnMessage` event handler (with active-channel suppression)
+
+**Files:**
+- Modify: `cmd/slk/main.go:2542-2681` (the `OnMessage` body)
+- Modify: `cmd/slk/event_handler_test.go`
+
+The current handler has two branches:
+- Inactive workspace: bumps `wctx.Channels[i].UnreadCount` and sends `WorkspaceUnreadMsg`.
+- Active workspace: dispatches `ui.NewMessageMsg`; the bump happens in `App.Update` via `a.sidebar.MarkUnread(msg.ChannelID)` after checking `msg.ChannelID != a.activeChannelID`.
+
+After this task, BOTH branches converge: the handler writes `UpdateChannelReadState(id, "", true)` whenever the message channel is NOT the currently-active channel. We move active-channel suppression directly into `OnMessage`.
+
+- [ ] **Step 1: Add an `activeChannelID` accessor to the handler**
+
+The handler already has `isActive func() bool` for active-workspace. We need a similar callback to compare against the active channel ID. Edit the `rtmEventHandler` struct (search `cmd/slk/main.go` for `type rtmEventHandler struct`) to add:
+
+```go
+type rtmEventHandler struct {
+    // ... existing fields ...
+    activeChannelID func() string // returns "" if no channel active or workspace inactive
+}
+```
+
+Find where `rtmEventHandler` is constructed (`cmd/slk/main.go`, search for `rtmEventHandler{`) and wire a closure that returns the current active channel id from the App via `router.Active()` + an exported app accessor, OR via a shared atomic variable. The simplest pattern is to follow the existing `isActive func() bool` wiring (see how that's set near construction) and add `activeChannelID` alongside it.
+
+If wiring through the App is awkward, define a simple shared variable:
+
+```go
+// In main.go near other shared state:
+var globalActiveChannelID atomic.Value // string
+
+// In wherever channel switches are processed (search for ChannelSwitchedMsg or
+// the function that sets the active channel), set:
+globalActiveChannelID.Store(channelID)
+
+// On workspace switch / channel close, set "":
+globalActiveChannelID.Store("")
+
+// Construct the handler with:
+activeChannelID: func() string {
+    v, _ := globalActiveChannelID.Load().(string)
+    return v
+},
+```
+
+Prefer the existing isActive pattern unless that requires deeper plumbing.
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to `cmd/slk/event_handler_test.go`:
+
+```go
+func TestOnMessage_InactiveChannel_SetsHasUnread(t *testing.T) {
+	db := newTestDB(t)
+	_ = db.UpsertChannel(cache.Channel{ID: "C1", WorkspaceID: "T1", Name: "general", Type: "channel"})
+	h := &rtmEventHandler{
+		db:              db,
+		wsCtx:           &WorkspaceContext{},
+		isActive:        func() bool { return true },
+		activeChannelID: func() string { return "C2" }, // viewing a different channel
+	}
+	h.OnMessage("C1", "U1", "1.001", "hi", "", "", false, nil, slack.Blocks{}, nil)
+
+	s, _ := db.GetChannelReadState("C1")
+	if !s.HasUnread {
+		t.Errorf("HasUnread = false, want true for inactive-channel message")
+	}
+}
+
+func TestOnMessage_ActiveChannel_DoesNotSetHasUnread(t *testing.T) {
+	db := newTestDB(t)
+	_ = db.UpsertChannel(cache.Channel{ID: "C1", WorkspaceID: "T1", Name: "general", Type: "channel"})
+	h := &rtmEventHandler{
+		db:              db,
+		wsCtx:           &WorkspaceContext{},
+		isActive:        func() bool { return true },
+		activeChannelID: func() string { return "C1" }, // viewing the same channel
+	}
+	h.OnMessage("C1", "U1", "1.001", "hi", "", "", false, nil, slack.Blocks{}, nil)
+
+	s, _ := db.GetChannelReadState("C1")
+	if s.HasUnread {
+		t.Errorf("HasUnread = true, want false (active-channel suppression)")
+	}
+}
+
+func TestOnMessage_InactiveWorkspace_StillSetsHasUnread(t *testing.T) {
+	db := newTestDB(t)
+	_ = db.UpsertChannel(cache.Channel{ID: "C1", WorkspaceID: "T1", Name: "general", Type: "channel"})
+	h := &rtmEventHandler{
+		db:              db,
+		wsCtx:           &WorkspaceContext{},
+		isActive:        func() bool { return false },
+		activeChannelID: func() string { return "" },
+	}
+	h.OnMessage("C1", "U1", "1.001", "hi", "", "", false, nil, slack.Blocks{}, nil)
+
+	s, _ := db.GetChannelReadState("C1")
+	if !s.HasUnread {
+		t.Errorf("HasUnread = false, want true (inactive workspace)")
+	}
+}
+```
+
+You may need to add imports: `"github.com/slack-go/slack"` and `"github.com/gammons/slk/internal/cache"` if missing. Check the existing event_handler_test.go imports.
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `go test ./cmd/slk/ -run TestOnMessage -v`
+Expected: FAIL.
+
+- [ ] **Step 4: Add the read-state write to OnMessage**
+
+Inside `OnMessage`, near the top after early-return guards but before any of the existing notification/caching work, add:
+
+```go
+// Read-state: any message in a channel the user is NOT actively viewing
+// becomes an unread. Active-channel suppression and the markChannelReadAsync
+// flow handle clearing.
+if h.activeChannelID == nil || h.activeChannelID() != channelID {
+    if err := h.db.UpdateChannelReadState(channelID, "", true); err != nil {
+        log.Printf("Warning: failed to set has_unread for %s: %v", channelID, err)
+    }
+}
+```
+
+Then DELETE the old inactive-workspace bump block (the one that mutates `wctx.Channels[i].UnreadCount` and sends `WorkspaceUnreadMsg` — keep the `WorkspaceUnreadMsg` send for now; we'll rip it in Task 17). For now, keep `WorkspaceUnreadMsg` so the rail still updates; we replace it later.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./cmd/slk/ -run TestOnMessage -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/slk/main.go cmd/slk/event_handler_test.go
+git commit -m "cmd/slk: route OnMessage through UpdateChannelReadState with active-channel suppression"
+```
+
+---
+
+### Task 11: Migrate bootstrap to `BatchUpdateChannelReadState`
+
+**Files:**
+- Modify: `cmd/slk/main.go:1597-1620` (the `connectWorkspace` block that populates from `GetUnreadCounts`)
+
+- [ ] **Step 1: Add test (bootstrap is hard to unit-test in isolation; rely on integration coverage)**
+
+The bootstrap flow runs inside `connectWorkspace` and depends on a live Slack client. Skip writing a new unit test for this task; coverage comes from the reconnect-backfill scenario test in Task 14 (the bootstrap and reconnect-catchup write paths share the same DB code path).
+
+- [ ] **Step 2: Replace the population block**
+
+Find the block at `cmd/slk/main.go:1597-1620`:
+
+```go
+unreadCounts, threadsAgg, ucErr := client.GetUnreadCounts()
+// ... existing handling of ucErr / threadsAgg ...
+unreadMap := make(map[string]int)
+for _, u := range unreadCounts {
+    if u.HasUnread {
+        unreadMap[u.ChannelID] = u.Count
+    }
+    if u.LastRead != "" {
+        wctx.LastReadMap[u.ChannelID] = u.LastRead
+        _ = db.UpdateLastReadTS(u.ChannelID, u.LastRead)
+    }
+}
+for i := range wctx.Channels {
+    if count, ok := unreadMap[wctx.Channels[i].ID]; ok {
+        wctx.Channels[i].UnreadCount = count
+    }
+    if lr, ok := wctx.LastReadMap[wctx.Channels[i].ID]; ok {
+        wctx.Channels[i].LastReadTS = lr
+    }
+}
+```
+
+Replace with:
+
+```go
+unreadCounts, threadsAgg, ucErr := client.GetUnreadCounts()
+// ... existing handling of ucErr / threadsAgg unchanged ...
+if ucErr == nil {
+    updates := make([]cache.ChannelReadStateUpdate, 0, len(unreadCounts))
+    for _, u := range unreadCounts {
+        updates = append(updates, cache.ChannelReadStateUpdate{
+            ChannelID:  u.ChannelID,
+            LastReadTS: u.LastRead, // may be ""; new API preserves existing in that case
+            HasUnread:  u.HasUnread,
+        })
+    }
+    if err := db.BatchUpdateChannelReadState(updates); err != nil {
+        log.Printf("Warning: bootstrap BatchUpdateChannelReadState: %v", err)
+    }
+}
+```
+
+Remove the in-memory `unreadMap` population and the `for i := range wctx.Channels` propagation entirely.
+
+- [ ] **Step 3: Verify build and tests**
+
+Run: `go build ./cmd/slk/ && go test ./cmd/slk/ -v`
+Expected: success.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/slk/main.go
+git commit -m "cmd/slk: bootstrap writes read state via BatchUpdateChannelReadState"
+```
+
+---
+
+### Task 12: Fix `runChannelPhase` to write read state on reconnect catch-up
+
+**Files:**
+- Modify: `cmd/slk/reconnect_backfill.go:99-158` (the `runChannelPhase` function)
+- Modify: `cmd/slk/reconnect_backfill_test.go`
+
+This is the fix for Symptom 2: "channels show as unread in slk after the user has read them in the official client."
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `cmd/slk/reconnect_backfill_test.go`:
+
+```go
+func TestRunChannelPhase_WritesReadStateForAllChannels(t *testing.T) {
+	db := newTestDB(t)
+	_ = db.UpsertChannel(cache.Channel{ID: "C1", WorkspaceID: "T1", Name: "a", Type: "channel"})
+	_ = db.UpsertChannel(cache.Channel{ID: "C2", WorkspaceID: "T1", Name: "b", Type: "channel"})
+	_ = db.UpsertChannel(cache.Channel{ID: "C3", WorkspaceID: "T1", Name: "c", Type: "channel"})
+
+	// Pre-seed C2 as unread, mirroring "user had unreads pre-suspend".
+	_ = db.UpdateChannelReadState("C2", "1.0000", true)
+
+	fh := &fakeHistory{
+		unreads: []slackclient.UnreadInfo{
+			{ChannelID: "C1", HasUnread: true, LastRead: "1.0010"},
+			{ChannelID: "C2", HasUnread: false, LastRead: "1.0020"}, // user read it in official client
+			{ChannelID: "C3", HasUnread: false, LastRead: "1.0030"},
+		},
+	}
+	b := newBackfillerForTest(t, db, fh, "T1")
+	if err := b.run(context.Background()); err != nil {
+		t.Fatalf("backfill run: %v", err)
+	}
+
+	s1, _ := db.GetChannelReadState("C1")
+	if !s1.HasUnread || s1.LastReadTS != "1.0010" {
+		t.Errorf("C1 = %+v", s1)
+	}
+	s2, _ := db.GetChannelReadState("C2")
+	if s2.HasUnread {
+		t.Errorf("C2 HasUnread still true after catch-up (Symptom 2 not fixed): %+v", s2)
+	}
+	if s2.LastReadTS != "1.0020" {
+		t.Errorf("C2 LastReadTS = %q, want %q", s2.LastReadTS, "1.0020")
+	}
+	s3, _ := db.GetChannelReadState("C3")
+	if s3.HasUnread || s3.LastReadTS != "1.0030" {
+		t.Errorf("C3 = %+v", s3)
+	}
+}
+```
+
+The helper `newBackfillerForTest` should mirror the existing test-only constructor pattern in this file. If one doesn't exist, write a thin wrapper that mirrors how `TestBackfill_OvernightSuspendScenario` constructs its backfiller (read the test file to find the exact pattern).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./cmd/slk/ -run TestRunChannelPhase_WritesReadStateForAllChannels -v`
+Expected: FAIL — C2 still `HasUnread=true`.
+
+- [ ] **Step 3: Update `runChannelPhase`**
+
+Edit `cmd/slk/reconnect_backfill.go:99-158`. Replace the block at lines 113-121:
+
+```go
+var unreadIDs []string
+if unreads, _, err := b.client.GetUnreadCounts(); err != nil {
+    debuglog.Backfill("team=%s GetUnreadCounts err=%v (falling back to cached-only)", b.workspaceID, err)
+} else {
+    for _, u := range unreads {
+        if u.HasUnread {
+            unreadIDs = append(unreadIDs, u.ChannelID)
+        }
+    }
+}
+```
+
+with:
+
+```go
+var unreadIDs []string
+if unreads, _, err := b.client.GetUnreadCounts(); err != nil {
+    debuglog.Backfill("team=%s GetUnreadCounts err=%v (falling back to cached-only)", b.workspaceID, err)
+} else {
+    updates := make([]cache.ChannelReadStateUpdate, 0, len(unreads))
+    for _, u := range unreads {
+        updates = append(updates, cache.ChannelReadStateUpdate{
+            ChannelID:  u.ChannelID,
+            LastReadTS: u.LastRead,
+            HasUnread:  u.HasUnread,
+        })
+        if u.HasUnread {
+            unreadIDs = append(unreadIDs, u.ChannelID)
+        }
+    }
+    if err := b.db.BatchUpdateChannelReadState(updates); err != nil {
+        debuglog.Backfill("team=%s BatchUpdateChannelReadState err=%v", b.workspaceID, err)
+    }
+}
+```
+
+The `unreadIDs` list is still used downstream to broaden the backfill set; only the read-state write is added.
+
+Make sure `cache` is imported in this file (`github.com/gammons/slk/internal/cache`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./cmd/slk/ -run TestRunChannelPhase_WritesReadStateForAllChannels -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full reconnect test suite**
+
+Run: `go test ./cmd/slk/ -run TestBackfill -v`
+Expected: existing tests still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/slk/reconnect_backfill.go cmd/slk/reconnect_backfill_test.go
+git commit -m "cmd/slk: reconnect catch-up writes read state for all channels in GetUnreadCounts response"
+```
+
+---
+
+## Phase 3: UI consumers — sidebar reads from DB
+
+### Task 13: Add `ReadStateChangedMsg` and `ReadStateReader` callback
+
+**Files:**
+- Modify: `internal/ui/app.go` (add message type near other Msg definitions)
+- Modify: `internal/ui/sidebar/model.go` (add reader callback field + setter)
+
+- [ ] **Step 1: Add the message type**
+
+In `internal/ui/app.go`, find the cluster of Msg type definitions near lines 200-250 (where `ChannelMarkedReadMsg`, `WorkspaceUnreadMsg`, etc. live). Add:
+
+```go
+// ReadStateChangedMsg is sent whenever the persistent read state changes,
+// to force panels that read from cache.GetWorkspaceReadState to re-render.
+// ChannelID may be "" if the change is multi-channel (e.g., batch update
+// from reconnect catch-up).
+type ReadStateChangedMsg struct {
+    WorkspaceID string
+    ChannelID   string
+}
+```
+
+- [ ] **Step 2: Add the reader callback to sidebar**
+
+In `internal/ui/sidebar/model.go`, find the `Model` struct (search for `type Model struct`). Add a new field:
+
+```go
+type Model struct {
+    // ... existing fields ...
+
+    // readStateReader returns the per-channel read state map for the
+    // active workspace, keyed by channel ID. May be nil during early
+    // construction; nil means "treat everything as no-unread."
+    readStateReader func() map[string]cache.ReadState
+}
+```
+
+Add import `"github.com/gammons/slk/internal/cache"` if missing.
+
+Add a setter:
+
+```go
+// SetReadStateReader installs a callback the sidebar calls during View()
+// to fetch per-channel read state. Must be set before the first render
+// for unread dots to appear.
+func (m *Model) SetReadStateReader(f func() map[string]cache.ReadState) {
+    m.readStateReader = f
+    m.invalidateCache()
+}
+```
+
+Use whatever the existing cache-invalidate helper is — check for `dirty()` or `invalidateCache()` or `m.cacheValid = false`. Match the existing pattern.
+
+- [ ] **Step 3: Wire the reader from main.go**
+
+In `cmd/slk/main.go`, find where `app.SetSectionsProvider(...)` is called (search for `SetSectionsProvider`) and add nearby:
+
+```go
+app.SetReadStateReader(func() map[string]cache.ReadState {
+    wctx := router.Active()
+    if wctx == nil {
+        return nil
+    }
+    state, err := db.GetWorkspaceReadState(wctx.WorkspaceID)
+    if err != nil {
+        log.Printf("Warning: GetWorkspaceReadState: %v", err)
+        return nil
+    }
+    return state
+})
+```
+
+And in `internal/ui/app.go`, add the `SetReadStateReader` method that forwards to the sidebar:
+
+```go
+func (a *App) SetReadStateReader(f func() map[string]cache.ReadState) {
+    a.readStateReader = f
+    a.sidebar.SetReadStateReader(f)
+}
+```
+
+with a corresponding `readStateReader` field on the `App` struct.
+
+- [ ] **Step 4: Handle `ReadStateChangedMsg` in `App.Update`**
+
+In `App.Update`, add a case alongside the other read-state-related Msg cases:
+
+```go
+case ReadStateChangedMsg:
+    a.sidebar.invalidateCache() // or m.dirty() — whatever the sidebar exposes
+    return a, nil
+```
+
+You may need to expose a public `Invalidate()` method on the sidebar Model if `invalidateCache` is unexported.
+
+- [ ] **Step 5: Verify build**
+
+Run: `go build ./...`
+Expected: success.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/ui/app.go internal/ui/sidebar/model.go cmd/slk/main.go
+git commit -m "ui: add ReadStateChangedMsg and SetReadStateReader plumbing"
+```
+
+---
+
+### Task 14: Sidebar `View()` reads from DB; delete `MarkUnread`/`ClearUnread`/`SetUnreadCount`
+
+**Files:**
+- Modify: `internal/ui/sidebar/model.go`
+- Modify: `internal/ui/sidebar/model_test.go` (delete or update tests)
+- Modify: `internal/ui/app.go` (delete the now-broken callers)
+
+- [ ] **Step 1: Capture read state at render time**
+
+In `internal/ui/sidebar/model.go`, find `View(height, width int) string` and `buildCache(width int)` (or whatever the row-rendering loop is called). Wherever the loop iterates `m.items` to produce row strings, add at the top of the function:
+
+```go
+var readState map[string]cache.ReadState
+if m.readStateReader != nil {
+    readState = m.readStateReader()
+}
+```
+
+Then everywhere the code currently checks `item.UnreadCount > 0`, change to:
+
+```go
+state := readState[item.ID]
+hasUnread := state.HasUnread
+```
+
+And use `hasUnread` in:
+- `model.go:1146-1154` (unread dot rendering)
+- `model.go:1230-1254` (bold/style switching)
+- `model.go:1156-1182` (prefix selection if it depends on unread)
+
+- [ ] **Step 2: Update `aggregateUnreadForSection`**
+
+Edit `internal/ui/sidebar/model.go:967-980`:
+
+```go
+func (m *Model) aggregateUnreadForSection(section string) int {
+    var readState map[string]cache.ReadState
+    if m.readStateReader != nil {
+        readState = m.readStateReader()
+    }
+    total := 0
+    for _, idx := range m.filtered {
+        item := m.items[idx]
+        if item.IsMuted {
+            continue
+        }
+        if m.sectionFor(item) != section {
+            continue
+        }
+        if readState[item.ID].HasUnread {
+            total++ // count channels-with-unreads, not sum-of-counts
+        }
+    }
+    return total
+}
+```
+
+- [ ] **Step 3: Delete `MarkUnread`, `ClearUnread`, `SetUnreadCount`**
+
+Delete the three functions in `internal/ui/sidebar/model.go`:
+- `MarkUnread` (lines ~714-733)
+- `ClearUnread` (lines ~735-750)
+- `SetUnreadCount` (lines ~752-778)
+
+- [ ] **Step 4: Update App.Update to stop calling them**
+
+In `internal/ui/app.go`:
+
+- Line ~1781 (`case NewMessageMsg:` → `a.sidebar.MarkUnread(msg.ChannelID)`): delete this call. The DB write happens in the WS handler now. After the line, send `ReadStateChangedMsg`:
+
+  ```go
+  case NewMessageMsg:
+      // (existing handling minus the MarkUnread call)
+      return a, func() tea.Msg { return ReadStateChangedMsg{ChannelID: msg.ChannelID} }
+  ```
+
+- Line ~2091 (`case ChannelMarkedReadMsg:` → `a.sidebar.ClearUnread(msg.ChannelID)`): replace with `a.sidebar.Invalidate()` (or send `ReadStateChangedMsg`).
+
+- Lines ~1876-1890 + ~5549 (`applyChannelMark` + `case MessageMarkedUnreadMsg:` + `case ChannelMarkedRemoteMsg:`): the `SetUnreadCount` call inside `applyChannelMark` goes away. The DB write happened in the WS handler (`OnChannelMarked` / mark-unread callback); the App just needs to invalidate the sidebar cache. Replace `a.sidebar.SetUnreadCount(channelID, unreadCount)` with `a.sidebar.Invalidate()`.
+
+If `Invalidate()` isn't yet exported, add to `internal/ui/sidebar/model.go`:
+
+```go
+// Invalidate forces the next View() call to re-read read state from the
+// installed reader, bypassing any internal caching.
+func (m *Model) Invalidate() {
+    m.dirty() // or whatever the existing helper is
+}
+```
+
+- [ ] **Step 5: Delete sidebar-model tests for removed methods**
+
+In `internal/ui/sidebar/model_test.go`, delete:
+- `TestMarkUnread_IncrementsCount`
+- `TestMarkUnread_BumpsVersionAndInvalidatesCache`
+- `TestMarkUnread_UnknownChannelIsNoop`
+- `TestMarkUnread_RendersDotAndBold`
+- `TestSetUnreadCount_SetsExactValue`
+- `TestSetUnreadCount_Zero_ClearsBadge`
+- `TestSetUnreadCount_UnknownChannel_NoOp`
+- `TestUpsertItem_ThenMarkUnread`
+
+These exercise methods that no longer exist.
+
+- [ ] **Step 6: Build and run tests**
+
+Run: `go build ./... && go test ./internal/ui/sidebar/ -v`
+Expected: build succeeds, sidebar tests pass.
+
+Run: `go test ./internal/ui/ -v`
+Expected: App tests pass (some that exercised the old paths may need updates — fix as needed by adjusting assertions to check the DB state rather than `sidebar.items[i].UnreadCount`).
+
+- [ ] **Step 7: Add a new sidebar-rendering test driven by DB state**
+
+Append to `internal/ui/sidebar/model_test.go`:
+
+```go
+func TestView_RendersDotFromReadStateReader(t *testing.T) {
+    m := New()
+    m.SetItems([]ChannelItem{
+        {ID: "C1", Name: "general", Type: "channel", Section: "channels"},
+        {ID: "C2", Name: "random", Type: "channel", Section: "channels"},
+    })
+    state := map[string]cache.ReadState{
+        "C1": {HasUnread: true},
+        "C2": {HasUnread: false},
+    }
+    m.SetReadStateReader(func() map[string]cache.ReadState { return state })
+
+    out := m.View(20, 30)
+    if !strings.Contains(out, "general") {
+        t.Fatalf("missing channel name; got:\n%s", out)
+    }
+    // The actual dot character depends on theme; assert that C1's row
+    // differs from C2's row in the dot prefix area. The cleanest check
+    // is to count occurrences of the dot rune used by the sidebar.
+    // Replace `unreadDotStr` below with the actual exported symbol if available.
+    dotCount := strings.Count(out, unreadDotStr)
+    if dotCount != 1 {
+        t.Errorf("expected exactly 1 unread dot, got %d. Output:\n%s", dotCount, out)
+    }
+}
+
+func TestView_MutedChannelNoDot(t *testing.T) {
+    m := New()
+    m.SetItems([]ChannelItem{
+        {ID: "C1", Name: "noisy", Type: "channel", Section: "channels", IsMuted: true},
+    })
+    state := map[string]cache.ReadState{"C1": {HasUnread: true}}
+    m.SetReadStateReader(func() map[string]cache.ReadState { return state })
+
+    out := m.View(20, 30)
+    if strings.Count(out, unreadDotStr) != 0 {
+        t.Errorf("muted channel should not show a dot. Output:\n%s", out)
+    }
+}
+```
+
+Adjust constructor names (`New()`, `SetItems`) and the dot constant to match what the sidebar package actually exposes — read the file to confirm.
+
+- [ ] **Step 8: Run new tests**
+
+Run: `go test ./internal/ui/sidebar/ -v`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add internal/ui/sidebar/model.go internal/ui/sidebar/model_test.go internal/ui/app.go
+git commit -m "ui: sidebar reads unread state from cache via reader callback"
+```
+
+---
+
+### Task 15: Send `ReadStateChangedMsg` from WS handlers
+
+The DB writes happen in `OnMessage`, `OnChannelMarked`, `markChannelReadAsync`, and the mark-unread callback. The sidebar will not re-render unless something pushes a tea.Msg through the program. We need each write to be paired with a `ReadStateChangedMsg` send.
+
+**Files:**
+- Modify: `cmd/slk/main.go` (the four write sites)
+
+- [ ] **Step 1: Add the send after each DB write**
+
+In `cmd/slk/main.go`:
+
+1. After the `UpdateChannelReadState` in `OnChannelMarked` (Task 7), before the `isActive`/program early returns:
+
+   ```go
+   if h.program != nil {
+       h.program.Send(ui.ReadStateChangedMsg{ChannelID: channelID})
+   }
+   ```
+
+   Keep the existing `ChannelMarkedRemoteMsg` send too — it carries the unreadCount for the toast.
+
+2. After the `UpdateChannelReadState` in `markChannelReadAsync` (Task 8), inside the goroutine:
+
+   ```go
+   if p != nil {
+       p.Send(ui.ChannelMarkedReadMsg{ChannelID: channelID})
+       p.Send(ui.ReadStateChangedMsg{ChannelID: channelID})
+   }
+   ```
+
+3. After the `UpdateChannelReadState` in the mark-unread callback (Task 9), the callback returns a `tea.Msg`. Have it return `ReadStateChangedMsg` chained with the existing `MessageMarkedUnreadMsg`. The simplest approach: emit the changed-msg by calling `app.program.Send(...)` if accessible, OR return a `tea.Batch(ReadStateChangedMsg{...}, MessageMarkedUnreadMsg{...})`. Use `tea.Batch` if the callback signature is `tea.Msg`; if so, switch to returning `tea.Cmd` by wrapping the existing return in a function. Easier: have App.Update for `MessageMarkedUnreadMsg` itself emit a follow-up `ReadStateChangedMsg`.
+
+   Pick the cleanest path: have `App.Update` for the `case MessageMarkedUnreadMsg:` arm (in `internal/ui/app.go:1876-1890`) return:
+
+   ```go
+   case MessageMarkedUnreadMsg:
+       // (existing handling)
+       return a, func() tea.Msg { return ReadStateChangedMsg{ChannelID: msg.ChannelID} }
+   ```
+
+4. After the `UpdateChannelReadState` in `OnMessage` (Task 10), the handler runs synchronously inside the WS dispatch goroutine. Add:
+
+   ```go
+   if h.program != nil {
+       h.program.Send(ui.ReadStateChangedMsg{ChannelID: channelID})
+   }
+   ```
+
+   Place it after the read-state write, regardless of the active-channel branch (so the sidebar gets a chance to clear stale state too).
+
+- [ ] **Step 2: Build and test**
+
+Run: `go build ./... && go test ./...`
+Expected: success.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/slk/main.go internal/ui/app.go
+git commit -m "cmd/slk: emit ReadStateChangedMsg whenever read state is written"
+```
+
+---
+
+### Task 16: Wire the workspace rail to `WorkspacesWithUnreads`
+
+**Files:**
+- Modify: `internal/ui/workspace/model.go`
+- Modify: `internal/ui/app.go`
+- Modify: `cmd/slk/main.go`
+
+The current rail uses `Model.SetUnread(teamID, hasUnread bool)` driven by `WorkspaceUnreadMsg` (which only fires on inactive-workspace new messages and never clears). After this task, the rail polls `db.WorkspacesWithUnreads()` on a `ReadStateChangedMsg` and refreshes its internal `HasUnread` flags.
+
+- [ ] **Step 1: Add a reader callback to the rail**
+
+In `internal/ui/workspace/model.go`, mirror the sidebar pattern:
+
+```go
+type Model struct {
+    // ... existing fields ...
+    unreadReader func() []string // returns workspace IDs with unreads
+}
+
+func (m *Model) SetUnreadReader(f func() []string) {
+    m.unreadReader = f
+}
+
+// RefreshUnreads pulls the latest set from the reader and updates each item.
+// Called by the App on ReadStateChangedMsg.
+func (m *Model) RefreshUnreads() {
+    if m.unreadReader == nil {
+        return
+    }
+    set := make(map[string]bool, len(m.items))
+    for _, id := range m.unreadReader() {
+        set[id] = true
+    }
+    for i := range m.items {
+        m.items[i].HasUnread = set[m.items[i].ID]
+    }
+}
+```
+
+- [ ] **Step 2: Wire the reader from main.go**
+
+In `cmd/slk/main.go`, near where `SetReadStateReader` was wired (Task 13):
+
+```go
+app.SetWorkspaceUnreadReader(func() []string {
+    ids, err := db.WorkspacesWithUnreads()
+    if err != nil {
+        log.Printf("Warning: WorkspacesWithUnreads: %v", err)
+        return nil
+    }
+    return ids
+})
+```
+
+In `internal/ui/app.go`:
+
+```go
+func (a *App) SetWorkspaceUnreadReader(f func() []string) {
+    a.workspaceRail.SetUnreadReader(f)
+}
+```
+
+- [ ] **Step 3: Refresh on ReadStateChangedMsg**
+
+In `internal/ui/app.go`, update the `case ReadStateChangedMsg:` arm to also refresh the rail:
+
+```go
+case ReadStateChangedMsg:
+    a.sidebar.Invalidate()
+    a.workspaceRail.RefreshUnreads()
+    return a, nil
+```
+
+- [ ] **Step 4: Stop sending `WorkspaceUnreadMsg`**
+
+The current `OnMessage` in `cmd/slk/main.go:2647-2652` sends `WorkspaceUnreadMsg` for the inactive-workspace case. Delete that send. The rail now refreshes whenever a `ReadStateChangedMsg` fires (Task 15 already routes that from `OnMessage`).
+
+Also delete the `case WorkspaceUnreadMsg:` arm in `App.Update` (`internal/ui/app.go:2207-2208`) and the `WorkspaceUnreadMsg` struct definition (`app.go:240-243`). Search for any other senders to be sure they're all removed.
+
+- [ ] **Step 5: Build and test**
+
+Run: `go build ./... && go test ./...`
+Expected: success.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/ui/workspace/model.go internal/ui/app.go cmd/slk/main.go
+git commit -m "ui: workspace rail unread dot driven by db.WorkspacesWithUnreads"
+```
+
+---
+
+## Phase 4: Remove the in-memory stores
+
+### Task 17: Remove `WorkspaceContext.LastReadMap`
+
+**Files:**
+- Modify: `cmd/slk/main.go` (multiple sites)
+
+Every reader of `wctx.LastReadMap` migrates to `db.GetChannelReadState(channelID).LastReadTS`.
+
+Per the exploration, the use sites are:
+
+- `main.go:150` — field declaration
+- `main.go:817` — `app.SetLastReadProvider(...)` closure
+- `main.go:875` — `lastReadTS := wctx.LastReadMap[channelID]` for `MessagesLoadedMsg`
+- `main.go:964` — inside `SetMessageMarkUnreader` (already handled in Task 9)
+- `main.go:1416` — init
+- `main.go:1609` — bootstrap write (already handled in Task 11)
+- `main.go:1617` — bootstrap propagate
+- `main.go:2011` — `markChannelReadAsync` (already handled in Task 8)
+- `main.go:2882-2883` — `OnChannelMarked` (already handled in Task 7)
+
+- [ ] **Step 1: Replace each read site with a DB call**
+
+For each remaining reader, change:
+
+```go
+lastReadTS := wctx.LastReadMap[channelID]
+```
+
+to:
+
+```go
+state, _ := db.GetChannelReadState(channelID)
+lastReadTS := state.LastReadTS
+```
+
+For the `app.SetLastReadProvider` closure at line 817:
+
+```go
+app.SetLastReadProvider(func(channelID string) string {
+    state, err := db.GetChannelReadState(channelID)
+    if err != nil {
+        return ""
+    }
+    return state.LastReadTS
+})
+```
+
+- [ ] **Step 2: Delete the field, init, and any remaining writers**
+
+Remove the `LastReadMap` field from the `WorkspaceContext` struct at line 150. Remove its initialization at line 1416 and anywhere else `LastReadMap = make(map[string]string)` appears. Search for any remaining references:
+
+```bash
+git grep -n LastReadMap
+```
+
+Every result must be deleted or migrated.
+
+- [ ] **Step 3: Build and test**
+
+Run: `go build ./... && go test ./...`
+Expected: success.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/slk/main.go
+git commit -m "cmd/slk: remove WorkspaceContext.LastReadMap (use cache.GetChannelReadState)"
+```
+
+---
+
+### Task 18: Remove `LastReadTS` and `UnreadCount` from `sidebar.ChannelItem`
+
+**Files:**
+- Modify: `internal/ui/sidebar/model.go:28-49` (the `ChannelItem` struct)
+- Modify: every site that constructs or reads `ChannelItem.LastReadTS` or `.UnreadCount`
+
+- [ ] **Step 1: Delete the fields**
+
+Edit the struct:
+
+```go
+type ChannelItem struct {
+    ID           string
+    Name         string
+    Type         string
+    Section      string
+    SectionOrder int
+    IsStarred    bool
+    Presence     string
+    DMUserID     string
+    IsMuted      bool
+}
+```
+
+- [ ] **Step 2: Fix every compile error**
+
+Run: `go build ./...`
+
+Expected: many compile failures. For each, the pattern is:
+- Construction site that sets `.LastReadTS` or `.UnreadCount`: delete those field assignments.
+- Read site: replace with `db.GetChannelReadState(item.ID).LastReadTS` or `.HasUnread`.
+
+Common sites (from the exploration):
+- `cmd/slk/channelitem.go` — drop any `LastReadTS:` / `UnreadCount:` from struct literals.
+- `cmd/slk/main.go` — any `wctx.Channels[i].LastReadTS = ...` or `wctx.Channels[i].UnreadCount = ...` deletions.
+- `internal/ui/sidebar/model.go` — any internal use (the dot-rendering paths were already swapped out in Task 14).
+- `internal/ui/app.go` — `WorkspaceSwitchedMsg.Channels` consumers.
+
+- [ ] **Step 3: Build and test**
+
+Run: `go build ./... && go test ./...`
+Expected: success.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "ui/sidebar: remove ChannelItem.LastReadTS and UnreadCount fields"
+```
+
+---
+
+### Task 19: Remove `LastReadTS` and `UnreadCount` from `cache.Channel`
+
+**Files:**
+- Modify: `internal/cache/channels.go` (struct, `UpsertChannel`, `GetChannel`, `ListChannels`)
+- Modify: `internal/cache/channels_test.go`
+- Modify: every caller
+
+This is the type-system enforcement called out in the spec.
+
+- [ ] **Step 1: Delete the fields from the struct**
+
+```go
+type Channel struct {
+    ID          string
+    WorkspaceID string
+    Name        string
+    Type        string
+    Topic       string
+    IsMember    bool
+    IsStarred   bool
+    UpdatedAt   int64
+}
+```
+
+- [ ] **Step 2: Update `UpsertChannel`, `GetChannel`, `ListChannels`**
+
+`UpsertChannel`: stop selecting `last_read_ts` and `unread_count` in the INSERT (they will use schema defaults). Drop them from the param list too:
+
+```go
+func (db *DB) UpsertChannel(ch Channel) error {
+    _, err := db.conn.Exec(`
+        INSERT INTO channels (id, workspace_id, name, type, topic, is_member, is_starred, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+            name=excluded.name,
+            type=excluded.type,
+            topic=excluded.topic,
+            is_member=excluded.is_member,
+            is_starred=excluded.is_starred,
+            updated_at=excluded.updated_at
+    `, ch.ID, ch.WorkspaceID, ch.Name, ch.Type, ch.Topic,
+        boolToInt(ch.IsMember), boolToInt(ch.IsStarred), ch.UpdatedAt)
+    if err != nil {
+        return fmt.Errorf("upserting channel: %w", err)
+    }
+    return nil
+}
+```
+
+`GetChannel` and `ListChannels`: drop `last_read_ts, unread_count` from the SELECT and the Scan target list:
+
+```go
+func (db *DB) GetChannel(id string) (Channel, error) {
+    var ch Channel
+    var isMember, isStarred int
+    err := db.conn.QueryRow(`
+        SELECT id, workspace_id, name, type, topic, is_member, is_starred, updated_at
+        FROM channels WHERE id = ?
+    `, id).Scan(&ch.ID, &ch.WorkspaceID, &ch.Name, &ch.Type, &ch.Topic,
+        &isMember, &isStarred, &ch.UpdatedAt)
+    if err != nil {
+        return ch, fmt.Errorf("getting channel: %w", err)
+    }
+    ch.IsMember = isMember == 1
+    ch.IsStarred = isStarred == 1
+    return ch, nil
+}
+```
+
+Same pattern for `ListChannels`.
+
+- [ ] **Step 3: Delete the legacy helpers**
+
+Remove from `internal/cache/channels.go`:
+- `UpdateUnreadCount` (lines 91-97)
+- `UpdateLastReadTS` (lines 99-109)
+- `GetLastReadTS` (lines 111-122)
+
+These have no remaining callers after Phase 2.
+
+- [ ] **Step 4: Update `internal/cache/channels_test.go`**
+
+Delete:
+- `TestUpdateUnreadCount`
+- `TestUpdateLastReadTS_RoundTrip`
+
+Update `TestUpsertAndGetChannel` to not assert against `LastReadTS` or `UnreadCount` (just delete those assertions).
+
+- [ ] **Step 5: Fix every other caller**
+
+Run: `go build ./...`
+Expected: compile failures in any file that referenced the removed fields. Fix each by deletion.
+
+- [ ] **Step 6: Build and test**
+
+Run: `go build ./... && go test ./...`
+Expected: success.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "cache: remove Channel.LastReadTS, Channel.UnreadCount, and legacy read-state helpers"
+```
+
+---
+
+## Phase 5: Integration test (lock in Symptom 2 fix)
+
+### Task 20: Extend `TestBackfill_OvernightSuspendScenario` with channel D
+
+**Files:**
+- Modify: `cmd/slk/reconnect_backfill_test.go:603-726`
+
+- [ ] **Step 1: Read the existing test**
+
+Open `cmd/slk/reconnect_backfill_test.go:603-726` (`TestBackfill_OvernightSuspendScenario`). Note the existing channel categories A, B, C and how they're set up.
+
+- [ ] **Step 2: Add channel D to the scenario**
+
+Add a fourth channel category to the test's setup section. Channel D semantics:
+
+- Pre-suspend state: has unreads (`HasUnread=true`) and `last_read_ts="1.0000"`.
+- During the offline window: the user read it in the official client.
+- `client.counts` at reconnect returns `HasUnread=false` and `LastRead="1.0100"`.
+
+In the test setup:
+
+```go
+// Channel D: was unread pre-suspend; user read it in the official client during the offline window.
+_ = db.UpsertChannel(cache.Channel{ID: "D", WorkspaceID: "T1", Name: "d", Type: "channel"})
+_ = db.UpdateChannelReadState("D", "1.0000", true) // pre-suspend snapshot
+```
+
+In the `fakeHistory.unreads`:
+
+```go
+{ChannelID: "D", HasUnread: false, LastRead: "1.0100"},
+```
+
+After `b.run(ctx)`, add assertions:
+
+```go
+d, _ := db.GetChannelReadState("D")
+if d.HasUnread {
+    t.Errorf("D HasUnread = true after backfill; Symptom 2 not fixed")
+}
+if d.LastReadTS != "1.0100" {
+    t.Errorf("D LastReadTS = %q, want %q", d.LastReadTS, "1.0100")
+}
+```
+
+- [ ] **Step 3: Run the test**
+
+Run: `go test ./cmd/slk/ -run TestBackfill_OvernightSuspendScenario -v`
+Expected: PASS.
+
+- [ ] **Step 4: Run the entire test suite**
+
+Run: `go test ./...`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/slk/reconnect_backfill_test.go
+git commit -m "test: lock in Symptom 2 fix with channel D in overnight-suspend scenario"
+```
+
+---
+
+## Phase 6: Cleanup & verification
+
+### Task 21: Verify no dead read-state state remains
+
+**Files:**
+- All
+
+- [ ] **Step 1: Grep for any lingering references**
+
+Run each of these. Any non-test, non-comment hit is a bug to fix:
+
+```bash
+git grep -n "LastReadMap"        # should be empty
+git grep -n "UpdateUnreadCount"  # should be empty
+git grep -n "UpdateLastReadTS"   # should be empty
+git grep -n "GetLastReadTS"      # should be empty
+git grep -n "\.UnreadCount"      # only ThreadsAggregate.UnreadCount remains (acceptable)
+git grep -n "MarkUnread\|ClearUnread\|SetUnreadCount" -- 'internal/ui/sidebar/*'  # should be empty in sidebar package
+git grep -n "WorkspaceUnreadMsg" # should be empty
+```
+
+For each unexpected hit, either delete it or migrate it. The `ThreadsAggregate.UnreadCount` field in `internal/slack/client.go` is unrelated (thread count) and stays.
+
+The `slackclient.UnreadInfo.Count` field is now unused by all production callers but the field stays in place — it's deserialized from Slack's response and removing it is out of scope for this branch.
+
+- [ ] **Step 2: Run race-detector test suite**
+
+Run: `go test -race ./...`
+Expected: PASS, no race warnings.
+
+- [ ] **Step 3: Run `go vet` and any project linters**
+
+Run: `go vet ./...`
+Expected: clean.
+
+- [ ] **Step 4: Manual smoke test**
+
+Start slk against a real workspace. Verify:
+
+1. Sidebar shows dots for channels that the official client also shows as unread.
+2. Open a channel in slk → dot clears.
+3. With slk closed, read a channel in the official client → reopen slk → after the reconnect catch-up settles (1-2 sec), the dot is gone.
+4. With slk closed, receive a message in another workspace → reopen slk → workspace rail dot lights up.
+5. Press `U` on a message → dot reappears.
+6. Switch workspaces twice → dots remain correct (no stale state from in-memory stores).
+
+- [ ] **Step 5: No-op commit if changes were needed; otherwise this task is verification only**
+
+If anything was fixed during the grep sweep:
+
+```bash
+git add -A
+git commit -m "cleanup: remove dead read-state references"
+```
+
+---
+
+### Task 22: Write release notes / update CHANGELOG
+
+**Files:**
+- Modify: `CHANGELOG.md` (or wherever release notes live — check `git log` for the project's convention)
+
+- [ ] **Step 1: Identify the changelog location**
+
+```bash
+ls CHANGELOG* docs/CHANGELOG* docs/changelog* 2>/dev/null
+```
+
+If none exist, skip this task; rely on the commit log.
+
+- [ ] **Step 2: Add an entry**
+
+```markdown
+## v0.7.12 (or v0.8.0)
+
+### Fixed
+- Channels now show as unread/read in sync with the official Slack client across disconnects. Read state is consolidated into a single SQLite source of truth; reconnect catch-up pulls the latest state via `client.counts`. (Fixes #N — replace with the issue reference if any.)
+
+### Changed
+- Sidebar section aggregates ("DMs (N)", "Channels (N)") now count channels-with-unreads instead of summing per-channel unread-message counts. The Slack `unread_count_display` value was sparse and inconsistent across channel types, so the integer count is being abandoned in favor of a boolean unread signal.
+
+### Internal
+- Removed `WorkspaceContext.LastReadMap`; `sidebar.ChannelItem.LastReadTS/UnreadCount`; `cache.Channel.LastReadTS/UnreadCount`. All callers go through the new `cache.UpdateChannelReadState` / `cache.GetWorkspaceReadState` API.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "changelog: note read-state sync rewrite"
+```
+
+---
+
+## Out of scope for this branch (genuine follow-ups)
+
+These are deliberately deferred (mirrors the spec's "Out of scope" section):
+
+1. Drop the now-deprecated `unread_count` column from the `channels` table.
+2. `GetHistorySince` `Capped: true` on exact-`maxTotal` even when no more pages remain (v0.7.11 follow-up).
+3. `GetUnreadCounts` ignores `ctx` (v0.7.11 follow-up).
+4. Move watermark helpers from `channels.go` to `channels_sync.go` (cohesion improvement noted in v0.7.11 reviews).
+5. Remove `slackclient.UnreadInfo.Count` field (unused after this branch).
+
+---
+
+## Self-review notes
+
+**Spec coverage check (re-skim of spec sections vs. tasks):**
+
+- "Root causes" 1 (`runChannelPhase` discards `LastRead`) → Task 12.
+- "Root causes" 2 (`UpsertChannel` clobbers) → Task 6 (regression test) + Task 19 (final cleanup).
+- "Root causes" 3 (`UnreadCount` set to `MentionCount`) → moot: integer count abandoned in favor of boolean. No fix needed.
+- "Root causes" 4 (`UpdateUnreadCount` unused) → Task 19 deletes it.
+- "Root causes" 5 (`OnChannelMarked` doesn't update `wctx.Channels[i]`) → Task 7 + Task 17 (eliminates that store entirely).
+- "Root causes" 6 (`OnMessage` bypasses `wctx.Channels`) → Task 10 + Task 17.
+- "Root causes" 7 (no reconnect catch-up for read state) → Task 12.
+- "Single mutation API" → Tasks 3–5 (functions exist), Tasks 7–12 (all writes routed).
+- "Schema changes" → Task 1 (`has_unread`); Task 19 (struct field removal); deprecated `unread_count` kept (deferred per spec).
+- "Data inflows" 6 sources → Tasks 7–12.
+- "Data outflows" sidebar dot, section aggregate, message pane "new messages", rail dot → Tasks 13–16.
+- "Active-channel handling" → Task 10.
+- "Test plan" enumerated tests → distributed across Tasks 3, 4, 5, 6, 7, 10, 12, 14, 20.
+
+**Placeholder scan:** No "TBD", "TODO", "implement later" anywhere. Each step has either complete code or specific grep/run/edit instructions.
+
+**Type consistency:** `ReadState{LastReadTS, HasUnread}`, `ChannelReadStateUpdate{ChannelID, LastReadTS, HasUnread}`, function names `UpdateChannelReadState`, `BatchUpdateChannelReadState`, `GetChannelReadState`, `GetWorkspaceReadState`, `WorkspacesWithUnreads` are used consistently throughout. Message type `ReadStateChangedMsg{WorkspaceID, ChannelID}` defined in Task 13 and used the same way thereafter.

--- a/docs/superpowers/specs/2026-05-17-read-state-sync-design.md
+++ b/docs/superpowers/specs/2026-05-17-read-state-sync-design.md
@@ -1,0 +1,218 @@
+# Read-State Sync Rewrite Design
+
+## Motivation
+
+After shipping v0.7.11 (which fixed silent message drops during reconnect backfill), user testing revealed a separate class of sync defects, visible side-by-side with the official Slack desktop client:
+
+1. Channels show unread in the official client but NOT in slk.
+2. Channels show as unread in slk after the user has read them in the official client.
+
+Investigation showed these are not symptoms of the v0.7.11 follow-ups (`Capped` semantics on exact-`maxTotal`, `GetUnreadCounts` ignoring `ctx`). They are caused by a separate set of defects in how slk handles read state, all rooted in a fundamental architectural problem: **read state lives in three different stores that are kept in sync only partially and only by some code paths.**
+
+## Root causes
+
+Read state per channel is currently spread across three stores:
+
+| Store | Fields | Written by |
+|---|---|---|
+| SQLite (`channels` table) | `last_read_ts`, `unread_count` | Bootstrap, `OnChannelMarked`, `markChannelReadAsync` |
+| In-memory `WorkspaceContext` | `Channels[i].LastReadTS`, `Channels[i].UnreadCount`, `LastReadMap` | Bootstrap, inactive-workspace `OnMessage` bump |
+| In-memory `sidebar` model | `items[i].UnreadCount` | `MarkUnread`/`ClearUnread`/`SetUnreadCount` from `App.Update` |
+
+The sidebar dot — the user-visible signal of "has unreads" — is driven entirely by the third store (`internal/ui/sidebar/model.go:1151-1153`). The other two are inputs at different lifecycle moments, and there is no single mutation path that updates all three together.
+
+Specific defects this produces:
+
+- **`runChannelPhase` discards `UnreadInfo.LastRead`.** (`cmd/slk/reconnect_backfill.go:113-121`) On reconnect, slk pulls `client.counts` but only uses `HasUnread` to broaden the backfill set; the freshly-served `LastRead` value is thrown away. If the user read a channel in the official client during a disconnect, the `channel_marked` event was missed by slk and there is no catch-up — the channel stays unread in slk forever (until manually opened).
+- **`UpsertChannel` clobbers read state via `ON CONFLICT DO UPDATE`.** (`internal/cache/channels.go:21-41`) Every channel re-upsert writes `last_read_ts` and `unread_count` to the zero values of the passed-in `cache.Channel` struct. Bootstrap (`upsertChannelInDB`, `cmd/slk/channelitem.go:101-109`) passes a struct without these fields set, wiping persisted read state. Restored immediately for channels that `client.counts` returns; permanently lost for channels it doesn't.
+- **`UnreadCount` is set to `MentionCount` (capped to ≥1), not the actual unread count.** (`internal/slack/client.go:728-754`) Slack's response contains `unread_count_display` which is parsed and discarded. The persisted count is consistently wrong by 1+ for any channel with unreads but no @-mentions.
+- **`db.UpdateUnreadCount` is declared but called from zero production sites.** The persisted column is frozen at bootstrap-time values.
+- **`OnChannelMarked` updates the DB and `LastReadMap` but not `wctx.Channels[i]`.** A workspace switch reseeds the sidebar from `wctx.Channels` and the cleared unread reappears.
+- **Active-workspace `OnMessage` mutations bypass `wctx.Channels`.** Live unread bumps go into `sidebar.items[i].UnreadCount`; `wctx.Channels[i].UnreadCount` is untouched. A workspace switch loses them.
+- **No catch-up on reconnect for read state at all.** Reconnect backfills message content but does not re-pull `last_read` for any channel.
+
+## Architectural decisions
+
+### One source of truth: SQLite
+
+Per-channel read state is canonically stored in SQLite. The in-memory `WorkspaceContext.LastReadMap` and the in-memory `ChannelItem.UnreadCount` are eliminated as separate stores. They are replaced by a single read path: a batched query at sidebar render time.
+
+The DB is fast enough that per-render queries are not a concern: bubbletea only re-renders on `tea.Msg` arrivals (single-digit/sec for typical use), the query is a single batched lookup against the workspace-scoped index, and the SQLite WAL configuration already in place handles concurrent reads without blocking the writer.
+
+### Boolean `has_unread`, not integer `unread_count`
+
+The user-visible unread signal is a dot. The integer count is meaningful only for section aggregates (e.g., "DMs (N)"). After this redesign, those aggregates count channels-with-unreads instead of summing unread-message-counts. This is a deliberate user-visible behavior change.
+
+Rationale:
+- Slack's `client.counts` does not reliably provide a true unread count (`unread_count_display` is sparse and inconsistent across channel types).
+- Maintaining an accurate integer count locally requires tracking every WS message increment/decrement, every read-mark reset, and reconciling against the server periodically. Each of those is a place for drift.
+- A boolean has only two states and a single authority (Slack's `has_unreads`). It cannot drift in the same way.
+- Section aggregates of "channels with unreads" are arguably more useful than "unread messages" anyway — the latter can grow into the hundreds and ceases to communicate urgency.
+
+### Single mutation API
+
+All read-state writes flow through one logical operation, exposed as two functions for the single-row and batched cases:
+
+```go
+// internal/cache/channels.go (or new file channels_read_state.go)
+
+// UpdateChannelReadState atomically updates the per-channel read state.
+// If lastReadTS == "", the existing last_read_ts is preserved (useful
+// for events that update has_unread only, e.g. new-message arrivals).
+// This is the ONLY function permitted to modify read state after bootstrap.
+func (db *DB) UpdateChannelReadState(channelID, lastReadTS string, hasUnread bool) error
+
+// BatchUpdateChannelReadState writes multiple updates in a single
+// transaction. Used by bootstrap and reconnect catch-up paths.
+func (db *DB) BatchUpdateChannelReadState(workspaceID string, updates []ChannelReadStateUpdate) error
+```
+
+And one read function:
+
+```go
+// GetWorkspaceReadState returns (channelID -> ReadState) for every
+// channel in the workspace. Single batched query. Called by the
+// sidebar View() at render time.
+func (db *DB) GetWorkspaceReadState(workspaceID string) (map[string]ReadState, error)
+
+type ReadState struct {
+    LastReadTS string
+    HasUnread  bool
+}
+```
+
+## Schema changes
+
+```sql
+-- Migration via the existing addColumnIfMissing helper:
+ALTER TABLE channels ADD COLUMN has_unread INTEGER NOT NULL DEFAULT 0
+```
+
+The existing `last_read_ts` column is kept as-is.
+
+The existing `unread_count` column is **kept for one release** as deprecated, ignored by all read paths, never updated by any write path. Drop in a follow-up release.
+
+The `cache.Channel` struct loses its `LastReadTS` and `UnreadCount` fields entirely. This is the type-system enforcement that prevents future code from bypassing the read-state API.
+
+## Data inflows
+
+The six (and only six) sources of read-state mutation:
+
+| Source | Call site | New write |
+|---|---|---|
+| Bootstrap | `connectWorkspace` (after `GetUnreadCounts`) | `BatchUpdateChannelReadState` for all channels in response |
+| Reconnect catch-up | `runChannelPhase` (after `GetUnreadCounts`) | `BatchUpdateChannelReadState` for all channels in response (including `HasUnread=false`) |
+| WS `*_marked` events | `OnChannelMarked` handler | `UpdateChannelReadState(id, eventTS, false)` |
+| New WS message, inactive channel | `OnMessage` handler | `UpdateChannelReadState(id, "", true)` |
+| User opens channel in slk | `markChannelReadAsync` (after server ack) | `UpdateChannelReadState(id, latestTS, false)` |
+| User presses `U` | `MarkChannelUnread` flow (after server ack) | `UpdateChannelReadState(id, boundaryTS, true)` |
+
+`UpsertChannel` is fixed to never touch `has_unread` or `last_read_ts` (they are removed from the `ON CONFLICT DO UPDATE` clause and from the `cache.Channel` struct).
+
+`wctx.LastReadMap` and the in-memory `Channels[i].LastReadTS`/`UnreadCount` fields are removed. Every consumer goes through the DB.
+
+`sidebar.ChannelItem.UnreadCount` is removed. The sidebar's `View()` calls `GetWorkspaceReadState` once per render and looks up `HasUnread` per item.
+
+`sidebar.MarkUnread` / `ClearUnread` / `SetUnreadCount` are deleted. The `App.Update` handlers that called them either (a) call `UpdateChannelReadState` directly (writing to DB triggers a re-render via a `ReadStateChangedMsg`), or (b) are deleted because their work moved into the WS handler.
+
+## Data outflows
+
+- **Sidebar dot.** `View()` reads from `GetWorkspaceReadState`. Dot rendered when `state.HasUnread && !item.IsMuted`. No internal state.
+- **Section aggregate.** Counts channels-with-unreads. Single-line change in `aggregateUnreadForSection`.
+- **Message pane "new messages" line.** Already reads `lastReadTS` from a per-channel call. Unaffected by the consolidation other than the call going through `GetChannelReadState(channelID)` instead of `wctx.LastReadMap`.
+- **Workspace rail dot.** Becomes "any channel in this workspace has `has_unread`." Implemented as a new cache function `db.WorkspacesWithUnreads() ([]string, error)` that returns the set of workspace IDs with at least one `has_unread=true` channel (single `SELECT DISTINCT workspace_id FROM channels WHERE has_unread = 1` query). Called by the rail's render path. Not derived from `GetWorkspaceReadState` because the rail needs cross-workspace data, not just the active workspace's.
+- **Notifications.** Unaffected — notification gating uses `notify.NotifyContext`, not the unread store.
+
+## Active-channel handling
+
+When a WS `OnMessage` arrives for the channel the user is actively viewing, `has_unread` should NOT be set to true. The handler checks `h.activeChannelID()` and skips the write if it matches. The existing `markChannelReadAsync` flow continues to advance `last_read_ts` and clear `has_unread` to `false` when appropriate.
+
+This is the same active-channel suppression logic as today, just relocated to `OnMessage` and routed through the single mutation API.
+
+## Non-goals (explicit deferrals)
+
+- **Periodic re-sync.** Considered and explicitly rejected. The WS event stream + reconnect catch-up should be sufficient. A periodic poll would mask real sync bugs rather than fix them. If we observe drift in production that the catch-up can't resolve, we diagnose the missing event path rather than paper over it with a timer.
+- **Dropping the `unread_count` column.** Kept for one release as dead-but-harmless. Removal is a follow-up.
+- **Restructuring the `OnMessage` handler beyond the active-channel check.** The handler does a lot (caching, notification, threading) and we don't touch the non-read-state branches.
+- **Changing the user-facing keybindings or visual design** of the sidebar dot or section aggregates beyond the count-of-channels-with-unreads semantic.
+
+## Test plan
+
+The user has explicitly called out: structural changes that don't break tests mean the tests aren't testing the right thing. This branch should produce both compile failures (from the `cache.Channel` field removal) and assertion failures in tests that exercised the old store-divergence behavior.
+
+### Tests expected to break (and require updates)
+
+- `internal/cache/channels_test.go::TestUpsertChannel*` — any test verifying that `ON CONFLICT DO UPDATE` clobbers `last_read_ts` is now testing the opposite invariant.
+- Any test constructing `cache.Channel{LastReadTS: "...", UnreadCount: N}` — compile failure (intentional).
+- `internal/ui/sidebar/model_test.go` — tests that called `MarkUnread`/`ClearUnread`/`SetUnreadCount` and checked the resulting `items[i].UnreadCount` will need to either be deleted (those methods are gone) or rewritten as integration tests that drive the new `UpdateChannelReadState` API and verify the rendered dot.
+- `cmd/slk/main_test.go` (if it tests `OnChannelMarked`) — verify the new DB-only write path.
+
+### New tests required
+
+**Cache layer (new file `internal/cache/channels_read_state_test.go`):**
+
+- `UpdateChannelReadState` writes both columns correctly.
+- `UpdateChannelReadState(id, "", true)` leaves `last_read_ts` unchanged.
+- `UpdateChannelReadState` is idempotent.
+- `BatchUpdateChannelReadState` is transactional (all-or-nothing on partial failure).
+- `GetWorkspaceReadState` returns all channels including ones at the default `has_unread=false`.
+- **Clobber regression**: `UpsertChannel` followed by `UpdateChannelReadState` followed by `UpsertChannel` — read state survives the second upsert. This is the test that proves the old bug is fixed.
+
+**Event handlers (`cmd/slk/main_test.go` or a new file):**
+
+- `OnChannelMarked` calls `UpdateChannelReadState(id, ts, false)` and does NOT mutate `wctx.Channels`.
+- `OnMessage` on an inactive channel calls `UpdateChannelReadState(id, "", true)`.
+- `OnMessage` on the active channel does NOT call `UpdateChannelReadState` (active-channel suppression).
+- `OnMessage` for an inactive workspace: same path as inactive channel (no special inactive-workspace branch).
+
+**Reconnect catch-up (`cmd/slk/reconnect_backfill_test.go`):**
+
+- `runChannelPhase` calls `BatchUpdateChannelReadState` for every channel in the `GetUnreadCounts` response, including `HasUnread=false`. This is the test that proves Symptom 2 is fixed.
+
+**Bootstrap (`cmd/slk/main_test.go` or new):**
+
+- `connectWorkspace` populates both `has_unread` and `last_read_ts` for both `HasUnread=true` and `HasUnread=false` channels returned by `client.counts`.
+
+**Sidebar render path:**
+
+- `View()` calls `GetWorkspaceReadState` exactly once per render.
+- Dot is rendered iff `state.HasUnread && !item.IsMuted`.
+- Muted-but-unread channels: no dot.
+- Channel not in the read-state map (race between channel creation and first read-state write): treated as `HasUnread=false` (no dot).
+
+**Integration test (extend `TestBackfill_OvernightSuspendScenario`):**
+
+Add a fourth channel category, "channel D": pre-suspend has unreads and a `last_read_ts`; during the offline window the user reads it in the official client. `client.counts` at reconnect returns `HasUnread=false` and a newer `LastRead` for D. After backfill, assertions:
+
+- `db.GetChannelReadState("D").HasUnread == false`
+- `db.GetChannelReadState("D").LastReadTS == newReadTS`
+
+This is the test that locks in Symptom 2's fix end-to-end.
+
+## Migration and rollout
+
+- Branch off `main` (currently at v0.7.11).
+- Land changes incrementally per the implementation plan.
+- Ship as v0.7.12 (or v0.8.0 if we decide the user-visible aggregate change warrants a minor bump).
+- On first launch after upgrade:
+  1. New `has_unread` column exists with default `0` for every existing channel.
+  2. WS reconnects fresh, `OnConnect` fires, `runChannelPhase` runs.
+  3. `GetUnreadCounts` is called, `BatchUpdateChannelReadState` populates current state.
+  4. Sidebar re-renders with correct dots.
+
+The window of "post-upgrade, pre-first-reconnect-completion" — typically sub-second — shows no unread dots. Acceptable.
+
+No user data is destroyed by the migration. Existing `last_read_ts` values are preserved (we only ADD `has_unread`).
+
+## Out of scope for this branch (genuine follow-ups)
+
+These items are not addressed by this design and remain as follow-ups, separate from the read-state work:
+
+1. v0.7.11 follow-up: `GetHistorySince` flags `Capped: true` on exact-`maxTotal` even when no more pages remain. Symptom: wasted re-fetch.
+2. v0.7.11 follow-up: `GetUnreadCounts` ignores `ctx`. Symptom: possible hang on shutdown.
+3. Drop the deprecated `unread_count` column after one release.
+4. Move the watermark helpers from `channels.go` to `channels_sync.go` for cohesion (noted in v0.7.11 reviews).
+
+## Open questions
+
+None. All design decisions are settled.

--- a/internal/cache/channels.go
+++ b/internal/cache/channels.go
@@ -13,15 +13,13 @@ type Channel struct {
 	Topic       string
 	IsMember    bool
 	IsStarred   bool
-	LastReadTS  string
-	UnreadCount int
 	UpdatedAt   int64
 }
 
 func (db *DB) UpsertChannel(ch Channel) error {
 	_, err := db.conn.Exec(`
-		INSERT INTO channels (id, workspace_id, name, type, topic, is_member, is_starred, last_read_ts, unread_count, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO channels (id, workspace_id, name, type, topic, is_member, is_starred, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			name=excluded.name,
 			type=excluded.type,
@@ -30,8 +28,7 @@ func (db *DB) UpsertChannel(ch Channel) error {
 			is_starred=excluded.is_starred,
 			updated_at=excluded.updated_at
 	`, ch.ID, ch.WorkspaceID, ch.Name, ch.Type, ch.Topic,
-		boolToInt(ch.IsMember), boolToInt(ch.IsStarred),
-		ch.LastReadTS, ch.UnreadCount, ch.UpdatedAt)
+		boolToInt(ch.IsMember), boolToInt(ch.IsStarred), ch.UpdatedAt)
 	if err != nil {
 		return fmt.Errorf("upserting channel: %w", err)
 	}
@@ -42,10 +39,10 @@ func (db *DB) GetChannel(id string) (Channel, error) {
 	var ch Channel
 	var isMember, isStarred int
 	err := db.conn.QueryRow(`
-		SELECT id, workspace_id, name, type, topic, is_member, is_starred, last_read_ts, unread_count, updated_at
+		SELECT id, workspace_id, name, type, topic, is_member, is_starred, updated_at
 		FROM channels WHERE id = ?
 	`, id).Scan(&ch.ID, &ch.WorkspaceID, &ch.Name, &ch.Type, &ch.Topic,
-		&isMember, &isStarred, &ch.LastReadTS, &ch.UnreadCount, &ch.UpdatedAt)
+		&isMember, &isStarred, &ch.UpdatedAt)
 	if err != nil {
 		return ch, fmt.Errorf("getting channel: %w", err)
 	}
@@ -56,7 +53,7 @@ func (db *DB) GetChannel(id string) (Channel, error) {
 
 func (db *DB) ListChannels(workspaceID string, membersOnly bool) ([]Channel, error) {
 	query := `
-		SELECT id, workspace_id, name, type, topic, is_member, is_starred, last_read_ts, unread_count, updated_at
+		SELECT id, workspace_id, name, type, topic, is_member, is_starred, updated_at
 		FROM channels WHERE workspace_id = ?`
 	args := []any{workspaceID}
 
@@ -76,7 +73,7 @@ func (db *DB) ListChannels(workspaceID string, membersOnly bool) ([]Channel, err
 		var ch Channel
 		var isMember, isStarred int
 		if err := rows.Scan(&ch.ID, &ch.WorkspaceID, &ch.Name, &ch.Type, &ch.Topic,
-			&isMember, &isStarred, &ch.LastReadTS, &ch.UnreadCount, &ch.UpdatedAt); err != nil {
+			&isMember, &isStarred, &ch.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scanning channel: %w", err)
 		}
 		ch.IsMember = isMember == 1
@@ -84,39 +81,6 @@ func (db *DB) ListChannels(workspaceID string, membersOnly bool) ([]Channel, err
 		channels = append(channels, ch)
 	}
 	return channels, rows.Err()
-}
-
-func (db *DB) UpdateUnreadCount(channelID string, count int) error {
-	_, err := db.conn.Exec(`UPDATE channels SET unread_count = ? WHERE id = ?`, count, channelID)
-	if err != nil {
-		return fmt.Errorf("updating unread count: %w", err)
-	}
-	return nil
-}
-
-// UpdateLastReadTS sets the last read timestamp for a channel.
-func (db *DB) UpdateLastReadTS(channelID, ts string) error {
-	_, err := db.conn.Exec(
-		`UPDATE channels SET last_read_ts = ? WHERE id = ?`,
-		ts, channelID,
-	)
-	if err != nil {
-		return fmt.Errorf("updating last_read_ts: %w", err)
-	}
-	return nil
-}
-
-// GetLastReadTS returns the last read timestamp for a channel.
-func (db *DB) GetLastReadTS(channelID string) (string, error) {
-	var ts string
-	err := db.conn.QueryRow(
-		`SELECT last_read_ts FROM channels WHERE id = ?`,
-		channelID,
-	).Scan(&ts)
-	if err != nil {
-		return "", err
-	}
-	return ts, nil
 }
 
 // SetChannelSyncedAt stores the unix timestamp (seconds) at which the

--- a/internal/cache/channels.go
+++ b/internal/cache/channels.go
@@ -28,8 +28,6 @@ func (db *DB) UpsertChannel(ch Channel) error {
 			topic=excluded.topic,
 			is_member=excluded.is_member,
 			is_starred=excluded.is_starred,
-			last_read_ts=excluded.last_read_ts,
-			unread_count=excluded.unread_count,
 			updated_at=excluded.updated_at
 	`, ch.ID, ch.WorkspaceID, ch.Name, ch.Type, ch.Topic,
 		boolToInt(ch.IsMember), boolToInt(ch.IsStarred),

--- a/internal/cache/channels_read_state.go
+++ b/internal/cache/channels_read_state.go
@@ -1,0 +1,57 @@
+package cache
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+// ReadState captures the per-channel read-state values that drive the
+// unread dot and "new messages" line. It is the canonical type for
+// passing read state across package boundaries.
+type ReadState struct {
+	LastReadTS string
+	HasUnread  bool
+}
+
+// ChannelReadStateUpdate is one entry in a batched read-state write.
+// LastReadTS == "" means "preserve the existing last_read_ts" (used by
+// events that update has_unread only, e.g. new-message arrivals).
+type ChannelReadStateUpdate struct {
+	ChannelID  string
+	LastReadTS string
+	HasUnread  bool
+}
+
+// UpdateChannelReadState atomically updates the per-channel read state.
+// If lastReadTS == "", the existing last_read_ts is preserved. This is
+// the ONLY function permitted to modify read state after bootstrap.
+func (db *DB) UpdateChannelReadState(channelID, lastReadTS string, hasUnread bool) error {
+	return fmt.Errorf("not implemented")
+}
+
+// BatchUpdateChannelReadState writes multiple updates in a single
+// transaction. Used by bootstrap and reconnect catch-up paths.
+func (db *DB) BatchUpdateChannelReadState(updates []ChannelReadStateUpdate) error {
+	return fmt.Errorf("not implemented")
+}
+
+// GetChannelReadState returns the read state for a single channel.
+// A missing row yields a zero-valued ReadState and a nil error.
+func (db *DB) GetChannelReadState(channelID string) (ReadState, error) {
+	return ReadState{}, fmt.Errorf("not implemented")
+}
+
+// GetWorkspaceReadState returns channelID -> ReadState for every
+// channel in the workspace. Single batched query. Called by the
+// sidebar View() at render time.
+func (db *DB) GetWorkspaceReadState(workspaceID string) (map[string]ReadState, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// WorkspacesWithUnreads returns the set of workspace IDs with at least
+// one has_unread=true channel. Used by the workspace rail.
+func (db *DB) WorkspacesWithUnreads() ([]string, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+var _ = sql.ErrNoRows // keep sql import for later use

--- a/internal/cache/channels_read_state.go
+++ b/internal/cache/channels_read_state.go
@@ -105,11 +105,43 @@ func (db *DB) GetChannelReadState(channelID string) (ReadState, error) {
 // channel in the workspace. Single batched query. Called by the
 // sidebar View() at render time.
 func (db *DB) GetWorkspaceReadState(workspaceID string) (map[string]ReadState, error) {
-	return nil, fmt.Errorf("not implemented")
+	rows, err := db.conn.Query(
+		`SELECT id, last_read_ts, has_unread FROM channels WHERE workspace_id = ?`,
+		workspaceID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query workspace read state: %w", err)
+	}
+	defer rows.Close()
+	out := make(map[string]ReadState)
+	for rows.Next() {
+		var id, lastRead string
+		var hasUnread int
+		if err := rows.Scan(&id, &lastRead, &hasUnread); err != nil {
+			return nil, fmt.Errorf("scan workspace read state: %w", err)
+		}
+		out[id] = ReadState{LastReadTS: lastRead, HasUnread: hasUnread == 1}
+	}
+	return out, rows.Err()
 }
 
 // WorkspacesWithUnreads returns the set of workspace IDs with at least
 // one has_unread=true channel. Used by the workspace rail.
 func (db *DB) WorkspacesWithUnreads() ([]string, error) {
-	return nil, fmt.Errorf("not implemented")
+	rows, err := db.conn.Query(
+		`SELECT DISTINCT workspace_id FROM channels WHERE has_unread = 1`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query workspaces with unreads: %w", err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan workspace id: %w", err)
+		}
+		out = append(out, id)
+	}
+	return out, rows.Err()
 }

--- a/internal/cache/channels_read_state.go
+++ b/internal/cache/channels_read_state.go
@@ -26,7 +26,19 @@ type ChannelReadStateUpdate struct {
 // If lastReadTS == "", the existing last_read_ts is preserved. This is
 // the ONLY function permitted to modify read state after bootstrap.
 func (db *DB) UpdateChannelReadState(channelID, lastReadTS string, hasUnread bool) error {
-	return fmt.Errorf("not implemented")
+	var q string
+	var args []any
+	if lastReadTS == "" {
+		q = `UPDATE channels SET has_unread = ? WHERE id = ?`
+		args = []any{boolToInt(hasUnread), channelID}
+	} else {
+		q = `UPDATE channels SET last_read_ts = ?, has_unread = ? WHERE id = ?`
+		args = []any{lastReadTS, boolToInt(hasUnread), channelID}
+	}
+	if _, err := db.conn.Exec(q, args...); err != nil {
+		return fmt.Errorf("updating channel read state: %w", err)
+	}
+	return nil
 }
 
 // BatchUpdateChannelReadState writes multiple updates in a single
@@ -38,7 +50,19 @@ func (db *DB) BatchUpdateChannelReadState(updates []ChannelReadStateUpdate) erro
 // GetChannelReadState returns the read state for a single channel.
 // A missing row yields a zero-valued ReadState and a nil error.
 func (db *DB) GetChannelReadState(channelID string) (ReadState, error) {
-	return ReadState{}, fmt.Errorf("not implemented")
+	var lastReadTS string
+	var hasUnread int
+	err := db.conn.QueryRow(
+		`SELECT last_read_ts, has_unread FROM channels WHERE id = ?`,
+		channelID,
+	).Scan(&lastReadTS, &hasUnread)
+	if err == sql.ErrNoRows {
+		return ReadState{}, nil
+	}
+	if err != nil {
+		return ReadState{}, fmt.Errorf("getting channel read state: %w", err)
+	}
+	return ReadState{LastReadTS: lastReadTS, HasUnread: hasUnread == 1}, nil
 }
 
 // GetWorkspaceReadState returns channelID -> ReadState for every
@@ -53,5 +77,3 @@ func (db *DB) GetWorkspaceReadState(workspaceID string) (map[string]ReadState, e
 func (db *DB) WorkspacesWithUnreads() ([]string, error) {
 	return nil, fmt.Errorf("not implemented")
 }
-
-var _ = sql.ErrNoRows // keep sql import for later use

--- a/internal/cache/channels_read_state.go
+++ b/internal/cache/channels_read_state.go
@@ -44,7 +44,43 @@ func (db *DB) UpdateChannelReadState(channelID, lastReadTS string, hasUnread boo
 // BatchUpdateChannelReadState writes multiple updates in a single
 // transaction. Used by bootstrap and reconnect catch-up paths.
 func (db *DB) BatchUpdateChannelReadState(updates []ChannelReadStateUpdate) error {
-	return fmt.Errorf("not implemented")
+	if len(updates) == 0 {
+		return nil
+	}
+	tx, err := db.conn.Begin()
+	if err != nil {
+		return fmt.Errorf("begin batch read-state tx: %w", err)
+	}
+	stmtBoth, err := tx.Prepare(`UPDATE channels SET last_read_ts = ?, has_unread = ? WHERE id = ?`)
+	if err != nil {
+		tx.Rollback()
+		return fmt.Errorf("prepare both: %w", err)
+	}
+	defer stmtBoth.Close()
+	stmtFlag, err := tx.Prepare(`UPDATE channels SET has_unread = ? WHERE id = ?`)
+	if err != nil {
+		tx.Rollback()
+		return fmt.Errorf("prepare flag: %w", err)
+	}
+	defer stmtFlag.Close()
+
+	for _, u := range updates {
+		if u.LastReadTS == "" {
+			if _, err := stmtFlag.Exec(boolToInt(u.HasUnread), u.ChannelID); err != nil {
+				tx.Rollback()
+				return fmt.Errorf("batch flag for %s: %w", u.ChannelID, err)
+			}
+		} else {
+			if _, err := stmtBoth.Exec(u.LastReadTS, boolToInt(u.HasUnread), u.ChannelID); err != nil {
+				tx.Rollback()
+				return fmt.Errorf("batch both for %s: %w", u.ChannelID, err)
+			}
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit batch read-state: %w", err)
+	}
+	return nil
 }
 
 // GetChannelReadState returns the read state for a single channel.

--- a/internal/cache/channels_read_state_test.go
+++ b/internal/cache/channels_read_state_test.go
@@ -140,3 +140,68 @@ func TestBatchUpdateChannelReadState_Transactional(t *testing.T) {
 		t.Errorf("after empty batch C1 = %+v", s)
 	}
 }
+
+func TestGetWorkspaceReadState_ReturnsAllChannels(t *testing.T) {
+	db, err := New(":memory:")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer db.Close()
+	newRSChannel(t, db, "C1", "T1")
+	newRSChannel(t, db, "C2", "T1")
+	newRSChannel(t, db, "C3", "T1")
+	newRSChannel(t, db, "C4", "T2") // different workspace
+
+	_ = db.UpdateChannelReadState("C1", "1.0001", true)
+	_ = db.UpdateChannelReadState("C2", "1.0002", false)
+	// C3 untouched — defaults
+
+	got, err := db.GetWorkspaceReadState("T1")
+	if err != nil {
+		t.Fatalf("GetWorkspaceReadState: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d entries, want 3 (C3 must be included with defaults): %+v", len(got), got)
+	}
+	if got["C1"].LastReadTS != "1.0001" || !got["C1"].HasUnread {
+		t.Errorf("C1 = %+v", got["C1"])
+	}
+	if got["C2"].LastReadTS != "1.0002" || got["C2"].HasUnread {
+		t.Errorf("C2 = %+v", got["C2"])
+	}
+	if got["C3"].LastReadTS != "" || got["C3"].HasUnread {
+		t.Errorf("C3 default = %+v", got["C3"])
+	}
+	if _, ok := got["C4"]; ok {
+		t.Errorf("C4 from other workspace should not be returned")
+	}
+}
+
+func TestWorkspacesWithUnreads(t *testing.T) {
+	db, err := New(":memory:")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer db.Close()
+	newRSChannel(t, db, "C1", "T1")
+	newRSChannel(t, db, "C2", "T2")
+	newRSChannel(t, db, "C3", "T3")
+
+	_ = db.UpdateChannelReadState("C1", "1.0", true)
+	_ = db.UpdateChannelReadState("C3", "1.0", true)
+	// C2/T2 has no unreads
+
+	got, err := db.WorkspacesWithUnreads()
+	if err != nil {
+		t.Fatalf("WorkspacesWithUnreads: %v", err)
+	}
+	want := map[string]bool{"T1": true, "T3": true}
+	if len(got) != 2 {
+		t.Fatalf("got %d ids, want 2: %v", len(got), got)
+	}
+	for _, id := range got {
+		if !want[id] {
+			t.Errorf("unexpected workspace %q", id)
+		}
+	}
+}

--- a/internal/cache/channels_read_state_test.go
+++ b/internal/cache/channels_read_state_test.go
@@ -81,3 +81,62 @@ func TestUpdateChannelReadState_Idempotent(t *testing.T) {
 		t.Errorf("state = %+v after 3 writes", state)
 	}
 }
+
+func TestBatchUpdateChannelReadState_WritesAll(t *testing.T) {
+	db, err := New(":memory:")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer db.Close()
+	newRSChannel(t, db, "C1", "T1")
+	newRSChannel(t, db, "C2", "T1")
+	newRSChannel(t, db, "C3", "T1")
+
+	updates := []ChannelReadStateUpdate{
+		{ChannelID: "C1", LastReadTS: "1.0001", HasUnread: true},
+		{ChannelID: "C2", LastReadTS: "1.0002", HasUnread: false},
+		{ChannelID: "C3", LastReadTS: "", HasUnread: true},
+	}
+	if err := db.BatchUpdateChannelReadState(updates); err != nil {
+		t.Fatalf("BatchUpdateChannelReadState: %v", err)
+	}
+	s1, _ := db.GetChannelReadState("C1")
+	if s1.LastReadTS != "1.0001" || !s1.HasUnread {
+		t.Errorf("C1 = %+v", s1)
+	}
+	s2, _ := db.GetChannelReadState("C2")
+	if s2.LastReadTS != "1.0002" || s2.HasUnread {
+		t.Errorf("C2 = %+v", s2)
+	}
+	s3, _ := db.GetChannelReadState("C3")
+	if s3.LastReadTS != "" || !s3.HasUnread {
+		t.Errorf("C3 = %+v (LastReadTS should be preserved empty)", s3)
+	}
+}
+
+func TestBatchUpdateChannelReadState_Transactional(t *testing.T) {
+	db, err := New(":memory:")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer db.Close()
+	newRSChannel(t, db, "C1", "T1")
+
+	// Seed C1
+	if err := db.UpdateChannelReadState("C1", "1.0", false); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Empty batch is a no-op and returns nil.
+	if err := db.BatchUpdateChannelReadState(nil); err != nil {
+		t.Errorf("nil batch: %v", err)
+	}
+	if err := db.BatchUpdateChannelReadState([]ChannelReadStateUpdate{}); err != nil {
+		t.Errorf("empty batch: %v", err)
+	}
+	// Original state untouched
+	s, _ := db.GetChannelReadState("C1")
+	if s.LastReadTS != "1.0" || s.HasUnread {
+		t.Errorf("after empty batch C1 = %+v", s)
+	}
+}

--- a/internal/cache/channels_read_state_test.go
+++ b/internal/cache/channels_read_state_test.go
@@ -205,3 +205,39 @@ func TestWorkspacesWithUnreads(t *testing.T) {
 		}
 	}
 }
+
+func TestUpsertChannel_DoesNotClobberReadState(t *testing.T) {
+	db, err := New(":memory:")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer db.Close()
+	newRSChannel(t, db, "C1", "T1")
+
+	// Set read state.
+	if err := db.UpdateChannelReadState("C1", "1700000000.000001", true); err != nil {
+		t.Fatalf("UpdateChannelReadState: %v", err)
+	}
+
+	// Re-upsert the channel with zero-value LastReadTS/UnreadCount.
+	// This mirrors what bootstrap (upsertChannelInDB) does today.
+	if err := db.UpsertChannel(Channel{
+		ID:          "C1",
+		WorkspaceID: "T1",
+		Name:        "renamed",
+		Type:        "channel",
+	}); err != nil {
+		t.Fatalf("re-upsert: %v", err)
+	}
+
+	state, err := db.GetChannelReadState("C1")
+	if err != nil {
+		t.Fatalf("GetChannelReadState: %v", err)
+	}
+	if state.LastReadTS != "1700000000.000001" {
+		t.Errorf("LastReadTS = %q, want preserved %q (clobber regression!)", state.LastReadTS, "1700000000.000001")
+	}
+	if !state.HasUnread {
+		t.Errorf("HasUnread = false after upsert (clobber regression!)")
+	}
+}

--- a/internal/cache/channels_read_state_test.go
+++ b/internal/cache/channels_read_state_test.go
@@ -1,0 +1,83 @@
+package cache
+
+import (
+	"testing"
+)
+
+func newRSChannel(t *testing.T, db *DB, id, workspaceID string) {
+	t.Helper()
+	if err := db.UpsertWorkspace(Workspace{ID: workspaceID, Name: "ws"}); err != nil {
+		t.Fatalf("UpsertWorkspace: %v", err)
+	}
+	if err := db.UpsertChannel(Channel{ID: id, WorkspaceID: workspaceID, Name: id, Type: "channel"}); err != nil {
+		t.Fatalf("UpsertChannel: %v", err)
+	}
+}
+
+func TestUpdateChannelReadState_WritesBothColumns(t *testing.T) {
+	db, err := New(":memory:")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer db.Close()
+	newRSChannel(t, db, "C1", "T1")
+
+	if err := db.UpdateChannelReadState("C1", "1700000000.000001", true); err != nil {
+		t.Fatalf("UpdateChannelReadState: %v", err)
+	}
+	state, err := db.GetChannelReadState("C1")
+	if err != nil {
+		t.Fatalf("GetChannelReadState: %v", err)
+	}
+	if state.LastReadTS != "1700000000.000001" {
+		t.Errorf("LastReadTS = %q, want %q", state.LastReadTS, "1700000000.000001")
+	}
+	if !state.HasUnread {
+		t.Errorf("HasUnread = false, want true")
+	}
+}
+
+func TestUpdateChannelReadState_EmptyTSPreservesExisting(t *testing.T) {
+	db, err := New(":memory:")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer db.Close()
+	newRSChannel(t, db, "C1", "T1")
+
+	if err := db.UpdateChannelReadState("C1", "1700000000.000001", false); err != nil {
+		t.Fatalf("first update: %v", err)
+	}
+	if err := db.UpdateChannelReadState("C1", "", true); err != nil {
+		t.Fatalf("second update: %v", err)
+	}
+	state, err := db.GetChannelReadState("C1")
+	if err != nil {
+		t.Fatalf("GetChannelReadState: %v", err)
+	}
+	if state.LastReadTS != "1700000000.000001" {
+		t.Errorf("LastReadTS = %q, want preserved %q", state.LastReadTS, "1700000000.000001")
+	}
+	if !state.HasUnread {
+		t.Errorf("HasUnread = false, want true")
+	}
+}
+
+func TestUpdateChannelReadState_Idempotent(t *testing.T) {
+	db, err := New(":memory:")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer db.Close()
+	newRSChannel(t, db, "C1", "T1")
+
+	for i := 0; i < 3; i++ {
+		if err := db.UpdateChannelReadState("C1", "1700000000.000001", true); err != nil {
+			t.Fatalf("iter %d: %v", i, err)
+		}
+	}
+	state, _ := db.GetChannelReadState("C1")
+	if state.LastReadTS != "1700000000.000001" || !state.HasUnread {
+		t.Errorf("state = %+v after 3 writes", state)
+	}
+}

--- a/internal/cache/channels_test.go
+++ b/internal/cache/channels_test.go
@@ -60,59 +60,6 @@ func TestListChannelsByWorkspace(t *testing.T) {
 	}
 }
 
-func TestUpdateUnreadCount(t *testing.T) {
-	db := setupDBWithWorkspace(t)
-	defer db.Close()
-
-	db.UpsertChannel(Channel{ID: "C1", WorkspaceID: "T1", Name: "general", Type: "channel", IsMember: true})
-
-	if err := db.UpdateUnreadCount("C1", 5); err != nil {
-		t.Fatal(err)
-	}
-
-	ch, _ := db.GetChannel("C1")
-	if ch.UnreadCount != 5 {
-		t.Errorf("expected unread count 5, got %d", ch.UnreadCount)
-	}
-}
-
-func TestUpdateLastReadTS_RoundTrip(t *testing.T) {
-	db := setupDBWithWorkspace(t)
-	defer db.Close()
-
-	db.UpsertChannel(Channel{ID: "C1", WorkspaceID: "T1", Name: "general", Type: "channel", IsMember: true})
-
-	if err := db.UpdateLastReadTS("C1", "1234567890.000100"); err != nil {
-		t.Fatal(err)
-	}
-
-	got, err := db.GetLastReadTS("C1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got != "1234567890.000100" {
-		t.Errorf("expected '1234567890.000100', got %q", got)
-	}
-
-	// Update again — overwrites prior value.
-	if err := db.UpdateLastReadTS("C1", "1234567890.000200"); err != nil {
-		t.Fatal(err)
-	}
-	got, _ = db.GetLastReadTS("C1")
-	if got != "1234567890.000200" {
-		t.Errorf("expected '1234567890.000200' after overwrite, got %q", got)
-	}
-
-	// Roll backward — also allowed (mark-unread will need this).
-	if err := db.UpdateLastReadTS("C1", "1234567890.000050"); err != nil {
-		t.Fatal(err)
-	}
-	got, _ = db.GetLastReadTS("C1")
-	if got != "1234567890.000050" {
-		t.Errorf("expected backward roll to '1234567890.000050', got %q", got)
-	}
-}
-
 func TestGetChannelSyncedAt_DefaultsToZero(t *testing.T) {
 	db := setupDBWithWorkspace(t)
 	defer db.Close()

--- a/internal/cache/db.go
+++ b/internal/cache/db.go
@@ -93,6 +93,7 @@ func (db *DB) migrate() error {
 		is_starred INTEGER NOT NULL DEFAULT 0,
 		last_read_ts TEXT NOT NULL DEFAULT '',
 		unread_count INTEGER NOT NULL DEFAULT 0,
+		has_unread INTEGER NOT NULL DEFAULT 0,
 		updated_at INTEGER NOT NULL DEFAULT 0,
 		FOREIGN KEY (workspace_id) REFERENCES workspaces(id)
 	);
@@ -186,6 +187,10 @@ func (db *DB) migrate() error {
 	}
 	if err := db.addColumnIfMissing("channels", "latest_synced_ts",
 		"ALTER TABLE channels ADD COLUMN latest_synced_ts TEXT NOT NULL DEFAULT ''"); err != nil {
+		return err
+	}
+	if err := db.addColumnIfMissing("channels", "has_unread",
+		"ALTER TABLE channels ADD COLUMN has_unread INTEGER NOT NULL DEFAULT 0"); err != nil {
 		return err
 	}
 

--- a/internal/cache/db_test.go
+++ b/internal/cache/db_test.go
@@ -48,6 +48,46 @@ func TestNewDBCreatesIndexes(t *testing.T) {
 	}
 }
 
+func TestMigration_AddsHasUnreadColumn(t *testing.T) {
+	db, err := New(":memory:")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer db.Close()
+
+	rows, err := db.conn.Query("PRAGMA table_info(channels)")
+	if err != nil {
+		t.Fatalf("PRAGMA: %v", err)
+	}
+	defer rows.Close()
+
+	found := false
+	for rows.Next() {
+		var cid int
+		var name, ctype string
+		var notnull, pk int
+		var dflt sql.NullString
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if name == "has_unread" {
+			found = true
+			if ctype != "INTEGER" {
+				t.Errorf("has_unread type = %q, want INTEGER", ctype)
+			}
+			if notnull != 1 {
+				t.Errorf("has_unread NOT NULL = %d, want 1", notnull)
+			}
+			if !dflt.Valid || dflt.String != "0" {
+				t.Errorf("has_unread default = %v, want 0", dflt)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("has_unread column not added")
+	}
+}
+
 // TestSubtypeMigrationOnPreExistingDB verifies that an existing
 // database created before the `subtype` column was added gets the
 // column added idempotently when New() is called against it.

--- a/internal/cache/threads_test.go
+++ b/internal/cache/threads_test.go
@@ -197,12 +197,11 @@ func TestListSubscribedThreads_SortByLastReplyTSDesc(t *testing.T) {
 func TestListSubscribedThreads_UnreadUsesPerThreadLastRead(t *testing.T) {
 	const selfID = "U1"
 	db := setupDBWithWorkspace(t)
-	// Set the channel's last_read_ts to a value AFTER the last reply —
-	// the old heuristic would say "read", but the per-thread LastRead
-	// from thread_subscriptions says "unread".
+	// The per-thread LastRead from thread_subscriptions is the sole
+	// source of truth for thread unread state; the legacy channel-level
+	// last_read_ts heuristic was removed.
 	if err := db.UpsertChannel(Channel{
 		ID: "C1", WorkspaceID: "T1", Name: "general", Type: "channel", IsMember: true,
-		LastReadTS: "1700000999.000000",
 	}); err != nil {
 		t.Fatalf("UpsertChannel: %v", err)
 	}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1786,7 +1786,12 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if !isThreadReply || msg.Message.Subtype == "thread_broadcast" {
 				debuglog.Cache("NewMessageMsg: channel=%s ts=%s decision=mark_unread",
 					msg.ChannelID, msg.Message.TS)
-				a.sidebar.MarkUnread(msg.ChannelID)
+				// The DB write that flips has_unread=true for this
+				// channel already happened in the WS-handler path
+				// (cache.UpdateChannelReadState). Force the sidebar
+				// to re-read read state so the dot appears on the
+				// next render.
+				a.sidebar.Invalidate()
 			} else {
 				debuglog.Cache("NewMessageMsg: channel=%s ts=%s decision=skipped_thread_reply_inactive",
 					msg.ChannelID, msg.Message.TS)
@@ -2096,7 +2101,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case ChannelMarkedReadMsg:
 		debuglog.Cache("ChannelMarkedReadMsg: channel=%s active=%s (optimistic clear)",
 			msg.ChannelID, a.activeChannelID)
-		a.sidebar.ClearUnread(msg.ChannelID)
+		a.sidebar.Invalidate()
 
 	case DMNameResolvedMsg:
 		items := a.sidebar.Items()
@@ -5567,7 +5572,7 @@ func (a *App) applyChannelMark(channelID, ts string, unreadCount int) {
 	if channelID == a.activeChannelID {
 		a.messagepane.SetLastReadTS(ts)
 	}
-	a.sidebar.SetUnreadCount(channelID, unreadCount)
+	a.sidebar.Invalidate()
 }
 
 // applyThreadMark updates local state for a thread-level read-state

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -237,10 +237,6 @@ type (
 		// sidebar reverts to its existing name-keyed buckets).
 		SectionsProvider sidebar.SectionsProvider
 	}
-	WorkspaceUnreadMsg struct {
-		TeamID    string
-		ChannelID string
-	}
 	// ReadStateChangedMsg is sent whenever the persistent read state changes,
 	// so panels that read from cache.GetWorkspaceReadState re-render.
 	// ChannelID may be "" if the change is multi-channel (e.g., batch update
@@ -2217,13 +2213,12 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, func() tea.Msg { return fetcher(team) })
 		}
 
-	case WorkspaceUnreadMsg:
-		a.workspaceRail.SetUnread(msg.TeamID, true)
-
 	case ReadStateChangedMsg:
 		// Persistent read state changed in the cache. Invalidate the
-		// sidebar so the next render re-reads from the DB.
+		// sidebar and refresh the workspace rail so both re-read
+		// from the DB.
 		a.sidebar.Invalidate()
+		a.workspaceRail.RefreshUnreads()
 		return a, nil
 
 	case ConversationOpenedMsg:
@@ -4126,6 +4121,7 @@ func (a *App) SetInitialLastReadTS(ts string) {
 // Setters for external use (wiring services)
 func (a *App) SetWorkspaces(items []workspace.WorkspaceItem) {
 	a.workspaceRail.SetItems(items)
+	a.workspaceRail.RefreshUnreads()
 	a.workspaceItems = items
 	// Update workspace finder items
 	var finderItems []workspacefinder.Item
@@ -4281,6 +4277,13 @@ func (a *App) SetChannelLastReadFetcher(fn func(channelID string) string) {
 // Must be set before the first render for unread dots to appear.
 func (a *App) SetReadStateReader(f func() map[string]cache.ReadState) {
 	a.sidebar.SetReadStateReader(f)
+}
+
+// SetWorkspaceUnreadReader installs the callback the workspace rail
+// uses on RefreshUnreads to learn which workspaces have at least one
+// channel with has_unread=true.
+func (a *App) SetWorkspaceUnreadReader(f func() []string) {
+	a.workspaceRail.SetUnreadReader(f)
 }
 
 // SetChannelVisitRecorder wires the callback that persists a channel

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1786,8 +1786,9 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// channel already happened in the WS-handler path
 				// (cache.UpdateChannelReadState). Force the sidebar
 				// to re-read read state so the dot appears on the
-				// next render.
-				a.sidebar.Invalidate()
+				// next render, and refresh the workspace rail so its
+				// HasUnread flag picks up the change too.
+				a.notifyReadStateChanged()
 			} else {
 				debuglog.Cache("NewMessageMsg: channel=%s ts=%s decision=skipped_thread_reply_inactive",
 					msg.ChannelID, msg.Message.TS)
@@ -2097,7 +2098,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case ChannelMarkedReadMsg:
 		debuglog.Cache("ChannelMarkedReadMsg: channel=%s active=%s (optimistic clear)",
 			msg.ChannelID, a.activeChannelID)
-		a.sidebar.Invalidate()
+		a.notifyReadStateChanged()
 
 	case DMNameResolvedMsg:
 		items := a.sidebar.Items()
@@ -2217,8 +2218,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Persistent read state changed in the cache. Invalidate the
 		// sidebar and refresh the workspace rail so both re-read
 		// from the DB.
-		a.sidebar.Invalidate()
-		a.workspaceRail.RefreshUnreads()
+		a.notifyReadStateChanged()
 		return a, nil
 
 	case ConversationOpenedMsg:
@@ -5561,6 +5561,16 @@ func (a *App) beginEditOfSelected() tea.Cmd {
 	return a.compose.Focus()
 }
 
+// notifyReadStateChanged invalidates the sidebar render cache and
+// refreshes the workspace rail's HasUnread flags. Call this whenever
+// per-channel read state is mutated via the DB API (i.e., wherever
+// a.sidebar.Invalidate() used to suffice). Pairing them prevents the
+// rail from going stale when the sidebar updates.
+func (a *App) notifyReadStateChanged() {
+	a.sidebar.Invalidate()
+	a.workspaceRail.RefreshUnreads()
+}
+
 // applyChannelMark updates local state for a channel-level read-state
 // change (used by both the local mark-unread press and the inbound
 // channel_marked WS event). channelID is the channel; ts is the new
@@ -5575,7 +5585,7 @@ func (a *App) applyChannelMark(channelID, ts string, unreadCount int) {
 	if channelID == a.activeChannelID {
 		a.messagepane.SetLastReadTS(ts)
 	}
-	a.sidebar.Invalidate()
+	a.notifyReadStateChanged()
 }
 
 // applyThreadMark updates local state for a thread-level read-state

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -241,6 +241,14 @@ type (
 		TeamID    string
 		ChannelID string
 	}
+	// ReadStateChangedMsg is sent whenever the persistent read state changes,
+	// so panels that read from cache.GetWorkspaceReadState re-render.
+	// ChannelID may be "" if the change is multi-channel (e.g., batch update
+	// from reconnect catch-up).
+	ReadStateChangedMsg struct {
+		WorkspaceID string
+		ChannelID   string
+	}
 	// ConversationOpenedMsg is sent when Slack delivers an mpim_open,
 	// im_created, group_joined, or channel_joined event. The TeamID
 	// disambiguates events for inactive workspaces; only events whose
@@ -2206,6 +2214,12 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case WorkspaceUnreadMsg:
 		a.workspaceRail.SetUnread(msg.TeamID, true)
+
+	case ReadStateChangedMsg:
+		// Persistent read state changed in the cache. Invalidate the
+		// sidebar so the next render re-reads from the DB.
+		a.sidebar.Invalidate()
+		return a, nil
 
 	case ConversationOpenedMsg:
 		if msg.TeamID == a.activeTeamID {
@@ -4255,6 +4269,13 @@ func (a *App) SetThreadMarker(fn ThreadMarkFunc) {
 // the unread boundary sits when they open a thread. Optional.
 func (a *App) SetChannelLastReadFetcher(fn func(channelID string) string) {
 	a.channelLastReadFetcher = fn
+}
+
+// SetReadStateReader installs a callback the sidebar (and any future
+// readers) will call at render time to fetch per-channel read state.
+// Must be set before the first render for unread dots to appear.
+func (a *App) SetReadStateReader(f func() map[string]cache.ReadState) {
+	a.sidebar.SetReadStateReader(f)
 }
 
 // SetChannelVisitRecorder wires the callback that persists a channel

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -717,7 +717,7 @@ type App struct {
 
 	// Callbacks
 	channelFetcher ChannelFetchFunc
-	// channelReadMarker fires Slack's MarkChannel + cache.UpdateLastReadTS
+	// channelReadMarker fires Slack's MarkChannel + cache.UpdateChannelReadState
 	// for the given channel up to ts. Returns a tea.Msg (typically
 	// ChannelMarkedReadMsg). Wired in cmd/slk/main.go's wireCallbacks.
 	// Tier 1 of ChannelSelectedMsg (cache fresh, no GetHistory) uses this

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -522,7 +522,7 @@ type MessageMarkedUnreadMsg struct {
 // Slack pushes a channel_marked / im_marked / group_marked / mpim_marked
 // event (read state changed in another client, or via this client's own
 // mark echoing back). The handler has already persisted the new
-// last_read_ts to SQLite + the in-memory LastReadMap; the App's
+// last_read_ts to SQLite via cache.UpdateChannelReadState; the App's
 // Update arm only updates the UI. No toast.
 type ChannelMarkedRemoteMsg struct {
 	ChannelID   string
@@ -4214,9 +4214,9 @@ func (a *App) SetMessageDeleter(fn MessageDeleteFunc) {
 
 // SetMessageMarkUnreader wires the conversations.mark / subscriptions.thread.mark
 // callback used by the U key. Implementations should perform the HTTP call
-// best-effort, persist the new last_read_ts to SQLite for channel-level
-// marks (no-op for thread-level until per-thread state lands), update the
-// in-memory LastReadMap, and return MessageMarkedUnreadMsg.
+// best-effort, persist the new last_read_ts to SQLite via
+// cache.UpdateChannelReadState for channel-level marks (no-op for
+// thread-level until per-thread state lands), and return MessageMarkedUnreadMsg.
 func (a *App) SetMessageMarkUnreader(fn MarkUnreadFunc) {
 	a.messageMarkUnreader = fn
 }

--- a/internal/ui/app_bench_test.go
+++ b/internal/ui/app_bench_test.go
@@ -20,10 +20,9 @@ func makeBenchApp() *App {
 	channels := make([]sidebar.ChannelItem, 100)
 	for i := range channels {
 		channels[i] = sidebar.ChannelItem{
-			ID:          fmt.Sprintf("C%d", i),
-			Name:        fmt.Sprintf("channel-%d", i),
-			Type:        "channel",
-			UnreadCount: i % 5,
+			ID:   fmt.Sprintf("C%d", i),
+			Name: fmt.Sprintf("channel-%d", i),
+			Type: "channel",
 		}
 	}
 	a.sidebar.SetItems(channels)

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -2484,6 +2484,13 @@ func TestMessageMarkedUnreadMsg_ChannelLevel_UpdatesPaneSidebarAndToasts(t *test
 		{TS: "3.0", UserID: "U1", Text: "third"},
 	})
 
+	// After the read-state sync rewrite, the sidebar's unread indicator
+	// is driven by the DB (via readStateReader), not by a per-item
+	// UnreadCount that the App layer mutates. The contract is now
+	// "the sidebar was invalidated so the next render re-reads state";
+	// capture the version pre/post to verify that.
+	verBefore := app.sidebar.Version()
+
 	_, cmd := app.Update(MessageMarkedUnreadMsg{
 		ChannelID:   "C1",
 		ThreadTS:    "",
@@ -2505,11 +2512,9 @@ func TestMessageMarkedUnreadMsg_ChannelLevel_UpdatesPaneSidebarAndToasts(t *test
 		t.Errorf("expected messagepane lastReadTS=1.0, got %q", got)
 	}
 
-	// Sidebar count was set.
-	for _, it := range app.sidebar.Items() {
-		if it.ID == "C1" && it.UnreadCount != 2 {
-			t.Errorf("expected sidebar UnreadCount=2, got %d", it.UnreadCount)
-		}
+	// Sidebar was invalidated so the next View() will re-read the DB.
+	if app.sidebar.Version() == verBefore {
+		t.Errorf("expected sidebar.Version() to bump after channel mark, stayed at %d", verBefore)
 	}
 }
 
@@ -2627,6 +2632,10 @@ func TestChannelMarkedRemoteMsg_UpdatesPaneAndSidebarSilently(t *testing.T) {
 		{TS: "2.0", UserID: "U1", Text: "second"},
 	})
 
+	// Sidebar invalidation contract (read-state sync rewrite): App
+	// flips sidebar.version; the next View() re-reads the DB.
+	verBefore := app.sidebar.Version()
+
 	_, cmd := app.Update(ChannelMarkedRemoteMsg{
 		ChannelID:   "C1",
 		TS:          "1.0",
@@ -2641,10 +2650,8 @@ func TestChannelMarkedRemoteMsg_UpdatesPaneAndSidebarSilently(t *testing.T) {
 	if got := app.messagepane.LastReadTS(); got != "1.0" {
 		t.Errorf("messagepane lastReadTS: got %q", got)
 	}
-	for _, it := range app.sidebar.Items() {
-		if it.ID == "C1" && it.UnreadCount != 1 {
-			t.Errorf("sidebar UnreadCount: got %d", it.UnreadCount)
-		}
+	if app.sidebar.Version() == verBefore {
+		t.Errorf("expected sidebar.Version() to bump after remote channel mark, stayed at %d", verBefore)
 	}
 }
 
@@ -2656,6 +2663,7 @@ func TestChannelMarkedRemoteMsg_InactiveChannel_OnlyUpdatesSidebar(t *testing.T)
 		{ID: "C_OTHER", Name: "elsewhere", Section: "Channels"},
 	})
 	prevLastRead := app.messagepane.LastReadTS()
+	verBefore := app.sidebar.Version()
 
 	_, _ = app.Update(ChannelMarkedRemoteMsg{
 		ChannelID: "C1", TS: "1.0", UnreadCount: 3,
@@ -2665,11 +2673,10 @@ func TestChannelMarkedRemoteMsg_InactiveChannel_OnlyUpdatesSidebar(t *testing.T)
 	if app.messagepane.LastReadTS() != prevLastRead {
 		t.Error("messagepane should be untouched when remote event is for non-active channel")
 	}
-	// Sidebar still updated.
-	for _, it := range app.sidebar.Items() {
-		if it.ID == "C1" && it.UnreadCount != 3 {
-			t.Errorf("expected C1 sidebar UnreadCount=3, got %d", it.UnreadCount)
-		}
+	// Sidebar still receives the invalidate signal so the next render
+	// reflects the new DB state for C1.
+	if app.sidebar.Version() == verBefore {
+		t.Errorf("expected sidebar.Version() to bump after remote channel mark, stayed at %d", verBefore)
 	}
 }
 
@@ -2729,24 +2736,33 @@ func TestConversationOpenedMsg_SidebarReceivesItemAndUnread(t *testing.T) {
 		},
 	})
 
+	// Capture sidebar version so we can verify the inbound NewMessageMsg
+	// invalidates the render cache. After the read-state sync rewrite,
+	// the App layer no longer mutates a per-channel UnreadCount on the
+	// sidebar — the DB write happens in the WS handler (OnMessage), and
+	// App.Update merely invalidates the sidebar so the next render
+	// re-reads has_unread from the DB.
+	verBefore := app.sidebar.Version()
+
 	// Then a message arrives for that mpdm while the user is elsewhere.
 	app.Update(NewMessageMsg{
 		ChannelID: "G1",
 		Message:   messages.MessageItem{TS: "1700000001.000000", UserID: "U2", Text: "hi"},
 	})
 
-	// The sidebar should now show G1 with UnreadCount > 0.
+	// G1 must be present in the sidebar (from the ConversationOpenedMsg)
+	// and the sidebar must have been invalidated by NewMessageMsg.
 	found := false
 	for _, it := range app.sidebar.AllItems() {
 		if it.ID == "G1" {
 			found = true
-			if it.UnreadCount < 1 {
-				t.Errorf("G1 UnreadCount = %d, want >= 1", it.UnreadCount)
-			}
 		}
 	}
 	if !found {
 		t.Errorf("G1 not in sidebar after ConversationOpenedMsg")
+	}
+	if app.sidebar.Version() == verBefore {
+		t.Errorf("expected sidebar.Version() to bump after inactive-channel NewMessageMsg, stayed at %d", verBefore)
 	}
 }
 

--- a/internal/ui/sidebar/bench_test.go
+++ b/internal/ui/sidebar/bench_test.go
@@ -11,10 +11,9 @@ func BenchmarkViewScroll(b *testing.B) {
 	channels := make([]ChannelItem, 100)
 	for i := range channels {
 		channels[i] = ChannelItem{
-			ID:          fmt.Sprintf("C%d", i),
-			Name:        fmt.Sprintf("channel-%d", i),
-			Type:        "channel",
-			UnreadCount: i % 5,
+			ID:   fmt.Sprintf("C%d", i),
+			Name: fmt.Sprintf("channel-%d", i),
+			Type: "channel",
 		}
 		if i%10 == 0 {
 			channels[i].Type = "dm"

--- a/internal/ui/sidebar/collapse_test.go
+++ b/internal/ui/sidebar/collapse_test.go
@@ -3,6 +3,8 @@ package sidebar
 import (
 	"strings"
 	"testing"
+
+	"github.com/gammons/slk/internal/cache"
 )
 
 func TestNew_DefaultCollapsesChannelsSection(t *testing.T) {
@@ -95,18 +97,27 @@ func TestNavigation_SkipsCollapsedSectionItems(t *testing.T) {
 
 func TestCollapsedHeader_ShowsAggregateUnreadBadge(t *testing.T) {
 	m := New([]ChannelItem{
-		{ID: "C1", Name: "general", Type: "channel", UnreadCount: 2},
-		{ID: "C2", Name: "random", Type: "channel", UnreadCount: 5},
+		{ID: "C1", Name: "general", Type: "channel"},
+		{ID: "C2", Name: "random", Type: "channel"},
 	})
-	// Channels is collapsed by default; aggregate badge should sum to 7.
+	// After the read-state sync rewrite, the aggregate counts
+	// channels-with-unreads (not the sum of per-channel counts), and
+	// the DB (read via readStateReader) is the source of truth.
+	m.SetReadStateReader(func() map[string]cache.ReadState {
+		return map[string]cache.ReadState{
+			"C1": {HasUnread: true},
+			"C2": {HasUnread: true},
+		}
+	})
+	// Channels is collapsed by default; aggregate badge should count 2.
 	view := m.View(15, 30)
-	if !strings.Contains(view, "•7") {
-		t.Errorf("collapsed header should show aggregate badge •7, got:\n%s", view)
+	if !strings.Contains(view, "•2") {
+		t.Errorf("collapsed header should show aggregate badge •2, got:\n%s", view)
 	}
 	// Expand, the badge disappears (per-channel dots take over).
 	m.ToggleCollapse("Channels")
 	view = m.View(15, 30)
-	if strings.Contains(view, "•7") {
+	if strings.Contains(view, "•2") {
 		t.Errorf("expanded header should not carry an aggregate badge:\n%s", view)
 	}
 }

--- a/internal/ui/sidebar/model.go
+++ b/internal/ui/sidebar/model.go
@@ -8,7 +8,6 @@ import (
 
 	"charm.land/lipgloss/v2"
 	"github.com/gammons/slk/internal/cache"
-	"github.com/gammons/slk/internal/debuglog"
 	"github.com/gammons/slk/internal/ui/messages"
 	"github.com/gammons/slk/internal/ui/styles"
 	kyoemoji "github.com/kyokomi/emoji/v2"
@@ -734,72 +733,6 @@ func (m *Model) VisibleItems() []ChannelItem {
 	return result
 }
 
-// MarkUnread increments the unread count for the given channel by 1.
-// No-op if the channel is not in the sidebar's items. Re-runs the filter
-// so a previously stale-hidden channel becomes visible again as soon as
-// its UnreadCount becomes non-zero (the staleness filter exempts items
-// with UnreadCount > 0).
-func (m *Model) MarkUnread(channelID string) {
-	for i := range m.items {
-		if m.items[i].ID == channelID {
-			before := m.items[i].UnreadCount
-			m.items[i].UnreadCount++
-			debuglog.Cache("sidebar.MarkUnread: channel=%s name=%q before=%d after=%d muted=%v",
-				channelID, m.items[i].Name, before, m.items[i].UnreadCount, m.items[i].IsMuted)
-			m.rebuildFilter()
-			m.rebuildNavPreserveCursor()
-			m.cacheValid = false
-			m.dirty()
-			return
-		}
-	}
-}
-
-// ClearUnread sets the unread count to 0 for the given channel.
-func (m *Model) ClearUnread(channelID string) {
-	for i := range m.items {
-		if m.items[i].ID == channelID {
-			before := m.items[i].UnreadCount
-			debuglog.Cache("sidebar.ClearUnread: channel=%s name=%q before=%d after=0 muted=%v",
-				channelID, m.items[i].Name, before, m.items[i].IsMuted)
-			if m.items[i].UnreadCount != 0 {
-				m.items[i].UnreadCount = 0
-				m.cacheValid = false
-				m.dirty()
-			}
-			return
-		}
-	}
-}
-
-// SetUnreadCount sets the unread count for the given channel to an exact
-// value (use n=0 to clear). Re-runs the staleness filter so a channel that
-// becomes unread reappears in the sidebar (the staleness rule exempts items
-// with UnreadCount > 0). No-op if the channel is not in the sidebar.
-//
-// Differs from MarkUnread (which only increments by 1) and ClearUnread
-// (which only sets to 0): this setter is used by mark-unread and by the
-// channel_marked WS event reconciliation, both of which know the desired
-// final count.
-func (m *Model) SetUnreadCount(channelID string, n int) {
-	for i := range m.items {
-		if m.items[i].ID == channelID {
-			before := m.items[i].UnreadCount
-			debuglog.Cache("sidebar.SetUnreadCount: channel=%s name=%q before=%d after=%d muted=%v",
-				channelID, m.items[i].Name, before, n, m.items[i].IsMuted)
-			if m.items[i].UnreadCount == n {
-				return
-			}
-			m.items[i].UnreadCount = n
-			m.rebuildFilter()
-			m.rebuildNavPreserveCursor()
-			m.cacheValid = false
-			m.dirty()
-			return
-		}
-	}
-}
-
 // UpdatePresenceByUser updates the presence for any DM item whose DMUserID matches.
 func (m *Model) UpdatePresenceByUser(userID, presence string) {
 	for i := range m.items {
@@ -981,13 +914,22 @@ func (m *Model) rebuildNavPreserveCursor() {
 	m.cursor = 0
 }
 
-// aggregateUnreadForSection returns the sum of UnreadCount across every
-// item in the named section that is currently in m.filtered. Used to
-// render an aggregate badge on collapsed section headers. Muted
-// channels are excluded so the aggregate matches the per-row treatment
-// (no dot, dim foreground) — the user has explicitly asked Slack to
-// ignore those channels' unread activity.
+// aggregateUnreadForSection returns the count of channels-with-unreads
+// in the named section that are currently in m.filtered. Used to render
+// an aggregate badge on collapsed section headers. Muted channels are
+// excluded so the aggregate matches the per-row treatment (no dot, dim
+// foreground) — the user has explicitly asked Slack to ignore those
+// channels' unread activity.
+//
+// After the read-state sync rewrite, integer unread counts are
+// abandoned in favor of a boolean has_unread per channel; section
+// aggregates count channels-with-unreads instead of summing per-channel
+// counts. The DB (read via readStateReader) is the source of truth.
 func (m *Model) aggregateUnreadForSection(section string) int {
+	var readState map[string]cache.ReadState
+	if m.readStateReader != nil {
+		readState = m.readStateReader()
+	}
 	total := 0
 	for _, idx := range m.filtered {
 		item := m.items[idx]
@@ -997,7 +939,9 @@ func (m *Model) aggregateUnreadForSection(section string) int {
 		if m.sectionFor(item) != section {
 			continue
 		}
-		total += item.UnreadCount
+		if readState[item.ID].HasUnread {
+			total++
+		}
 	}
 	return total
 }
@@ -1039,6 +983,16 @@ func (m *Model) buildCache(width int) {
 	m.cacheWidth = width
 	m.cacheRows = m.cacheRows[:0]
 	m.cacheFiller = lipgloss.NewStyle().Width(width).Background(styles.SidebarBackground).Render("")
+
+	// Per-channel read state for the active workspace. The DB is the
+	// source of truth for unread indicators; ChannelItem.UnreadCount
+	// is no longer consulted by rendering. A nil reader (early
+	// construction, tests without wiring) means "treat everything as
+	// no-unread" — lookups on a nil map return the zero ReadState.
+	var readState map[string]cache.ReadState
+	if m.readStateReader != nil {
+		readState = m.readStateReader()
+	}
 
 	// Reverse-index nav by section name and by filter idx so we can map
 	// each rendered row back to its nav index. Headers are uniquely
@@ -1166,13 +1120,18 @@ func (m *Model) buildCache(width int) {
 			continue
 		}
 
+		// hasUnread is the rendering-facing boolean: "should this row
+		// pop visually?" It's a function of the DB's has_unread for
+		// this channel AND the user's mute pref. Muted channels never
+		// pop, even when they have new messages — Slack's contract is
+		// "muted = no notification surface". The dimmer ChannelMuted
+		// style below distinguishes muted-with-unreads from a fully
+		// read row visually.
+		hasUnread := readState[item.ID].HasUnread && !item.IsMuted
+
 		// Unread dot indicator (same regardless of selection state).
-		// Muted channels never get the dot — Slack's contract is "muted
-		// = no notification surface", so even unread activity should not
-		// pull the eye. The dimmer ChannelMuted style below distinguishes
-		// muted-with-unreads from a fully read row.
 		unreadDot := " "
-		if item.UnreadCount > 0 && !item.IsMuted {
+		if hasUnread {
 			unreadDot = unreadDotStr
 		}
 
@@ -1189,13 +1148,13 @@ func (m *Model) buildCache(width int) {
 		case "private":
 			// Muted channels use the plain glyph regardless of unread
 			// state so the row reads as quiet across all of its parts.
-			if item.UnreadCount > 0 && !item.IsMuted {
+			if hasUnread {
 				prefix = privatePrefix
 			} else {
 				prefix = privatePrefixMuted
 			}
 		case "app":
-			if item.UnreadCount > 0 && !item.IsMuted {
+			if hasUnread {
 				prefix = appPrefix
 			} else {
 				prefix = appPrefixMuted
@@ -1250,11 +1209,11 @@ func (m *Model) buildCache(width int) {
 		// renders visibly brighter than read public channels which
 		// have no inline ANSI in their prefix at all.
 		boldAttr := ""
-		if item.UnreadCount > 0 && !item.IsMuted {
+		if hasUnread {
 			boldAttr = "\x1b[1m"
 		}
 		normalFg := messages.SidebarMutedFgANSI()
-		if item.UnreadCount > 0 && !item.IsMuted {
+		if hasUnread {
 			normalFg = messages.SidebarFgANSI()
 		}
 		normalAttrs := messages.SidebarBgANSI() + normalFg + boldAttr
@@ -1265,12 +1224,13 @@ func (m *Model) buildCache(width int) {
 
 		// Pick base style for non-selected state. Muted always wins
 		// over Unread/Normal so muted-with-unreads renders dim, not
-		// bright-and-bold.
+		// bright-and-bold. (hasUnread already excludes muted, but
+		// keep the explicit IsMuted arm first for clarity.)
 		var baseStyle lipgloss.Style
 		switch {
 		case item.IsMuted:
 			baseStyle = styles.ChannelMuted
-		case item.UnreadCount > 0:
+		case hasUnread:
 			baseStyle = styles.ChannelUnread
 		default:
 			baseStyle = styles.ChannelNormal
@@ -1356,7 +1316,8 @@ func (m *Model) sectionDisplayMeta(sectionKey string) (name, emoji string) {
 // renderSectionHeaderLabel returns the (normal, selected) label
 // strings for a section header. Headers show a triangle indicating
 // expand/collapse state and, when collapsed, an aggregate unread badge
-// summing UnreadCount across every visible item in the section.
+// counting channels-with-unreads across every visible item in the
+// section (sourced from the read-state DB via readStateReader).
 //
 // In Slack mode, the `name` parameter is a section ID — we look up the
 // user-visible name and (if any) emoji shortcode from the provider and

--- a/internal/ui/sidebar/model.go
+++ b/internal/ui/sidebar/model.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"charm.land/lipgloss/v2"
+	"github.com/gammons/slk/internal/cache"
 	"github.com/gammons/slk/internal/debuglog"
 	"github.com/gammons/slk/internal/ui/messages"
 	"github.com/gammons/slk/internal/ui/styles"
@@ -196,6 +197,11 @@ type Model struct {
 	// orderedSections function returns the provider's verbatim order
 	// and headers are keyed by section ID instead of name.
 	sectionsProvider SectionsProvider
+	// readStateReader returns the per-channel read state map for the
+	// active workspace, keyed by channel ID. Set by App via
+	// SetReadStateReader. May be nil — nil means "treat everything as
+	// no-unread" (used during early construction).
+	readStateReader func() map[string]cache.ReadState
 	// collapseByID parallels `collapsed` for Slack-mode (ID-keyed).
 	// Renames preserve collapse state because the ID is stable.
 	// Populated lazily; lookups treat nil as empty. Used in Task 9.
@@ -261,6 +267,23 @@ func (m *Model) SetSectionsProvider(p SectionsProvider) {
 	m.sectionsProvider = p
 	m.rebuildFilter()
 	m.rebuildNavPreserveCursor()
+	m.cacheValid = false
+	m.dirty()
+}
+
+// SetReadStateReader installs a callback that returns the per-channel
+// read state map for the workspace currently presented by this sidebar.
+// Called by View() at render time. Setting it invalidates the row cache
+// so the next render reflects the new source.
+func (m *Model) SetReadStateReader(f func() map[string]cache.ReadState) {
+	m.readStateReader = f
+	m.cacheValid = false
+	m.dirty()
+}
+
+// Invalidate forces the next View() call to re-read read state from
+// the installed reader. Called by App.Update on ReadStateChangedMsg.
+func (m *Model) Invalidate() {
 	m.cacheValid = false
 	m.dirty()
 }

--- a/internal/ui/sidebar/model.go
+++ b/internal/ui/sidebar/model.go
@@ -26,19 +26,14 @@ const (
 )
 
 type ChannelItem struct {
-	ID            string
-	Name          string
-	Type          string // channel, dm, group_dm, private, app
-	Section       string // section name for grouping (e.g. "Engineering", "Starred")
-	SectionOrder  int    // sort order from config; lower = higher in sidebar (custom sections only)
-	UnreadCount   int
-	IsStarred     bool
-	Presence      string // for DMs: active, away, dnd
-	DMUserID      string // for DMs: the user ID of the other party
-	// LastReadTS is the Slack-format timestamp of the user's last
-	// read marker for this channel ("1700000001.000000"). Used by
-	// the staleness filter; empty means "never read" or "no signal".
-	LastReadTS string
+	ID           string
+	Name         string
+	Type         string // channel, dm, group_dm, private, app
+	Section      string // section name for grouping (e.g. "Engineering", "Starred")
+	SectionOrder int    // sort order from config; lower = higher in sidebar (custom sections only)
+	IsStarred    bool
+	Presence     string // for DMs: active, away, dnd
+	DMUserID     string // for DMs: the user ID of the other party
 	// IsMuted reports whether the user has muted this channel (via
 	// Slack's muted_channels user pref). Muted channels render with a
 	// dimmer foreground and suppress their unread dot; they also do
@@ -206,7 +201,8 @@ type Model struct {
 	// Populated lazily; lookups treat nil as empty. Used in Task 9.
 	collapseByID map[string]bool
 
-	// Staleness filter: items whose LastReadTS is older than
+	// Staleness filter: items whose last_read_ts (from the read-state
+	// DB, fetched via readStateReader in rebuildFilter) is older than
 	// staleThreshold are dropped from `filtered` (i.e. hidden from the
 	// rendered sidebar). 0 disables the feature. activeID names the
 	// channel currently displayed in the message pane and is always
@@ -587,11 +583,11 @@ func (m *Model) SetItems(items []ChannelItem) {
 }
 
 // UpsertItem inserts a new ChannelItem keyed by ID, or updates an existing
-// item in place if the ID is already present. On update, all fields EXCEPT
-// UnreadCount and LastReadTS are overwritten from the supplied item; those
-// two are preserved because Slack's mpim_open / im_created / group_joined
-// payloads do not carry unread state, so clobbering would erase live
-// indicators we want to keep visible.
+// item in place if the ID is already present. On update, all descriptive
+// fields are overwritten from the supplied item. Read state (HasUnread,
+// LastReadTS) is no longer mirrored on ChannelItem -- it lives exclusively
+// in the read-state DB and is read at render time via the readStateReader
+// callback, so there's nothing to preserve here.
 //
 // Re-runs the staleness filter so a freshly-added item (or one whose
 // staleness state may have changed) is reflected in the visible list
@@ -599,12 +595,7 @@ func (m *Model) SetItems(items []ChannelItem) {
 func (m *Model) UpsertItem(item ChannelItem) {
 	for i := range m.items {
 		if m.items[i].ID == item.ID {
-			// Preserve unread/last-read; overwrite descriptive fields.
-			preservedUnread := m.items[i].UnreadCount
-			preservedLastRead := m.items[i].LastReadTS
 			m.items[i] = item
-			m.items[i].UnreadCount = preservedUnread
-			m.items[i].LastReadTS = preservedLastRead
 			m.rebuildFilter()
 			m.rebuildNavPreserveCursor()
 			m.cacheValid = false
@@ -793,6 +784,15 @@ func (m *Model) rebuildFilter() {
 	m.filtered = nil
 	lower := strings.ToLower(m.filter)
 	now := m.now()
+	// Fetch read state once for the whole filter pass so IsStale can
+	// see the same hasUnread/lastReadTS the rest of the sidebar does.
+	// nil-safe: when no reader is installed (early construction, some
+	// tests) every lookup returns the zero value and IsStale's
+	// type-aware empty-LastReadTS branch handles it.
+	var readState map[string]cache.ReadState
+	if m.readStateReader != nil {
+		readState = m.readStateReader()
+	}
 	for i, item := range m.items {
 		if m.filter != "" && !strings.Contains(strings.ToLower(item.Name), lower) {
 			continue
@@ -800,7 +800,8 @@ func (m *Model) rebuildFilter() {
 		// Staleness filter: drop items the user hasn't read in a long
 		// time, with the active channel always exempt so it can't
 		// disappear out from under them.
-		if item.ID != m.activeID && IsStale(item, m.staleThreshold, now) {
+		state := readState[item.ID]
+		if item.ID != m.activeID && IsStale(item, state.HasUnread, state.LastReadTS, m.staleThreshold, now) {
 			continue
 		}
 		m.filtered = append(m.filtered, i)

--- a/internal/ui/sidebar/model_test.go
+++ b/internal/ui/sidebar/model_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gammons/slk/internal/cache"
 	"github.com/gammons/slk/internal/ui/messages"
 )
 
@@ -197,71 +198,6 @@ func TestThreadsItem_SelectByIDClearsThreadsSelection(t *testing.T) {
 	}
 }
 
-func TestMarkUnread_IncrementsCount(t *testing.T) {
-	m := New([]ChannelItem{
-		{ID: "C1", Name: "general", Type: "channel", UnreadCount: 0},
-		{ID: "C2", Name: "random", Type: "channel", UnreadCount: 2},
-	})
-	m.MarkUnread("C1")
-	if got := m.Items()[0].UnreadCount; got != 1 {
-		t.Errorf("MarkUnread should bump UnreadCount from 0 to 1, got %d", got)
-	}
-	m.MarkUnread("C2")
-	if got := m.Items()[1].UnreadCount; got != 3 {
-		t.Errorf("MarkUnread should bump existing count from 2 to 3, got %d", got)
-	}
-}
-
-func TestMarkUnread_BumpsVersionAndInvalidatesCache(t *testing.T) {
-	m := New([]ChannelItem{{ID: "C1", Name: "general", Type: "channel"}})
-	// Prime the cache.
-	_ = m.View(10, 30)
-	v1 := m.Version()
-	m.MarkUnread("C1")
-	v2 := m.Version()
-	if v2 == v1 {
-		t.Errorf("MarkUnread should bump version, got %d -> %d", v1, v2)
-	}
-}
-
-func TestMarkUnread_UnknownChannelIsNoop(t *testing.T) {
-	m := New([]ChannelItem{{ID: "C1", Name: "general", Type: "channel"}})
-	v1 := m.Version()
-	m.MarkUnread("C-does-not-exist")
-	v2 := m.Version()
-	if v1 != v2 {
-		t.Errorf("MarkUnread on unknown channel should not bump version, got %d -> %d", v1, v2)
-	}
-}
-
-func TestMarkUnread_RendersDotAndBold(t *testing.T) {
-	m := New([]ChannelItem{{ID: "C1", Name: "general", Type: "channel", UnreadCount: 0}})
-	// Expand Channels so the channel row itself is rendered (otherwise
-	// the unread bump only changes the aggregate badge on the header).
-	m.ToggleCollapse("Channels")
-	before := m.View(10, 30)
-	// Find the line for "general" before bumping.
-	var beforeLine string
-	for _, line := range strings.Split(before, "\n") {
-		if strings.Contains(line, "general") {
-			beforeLine = line
-			break
-		}
-	}
-	m.MarkUnread("C1")
-	after := m.View(10, 30)
-	var afterLine string
-	for _, line := range strings.Split(after, "\n") {
-		if strings.Contains(line, "general") {
-			afterLine = line
-			break
-		}
-	}
-	if beforeLine == afterLine {
-		t.Errorf("expected sidebar render to change after MarkUnread; before=%q after=%q", beforeLine, afterLine)
-	}
-}
-
 func TestSidebarFilter(t *testing.T) {
 	channels := []ChannelItem{
 		{ID: "C1", Name: "general", Type: "channel"},
@@ -284,55 +220,6 @@ func TestSidebarFilter(t *testing.T) {
 	visible = m.VisibleItems()
 	if len(visible) != 3 {
 		t.Errorf("expected 3 items after clear filter, got %d", len(visible))
-	}
-}
-
-func TestSetUnreadCount_SetsExactValue(t *testing.T) {
-	m := New([]ChannelItem{
-		{ID: "C1", Name: "general", Section: "Channels"},
-	})
-
-	m.SetUnreadCount("C1", 7)
-
-	for _, it := range m.Items() {
-		if it.ID == "C1" {
-			if it.UnreadCount != 7 {
-				t.Errorf("expected UnreadCount=7, got %d", it.UnreadCount)
-			}
-			return
-		}
-	}
-	t.Fatal("C1 not found in items")
-}
-
-func TestSetUnreadCount_Zero_ClearsBadge(t *testing.T) {
-	m := New([]ChannelItem{{ID: "C1", Name: "general", Section: "Channels"}})
-	m.MarkUnread("C1")
-	m.MarkUnread("C1")
-	// preconditions: count is 2.
-
-	m.SetUnreadCount("C1", 0)
-
-	for _, it := range m.Items() {
-		if it.ID == "C1" {
-			if it.UnreadCount != 0 {
-				t.Errorf("expected UnreadCount=0, got %d", it.UnreadCount)
-			}
-			return
-		}
-	}
-}
-
-func TestSetUnreadCount_UnknownChannel_NoOp(t *testing.T) {
-	m := New([]ChannelItem{{ID: "C1", Name: "general", Section: "Channels"}})
-
-	// Should not panic, should not affect existing items.
-	m.SetUnreadCount("CDOESNOTEXIST", 5)
-
-	for _, it := range m.Items() {
-		if it.ID == "C1" && it.UnreadCount != 0 {
-			t.Errorf("untouched item changed: %d", it.UnreadCount)
-		}
 	}
 }
 
@@ -378,27 +265,13 @@ func TestUpsertItem_UpdatesExistingChannel(t *testing.T) {
 	}
 }
 
-func TestUpsertItem_ThenMarkUnread(t *testing.T) {
-	m := New(nil)
-	m.SetItems([]ChannelItem{{ID: "C1", Name: "general", Type: "channel"}})
-	// Simulate the bug scenario: a new mpdm shows up via mpim_open,
-	// then a message arrives. MarkUnread must successfully bump the
-	// count on the freshly-upserted item.
-	m.UpsertItem(ChannelItem{ID: "G1", Name: "alice, bob", Type: "group_dm"})
-	m.MarkUnread("G1")
-
-	items := m.AllItems()
-	for _, it := range items {
-		if it.ID == "G1" && it.UnreadCount != 1 {
-			t.Errorf("G1 UnreadCount = %d, want 1", it.UnreadCount)
-		}
-	}
-}
-
 func TestRender_UnreadDMRow_KeepsBoldAfterPrefixReset(t *testing.T) {
 	m := New(nil)
 	m.SetItems([]ChannelItem{
-		{ID: "D1", Name: "alice", Type: "dm", Presence: "active", UnreadCount: 1},
+		{ID: "D1", Name: "alice", Type: "dm", Presence: "active"},
+	})
+	m.SetReadStateReader(func() map[string]cache.ReadState {
+		return map[string]cache.ReadState{"D1": {HasUnread: true}}
 	})
 
 	out := m.View(20, 40)
@@ -541,7 +414,10 @@ func TestRender_ReadDMRow_RestoresMutedFgAfterPrefixReset(t *testing.T) {
 func TestRender_UnreadDMRow_RestoresBrightFgAfterPrefixReset(t *testing.T) {
 	m := New(nil)
 	m.SetItems([]ChannelItem{
-		{ID: "D1", Name: "alice", Type: "dm", Presence: "active", UnreadCount: 1},
+		{ID: "D1", Name: "alice", Type: "dm", Presence: "active"},
+	})
+	m.SetReadStateReader(func() map[string]cache.ReadState {
+		return map[string]cache.ReadState{"D1": {HasUnread: true}}
 	})
 	out := m.View(20, 40)
 
@@ -773,5 +649,51 @@ func TestCollapseByID_IndependentFromConfigMode(t *testing.T) {
 	// but a custom "A" name has not been touched so it should be expanded.
 	if m.IsCollapsed("A") {
 		t.Errorf("collapse state for ID 'A' bled into config mode")
+	}
+}
+
+// TestView_RendersDotFromReadStateReader confirms the unread dot
+// indicator is driven by the readStateReader callback (the DB),
+// not by ChannelItem.UnreadCount. C1 has HasUnread=true via the
+// reader so its row should render the "●" glyph; C2 has
+// HasUnread=false and should not.
+func TestView_RendersDotFromReadStateReader(t *testing.T) {
+	m := New([]ChannelItem{
+		{ID: "C1", Name: "general", Type: "channel"},
+		{ID: "C2", Name: "random", Type: "channel"},
+	})
+	// Channels section starts collapsed by default; expand so the
+	// per-row dots are rendered (the collapsed-header aggregate
+	// badge uses a different glyph "•").
+	m.ToggleCollapse("Channels")
+	m.SetReadStateReader(func() map[string]cache.ReadState {
+		return map[string]cache.ReadState{
+			"C1": {HasUnread: true},
+			"C2": {HasUnread: false},
+		}
+	})
+
+	out := m.View(20, 30)
+	dotCount := strings.Count(out, "●")
+	if dotCount != 1 {
+		t.Errorf("expected exactly 1 unread dot, got %d. Output:\n%s", dotCount, out)
+	}
+}
+
+// TestView_MutedChannelNoDot confirms that a muted channel never
+// renders the unread dot even when HasUnread=true. Slack's contract:
+// muted = no notification surface.
+func TestView_MutedChannelNoDot(t *testing.T) {
+	m := New([]ChannelItem{
+		{ID: "C1", Name: "noisy", Type: "channel", IsMuted: true},
+	})
+	m.ToggleCollapse("Channels")
+	m.SetReadStateReader(func() map[string]cache.ReadState {
+		return map[string]cache.ReadState{"C1": {HasUnread: true}}
+	})
+
+	out := m.View(20, 30)
+	if strings.Count(out, "●") != 0 {
+		t.Errorf("muted channel should not show a dot. Output:\n%s", out)
 	}
 }

--- a/internal/ui/sidebar/model_test.go
+++ b/internal/ui/sidebar/model_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestSidebarView(t *testing.T) {
 	channels := []ChannelItem{
-		{ID: "C1", Name: "general", Type: "channel", UnreadCount: 0},
-		{ID: "C2", Name: "random", Type: "channel", UnreadCount: 3},
+		{ID: "C1", Name: "general", Type: "channel"},
+		{ID: "C2", Name: "random", Type: "channel"},
 		{ID: "C3", Name: "alice", Type: "dm", Presence: "active"},
 	}
 
@@ -246,7 +246,7 @@ func TestUpsertItem_AddsNewChannel(t *testing.T) {
 
 func TestUpsertItem_UpdatesExistingChannel(t *testing.T) {
 	m := New(nil)
-	m.SetItems([]ChannelItem{{ID: "G1", Name: "old name", Type: "group_dm", UnreadCount: 3}})
+	m.SetItems([]ChannelItem{{ID: "G1", Name: "old name", Type: "group_dm"}})
 
 	m.UpsertItem(ChannelItem{ID: "G1", Name: "new name", Type: "group_dm"})
 
@@ -257,12 +257,13 @@ func TestUpsertItem_UpdatesExistingChannel(t *testing.T) {
 	if items[0].Name != "new name" {
 		t.Errorf("Name = %q, want %q", items[0].Name, "new name")
 	}
-	// UnreadCount must be preserved on update — Slack's mpim_open does
-	// not carry unread state, and clobbering a live count to 0 would
-	// erase the indicator we're trying to fix.
-	if items[0].UnreadCount != 3 {
-		t.Errorf("UnreadCount = %d, want 3 (preserved)", items[0].UnreadCount)
-	}
+	// Read state (HasUnread, LastReadTS) used to live on ChannelItem
+	// and needed preservation across upserts because Slack's mpim_open
+	// / im_created / group_joined payloads don't carry it. Those
+	// fields are gone now -- the read-state DB is the single source of
+	// truth -- so there's nothing for UpsertItem to preserve and
+	// nothing to assert here beyond the descriptive-field overwrite
+	// above.
 }
 
 func TestRender_UnreadDMRow_KeepsBoldAfterPrefixReset(t *testing.T) {
@@ -294,7 +295,7 @@ func TestRender_UnreadDMRow_KeepsBoldAfterPrefixReset(t *testing.T) {
 func TestRender_ReadDMRow_DoesNotEmitBoldAfterReset(t *testing.T) {
 	m := New(nil)
 	m.SetItems([]ChannelItem{
-		{ID: "D1", Name: "alice", Type: "dm", Presence: "active", UnreadCount: 0},
+		{ID: "D1", Name: "alice", Type: "dm", Presence: "active"},
 	})
 
 	out := m.View(20, 40)
@@ -376,7 +377,7 @@ func TestRender_ReadThreadsRow_DoesNotEmitBoldAfterReset(t *testing.T) {
 func TestRender_ReadDMRow_RestoresMutedFgAfterPrefixReset(t *testing.T) {
 	m := New(nil)
 	m.SetItems([]ChannelItem{
-		{ID: "D1", Name: "alice", Type: "dm", Presence: "active", UnreadCount: 0},
+		{ID: "D1", Name: "alice", Type: "dm", Presence: "active"},
 	})
 	out := m.View(20, 40)
 
@@ -452,7 +453,7 @@ func TestRender_UnreadDMRow_RestoresBrightFgAfterPrefixReset(t *testing.T) {
 func TestRender_ReadGroupDMRow_RestoresMutedFgAfterPrefixReset(t *testing.T) {
 	m := New(nil)
 	m.SetItems([]ChannelItem{
-		{ID: "G1", Name: "design-trio", Type: "group_dm", UnreadCount: 0},
+		{ID: "G1", Name: "design-trio", Type: "group_dm"},
 	})
 	out := m.View(20, 40)
 

--- a/internal/ui/sidebar/muted_test.go
+++ b/internal/ui/sidebar/muted_test.go
@@ -3,6 +3,8 @@ package sidebar
 import (
 	"strings"
 	"testing"
+
+	"github.com/gammons/slk/internal/cache"
 )
 
 // The unread blue dot is "●" (U+25CF). Muted-with-unreads channels
@@ -11,7 +13,10 @@ import (
 // muted row has activity, not the dot.
 func TestMutedChannel_SuppressesUnreadDot(t *testing.T) {
 	m := New([]ChannelItem{
-		{ID: "C1", Name: "noisy", Type: "channel", UnreadCount: 5, IsMuted: true},
+		{ID: "C1", Name: "noisy", Type: "channel", IsMuted: true},
+	})
+	m.SetReadStateReader(func() map[string]cache.ReadState {
+		return map[string]cache.ReadState{"C1": {HasUnread: true}}
 	})
 	m.ToggleCollapse("Channels") // expand so the row renders
 	view := m.View(10, 30)
@@ -31,12 +36,14 @@ func TestMutedChannel_SuppressesUnreadDot(t *testing.T) {
 	}
 }
 
-// Sanity: an unmuted channel with the same unread count *does* get
-// the dot. Guards against the suppression accidentally firing for
-// every row.
+// Sanity: an unmuted channel with unreads *does* get the dot. Guards
+// against the suppression accidentally firing for every row.
 func TestUnmutedChannel_StillGetsUnreadDot(t *testing.T) {
 	m := New([]ChannelItem{
-		{ID: "C1", Name: "noisy", Type: "channel", UnreadCount: 5, IsMuted: false},
+		{ID: "C1", Name: "noisy", Type: "channel", IsMuted: false},
+	})
+	m.SetReadStateReader(func() map[string]cache.ReadState {
+		return map[string]cache.ReadState{"C1": {HasUnread: true}}
 	})
 	m.ToggleCollapse("Channels")
 	view := m.View(10, 30)
@@ -56,22 +63,29 @@ func TestUnmutedChannel_StillGetsUnreadDot(t *testing.T) {
 	}
 }
 
-// Aggregate badge on a collapsed section header sums per-row unread
-// counts. Muted channels are explicitly excluded so the badge matches
-// the per-row treatment (no dot, dim foreground).
+// Aggregate badge on a collapsed section header counts
+// channels-with-unreads. Muted channels are explicitly excluded so the
+// badge matches the per-row treatment (no dot, dim foreground).
 func TestAggregateBadge_ExcludesMutedChannels(t *testing.T) {
 	m := New([]ChannelItem{
-		{ID: "C1", Name: "general", Type: "channel", UnreadCount: 2, IsMuted: false},
-		{ID: "C2", Name: "noisy", Type: "channel", UnreadCount: 5, IsMuted: true},
-		{ID: "C3", Name: "alerts", Type: "channel", UnreadCount: 3, IsMuted: false},
+		{ID: "C1", Name: "general", Type: "channel", IsMuted: false},
+		{ID: "C2", Name: "noisy", Type: "channel", IsMuted: true},
+		{ID: "C3", Name: "alerts", Type: "channel", IsMuted: false},
 	})
-	// Collapsed by default; aggregate badge should be 2+3=5 (excluding
-	// the muted C2's contribution of 5).
+	m.SetReadStateReader(func() map[string]cache.ReadState {
+		return map[string]cache.ReadState{
+			"C1": {HasUnread: true},
+			"C2": {HasUnread: true}, // muted: must not count
+			"C3": {HasUnread: true},
+		}
+	})
+	// Collapsed by default; aggregate counts 2 channels-with-unreads
+	// (C1 and C3); the muted C2 must not contribute.
 	view := m.View(15, 30)
-	if !strings.Contains(view, "•5") {
-		t.Errorf("expected aggregate badge •5 (muted excluded), got:\n%s", view)
+	if !strings.Contains(view, "•2") {
+		t.Errorf("expected aggregate badge •2 (muted excluded), got:\n%s", view)
 	}
-	if strings.Contains(view, "•10") {
+	if strings.Contains(view, "•3") {
 		t.Errorf("aggregate badge counted muted channel toward total:\n%s", view)
 	}
 }
@@ -81,8 +95,14 @@ func TestAggregateBadge_ExcludesMutedChannels(t *testing.T) {
 // a stray "•0" (or worse, the unmuted code path).
 func TestAggregateBadge_AllMutedDropsBadge(t *testing.T) {
 	m := New([]ChannelItem{
-		{ID: "C1", Name: "noisy", Type: "channel", UnreadCount: 9, IsMuted: true},
-		{ID: "C2", Name: "spammy", Type: "channel", UnreadCount: 4, IsMuted: true},
+		{ID: "C1", Name: "noisy", Type: "channel", IsMuted: true},
+		{ID: "C2", Name: "spammy", Type: "channel", IsMuted: true},
+	})
+	m.SetReadStateReader(func() map[string]cache.ReadState {
+		return map[string]cache.ReadState{
+			"C1": {HasUnread: true},
+			"C2": {HasUnread: true},
+		}
 	})
 	view := m.View(15, 30)
 	// Find the Channels header line.

--- a/internal/ui/sidebar/staleness.go
+++ b/internal/ui/sidebar/staleness.go
@@ -10,19 +10,25 @@ import (
 // IsStale reports whether a channel should be auto-hidden from the
 // sidebar because it has been inactive longer than threshold.
 //
-// "Inactive" means: now - parseSlackTS(item.LastReadTS) > threshold.
+// hasUnread and lastReadTS are read state for the item, supplied by
+// the caller (the sidebar Model passes them through from its
+// readStateReader callback). Keeping these as parameters rather than
+// fields on ChannelItem lets the staleness predicate remain pure and
+// trivially testable without touching the DB.
+//
+// "Inactive" means: now - parseSlackTS(lastReadTS) > threshold.
 //
 // A channel is NEVER stale (returns false) when:
 //   - threshold <= 0 (feature disabled)
-//   - item.UnreadCount > 0 (active conversation)
+//   - hasUnread (active conversation)
 //   - item.Section != "" (matches a user-curated [sections.*] glob)
-//   - LastReadTS is malformed or in the future (defensive defaults)
+//   - lastReadTS is malformed or in the future (defensive defaults)
 //
-// Empty LastReadTS is type-aware:
+// Empty lastReadTS is type-aware:
 //   - For "dm" and "group_dm", empty IS stale. Slack's client.counts
 //     endpoint only returns these types when the conversation is
 //     currently "open"; absence in counts (which surfaces here as
-//     empty LastReadTS) is Slack's canonical "this conversation is
+//     empty lastReadTS) is Slack's canonical "this conversation is
 //     closed" signal. Roughly half of the user's DMs and 98% of
 //     mpdms in real workspaces fall into this bucket.
 //   - For "channel" and "private", empty is unexpected (the API
@@ -33,22 +39,22 @@ import (
 // channel") are NOT handled here. The sidebar Model layer applies
 // that on top of this predicate so this function stays pure and
 // trivially testable.
-func IsStale(item ChannelItem, threshold time.Duration, now time.Time) bool {
+func IsStale(item ChannelItem, hasUnread bool, lastReadTS string, threshold time.Duration, now time.Time) bool {
 	if threshold <= 0 {
 		return false
 	}
-	if item.UnreadCount > 0 {
+	if hasUnread {
 		return false
 	}
 	if item.Section != "" {
 		return false
 	}
-	if item.LastReadTS == "" {
+	if lastReadTS == "" {
 		// dm/group_dm without a last_read = closed conversation.
 		// Other types: defensive, prefer to show.
 		return item.Type == "dm" || item.Type == "group_dm"
 	}
-	lastRead, ok := parseSlackTS(item.LastReadTS)
+	lastRead, ok := parseSlackTS(lastReadTS)
 	if !ok {
 		return false
 	}

--- a/internal/ui/sidebar/staleness_test.go
+++ b/internal/ui/sidebar/staleness_test.go
@@ -3,6 +3,8 @@ package sidebar
 import (
 	"testing"
 	"time"
+
+	"github.com/gammons/slk/internal/cache"
 )
 
 func TestIsStale(t *testing.T) {
@@ -15,102 +17,120 @@ func TestIsStale(t *testing.T) {
 	}
 
 	cases := []struct {
-		name      string
-		item      ChannelItem
-		threshold time.Duration
-		want      bool
+		name       string
+		item       ChannelItem
+		hasUnread  bool
+		lastReadTS string
+		threshold  time.Duration
+		want       bool
 	}{
 		{
-			name:      "fresh: read 1 day ago",
-			item:      ChannelItem{ID: "C1", LastReadTS: tsAt(now.Add(-24 * time.Hour))},
-			threshold: threshold,
-			want:      false,
+			name:       "fresh: read 1 day ago",
+			item:       ChannelItem{ID: "C1"},
+			lastReadTS: tsAt(now.Add(-24 * time.Hour)),
+			threshold:  threshold,
+			want:       false,
 		},
 		{
-			name:      "stale: read 60 days ago",
-			item:      ChannelItem{ID: "C1", LastReadTS: tsAt(now.Add(-60 * 24 * time.Hour))},
-			threshold: threshold,
-			want:      true,
+			name:       "stale: read 60 days ago",
+			item:       ChannelItem{ID: "C1"},
+			lastReadTS: tsAt(now.Add(-60 * 24 * time.Hour)),
+			threshold:  threshold,
+			want:       true,
 		},
 		{
-			name:      "edge: read exactly 30 days ago is NOT stale",
-			item:      ChannelItem{ID: "C1", LastReadTS: tsAt(now.Add(-30 * 24 * time.Hour))},
-			threshold: threshold,
-			want:      false,
+			name:       "edge: read exactly 30 days ago is NOT stale",
+			item:       ChannelItem{ID: "C1"},
+			lastReadTS: tsAt(now.Add(-30 * 24 * time.Hour)),
+			threshold:  threshold,
+			want:       false,
 		},
 		{
-			name:      "edge: read 30 days + 1 minute ago IS stale",
-			item:      ChannelItem{ID: "C1", LastReadTS: tsAt(now.Add(-30*24*time.Hour - time.Minute))},
-			threshold: threshold,
-			want:      true,
+			name:       "edge: read 30 days + 1 minute ago IS stale",
+			item:       ChannelItem{ID: "C1"},
+			lastReadTS: tsAt(now.Add(-30*24*time.Hour - time.Minute)),
+			threshold:  threshold,
+			want:       true,
 		},
 		{
-			name:      "exception: unread > 0 is never stale",
-			item:      ChannelItem{ID: "C1", LastReadTS: tsAt(now.Add(-90 * 24 * time.Hour)), UnreadCount: 1},
-			threshold: threshold,
-			want:      false,
+			name:       "exception: unread > 0 is never stale",
+			item:       ChannelItem{ID: "C1"},
+			lastReadTS: tsAt(now.Add(-90 * 24 * time.Hour)),
+			hasUnread:  true,
+			threshold:  threshold,
+			want:       false,
 		},
 		{
-			name:      "exception: custom-section channel is never stale",
-			item:      ChannelItem{ID: "C1", LastReadTS: tsAt(now.Add(-90 * 24 * time.Hour)), Section: "Engineering"},
-			threshold: threshold,
-			want:      false,
+			name:       "exception: custom-section channel is never stale",
+			item:       ChannelItem{ID: "C1", Section: "Engineering"},
+			lastReadTS: tsAt(now.Add(-90 * 24 * time.Hour)),
+			threshold:  threshold,
+			want:       false,
 		},
 		{
 			// Public/private channels always include a last_read in
 			// client.counts, so an empty value here likely means
 			// "brand-new join, counts hasn't refreshed yet" -- show
 			// rather than hide.
-			name:      "empty LastReadTS on public channel is NOT stale",
-			item:      ChannelItem{ID: "C1", Type: "channel", LastReadTS: ""},
-			threshold: threshold,
-			want:      false,
+			name:       "empty LastReadTS on public channel is NOT stale",
+			item:       ChannelItem{ID: "C1", Type: "channel"},
+			lastReadTS: "",
+			threshold:  threshold,
+			want:       false,
 		},
 		{
-			name:      "empty LastReadTS on private channel is NOT stale",
-			item:      ChannelItem{ID: "C1", Type: "private", LastReadTS: ""},
-			threshold: threshold,
-			want:      false,
+			name:       "empty LastReadTS on private channel is NOT stale",
+			item:       ChannelItem{ID: "C1", Type: "private"},
+			lastReadTS: "",
+			threshold:  threshold,
+			want:       false,
 		},
 		{
 			// Slack's client.counts only returns dm/group_dm entries
 			// for currently-open conversations. Absence (empty
-			// LastReadTS) is the canonical "this conversation is
+			// lastReadTS) is the canonical "this conversation is
 			// closed/stale" signal for these types.
-			name:      "empty LastReadTS on dm IS stale",
-			item:      ChannelItem{ID: "DM1", Type: "dm", LastReadTS: ""},
-			threshold: threshold,
-			want:      true,
+			name:       "empty LastReadTS on dm IS stale",
+			item:       ChannelItem{ID: "DM1", Type: "dm"},
+			lastReadTS: "",
+			threshold:  threshold,
+			want:       true,
 		},
 		{
-			name:      "empty LastReadTS on group_dm IS stale",
-			item:      ChannelItem{ID: "MPDM1", Type: "group_dm", LastReadTS: ""},
-			threshold: threshold,
-			want:      true,
+			name:       "empty LastReadTS on group_dm IS stale",
+			item:       ChannelItem{ID: "MPDM1", Type: "group_dm"},
+			lastReadTS: "",
+			threshold:  threshold,
+			want:       true,
 		},
 		{
-			name:      "empty LastReadTS on stale dm respects unread exception",
-			item:      ChannelItem{ID: "DM1", Type: "dm", LastReadTS: "", UnreadCount: 1},
-			threshold: threshold,
-			want:      false,
+			name:       "empty LastReadTS on stale dm respects unread exception",
+			item:       ChannelItem{ID: "DM1", Type: "dm"},
+			lastReadTS: "",
+			hasUnread:  true,
+			threshold:  threshold,
+			want:       false,
 		},
 		{
-			name:      "empty LastReadTS respects threshold=0 disable",
-			item:      ChannelItem{ID: "MPDM1", Type: "group_dm", LastReadTS: ""},
-			threshold: 0,
-			want:      false,
+			name:       "empty LastReadTS respects threshold=0 disable",
+			item:       ChannelItem{ID: "MPDM1", Type: "group_dm"},
+			lastReadTS: "",
+			threshold:  0,
+			want:       false,
 		},
 		{
-			name:      "malformed LastReadTS is treated as not stale",
-			item:      ChannelItem{ID: "C1", LastReadTS: "not-a-timestamp"},
-			threshold: threshold,
-			want:      false,
+			name:       "malformed LastReadTS is treated as not stale",
+			item:       ChannelItem{ID: "C1"},
+			lastReadTS: "not-a-timestamp",
+			threshold:  threshold,
+			want:       false,
 		},
 		{
-			name:      "future LastReadTS is treated as not stale",
-			item:      ChannelItem{ID: "C1", LastReadTS: tsAt(now.Add(24 * time.Hour))},
-			threshold: threshold,
-			want:      false,
+			name:       "future LastReadTS is treated as not stale",
+			item:       ChannelItem{ID: "C1"},
+			lastReadTS: tsAt(now.Add(24 * time.Hour)),
+			threshold:  threshold,
+			want:       false,
 		},
 		{
 			// Slack uses "0000000000.000000" as the LastRead value for
@@ -118,36 +138,41 @@ func TestIsStale(t *testing.T) {
 			// treated as the most-stale of all (never opened) and
 			// auto-hidden. Regression: previously parseSlackTS
 			// rejected sec<=0, so these stayed visible forever.
-			name:      "Slack 'never read' sentinel '0000000000.000000' is stale",
-			item:      ChannelItem{ID: "MPDM1", LastReadTS: "0000000000.000000"},
-			threshold: threshold,
-			want:      true,
+			name:       "Slack 'never read' sentinel '0000000000.000000' is stale",
+			item:       ChannelItem{ID: "MPDM1"},
+			lastReadTS: "0000000000.000000",
+			threshold:  threshold,
+			want:       true,
 		},
 		{
-			name:      "Slack 'never read' bare zero '0' is stale",
-			item:      ChannelItem{ID: "MPDM2", LastReadTS: "0"},
-			threshold: threshold,
-			want:      true,
+			name:       "Slack 'never read' bare zero '0' is stale",
+			item:       ChannelItem{ID: "MPDM2"},
+			lastReadTS: "0",
+			threshold:  threshold,
+			want:       true,
 		},
 		{
-			name:      "threshold 0 disables staleness entirely",
-			item:      ChannelItem{ID: "C1", LastReadTS: tsAt(now.Add(-365 * 24 * time.Hour))},
-			threshold: 0,
-			want:      false,
+			name:       "threshold 0 disables staleness entirely",
+			item:       ChannelItem{ID: "C1"},
+			lastReadTS: tsAt(now.Add(-365 * 24 * time.Hour)),
+			threshold:  0,
+			want:       false,
 		},
 		{
-			name:      "negative threshold disables staleness",
-			item:      ChannelItem{ID: "C1", LastReadTS: tsAt(now.Add(-365 * 24 * time.Hour))},
-			threshold: -time.Hour,
-			want:      false,
+			name:       "negative threshold disables staleness",
+			item:       ChannelItem{ID: "C1"},
+			lastReadTS: tsAt(now.Add(-365 * 24 * time.Hour)),
+			threshold:  -time.Hour,
+			want:       false,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := IsStale(tc.item, tc.threshold, now)
+			got := IsStale(tc.item, tc.hasUnread, tc.lastReadTS, tc.threshold, now)
 			if got != tc.want {
-				t.Errorf("IsStale(%+v, %v) = %v, want %v", tc.item, tc.threshold, got, tc.want)
+				t.Errorf("IsStale(%+v, hasUnread=%v, lastReadTS=%q, %v) = %v, want %v",
+					tc.item, tc.hasUnread, tc.lastReadTS, tc.threshold, got, tc.want)
 			}
 		})
 	}
@@ -172,14 +197,26 @@ func TestSidebar_HidesStaleChannels(t *testing.T) {
 	fresh := tsAt(now.Add(-1 * 24 * time.Hour))
 
 	items := []ChannelItem{
-		{ID: "C-fresh", Name: "general", Type: "channel", LastReadTS: fresh},
-		{ID: "C-stale", Name: "old-project", Type: "channel", LastReadTS: stale},
-		{ID: "C-stale-unread", Name: "old-but-pinged", Type: "channel", LastReadTS: stale, UnreadCount: 1},
-		{ID: "C-stale-section", Name: "alerts-old", Type: "channel", LastReadTS: stale, Section: "Alerts"},
-		{ID: "DM-stale-active", Name: "alice", Type: "dm", LastReadTS: stale},
+		{ID: "C-fresh", Name: "general", Type: "channel"},
+		{ID: "C-stale", Name: "old-project", Type: "channel"},
+		{ID: "C-stale-unread", Name: "old-but-pinged", Type: "channel"},
+		{ID: "C-stale-section", Name: "alerts-old", Type: "channel", Section: "Alerts"},
+		{ID: "DM-stale-active", Name: "alice", Type: "dm"},
+	}
+
+	// Per-channel read state, mirroring what the live readStateReader
+	// (DB-backed) would return. C-stale-unread carries a HasUnread=true
+	// signal to exercise the unread-exception branch of IsStale.
+	readState := map[string]cache.ReadState{
+		"C-fresh":         {LastReadTS: fresh},
+		"C-stale":         {LastReadTS: stale},
+		"C-stale-unread":  {LastReadTS: stale, HasUnread: true},
+		"C-stale-section": {LastReadTS: stale},
+		"DM-stale-active": {LastReadTS: stale},
 	}
 
 	m := New(items)
+	m.SetReadStateReader(func() map[string]cache.ReadState { return readState })
 	m.SetNowFunc(func() time.Time { return now })
 	m.SetStaleThreshold(30 * 24 * time.Hour)
 	m.SetActiveChannelID("DM-stale-active")

--- a/internal/ui/workspace/model.go
+++ b/internal/ui/workspace/model.go
@@ -19,6 +19,10 @@ type Model struct {
 	items    []WorkspaceItem
 	selected int
 	version  int64
+	// unreadReader returns the set of workspace IDs that currently
+	// have at least one channel with has_unread=true. Set by App via
+	// SetUnreadReader; called by RefreshUnreads.
+	unreadReader func() []string
 }
 
 // Version returns a counter that increments any time the View() output could
@@ -78,6 +82,35 @@ func (m *Model) SetUnread(teamID string, hasUnread bool) {
 			}
 			return
 		}
+	}
+}
+
+// SetUnreadReader installs the callback used by RefreshUnreads.
+func (m *Model) SetUnreadReader(f func() []string) {
+	m.unreadReader = f
+}
+
+// RefreshUnreads pulls the latest set of workspaces-with-unreads from
+// the reader and updates each item's HasUnread field. Called by App
+// on ReadStateChangedMsg. No-op if no reader is installed.
+func (m *Model) RefreshUnreads() {
+	if m.unreadReader == nil {
+		return
+	}
+	set := make(map[string]bool, len(m.items))
+	for _, id := range m.unreadReader() {
+		set[id] = true
+	}
+	changed := false
+	for i := range m.items {
+		want := set[m.items[i].ID]
+		if m.items[i].HasUnread != want {
+			m.items[i].HasUnread = want
+			changed = true
+		}
+	}
+	if changed {
+		m.dirty()
 	}
 }
 

--- a/internal/wake/detector.go
+++ b/internal/wake/detector.go
@@ -1,0 +1,108 @@
+// Package wake provides cross-platform detection of system
+// suspend/wake-from-sleep events via a wall-clock-jump heuristic.
+//
+// When the OS suspends the process (laptop lid close, systemctl
+// suspend, etc.), all goroutines pause and wall-clock time advances
+// without the process observing it. On wake, time.Now() jumps forward
+// by the sleep duration. The Detector schedules periodic checks via
+// a ticker; if the actual elapsed wall-clock time between checks
+// exceeds the expected interval plus a small threshold, the gap is
+// reported via the onWake callback.
+//
+// This is intentionally cross-platform and dependency-free. It does
+// not use D-Bus (Linux) or IOKit (macOS), which would require either
+// platform-specific code or CGO. The clock-jump heuristic is a small
+// generality loss — a brief, deliberate `date` change on Linux would
+// also trigger it — in exchange for one implementation that works
+// everywhere.
+//
+// Typical usage:
+//
+//	d := wake.New(10*time.Second, 5*time.Second, func(elapsed time.Duration) {
+//	    log.Printf("system slept for ~%v, triggering catch-up", elapsed)
+//	    // ... reconcile state with the server here
+//	})
+//	go d.Run(ctx)
+package wake
+
+import (
+	"context"
+	"time"
+)
+
+// Detector observes wall-clock time at fixed intervals and reports
+// jumps larger than the expected interval. Construct with New; drive
+// with Run (production) or Step (tests).
+type Detector struct {
+	interval  time.Duration
+	threshold time.Duration
+	onWake    func(elapsed time.Duration)
+
+	// now is the wall-clock source. Defaults to time.Now in New;
+	// tests override the field directly to inject a controlled clock.
+	now func() time.Time
+
+	// initialized is false until the first Step seeds last.
+	initialized bool
+	// last is the most recent observation. Only meaningful when
+	// initialized.
+	last time.Time
+}
+
+// New constructs a Detector. interval is the expected gap between
+// observations; threshold is the slack we allow before declaring a
+// jump (so normal scheduling jitter doesn't false-positive). onWake
+// is invoked synchronously on the goroutine that calls Step (or Run's
+// goroutine) when a jump is observed; it must be cheap or dispatch
+// the actual work to another goroutine.
+//
+// The zero Detector is not usable; always construct via New.
+func New(interval, threshold time.Duration, onWake func(time.Duration)) *Detector {
+	return &Detector{
+		interval:  interval,
+		threshold: threshold,
+		onWake:    onWake,
+		now:       time.Now,
+	}
+}
+
+// Step records a single clock observation. The first call seeds the
+// baseline; subsequent calls compute elapsed-since-previous and fire
+// onWake if it exceeds interval+threshold.
+//
+// Exported for tests so the logic can be exercised without spawning
+// a goroutine and without relying on a real ticker. Run calls this
+// internally on every tick.
+func (d *Detector) Step() {
+	now := d.now()
+	if !d.initialized {
+		d.last = now
+		d.initialized = true
+		return
+	}
+	elapsed := now.Sub(d.last)
+	d.last = now
+	if elapsed > d.interval+d.threshold {
+		d.onWake(elapsed)
+	}
+}
+
+// Run drives Step on a ticker until ctx is cancelled. Blocks; intended
+// to be invoked in a goroutine.
+//
+// The first Step happens immediately to seed the baseline; subsequent
+// Steps happen on every tick of interval. On ctx cancellation Run
+// returns promptly without firing further callbacks.
+func (d *Detector) Run(ctx context.Context) {
+	d.Step()
+	ticker := time.NewTicker(d.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			d.Step()
+		}
+	}
+}

--- a/internal/wake/detector_test.go
+++ b/internal/wake/detector_test.go
@@ -1,0 +1,273 @@
+package wake
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeClock returns whatever its current field says. Tests advance
+// the clock via Advance or Set. The mutex is necessary for the
+// TestRun_* tests where the detector goroutine reads concurrently
+// with the test goroutine; serialized Step tests don't strictly need
+// it but pay nothing for it.
+type fakeClock struct {
+	mu      sync.Mutex
+	current time.Time
+}
+
+func (f *fakeClock) Now() time.Time {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.current
+}
+
+func (f *fakeClock) Set(t time.Time) {
+	f.mu.Lock()
+	f.current = t
+	f.mu.Unlock()
+}
+
+func (f *fakeClock) Advance(d time.Duration) {
+	f.mu.Lock()
+	f.current = f.current.Add(d)
+	f.mu.Unlock()
+}
+
+func TestNew_DefaultsToRealClock(t *testing.T) {
+	d := New(time.Second, time.Second, func(time.Duration) {})
+	if d.now == nil {
+		t.Fatal("New should default now to a non-nil function")
+	}
+	t1 := d.now()
+	time.Sleep(time.Millisecond)
+	t2 := d.now()
+	if !t2.After(t1) {
+		t.Errorf("now() did not advance — not wired to real clock? t1=%v t2=%v", t1, t2)
+	}
+}
+
+func TestStep_NoJump_NoCallback(t *testing.T) {
+	fc := &fakeClock{current: time.Unix(1000, 0)}
+	fired := 0
+	d := &Detector{
+		interval:  10 * time.Second,
+		threshold: 5 * time.Second,
+		now:       fc.Now,
+		onWake:    func(time.Duration) { fired++ },
+	}
+	d.Step() // seed baseline at t=1000
+	fc.Advance(10 * time.Second)
+	d.Step() // elapsed = 10s, not > 15s threshold
+	if fired != 0 {
+		t.Errorf("callback fired %d times on normal tick; want 0", fired)
+	}
+}
+
+func TestStep_JumpAboveThreshold_FiresCallback(t *testing.T) {
+	fc := &fakeClock{current: time.Unix(1000, 0)}
+	var got time.Duration
+	fired := 0
+	d := &Detector{
+		interval:  10 * time.Second,
+		threshold: 5 * time.Second,
+		now:       fc.Now,
+		onWake:    func(e time.Duration) { fired++; got = e },
+	}
+	d.Step()
+	fc.Advance(2 * time.Minute)
+	d.Step()
+	if fired != 1 {
+		t.Errorf("fired = %d, want 1", fired)
+	}
+	if got != 2*time.Minute {
+		t.Errorf("elapsed = %v, want 2m", got)
+	}
+}
+
+func TestStep_JumpBelowThreshold_NoCallback(t *testing.T) {
+	fc := &fakeClock{current: time.Unix(1000, 0)}
+	fired := 0
+	d := &Detector{
+		interval:  10 * time.Second,
+		threshold: 5 * time.Second,
+		now:       fc.Now,
+		onWake:    func(time.Duration) { fired++ },
+	}
+	d.Step()
+	// 14s is greater than interval (10s) but less than interval+threshold (15s).
+	// This is the "scheduling jitter" zone we explicitly tolerate.
+	fc.Advance(14 * time.Second)
+	d.Step()
+	if fired != 0 {
+		t.Errorf("callback fired %d times in jitter zone; want 0", fired)
+	}
+}
+
+func TestStep_ExactlyAtThreshold_NoCallback(t *testing.T) {
+	// Boundary: elapsed == interval+threshold uses strict >. A jump of
+	// exactly the threshold should NOT fire; only strictly larger.
+	fc := &fakeClock{current: time.Unix(1000, 0)}
+	fired := 0
+	d := &Detector{
+		interval:  10 * time.Second,
+		threshold: 5 * time.Second,
+		now:       fc.Now,
+		onWake:    func(time.Duration) { fired++ },
+	}
+	d.Step()
+	fc.Advance(15 * time.Second)
+	d.Step()
+	if fired != 0 {
+		t.Errorf("callback fired %d times at exact threshold; want 0 (strict >)", fired)
+	}
+}
+
+func TestStep_OneNanosecondAboveThreshold_FiresCallback(t *testing.T) {
+	// Companion to TestStep_ExactlyAtThreshold: one ns over the
+	// boundary must fire. Together these tests pin down the strict-> contract.
+	fc := &fakeClock{current: time.Unix(1000, 0)}
+	fired := 0
+	d := &Detector{
+		interval:  10 * time.Second,
+		threshold: 5 * time.Second,
+		now:       fc.Now,
+		onWake:    func(time.Duration) { fired++ },
+	}
+	d.Step()
+	fc.Advance(15*time.Second + 1)
+	d.Step()
+	if fired != 1 {
+		t.Errorf("callback fired %d times at threshold+1ns; want 1", fired)
+	}
+}
+
+func TestStep_MultipleJumps_FireEach(t *testing.T) {
+	fc := &fakeClock{current: time.Unix(1000, 0)}
+	var elapsed []time.Duration
+	d := &Detector{
+		interval:  10 * time.Second,
+		threshold: 5 * time.Second,
+		now:       fc.Now,
+		onWake:    func(e time.Duration) { elapsed = append(elapsed, e) },
+	}
+	d.Step() // seed
+	fc.Advance(60 * time.Second)
+	d.Step() // jump 1: 60s
+	fc.Advance(120 * time.Second)
+	d.Step() // jump 2: 120s
+	if len(elapsed) != 2 {
+		t.Fatalf("fired %d times, want 2: %v", len(elapsed), elapsed)
+	}
+	if elapsed[0] != 60*time.Second {
+		t.Errorf("first jump = %v, want 60s", elapsed[0])
+	}
+	if elapsed[1] != 120*time.Second {
+		t.Errorf("second jump = %v, want 120s", elapsed[1])
+	}
+}
+
+func TestStep_NormalTickAfterJump_DoesNotRefire(t *testing.T) {
+	// After a jump fires, the next normal tick should NOT re-fire
+	// (the baseline `last` must have advanced to the post-jump time).
+	fc := &fakeClock{current: time.Unix(1000, 0)}
+	fired := 0
+	d := &Detector{
+		interval:  10 * time.Second,
+		threshold: 5 * time.Second,
+		now:       fc.Now,
+		onWake:    func(time.Duration) { fired++ },
+	}
+	d.Step() // seed
+	fc.Advance(60 * time.Second)
+	d.Step() // fires
+	if fired != 1 {
+		t.Fatalf("expected fire on jump")
+	}
+	fc.Advance(10 * time.Second)
+	d.Step() // normal tick, must not fire
+	if fired != 1 {
+		t.Errorf("callback re-fired on normal tick after jump; baseline not advanced")
+	}
+}
+
+func TestStep_FirstCallSeedsWithoutFiring(t *testing.T) {
+	// The very first Step seeds last; even if `now` returns wildly
+	// in the future, no callback should fire because there's no
+	// baseline to compare to.
+	fc := &fakeClock{current: time.Unix(9_999_999, 0)}
+	fired := 0
+	d := &Detector{
+		interval:  10 * time.Second,
+		threshold: 5 * time.Second,
+		now:       fc.Now,
+		onWake:    func(time.Duration) { fired++ },
+	}
+	d.Step()
+	if fired != 0 {
+		t.Errorf("callback fired %d times on first Step; want 0 (seeding only)", fired)
+	}
+	if !d.initialized {
+		t.Errorf("first Step did not set initialized=true")
+	}
+	if !d.last.Equal(fc.Now()) {
+		t.Errorf("first Step did not store baseline; last=%v want=%v", d.last, fc.Now())
+	}
+}
+
+func TestRun_ContextCancellation_ReturnsCleanly(t *testing.T) {
+	// Drive Run with a real ticker for a short period, then cancel.
+	// Confirm the goroutine exits within a generous timeout.
+	d := New(10*time.Millisecond, 5*time.Millisecond, func(time.Duration) {})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		d.Run(ctx)
+		close(done)
+	}()
+	// Let the loop spin a few times.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+		// success
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return within 1s after ctx cancel")
+	}
+}
+
+func TestRun_FiresOnSimulatedJump(t *testing.T) {
+	// Integration check that Run actually calls Step on every tick.
+	// We can't synchronize a real ticker with manual fake-clock
+	// advances without races, so we keep the test scope narrow:
+	// confirm that *after* simulating a large clock jump on the fake
+	// clock, the callback eventually fires. The Step tests cover the
+	// exact-threshold and below-threshold cases — this test only
+	// proves Run wires Step to the ticker.
+	fc := &fakeClock{current: time.Unix(1000, 0)}
+	fired := make(chan time.Duration, 10)
+	d := New(5*time.Millisecond, 5*time.Millisecond, func(e time.Duration) {
+		fired <- e
+	})
+	d.now = fc.Now
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go d.Run(ctx)
+
+	// Give Run a moment to seed the baseline.
+	time.Sleep(20 * time.Millisecond)
+
+	// Simulate a wake: advance the fake clock by 2 seconds. The next
+	// tick (within ~5ms) calls Step, observes the jump, fires onWake.
+	fc.Advance(2 * time.Second)
+	select {
+	case e := <-fired:
+		if e < 2*time.Second {
+			t.Errorf("callback elapsed = %v, want >= 2s", e)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("callback not fired within 500ms of simulated jump")
+	}
+}


### PR DESCRIPTION
## Summary

Consolidates per-channel read state (unread dot + last-read timestamp) into a single SQLite source of truth, eliminating the three-store divergence that was driving real-world sync defects against the official Slack client.

Before this branch, read state lived in three stores kept in sync only partially: SQLite columns, `WorkspaceContext.LastReadMap`, and `sidebar.ChannelItem.UnreadCount`. Symptoms included channels marked read in the official client staying unread in slk forever, and channels marked unread on phone never appearing in slk.

**Architecture**

- New `has_unread` boolean column on the `channels` table.
- Single mutation API: `UpdateChannelReadState` / `BatchUpdateChannelReadState`. Type system enforces this — the old struct fields are gone.
- Read path: sidebar and workspace rail consult `GetWorkspaceReadState` / `WorkspacesWithUnreads` at render time via injected reader callbacks.
- Six write paths (bootstrap, reconnect catch-up, `*_marked` events, new-message events, local mark-read, local mark-unread) all funnel through the same API.
- Section aggregates now count channels-with-unreads instead of summing integer counts. The integer count was unreliable and the boolean was sufficient — deliberate user-visible behavior change called out in the spec.

**Root causes fixed**

1. `runChannelPhase` discarded `UnreadInfo.LastRead` — reconnect catch-up never reconciled channels read elsewhere.
2. `UpsertChannel`'s `ON CONFLICT DO UPDATE` clobbered persisted read state on every channel re-upsert.
3. `OnChannelMarked` hardcoded `has_unread=false`, swallowing every remote mark-unread (post-review bug fix).
4. `OnChannelMarked` didn't mirror to `wctx.Channels[i]`; workspace switches lost the clear.
5. Active-workspace `OnMessage` bypassed `wctx.Channels`; workspace switches lost the unread bump.
6. No reconnect catch-up for read state at all.
7. Short sleeps (<60s WS read deadline) left the TCP connection alive, so `OnConnect` never fired and no catch-up ran. New cross-platform clock-jump wake detector forces a catch-up on resume.

**Spec & plan**

- Design: [`docs/superpowers/specs/2026-05-17-read-state-sync-design.md`](docs/superpowers/specs/2026-05-17-read-state-sync-design.md)
- Implementation plan: [`docs/superpowers/plans/2026-05-17-read-state-sync.md`](docs/superpowers/plans/2026-05-17-read-state-sync.md)

**Migration**

- New `has_unread` column added via `addColumnIfMissing` (no data loss).
- Deprecated `unread_count` column retained for one release per spec — never read, never written. Drop in a follow-up.
- On first launch after upgrade, sub-second window with no unread dots until the initial backfill completes.

## Test Plan

- [x] Cache layer: 7 new tests (`internal/cache/channels_read_state_test.go`) — `UpdateChannelReadState`, `BatchUpdateChannelReadState`, `GetWorkspaceReadState`, `WorkspacesWithUnreads`, clobber-regression.
- [x] Event handlers: `OnChannelMarked` (3 cases: read, remote mark-unread, inactive workspace), `OnMessage` (active/inactive channel, active/inactive workspace, thread-reply, thread-broadcast).
- [x] Reconnect catch-up: `TestRunChannelPhase_WritesReadStateForAllChannels` + extended `TestBackfill_OvernightSuspendScenario` with channel D (read elsewhere during offline window).
- [x] Sidebar render: dot driven by reader callback, muted suppression, aggregate counts channels-not-counts.
- [x] Wake detector: 11 tests (`internal/wake/detector_test.go`) — boundary conditions, no spurious refire, multiple jumps, context cancellation, real-ticker integration.
- [x] `go vet ./...` clean (modulo pre-existing emoji probe warning unrelated to this branch).
- [x] `go test ./...` and `go test -race ./...` both green.
- [x] Manual smoke: laptop suspend/wake with messages marked unread on phone — dots appear after `wake detected` log line. (Final iteration to confirm in a fresh session.)

## Out of scope (genuine follow-ups)

1. Drop deprecated `unread_count` column.
2. v0.7.11 follow-ups: `Capped` semantics on exact-`maxTotal`, `GetUnreadCounts` ignores `ctx`.
3. Move watermark helpers from `channels.go` to `channels_sync.go` for cohesion.
4. Remove now-vestigial `unreadCount` parameter on `applyChannelMark` and the dead `UnreadCount` fields on `MessageMarkedUnreadMsg` / `ChannelMarkedRemoteMsg` / `MarkUnreadMsg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)