### PR TITLE
fix: wrap Kitty image escapes for tmux passthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,39 @@ slk --add-workspace
 
 Full walkthrough: [Setup wiki page](https://github.com/gammons/slk/wiki/Setup).
 
+## Inline images in tmux
+
+`slk` can render native Kitty graphics inside tmux, but tmux passthrough
+must be enabled. Add this to your tmux config:
+
+```tmux
+set -g allow-passthrough on 
+```
+
+Then fully restart tmux:
+
+```bash
+tmux kill-server
+```
+
+Inside tmux, verify the active setting:
+
+```bash
+tmux show -gv allow-passthrough
+```
+
+Expected output is `all` (or `on`).
+
+To force Kitty image rendering in `slk`, set:
+
+```toml
+[appearance]
+image_protocol = "kitty"
+```
+
+`image_protocol = "auto"` remains conservative inside tmux and falls back
+to half-block rendering.
+
 ## Debugging
 
 Set `SLK_DEBUG=1` to enable a comprehensive debug log written to

--- a/README.md
+++ b/README.md
@@ -72,36 +72,26 @@ Full walkthrough: [Setup wiki page](https://github.com/gammons/slk/wiki/Setup).
 
 ## Inline images in tmux
 
-`slk` can render native Kitty graphics inside tmux, but tmux passthrough
-must be enabled. Add this to your tmux config:
+If you run `slk` inside tmux on a Kitty-capable terminal (Kitty, Ghostty,
+WezTerm), images render natively as long as tmux passthrough is enabled:
 
 ```tmux
-set -g allow-passthrough on 
+set -g allow-passthrough on
 ```
 
-Then fully restart tmux:
-
-```bash
-tmux kill-server
-```
-
-Inside tmux, verify the active setting:
+Reload tmux for the setting to take effect (`tmux kill-server`, then
+reattach). Verify with:
 
 ```bash
 tmux show -gv allow-passthrough
 ```
 
-Expected output is `all` (or `on`).
+Expected output: `on` (or `all`).
 
-To force Kitty image rendering in `slk`, set:
-
-```toml
-[appearance]
-image_protocol = "kitty"
-```
-
-`image_protocol = "auto"` remains conservative inside tmux and falls back
-to half-block rendering.
+If passthrough is off, `slk` detects this at startup and falls back to
+half-block rendering automatically — no config change needed. To force a
+specific renderer regardless of detection, set `image_protocol` in
+`config.toml` to `kitty`, `sixel`, `halfblock`, or `off`.
 
 ## Debugging
 

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -558,6 +558,7 @@ func run() error {
 	// cache so the cache can pick the right rendering path (kitty
 	// graphics for sharp pixels, halfblock otherwise).
 	proto := imgpkg.Detect(imgpkg.CaptureEnv(), cfg.Appearance.ImageProtocol)
+	debuglog.ImgRender("image protocol detect: cfg=%q result=%s", cfg.Appearance.ImageProtocol, proto)
 
 	// Optional: run kitty version probe if detected as kitty AND stdin is a TTY.
 	// Must happen BEFORE bubbletea takes over the terminal.

--- a/internal/avatar/kitty_test.go
+++ b/internal/avatar/kitty_test.go
@@ -26,6 +26,7 @@ import (
 //   - the rendered string contains the placeholder rune,
 //   - the rendered string spans exactly AvatarRows lines.
 func TestRender_KittyAvatarUploadsAndPlaceholders(t *testing.T) {
+	t.Setenv("TMUX", "")
 	src := image.NewRGBA(image.Rect(0, 0, 32, 32))
 	for y := 0; y < 32; y++ {
 		for x := 0; x < 32; x++ {

--- a/internal/image/capability.go
+++ b/internal/image/capability.go
@@ -1,8 +1,13 @@
 package image
 
 import (
+	"context"
 	"os"
+	"os/exec"
 	"strings"
+	"time"
+
+	"github.com/gammons/slk/internal/debuglog"
 )
 
 // Env is a snapshot of terminal-related environment variables.
@@ -29,9 +34,42 @@ func CaptureEnv() Env {
 // getenv is overridable in tests.
 var getenv = os.Getenv
 
+// tmuxClientTerm asks the running tmux server for the TERM value of the
+// currently attached client. tmux strips the outer terminal's identity
+// from a pane's env (sets TERM=tmux-*, TERM_PROGRAM=tmux, etc.), so this
+// is how we recover it. Returns "" on any failure or if tmux is missing.
+//
+// Overridable for tests.
+var tmuxClientTerm = func() string {
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "tmux", "display-message", "-p", "#{client_termname}")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
 // Detect picks the rendering protocol for the current terminal.
 // cfg is the user's config value (e.g. "auto", "kitty", "sixel", "halfblock", "off").
 // Anything other than the four explicit values is treated as "auto".
+//
+// Under tmux, env vars that identify the outer terminal are stripped:
+// TERM becomes tmux-256color, TERM_PROGRAM becomes "tmux", and
+// KITTY_WINDOW_ID is only present if the user happens to have started
+// tmux from inside kitty (often false after a reattach). To recover
+// the outer terminal's identity, we ask tmux via display-message
+// #{client_termname}. Kitty graphics escapes are wrapped in the tmux
+// DCS passthrough envelope at emit time (see writeKittySequence) and
+// the startup probe in cmd/slk confirms the terminal actually
+// acknowledges the upload — if allow-passthrough is off, the probe
+// times out and the caller downgrades to halfblock.
+//
+// Sixel under tmux is treated more conservatively: sixel has no
+// equivalent of the kitty graphics ;OK reply, so we can't probe-verify
+// it, and re-emitting sixel per redraw under tmux passthrough is
+// bandwidth-hostile.
 func Detect(env Env, cfg string) Protocol {
 	switch strings.ToLower(strings.TrimSpace(cfg)) {
 	case "off":
@@ -44,15 +82,27 @@ func Detect(env Env, cfg string) Protocol {
 		return ProtoKitty
 	}
 	// auto
-	if env.TMUX != "" {
-		return ProtoHalfBlock
-	}
 	if env.KittyWindowID != "" || env.Term == "xterm-kitty" {
 		return ProtoKitty
 	}
 	switch env.TermProgram {
 	case "ghostty", "WezTerm":
 		return ProtoKitty
+	}
+	if env.TMUX != "" {
+		// tmux has stripped TERM and TERM_PROGRAM. Ask tmux what the
+		// attached client's terminal actually is.
+		raw := tmuxClientTerm()
+		outer := strings.ToLower(raw)
+		debuglog.ImgRender("tmux client_termname=%q", raw)
+		if strings.Contains(outer, "kitty") ||
+			strings.Contains(outer, "ghostty") ||
+			strings.Contains(outer, "wezterm") {
+			return ProtoKitty
+		}
+		// No kitty-capable outer terminal detected; stay conservative.
+		// Sixel-under-tmux is also halfblock — see function doc.
+		return ProtoHalfBlock
 	}
 	if env.Term == "foot" || env.Term == "mlterm" {
 		return ProtoSixel

--- a/internal/image/capability_test.go
+++ b/internal/image/capability_test.go
@@ -2,6 +2,14 @@ package image
 
 import "testing"
 
+// withTmuxClientTerm overrides the tmux query for the duration of the test.
+func withTmuxClientTerm(t *testing.T, term string) {
+	t.Helper()
+	orig := tmuxClientTerm
+	tmuxClientTerm = func() string { return term }
+	t.Cleanup(func() { tmuxClientTerm = orig })
+}
+
 func TestDetect_ConfigOverrides(t *testing.T) {
 	cases := []struct {
 		cfg  string
@@ -20,10 +28,62 @@ func TestDetect_ConfigOverrides(t *testing.T) {
 	}
 }
 
-func TestDetect_TmuxForcesHalfBlock(t *testing.T) {
-	env := Env{TMUX: "/tmp/tmux", KittyWindowID: "1", Term: "xterm-kitty"}
+// Pre-tmux env signals still work if they happened to propagate (e.g.
+// user launched tmux from inside kitty, KITTY_WINDOW_ID survived).
+func TestDetect_TmuxKittyHostFromInheritedEnv(t *testing.T) {
+	withTmuxClientTerm(t, "")
+	cases := []Env{
+		{TMUX: "/tmp/tmux", KittyWindowID: "1"},
+		{TMUX: "/tmp/tmux", Term: "xterm-kitty"},
+		{TMUX: "/tmp/tmux", TermProgram: "ghostty"},
+		{TMUX: "/tmp/tmux", TermProgram: "WezTerm"},
+	}
+	for i, env := range cases {
+		if got := Detect(env, "auto"); got != ProtoKitty {
+			t.Errorf("case %d (%+v): want kitty, got %v", i, env, got)
+		}
+	}
+}
+
+// The real-world case: tmux has stripped TERM and TERM_PROGRAM, but
+// asking tmux for the client's TERM reveals a kitty-capable host.
+func TestDetect_TmuxRecoversKittyViaClientTerm(t *testing.T) {
+	cases := []struct {
+		clientTerm string
+		desc       string
+	}{
+		{"xterm-kitty", "kitty"},
+		{"xterm-ghostty", "ghostty"},
+		{"wezterm", "wezterm"},
+		{"WezTerm", "wezterm capitalized"},
+	}
+	tmuxEnv := Env{TMUX: "/tmp/tmux", Term: "tmux-256color", TermProgram: "tmux"}
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			withTmuxClientTerm(t, tc.clientTerm)
+			if got := Detect(tmuxEnv, "auto"); got != ProtoKitty {
+				t.Errorf("tmux client=%q: want kitty, got %v", tc.clientTerm, got)
+			}
+		})
+	}
+}
+
+// Tmux + non-kitty client → halfblock. tmux query is consulted but
+// returns a non-kitty terminal.
+func TestDetect_TmuxNonKittyClientIsHalfBlock(t *testing.T) {
+	withTmuxClientTerm(t, "xterm-256color")
+	env := Env{TMUX: "/tmp/tmux", Term: "tmux-256color", TermProgram: "tmux"}
 	if got := Detect(env, "auto"); got != ProtoHalfBlock {
-		t.Errorf("expected halfblock under tmux, got %v", got)
+		t.Errorf("tmux + xterm client should halfblock, got %v", got)
+	}
+}
+
+// Tmux + tmux command unavailable/empty → halfblock fallback.
+func TestDetect_TmuxQueryFailsFallsThrough(t *testing.T) {
+	withTmuxClientTerm(t, "")
+	env := Env{TMUX: "/tmp/tmux", Term: "tmux-256color", TermProgram: "tmux"}
+	if got := Detect(env, "auto"); got != ProtoHalfBlock {
+		t.Errorf("tmux query failure should halfblock, got %v", got)
 	}
 }
 

--- a/internal/image/kitty.go
+++ b/internal/image/kitty.go
@@ -7,6 +7,7 @@ import (
 	"image"
 	imgpng "image/png"
 	"io"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -51,6 +52,22 @@ var kittyDiacritics = []rune{
 }
 
 const placeholderRune = '\U0010EEEE'
+
+func inTmux() bool {
+	return os.Getenv("TMUX") != ""
+}
+
+func wrapForTmux(seq string) string {
+	return "\x1bPtmux;" + strings.ReplaceAll(seq, "\x1b", "\x1b\x1b") + "\x1b\\"
+}
+
+func writeKittySequence(w io.Writer, seq string) error {
+	if inTmux() {
+		seq = wrapForTmux(seq)
+	}
+	_, err := io.WriteString(w, seq)
+	return err
+}
 
 // KittyRenderer encodes images via the kitty graphics protocol with
 // unicode-placeholder placement.
@@ -184,7 +201,8 @@ func emitKittyUpload(w io.Writer, id uint32, payload string, cols, rows int) err
 		} else {
 			hdr = fmt.Sprintf("m=%d", more)
 		}
-		if _, err := fmt.Fprintf(w, "\x1b_G%s;%s\x1b\\", hdr, payload[i:end]); err != nil {
+		seq := fmt.Sprintf("\x1b_G%s;%s\x1b\\", hdr, payload[i:end])
+		if err := writeKittySequence(w, seq); err != nil {
 			return err
 		}
 	}

--- a/internal/image/kitty_test.go
+++ b/internal/image/kitty_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestKitty_UploadEscapeFormat(t *testing.T) {
+	t.Setenv("TMUX", "")
 	src := makeSolid(64, 64, imgcolor.RGBA{1, 2, 3, 255})
 	r := NewKittyRenderer(NewRegistry())
 	out := r.Render(src, image.Pt(10, 5))
@@ -45,7 +46,35 @@ func TestKitty_UploadEscapeFormat(t *testing.T) {
 	}
 }
 
+func TestKitty_WrapForTmux(t *testing.T) {
+	inner := "\x1b_Ga=T;payload\x1b\\"
+	want := "\x1bPtmux;\x1b\x1b_Ga=T;payload\x1b\x1b\\\x1b\\"
+	if got := wrapForTmux(inner); got != want {
+		t.Fatalf("wrapForTmux() = %q, want %q", got, want)
+	}
+}
+
+func TestKitty_UploadEscapeWrappedInTmux(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/tmux")
+
+	var buf bytes.Buffer
+	if err := emitKittyUpload(&buf, 42, "abcd", 10, 5); err != nil {
+		t.Fatal(err)
+	}
+	s := buf.String()
+	if !strings.HasPrefix(s, "\x1bPtmux;\x1b\x1b_G") {
+		t.Fatalf("expected tmux-wrapped kitty upload, got %q", s[:minInt(20, len(s))])
+	}
+	if !strings.HasSuffix(s, "\x1b\x1b\\\x1b\\") {
+		t.Fatalf("expected doubled inner ST plus tmux ST suffix, got %q", s)
+	}
+	if !strings.Contains(s, "a=T") || !strings.Contains(s, "U=1") {
+		t.Fatalf("wrapped upload missing kitty parameters: %q", s)
+	}
+}
+
 func TestKitty_SecondRenderSameImageNoFlush(t *testing.T) {
+	t.Setenv("TMUX", "")
 	reg := NewRegistry()
 	r := NewKittyRenderer(reg)
 	src := makeSolid(8, 8, imgcolor.RGBA{1, 2, 3, 255})
@@ -75,12 +104,12 @@ func TestKitty_SecondRenderSameImageNoFlush(t *testing.T) {
 // TestKitty_RerenderBeforeUploadStillFlushes captures the messages-pane
 // cache-rebuild race that previously dropped images on the floor:
 //
-//   1. buildCache calls RenderKey → fresh=true, OnFlush closure captured
-//      in a viewEntry. View() hasn't run yet, so the closure has NOT
-//      fired (no bytes on the wire).
-//   2. SetMessages is called again (e.g. network-verify after a cache hit)
-//      → m.cache = nil, discarding the viewEntry and its closure.
-//   3. buildCache runs again → RenderKey for the same (key, target).
+//  1. buildCache calls RenderKey → fresh=true, OnFlush closure captured
+//     in a viewEntry. View() hasn't run yet, so the closure has NOT
+//     fired (no bytes on the wire).
+//  2. SetMessages is called again (e.g. network-verify after a cache hit)
+//     → m.cache = nil, discarding the viewEntry and its closure.
+//  3. buildCache runs again → RenderKey for the same (key, target).
 //
 // Under the buggy semantic, step 3 would return OnFlush=nil because the
 // registry had already minted an ID — even though no bytes were ever
@@ -92,6 +121,7 @@ func TestKitty_SecondRenderSameImageNoFlush(t *testing.T) {
 // the first render WITHOUT firing it, then asserts the second render
 // also hands back a fireable OnFlush.
 func TestKitty_RerenderBeforeUploadStillFlushes(t *testing.T) {
+	t.Setenv("TMUX", "")
 	reg := NewRegistry()
 	r := NewKittyRenderer(reg)
 	src := makeSolid(8, 8, imgcolor.RGBA{1, 2, 3, 255})

--- a/internal/image/probe.go
+++ b/internal/image/probe.go
@@ -24,7 +24,7 @@ func ProbeKittyGraphics(w io.Writer, r io.Reader, timeout time.Duration) bool {
 	const tinyPNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+P+/HgAFhAJ/wlseKgAAAABJRU5ErkJggg=="
 	const probeID = 9999
 	header := fmt.Sprintf("a=T,f=100,t=d,i=%d,q=0", probeID)
-	if _, err := fmt.Fprintf(w, "\x1b_G%s;%s\x1b\\", header, tinyPNG); err != nil {
+	if err := writeKittySequence(w, fmt.Sprintf("\x1b_G%s;%s\x1b\\", header, tinyPNG)); err != nil {
 		return false
 	}
 

--- a/internal/image/probe_test.go
+++ b/internal/image/probe_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestProbeKittyGraphics_TimeoutFails(t *testing.T) {
+	t.Setenv("TMUX", "")
 	r := blockingReader{}
 	var w bytes.Buffer
 	ok := ProbeKittyGraphics(&w, r, 50*time.Millisecond)
@@ -16,6 +17,19 @@ func TestProbeKittyGraphics_TimeoutFails(t *testing.T) {
 	}
 	if !strings.Contains(w.String(), "\x1b_G") {
 		t.Errorf("expected \\e_G in probe output, got %q", w.String())
+	}
+}
+
+func TestProbeKittyGraphics_WrapsProbeInTmux(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/tmux")
+	r := blockingReader{}
+	var w bytes.Buffer
+	ok := ProbeKittyGraphics(&w, r, 50*time.Millisecond)
+	if ok {
+		t.Error("expected probe to fail on timeout")
+	}
+	if !strings.HasPrefix(w.String(), "\x1bPtmux;\x1b\x1b_G") {
+		t.Errorf("expected tmux-wrapped kitty probe, got %q", w.String())
 	}
 }
 


### PR DESCRIPTION
Note: This is slop. But it allows images to render native (instead of halfblock) in kitty when tmux is being used. I figured it was worth making a PR for because I assume a lot of people using a terminal slack app are also using tmux with it like me.

## Summary

- wrap Kitty graphics uploads in tmux DCS passthrough when running under tmux
- apply the same wrapping to the Kitty graphics probe
- add tests for tmux wrapping behavior while preserving existing non-tmux output expectations

## Why

When `image_protocol = "kitty"` is forced inside tmux, slk currently emits raw Kitty graphics APC sequences. tmux strips those sequences unless applications wrap them in the `ESC Ptmux; ... ESC \` passthrough envelope with inner ESC bytes doubled. This makes forced Kitty image rendering work inside tmux while leaving `auto` detection behavior unchanged.

## Notes

This intentionally does not change the conservative auto-detection path where tmux still selects halfblock. Users who want native images inside tmux should explicitly set:

```toml
[appearance]
image_protocol = "kitty"
```

## Verification

- `go test ./internal/image ./internal/avatar`
- `go test ./...`
- `go build -o /tmp/opencode/slk-patched ./cmd/slk`
- manually tested in kitty + tmux with `image_protocol = "kitty"`