### PR TITLE
ui: render sent messages instantly without waiting for HTTP

### DIFF
--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -515,6 +515,14 @@ func run() error {
 	ctx := context.Background()
 	tsFormat := cfg.Appearance.TimestampFormat
 
+	// Used by the optimistic instant-display path on send: the App
+	// mints a placeholder MessageItem before the chat.postMessage HTTP
+	// round-trip and needs a Timestamp string that renders identically
+	// to messages arriving through the normal load path.
+	app.SetNowTimestampFormatter(func() string {
+		return time.Now().Format(tsFormat)
+	})
+
 	// Initialize shared image cache (used for avatars and inline images).
 	imagesDir := filepath.Join(cacheDir, "images")
 	imageCache, err := imgpkg.NewCache(imagesDir, cfg.Cache.MaxImageCacheMB)
@@ -924,7 +932,7 @@ func run() error {
 		app.SetMessageSender(func(channelID, text string) tea.Msg {
 			wctx := router.Active()
 			if wctx == nil {
-				return nil
+				return ui.MessageSendFailedMsg{ChannelID: channelID, Reason: "no active workspace"}
 			}
 			client := wctx.Client
 			userNames := wctx.UserNames
@@ -932,7 +940,7 @@ func run() error {
 			ts, sentMrkdwn, err := client.SendMessage(ctx, channelID, text)
 			if err != nil {
 				log.Printf("Warning: failed to send message: %v", err)
-				return nil
+				return ui.MessageSendFailedMsg{ChannelID: channelID, Reason: err.Error()}
 			}
 			userName := "you"
 			if resolved, ok := userNames[client.UserID()]; ok {
@@ -1140,7 +1148,7 @@ func run() error {
 		app.SetThreadReplySender(func(channelID, threadTS, text string) tea.Msg {
 			wctx := router.Active()
 			if wctx == nil {
-				return nil
+				return ui.ThreadReplySendFailedMsg{ChannelID: channelID, ThreadTS: threadTS, Reason: "no active workspace"}
 			}
 			client := wctx.Client
 			userNames := wctx.UserNames
@@ -1148,7 +1156,7 @@ func run() error {
 			ts, sentMrkdwn, err := client.SendReply(ctx, channelID, threadTS, text)
 			if err != nil {
 				log.Printf("Warning: failed to send thread reply: %v", err)
-				return nil
+				return ui.ThreadReplySendFailedMsg{ChannelID: channelID, ThreadTS: threadTS, Reason: err.Error()}
 			}
 			userName := "you"
 			if resolved, ok := userNames[client.UserID()]; ok {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gammons/slk/internal/debuglog"
 	"github.com/gammons/slk/internal/emoji"
 	imgpkg "github.com/gammons/slk/internal/image"
+	"github.com/gammons/slk/internal/slack/mrkdwn"
 	"github.com/gammons/slk/internal/ui/channelfinder"
 	"github.com/gammons/slk/internal/ui/channelpicker"
 	"github.com/gammons/slk/internal/ui/compose"
@@ -150,7 +151,16 @@ type (
 	ThreadReplySentMsg struct {
 		ChannelID string
 		ThreadTS  string
+		LocalTS   string // optimistic-placeholder id; see MessageSentMsg.LocalTS
 		Message   messages.MessageItem
+	}
+	// ThreadReplySendFailedMsg is returned when chat.postMessage for a
+	// thread reply fails. Mirrors MessageSendFailedMsg.
+	ThreadReplySendFailedMsg struct {
+		ChannelID string
+		ThreadTS  string
+		LocalTS   string
+		Reason    string
 	}
 	// ThreadsViewActivatedMsg is dispatched when the user picks the
 	// synthetic Threads sidebar row. The App switches the message pane to
@@ -440,9 +450,24 @@ type OlderMessagesFetchFunc func(channelID, oldestTS string) tea.Msg
 type MessageSendFunc func(channelID, text string) tea.Msg
 
 // MessageSentMsg is returned after a message is successfully sent.
+// LocalTS, if non-empty, identifies the optimistic placeholder added
+// when the user pressed Enter. The handler uses it to swap the
+// placeholder for the authoritative Message in place. LocalTS may be
+// empty for legacy/test callers that fire this message without a
+// preceding SendMessageMsg.
 type MessageSentMsg struct {
 	ChannelID string
+	LocalTS   string
 	Message   messages.MessageItem
+}
+
+// MessageSendFailedMsg is returned when chat.postMessage fails. The
+// App's handler removes the optimistic placeholder identified by
+// LocalTS (if any) and shows a toast.
+type MessageSendFailedMsg struct {
+	ChannelID string
+	LocalTS   string
+	Reason    string
 }
 
 // EditMessageMsg is emitted when the user submits an edit. App.Update
@@ -850,6 +875,23 @@ type App struct {
 	// while slk is open) do NOT update this map and continue to
 	// display via the normal WS-echo path.
 	lastSelfSendByChannel map[string]time.Time
+
+	// localTSCounter is incremented per optimistic-placeholder message
+	// so each one carries a unique TS-shaped ("local:<counter>") id.
+	// SendMessageMsg / SendThreadReplyMsg use this to mint a placeholder
+	// id, then MessageSentMsg / ThreadReplySentMsg uses it to swap the
+	// placeholder for the authoritative Slack-assigned TS once the
+	// chat.postMessage HTTP response arrives.
+	localTSCounter uint64
+
+	// nowTimestampFormatter renders "now" using the same format used
+	// for message timestamps elsewhere (configured via
+	// cfg.Appearance.TimestampFormat in main.go). Used by the optimistic
+	// instant-display path to populate the Timestamp field of a
+	// placeholder MessageItem so it renders identically to messages
+	// that arrived via the normal HTTP-response / WS-echo paths.
+	// Falls back to time.Now().Format("3:04 PM") when unset.
+	nowTimestampFormatter func() string
 
 	// Loading overlay
 	loading       bool
@@ -1407,6 +1449,12 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return statusbar.CopiedClearMsg{}
 		}))
 
+	case statusbar.SendFailedMsg:
+		a.statusbar.SetToast("Send failed: " + truncateReason(msg.Reason, 40))
+		cmds = append(cmds, tea.Tick(3*time.Second, func(time.Time) tea.Msg {
+			return statusbar.CopiedClearMsg{}
+		}))
+
 	case statusbar.EditNotOwnMsg:
 		a.statusbar.SetToast("Can only edit your own messages")
 		cmds = append(cmds, tea.Tick(2*time.Second, func(time.Time) tea.Msg {
@@ -1799,30 +1847,90 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// the user's send intent is what controls WS-echo suppression
 		// for self-user messages on this channel.
 		a.markSelfSendInFlight(msg.ChannelID)
+		// Instant-display: append an optimistic placeholder for the
+		// active channel immediately, before the chat.postMessage HTTP
+		// round-trip. The placeholder carries a "local:<n>" TS so the
+		// MessageSentMsg / MessageSendFailedMsg handler can find and
+		// swap (or remove) it once the HTTP result lands.
+		//
+		// We only render the placeholder when the send is for the
+		// channel currently in view. For background sends (rare —
+		// would require sending while in a different view) we skip
+		// the placeholder; the HTTP response will fall back to
+		// UpsertSelfSent's append path.
+		//
+		// Convert the user-typed CommonMark to Slack mrkdwn before
+		// rendering so the placeholder picks up bold / italic / code /
+		// link styling immediately. Without this, "**bold**" would
+		// render literally until the chat.postMessage HTTP response
+		// landed and the swap dropped in Slack's converted form. The
+		// converter is the same one used by client.SendMessage, so
+		// the placeholder and the swapped message render identically
+		// for the common case (no rich_text_block paragraph quirks).
+		localTS := a.nextLocalTS()
+		optimisticText, _ := mrkdwn.Convert(msg.Text)
+		if msg.ChannelID == a.activeChannelID {
+			a.messagepane.AppendMessage(messages.MessageItem{
+				TS:        localTS,
+				UserID:    a.currentUserID,
+				UserName:  a.userNameFor(a.currentUserID),
+				Text:      optimisticText,
+				Timestamp: a.nowFormatted(),
+			})
+		}
 		if a.messageSender != nil {
 			sender := a.messageSender
 			chID, text := msg.ChannelID, msg.Text
 			cmds = append(cmds, func() tea.Msg {
-				return sender(chID, text)
+				result := sender(chID, text)
+				// Attach LocalTS so the receiving handler can swap or
+				// remove the placeholder. Senders shouldn't need to
+				// know about LocalTS themselves.
+				switch r := result.(type) {
+				case MessageSentMsg:
+					r.LocalTS = localTS
+					return r
+				case MessageSendFailedMsg:
+					r.LocalTS = localTS
+					return r
+				}
+				return result
 			})
 		}
 
 	case MessageSentMsg:
-		// Optimistic add using the chat.postMessage HTTP response. The
-		// matching WS echo (if it arrives) is filtered in NewMessageMsg
-		// via isSelfSent so we don't double-render. We use UpsertSelfSent
-		// rather than AppendMessage so that the optimistic text wins
-		// even when the WS echo races ahead and was already stored
-		// (Slack may normalise wire-form text — e.g. flatten paragraph
-		// breaks for rich_text_block messages — but our renderer only
-		// reads the Text field; without upserting, multi-line composed
-		// messages render horizontally when the echo arrives first).
+		// The chat.postMessage HTTP response landed. If a "local:..."
+		// placeholder is in the pane from the instant-display path
+		// (SendMessageMsg above), swap it for the authoritative
+		// message. Otherwise — e.g. test paths firing MessageSentMsg
+		// directly, or the user navigated away and back between
+		// Enter and the HTTP response — fall back to UpsertSelfSent
+		// which appends-or-replaces by Slack TS.
+		//
+		// UpsertSelfSent is also the fallback for any racing WS echo
+		// that managed to slip past selfSendInFlight: if AppendMessage
+		// stored the echo's normalised text first, UpsertSelfSent
+		// replaces it with our converted-mrkdwn text. See
+		// internal/ui/messages/model.go for both methods' contracts.
 		if msg.Message.TS != "" {
 			a.recordSelfSent(msg.Message.TS)
 			if msg.ChannelID == a.activeChannelID {
-				a.messagepane.UpsertSelfSent(msg.Message)
+				if !a.messagepane.SwapLocalSent(msg.LocalTS, msg.Message) {
+					a.messagepane.UpsertSelfSent(msg.Message)
+				}
 			}
 		}
+
+	case MessageSendFailedMsg:
+		// The chat.postMessage HTTP call failed; roll back the
+		// optimistic placeholder so the user can see the send didn't
+		// go through. A toast surfaces the reason.
+		if msg.ChannelID == a.activeChannelID && msg.LocalTS != "" {
+			a.messagepane.RemoveLocalSent(msg.LocalTS)
+		}
+		cmds = append(cmds, func() tea.Msg {
+			return statusbar.SendFailedMsg{Reason: msg.Reason}
+		})
 
 	case EditMessageMsg:
 		a.markSelfSendInFlight(msg.ChannelID)
@@ -2003,24 +2111,52 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case SendThreadReplyMsg:
 		a.markSelfSendInFlight(msg.ChannelID)
+		// Instant-display: append an optimistic placeholder to the
+		// thread panel immediately, before the chat.postMessage HTTP
+		// round-trip. Mirrors the SendMessageMsg path; see there for
+		// the LocalTS / swap-or-remove contract and the mrkdwn.Convert
+		// rationale.
+		localTS := a.nextLocalTS()
+		optimisticText, _ := mrkdwn.Convert(msg.Text)
+		if a.threadVisible && msg.ThreadTS == a.threadPanel.ThreadTS() && msg.ChannelID == a.threadPanel.ChannelID() {
+			a.threadPanel.AddReply(messages.MessageItem{
+				TS:        localTS,
+				UserID:    a.currentUserID,
+				UserName:  a.userNameFor(a.currentUserID),
+				Text:      optimisticText,
+				Timestamp: a.nowFormatted(),
+				ThreadTS:  msg.ThreadTS,
+			})
+		}
 		if a.threadReplySender != nil {
 			sender := a.threadReplySender
 			chID, ts, text := msg.ChannelID, msg.ThreadTS, msg.Text
 			cmds = append(cmds, func() tea.Msg {
-				return sender(chID, ts, text)
+				result := sender(chID, ts, text)
+				switch r := result.(type) {
+				case ThreadReplySentMsg:
+					r.LocalTS = localTS
+					return r
+				case ThreadReplySendFailedMsg:
+					r.LocalTS = localTS
+					return r
+				}
+				return result
 			})
 		}
 
 	case ThreadReplySentMsg:
-		// Optimistic add using the chat.postMessage HTTP response. The
-		// internal Slack flannel WebSocket does not always echo
-		// self-posted thread replies as a plain "message" event the
-		// dispatcher recognizes, so relying on the echo alone meant the
-		// user's own thread reply wouldn't appear until the next time
-		// they reopened the app (whereupon GetReplies would pull it via
-		// HTTP). Optimistically applying all the side effects here makes
-		// the panel update immediately. If the echo does arrive it is
-		// filtered out via isSelfSent in NewMessageMsg.
+		// chat.postMessage for the thread reply landed. If a "local:..."
+		// placeholder is in the thread panel from the instant-display
+		// path (SendThreadReplyMsg above), swap it for the
+		// authoritative message; otherwise fall back to
+		// UpsertSelfSentReply.
+		//
+		// Note: the internal Slack flannel WebSocket does not always
+		// echo self-posted thread replies as a plain "message" event,
+		// so we cannot rely on the WS echo alone — the HTTP response
+		// must apply all the side effects (parent reply count, threads
+		// dirty) here.
 		if msg.Message.TS != "" {
 			a.recordSelfSent(msg.Message.TS)
 			// Update the thread panel whenever the visible thread matches,
@@ -2029,12 +2165,10 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// thread's channel, so gating on it here meant the user's own
 			// reply was sent to Slack but never appended locally -- they
 			// had to leave and re-enter the thread to see it.
-			//
-			// UpsertSelfSentReply (rather than AddReply) ensures the
-			// optimistic, locally-converted-mrkdwn text wins even when
-			// the WS echo races ahead and was already stored.
 			if a.threadVisible && msg.ThreadTS == a.threadPanel.ThreadTS() && msg.ChannelID == a.threadPanel.ChannelID() {
-				a.threadPanel.UpsertSelfSentReply(msg.Message)
+				if !a.threadPanel.SwapLocalSentReply(msg.LocalTS, msg.Message) {
+					a.threadPanel.UpsertSelfSentReply(msg.Message)
+				}
 			}
 			if msg.ChannelID == a.activeChannelID {
 				a.messagepane.IncrementReplyCount(msg.ThreadTS, msg.Message.TS)
@@ -2043,6 +2177,16 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				cmds = append(cmds, c)
 			}
 		}
+
+	case ThreadReplySendFailedMsg:
+		// chat.postMessage for the thread reply failed; roll back the
+		// optimistic placeholder. Mirrors MessageSendFailedMsg.
+		if a.threadVisible && msg.ThreadTS == a.threadPanel.ThreadTS() && msg.ChannelID == a.threadPanel.ChannelID() && msg.LocalTS != "" {
+			a.threadPanel.RemoveLocalSentReply(msg.LocalTS)
+		}
+		cmds = append(cmds, func() tea.Msg {
+			return statusbar.SendFailedMsg{Reason: msg.Reason}
+		})
 
 	case ConnectionStateMsg:
 		a.statusbar.SetConnectionState(statusbar.ConnectionState(msg.State))
@@ -4624,6 +4768,33 @@ func (a *App) SetPermalinkFetcher(fn PermalinkFetchFunc) {
 func (a *App) SetCurrentUserID(userID string) {
 	a.currentUserID = userID
 	a.threadsView.SetSelfUserID(userID)
+}
+
+// SetNowTimestampFormatter wires the formatter used to render the
+// Timestamp field of an optimistic instant-display message. main.go
+// passes a closure that uses cfg.Appearance.TimestampFormat so the
+// placeholder's time renders identically to the surrounding messages.
+func (a *App) SetNowTimestampFormatter(fn func() string) {
+	a.nowTimestampFormatter = fn
+}
+
+// nowFormatted returns the current time rendered via the configured
+// formatter, falling back to a sensible default when none is wired
+// (e.g. in tests).
+func (a *App) nowFormatted() string {
+	if a.nowTimestampFormatter != nil {
+		return a.nowTimestampFormatter()
+	}
+	return time.Now().Format("3:04 PM")
+}
+
+// nextLocalTS mints a unique placeholder id for an optimistic instant-
+// display message. The "local:" prefix makes it trivially
+// distinguishable from a Slack-assigned TS (which is always of the
+// form "<seconds>.<microseconds>").
+func (a *App) nextLocalTS() string {
+	a.localTSCounter++
+	return fmt.Sprintf("local:%d", a.localTSCounter)
 }
 
 func (a *App) SetFrecentFuncs(load FrecentLoadFunc, record FrecentRecordFunc) {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -1031,6 +1031,52 @@ func TestApp_ThreadReplySentOptimisticallyAddsToThreadPanel(t *testing.T) {
 	}
 }
 
+// TestSendThreadReply_InstantDisplay asserts that a thread reply
+// appears in the thread panel the moment SendThreadReplyMsg is
+// dispatched, before any HTTP round-trip. The placeholder is
+// swapped in place when ThreadReplySentMsg lands.
+func TestSendThreadReply_InstantDisplay(t *testing.T) {
+	app := NewApp()
+	app.SetCurrentUserID("USELF")
+	app.activeChannelID = "C1"
+	parent := messages.MessageItem{TS: "1700000000.000100"}
+	app.threadPanel.SetThread(parent, nil, "C1", "1700000000.000100")
+	app.threadVisible = true
+
+	app.Update(SendThreadReplyMsg{
+		ChannelID: "C1",
+		ThreadTS:  "1700000000.000100",
+		Text:      "instant reply",
+	})
+
+	if got := app.threadPanel.ReplyCount(); got != 1 {
+		t.Fatalf("instant-display: expected 1 placeholder reply, got %d", got)
+	}
+
+	// Capture the placeholder's local TS for the swap.
+	localTS := app.threadPanel.Replies()[0].TS
+	if !strings.HasPrefix(localTS, "local:") {
+		t.Errorf("placeholder reply TS = %q, want local:... id", localTS)
+	}
+
+	app.Update(ThreadReplySentMsg{
+		ChannelID: "C1",
+		ThreadTS:  "1700000000.000100",
+		LocalTS:   localTS,
+		Message: messages.MessageItem{
+			TS: "1700000050.000400", UserID: "USELF", UserName: "you",
+			Text: "instant reply", ThreadTS: "1700000000.000100",
+		},
+	})
+
+	if got := app.threadPanel.ReplyCount(); got != 1 {
+		t.Fatalf("post-swap: expected 1 reply, got %d", got)
+	}
+	if got := app.threadPanel.Replies()[0].TS; got != "1700000050.000400" {
+		t.Errorf("post-swap TS = %q, want real Slack TS", got)
+	}
+}
+
 func TestApp_NewMessageEchoOfSelfSentIsSkipped(t *testing.T) {
 	app := NewApp()
 	app.SetCurrentUserID("USELF")
@@ -2787,8 +2833,8 @@ func TestConversationOpenedMsg_InactiveWorkspaceIgnored(t *testing.T) {
 // TestSelfSendInFlight_SuppressesEarlyWSEcho asserts that when a slk-
 // originated send has been marked in-flight for a channel, an
 // arriving WS echo from the same user is dropped. Without this guard,
-// the WS echo (with Slack's normalised text) would render briefly,
-// then flicker-replace with the optimistic version.
+// the WS echo (with Slack's normalised text) would render alongside
+// the instant-display placeholder, double-rendering the same message.
 //
 // Cross-session messages (where lastSelfSendByChannel is NOT updated
 // for that channel because the user sent from another tool) must
@@ -2798,28 +2844,40 @@ func TestSelfSendInFlight_SuppressesEarlyWSEcho(t *testing.T) {
 	app.SetCurrentUserID("USELF")
 	app.activeChannelID = "C1"
 
-	// User submits a slk-originated send. SendMessageMsg dispatch
-	// records the in-flight timestamp.
+	// User submits a slk-originated send. SendMessageMsg appends an
+	// optimistic placeholder (instant-display) AND records the
+	// in-flight timestamp.
 	app.Update(SendMessageMsg{ChannelID: "C1", Text: "Hello\nWorld"})
 
+	// Instant-display placeholder is in the pane immediately.
+	if got := len(app.messagepane.Messages()); got != 1 {
+		t.Fatalf("expected 1 optimistic placeholder after SendMessageMsg, got %d", got)
+	}
+	if got := app.messagepane.Messages()[0].Text; got != "Hello\nWorld" {
+		t.Errorf("placeholder Text = %q, want %q", got, "Hello\nWorld")
+	}
+
 	// Slack's WS echo arrives BEFORE chat.postMessage HTTP responds.
-	// Currently no MessageSentMsg has fired, so isSelfSent(ts) is false.
+	// selfSendInFlight must drop it so we don't double-render.
 	app.Update(NewMessageMsg{
 		ChannelID: "C1",
 		Message: messages.MessageItem{
 			TS: "1700000999.000001", UserID: "USELF", Text: "Hello World",
 		},
 	})
-
-	// The echo must NOT have been added yet — the optimistic path
-	// will add it later via UpsertSelfSent with the correct text.
-	if got := len(app.messagepane.Messages()); got != 0 {
-		t.Errorf("WS echo added before optimistic; got %d messages, want 0", got)
+	if got := len(app.messagepane.Messages()); got != 1 {
+		t.Errorf("WS echo double-rendered alongside placeholder; got %d messages, want 1", got)
 	}
 
-	// Now MessageSentMsg arrives with the converted-mrkdwn text.
+	// MessageSentMsg arrives with the converted-mrkdwn text. The
+	// LocalTS field — assigned in the SendMessageMsg handler and
+	// threaded through the sender closure — lets the handler swap the
+	// placeholder for the authoritative message in place. The
+	// test simulates that wiring by reading the placeholder's TS.
+	localTS := app.messagepane.Messages()[0].TS
 	app.Update(MessageSentMsg{
 		ChannelID: "C1",
+		LocalTS:   localTS,
 		Message: messages.MessageItem{
 			TS: "1700000999.000001", UserID: "USELF", Text: "Hello\nWorld",
 		},
@@ -2827,10 +2885,114 @@ func TestSelfSendInFlight_SuppressesEarlyWSEcho(t *testing.T) {
 
 	got := app.messagepane.Messages()
 	if len(got) != 1 {
-		t.Fatalf("expected 1 message, got %d", len(got))
+		t.Fatalf("expected 1 message after swap, got %d", len(got))
+	}
+	if got[0].TS != "1700000999.000001" {
+		t.Errorf("after swap TS = %q, want real Slack TS", got[0].TS)
 	}
 	if got[0].Text != "Hello\nWorld" {
 		t.Errorf("Text = %q, want %q", got[0].Text, "Hello\nWorld")
+	}
+}
+
+// TestSendMessage_InstantDisplay asserts the quality-of-life
+// guarantee: the user's message must appear in the active channel
+// pane the moment SendMessageMsg is dispatched — before any HTTP
+// round-trip. The placeholder is replaced in place when MessageSentMsg
+// lands; its position in the list is preserved.
+func TestSendMessage_InstantDisplay(t *testing.T) {
+	app := NewApp()
+	app.SetCurrentUserID("USELF")
+	app.activeChannelID = "C1"
+	app.userNames = map[string]string{"USELF": "you"}
+
+	app.Update(SendMessageMsg{ChannelID: "C1", Text: "hello"})
+
+	msgs := app.messagepane.Messages()
+	if len(msgs) != 1 {
+		t.Fatalf("instant-display: expected 1 message after SendMessageMsg, got %d", len(msgs))
+	}
+	if msgs[0].Text != "hello" {
+		t.Errorf("placeholder Text = %q, want %q", msgs[0].Text, "hello")
+	}
+	if msgs[0].UserID != "USELF" {
+		t.Errorf("placeholder UserID = %q, want USELF", msgs[0].UserID)
+	}
+	if msgs[0].UserName != "you" {
+		t.Errorf("placeholder UserName = %q, want you", msgs[0].UserName)
+	}
+	if !strings.HasPrefix(msgs[0].TS, "local:") {
+		t.Errorf("placeholder TS = %q, want a local:... id", msgs[0].TS)
+	}
+
+	// Once the HTTP response arrives, the placeholder is swapped for
+	// the authoritative message. The list length stays at 1; the TS
+	// changes from local:... to the real Slack TS.
+	localTS := msgs[0].TS
+	app.Update(MessageSentMsg{
+		ChannelID: "C1",
+		LocalTS:   localTS,
+		Message: messages.MessageItem{
+			TS: "1700000999.000003", UserID: "USELF", UserName: "you", Text: "hello",
+		},
+	})
+
+	msgs = app.messagepane.Messages()
+	if len(msgs) != 1 {
+		t.Fatalf("post-swap: expected 1 message, got %d", len(msgs))
+	}
+	if msgs[0].TS != "1700000999.000003" {
+		t.Errorf("post-swap TS = %q, want real Slack TS", msgs[0].TS)
+	}
+}
+
+// TestSendMessage_InstantDisplayConvertsCommonMarkToSlackMrkdwn locks
+// in the bug fix where the optimistic placeholder was storing the
+// user's raw CommonMark text. The slk renderer expects Slack mrkdwn
+// (single-asterisk bold, single-underscore italic, single-backtick
+// code), so without conversion the placeholder rendered "**bold**"
+// literally and then re-rendered with proper styling once the HTTP
+// response brought back the converted text. We now convert in the
+// App before storing.
+func TestSendMessage_InstantDisplayConvertsCommonMarkToSlackMrkdwn(t *testing.T) {
+	app := NewApp()
+	app.SetCurrentUserID("USELF")
+	app.activeChannelID = "C1"
+
+	app.Update(SendMessageMsg{ChannelID: "C1", Text: "**bold** and _italic_"})
+
+	msgs := app.messagepane.Messages()
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 placeholder, got %d", len(msgs))
+	}
+	// mrkdwn.Convert("**bold** and _italic_") => "*bold* and _italic_"
+	if got, want := msgs[0].Text, "*bold* and _italic_"; got != want {
+		t.Errorf("placeholder Text = %q, want %q (CommonMark should be converted to Slack mrkdwn)", got, want)
+	}
+}
+
+// TestSendMessage_FailureRollsBackPlaceholder asserts that when
+// MessageSendFailedMsg arrives, the optimistic placeholder is removed
+// so the user can see the send did not go through.
+func TestSendMessage_FailureRollsBackPlaceholder(t *testing.T) {
+	app := NewApp()
+	app.SetCurrentUserID("USELF")
+	app.activeChannelID = "C1"
+
+	app.Update(SendMessageMsg{ChannelID: "C1", Text: "oops"})
+	if got := len(app.messagepane.Messages()); got != 1 {
+		t.Fatalf("setup: expected 1 placeholder, got %d", got)
+	}
+	localTS := app.messagepane.Messages()[0].TS
+
+	app.Update(MessageSendFailedMsg{
+		ChannelID: "C1",
+		LocalTS:   localTS,
+		Reason:    "network error",
+	})
+
+	if got := len(app.messagepane.Messages()); got != 0 {
+		t.Errorf("after failure expected placeholder removed, got %d messages", got)
 	}
 }
 

--- a/internal/ui/messages/model.go
+++ b/internal/ui/messages/model.go
@@ -622,6 +622,61 @@ func (m *Model) AppendMessage(msg MessageItem) {
 	m.selected = len(m.messages) - 1
 }
 
+// SwapLocalSent replaces an optimistic placeholder identified by
+// localTS (an internal "local:..." id assigned when the user pressed
+// Enter, before the chat.postMessage HTTP response carried back the
+// authoritative Slack TS) with the authoritative msg. The placeholder
+// keeps its position in the list so the rendered order matches what
+// the user saw when they hit Enter, but the entry's contents are
+// fully replaced (text, real TS, attachments, etc.).
+//
+// Returns true if a row matching localTS was found and swapped, false
+// otherwise. Callers that get false should typically fall back to
+// UpsertSelfSent so the message still lands (e.g. the user navigated
+// away from the channel between Enter and the HTTP response, so the
+// placeholder isn't in the current model).
+func (m *Model) SwapLocalSent(localTS string, msg MessageItem) bool {
+	if localTS == "" {
+		return false
+	}
+	for i := len(m.messages) - 1; i >= 0; i-- {
+		if m.messages[i].TS == localTS {
+			m.messages[i] = msg
+			m.cache = nil
+			m.dirty()
+			// Same rationale as UpsertSelfSent's replace branch: the
+			// authoritative entry may differ in height (e.g. server-
+			// rendered blocks) and the snap anchor needs to refresh.
+			m.hasSnapped = false
+			return true
+		}
+	}
+	return false
+}
+
+// RemoveLocalSent removes an optimistic placeholder identified by
+// localTS. Used when the chat.postMessage HTTP call fails and we want
+// to roll back the instant-display add. Returns true if a row was
+// removed.
+func (m *Model) RemoveLocalSent(localTS string) bool {
+	if localTS == "" {
+		return false
+	}
+	for i := len(m.messages) - 1; i >= 0; i-- {
+		if m.messages[i].TS == localTS {
+			m.messages = append(m.messages[:i], m.messages[i+1:]...)
+			m.cache = nil
+			m.dirty()
+			m.hasSnapped = false
+			if m.selected >= len(m.messages) && len(m.messages) > 0 {
+				m.selected = len(m.messages) - 1
+			}
+			return true
+		}
+	}
+	return false
+}
+
 // UpsertSelfSent is the optimistic-add variant of AppendMessage for
 // messages we just sent ourselves. If a message with the same TS
 // already exists (e.g. a WS echo arrived faster than the HTTP

--- a/internal/ui/statusbar/model.go
+++ b/internal/ui/statusbar/model.go
@@ -360,6 +360,11 @@ type DNDTickMsg struct{}
 // showing the toast and scheduling a CopiedClearMsg.
 type EditFailedMsg struct{ Reason string }
 
+// SendFailedMsg is delivered when chat.postMessage fails (either for a
+// top-level send or a thread reply). App handles by showing the toast
+// and scheduling a CopiedClearMsg.
+type SendFailedMsg struct{ Reason string }
+
 // DeleteFailedMsg is delivered when chat.delete fails.
 type DeleteFailedMsg struct{ Reason string }
 

--- a/internal/ui/thread/model.go
+++ b/internal/ui/thread/model.go
@@ -297,6 +297,47 @@ func (m *Model) AddReply(msg messages.MessageItem) {
 	m.selected = len(m.replies) - 1
 }
 
+// SwapLocalSentReply replaces an optimistic placeholder identified
+// by localTS (an internal "local:..." id assigned when the user
+// pressed Enter on a thread reply, before chat.postMessage returned
+// the real Slack TS) with the authoritative msg. Returns true if a
+// row matching localTS was found and swapped, false otherwise.
+// Mirrors messages.Model.SwapLocalSent.
+func (m *Model) SwapLocalSentReply(localTS string, msg messages.MessageItem) bool {
+	if localTS == "" {
+		return false
+	}
+	for i := len(m.replies) - 1; i >= 0; i-- {
+		if m.replies[i].TS == localTS {
+			m.replies[i] = msg
+			m.InvalidateCache()
+			return true
+		}
+	}
+	return false
+}
+
+// RemoveLocalSentReply removes an optimistic placeholder reply
+// identified by localTS. Used when the chat.postMessage HTTP call
+// fails and we want to roll back the instant-display add. Returns
+// true if a row was removed.
+func (m *Model) RemoveLocalSentReply(localTS string) bool {
+	if localTS == "" {
+		return false
+	}
+	for i := len(m.replies) - 1; i >= 0; i-- {
+		if m.replies[i].TS == localTS {
+			m.replies = append(m.replies[:i], m.replies[i+1:]...)
+			m.InvalidateCache()
+			if m.selected >= len(m.replies) && len(m.replies) > 0 {
+				m.selected = len(m.replies) - 1
+			}
+			return true
+		}
+	}
+	return false
+}
+
 // UpsertSelfSentReply is the optimistic-add variant of AddReply for
 // thread replies the user just sent themselves. If a reply with the
 // same TS already exists (e.g. a WS echo arrived faster than the


### PR DESCRIPTION
## Summary

Channel sends and thread replies now appear in the pane the moment the user hits Enter, instead of after the `chat.postMessage` HTTP round-trip. The optimistic placeholder is swapped in place for the authoritative Slack message when the HTTP response arrives. On failure the placeholder is rolled back and a `Send failed: …` toast is shown.

## Mechanics

- New `SendMessageMsg` / `SendThreadReplyMsg` handler arms mint a `"local:<n>"` placeholder TS, run `mrkdwn.Convert` on the user-typed text so CommonMark renders styled immediately, and append to the active channel / open thread.
- The sender closure attaches the `LocalTS` to whatever it returns; `MessageSentMsg` / `ThreadReplySentMsg` now carry a `LocalTS` field so the handler can call `messagepane.SwapLocalSent(localTS, realMsg)` (or `threadPanel.SwapLocalSentReply`) to swap by position.
- New `MessageSendFailedMsg` / `ThreadReplySendFailedMsg` types let `cmd/slk/main.go` surface send failures (previously it returned `nil` and silently dropped). The handler calls `RemoveLocalSent` / `RemoveLocalSentReply` and emits `statusbar.SendFailedMsg`.
- New `SetNowTimestampFormatter` lets `main.go` inject the same `tsFormat` used elsewhere so the placeholder's time renders identically to surrounding messages.

WS-echo dedup is unchanged: `selfSendInFlight` (3s channel-level window) still suppresses early-arriving echoes (the placeholder occupies the slot); `isSelfSent(realTS)` still handles late-arriving echoes after the swap.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — full suite green
- [x] New tests: `TestSendMessage_InstantDisplay`, `TestSendMessage_InstantDisplayConvertsCommonMarkToSlackMrkdwn`, `TestSendMessage_FailureRollsBackPlaceholder`, `TestSendThreadReply_InstantDisplay`
- [x] `TestSelfSendInFlight_SuppressesEarlyWSEcho` updated to reflect the new semantics (placeholder now present immediately; echo must not double-render)
- [x] Manual: type a channel message with `**bold**` / `_italic_` and hit Enter — renders styled immediately, no flicker when the HTTP response lands
- [x] Manual: open a thread, reply, confirm the same instant-display + no-flicker behavior
- [x] Manual: disconnect network, send a message — placeholder is removed and `Send failed: …` toast appears