### PR TITLE
Mention picker: channel-membership awareness + external (Slack Connect) users

### DIFF
--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -942,6 +942,14 @@ func run() error {
 			if wctx == nil || wctx.Membership == nil {
 				return
 			}
+			// Note: EnsureFresh synchronously calls pushSnapshot, which
+			// invokes p.Send(ChannelMembershipMsg). bubbletea v2's program
+			// channel is unbuffered (charm.land/bubbletea/v2 tea.go:598),
+			// so p.Send blocks until the Update goroutine receives. The
+			// App invokes this fetcher in a goroutine for exactly that
+			// reason (see app.go ChannelSelectedMsg handler) — we can
+			// call EnsureFresh synchronously here because we're already
+			// off the Update goroutine.
 			wctx.Membership.EnsureFresh(context.Background(), channelID)
 		})
 

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gammons/slk/internal/notify"
 	"github.com/gammons/slk/internal/service"
 	slackclient "github.com/gammons/slk/internal/slack"
+	"github.com/gammons/slk/internal/slack/membership"
 	"github.com/gammons/slk/internal/ui"
 	"github.com/gammons/slk/internal/ui/channelfinder"
 	"github.com/gammons/slk/internal/ui/compose"
@@ -178,6 +179,12 @@ type WorkspaceContext struct {
 	// fetch; the goroutine emits ui.UserResolvedMsg back into the
 	// program, which patches in-history rows live.
 	UserResolver *userResolver
+	// Membership owns per-channel member sets for this workspace:
+	// SQLite-backed cache + eager fetch on channel switch + live
+	// member_joined/left WS deltas + external-user resolution. Set
+	// in connectWorkspace alongside UserResolver (it depends on the
+	// resolver to trigger external-user lookups for newly-seen IDs).
+	Membership *membership.Manager
 }
 
 // workspaceRouter holds the program-wide "active workspace" pointer.
@@ -242,6 +249,25 @@ func (r *userResolver) Request(userID string) {
 		return
 	}
 	if _, exists := r.inflight.LoadOrStore(userID, struct{}{}); exists {
+		return
+	}
+	// Skip if already resolved (in cache.User). This is the hot path
+	// for membership.Manager which calls Request for every channel
+	// member returned by conversations.members; without this, every
+	// channel-switch refetches users.info for each member, which is
+	// O(channel-size) API calls per switch (a 1000-member shared
+	// channel = 1000 calls). Stale-data refresh is the responsibility
+	// of an explicit re-resolution path (not implemented here); this
+	// gate is for "first time we see this user".
+	//
+	// Order matters: inflight.LoadOrStore first (claim the slot),
+	// THEN the cache check (bail if cached), with inflight.Delete on
+	// the bail path. This avoids a race where two concurrent Requests
+	// both miss the cache, both then LoadOrStore (one wins, the loser
+	// silently returns). Store-first + check-second means at most one
+	// goroutine ever passes the cache check.
+	if _, err := r.db.GetUser(userID); err == nil {
+		r.inflight.Delete(userID)
 		return
 	}
 	go func() {
@@ -911,6 +937,14 @@ func run() error {
 			return db.GetChannelSyncedAt(channelID)
 		})
 
+		app.SetChannelMembershipFetcher(func(channelID string) {
+			wctx := router.Active()
+			if wctx == nil || wctx.Membership == nil {
+				return
+			}
+			wctx.Membership.EnsureFresh(context.Background(), channelID)
+		})
+
 		app.SetChannelFetcher(func(channelID, channelName string) tea.Msg {
 			wctx := router.Active()
 			if wctx == nil {
@@ -1248,6 +1282,19 @@ func run() error {
 		activeTeamID = teamID
 		router.Set(wctx)
 
+		// Build external-user set from cached records so the mention
+		// picker reflects Slack Connect / shared-channel guest status
+		// for the workspace we're switching into. Best-effort: empty
+		// map on error.
+		external := map[string]bool{}
+		if users, err := db.ListUsers(wctx.TeamID); err == nil {
+			for _, u := range users {
+				if u.IsExternal {
+					external[u.ID] = true
+				}
+			}
+		}
+
 		return ui.WorkspaceSwitchedMsg{
 			TeamID:           wctx.TeamID,
 			TeamName:         wctx.TeamName,
@@ -1255,6 +1302,7 @@ func run() error {
 			Channels:         wctx.Channels,
 			FinderItems:      wctx.FinderItems,
 			UserNames:        wctx.UserNames,
+			ExternalUsers:    external,
 			UserID:           wctx.UserID,
 			CustomEmoji:      wctx.CustomEmoji,
 			SectionsProvider: sectionsProviderAdapter{store: wctx.SectionStore},
@@ -1376,6 +1424,21 @@ func run() error {
 			wctx.ConnMgr = slackclient.NewConnectionManager(wctx.Client, handler)
 			go wctx.ConnMgr.Run(ctx)
 
+			// Build external-user set from cached records so the
+			// mention picker can flag Slack Connect / shared-channel
+			// guests on first render, without waiting for fresh
+			// userResolver lookups. Best-effort: empty map on error
+			// (the picker just won't flag anyone until live resolution
+			// fires).
+			external := map[string]bool{}
+			if users, err := db.ListUsers(wctx.TeamID); err == nil {
+				for _, u := range users {
+					if u.IsExternal {
+						external[u.ID] = true
+					}
+				}
+			}
+
 			p.Send(ui.WorkspaceReadyMsg{
 				TeamID:           wctx.TeamID,
 				TeamName:         wctx.TeamName,
@@ -1383,6 +1446,7 @@ func run() error {
 				Channels:         wctx.Channels,
 				FinderItems:      wctx.FinderItems,
 				UserNames:        wctx.UserNames,
+				ExternalUsers:    external,
 				UserID:           wctx.UserID,
 				CustomEmoji:      wctx.CustomEmoji, // empty at this point; filled by the goroutine below
 				SectionsProvider: sectionsProviderAdapter{store: wctx.SectionStore},
@@ -1534,6 +1598,23 @@ func connectWorkspace(ctx context.Context, token slackclient.Token, db *cache.DB
 		},
 	)
 
+	// Per-workspace channel-membership manager. *slackclient.Client
+	// structurally satisfies membership.ConversationMemberAPI; the
+	// user resolver satisfies membership.UserResolver. The push
+	// callback funnels member-set snapshots into the App via
+	// ui.ChannelMembershipMsg for picker hydration.
+	wctx.Membership = membership.New(
+		wctx.TeamID,
+		wctx.Client,
+		db,
+		func(channelID string, memberIDs []string) {
+			if p != nil {
+				p.Send(ui.ChannelMembershipMsg{ChannelID: channelID, MemberIDs: memberIDs})
+			}
+		},
+		wctx.UserResolver,
+	)
+
 	// Seed last-visited timestamps for the channel finder's recency
 	// sort. Best-effort: failure is logged and the map stays empty,
 	// which means the finder uses its default order until the user
@@ -1608,6 +1689,11 @@ func connectWorkspace(ctx context.Context, token slackclient.Token, db *cache.DB
 			if isBot {
 				wctx.BotUserIDs[u.ID] = true
 			}
+			// Slack Connect / shared-channel guests have a TeamID
+			// that differs from this workspace's home TeamID. Empty
+			// TeamID is treated as internal (under-detect rather than
+			// falsely flag). Mirrors userResolver.Request semantics.
+			isExternal := u.TeamID != "" && u.TeamID != client.TeamID()
 			db.UpsertUser(cache.User{
 				ID:          u.ID,
 				WorkspaceID: client.TeamID(),
@@ -1616,6 +1702,7 @@ func connectWorkspace(ctx context.Context, token slackclient.Token, db *cache.DB
 				AvatarURL:   u.Profile.Image32,
 				Presence:    "away",
 				IsBot:       isBot,
+				IsExternal:  isExternal,
 			})
 			// Record the avatar URL for lazy fetch (mirrors the cached-
 			// user seed above). The eager Preload was the second wave
@@ -1893,6 +1980,7 @@ func resolveUser(client *slackclient.Client, userID string, userNames map[string
 			// Have name but no avatar — try to fetch profile for avatar URL
 			if u, err := client.GetUserProfile(userID); err == nil {
 				isBot := u.IsBot || u.IsAppUser
+				isExternal := u.TeamID != "" && u.TeamID != client.TeamID()
 				avatarCache.Preload(userID, u.Profile.Image32)
 				db.UpsertUser(cache.User{
 					ID:          userID,
@@ -1902,6 +1990,7 @@ func resolveUser(client *slackclient.Client, userID string, userNames map[string
 					AvatarURL:   u.Profile.Image32,
 					Presence:    "away",
 					IsBot:       isBot,
+					IsExternal:  isExternal,
 				})
 				return name, isBot
 			}
@@ -1918,6 +2007,7 @@ func resolveUser(client *slackclient.Client, userID string, userNames map[string
 			name = u.Name
 		}
 		isBot := u.IsBot || u.IsAppUser
+		isExternal := u.TeamID != "" && u.TeamID != client.TeamID()
 		userNames[userID] = name
 		avatarCache.Preload(userID, u.Profile.Image32)
 		db.UpsertUser(cache.User{
@@ -1928,6 +2018,7 @@ func resolveUser(client *slackclient.Client, userID string, userNames map[string
 			AvatarURL:   u.Profile.Image32,
 			Presence:    "away",
 			IsBot:       isBot,
+			IsExternal:  isExternal,
 		})
 		return name, isBot
 	}
@@ -2871,6 +2962,19 @@ func (h *rtmEventHandler) OnConnect() {
 	// GetHistorySince calls return zero messages quickly. The 4-wide
 	// concurrency cap bounds the cost.
 	h.triggerBackfill("reconnect")
+
+	// Force-stale the active channel's membership cache and re-fetch.
+	// The WS may have missed member_joined/left deltas during the
+	// disconnect window; a fresh full fetch reconciles divergence.
+	// Inactive channels stay as-is — they'll re-fetch on their next
+	// EnsureFresh via the channel-switch fetcher path.
+	if h.wsCtx != nil && h.wsCtx.Membership != nil && h.activeChannelID != nil {
+		activeID := h.activeChannelID()
+		if activeID != "" {
+			h.wsCtx.Membership.ForceStale(activeID)
+			h.wsCtx.Membership.EnsureFresh(context.Background(), activeID)
+		}
+	}
 }
 
 // triggerBackfill kicks off a reconnect-style backfill pass for this
@@ -3239,11 +3343,17 @@ func (h *rtmEventHandler) OnPrefChange(name, value string) {
 }
 
 func (h *rtmEventHandler) OnMemberJoined(channelID, userID string) {
-	// TODO(membership-plan-task-13): wire to membership.Manager.
+	if h.wsCtx == nil || h.wsCtx.Membership == nil {
+		return
+	}
+	h.wsCtx.Membership.ApplyJoin(channelID, userID)
 }
 
 func (h *rtmEventHandler) OnMemberLeft(channelID, userID string) {
-	// TODO(membership-plan-task-13): wire to membership.Manager.
+	if h.wsCtx == nil || h.wsCtx.Membership == nil {
+		return
+	}
+	h.wsCtx.Membership.ApplyLeave(channelID, userID)
 }
 
 // refreshMutedForActive walks wctx.Channels, refreshes each item's

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -3228,6 +3228,14 @@ func (h *rtmEventHandler) OnPrefChange(name, value string) {
 	h.refreshMutedForActive()
 }
 
+func (h *rtmEventHandler) OnMemberJoined(channelID, userID string) {
+	// TODO(membership-plan-task-13): wire to membership.Manager.
+}
+
+func (h *rtmEventHandler) OnMemberLeft(channelID, userID string) {
+	// TODO(membership-plan-task-13): wire to membership.Manager.
+}
+
 // refreshMutedForActive walks wctx.Channels, refreshes each item's
 // IsMuted flag from the current MuteStore, and posts a
 // SectionsRefreshedMsg so the App rebuilds the sidebar from the

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -260,6 +260,12 @@ func (r *userResolver) Request(userID string) {
 			name = u.Name
 		}
 		isBot := u.IsBot || u.IsAppUser
+		// r.teamID is the workspace's home TeamID; u.TeamID is the
+		// user's home TeamID. If they differ (and u.TeamID is set),
+		// the user is a Slack Connect / shared-channel guest. Treat
+		// an empty u.TeamID as internal — better to under-detect than
+		// to falsely flag.
+		isExternal := u.TeamID != "" && u.TeamID != r.teamID
 		// Persist to the cache DB (its own goroutine-safe SQLite
 		// connection) and the avatar cache (internal RWMutex), but
 		// do NOT write r.userNames[userID] from this goroutine —
@@ -282,6 +288,7 @@ func (r *userResolver) Request(userID string) {
 			AvatarURL:   u.Profile.Image32,
 			Presence:    "away",
 			IsBot:       isBot,
+			IsExternal:  isExternal,
 		})
 		if r.send != nil {
 			r.send(ui.UserResolvedMsg{
@@ -290,6 +297,9 @@ func (r *userResolver) Request(userID string) {
 				DisplayName: name,
 				IsBot:       isBot,
 			})
+		}
+		if isExternal && r.send != nil {
+			r.send(ui.UserExternalMsg{UserID: userID, IsExternal: true})
 		}
 	}()
 }

--- a/docs/superpowers/specs/2026-05-20-mention-picker-channel-membership-design.md
+++ b/docs/superpowers/specs/2026-05-20-mention-picker-channel-membership-design.md
@@ -1,0 +1,311 @@
+# Mention Picker Channel Membership Design
+
+Date: 2026-05-20
+
+## Problem
+
+The `@`-mention picker today shows the entire workspace user directory, undifferentiated. Two consequences for users:
+
+1. People who are **not in the current channel** are mixed in with channel members. Mentioning them is technically allowed but is usually a mistake; the picker offers no signal that the person can't see the channel.
+2. **External users** (Slack Connect / shared channels) never appear in the picker at all. They're not in `users.list` for our workspace, so `wctx.UserNames` never contains them, so they're invisible to the picker even when they're sitting in the same shared channel.
+
+Additionally, every non-special row currently renders with a trailing empty parenthetical — e.g. `jane.doe ()` — because `mentionpicker.User.Username` is always blank in production. That's a pre-existing rendering bug we'll fix in the same change since we're already in the rendering code.
+
+## Scope
+
+In scope:
+
+- Channel membership awareness in the mention picker: muted text + `(not in channel)` suffix for non-members, members-first sort.
+- External user discovery and display: external users from shared channels appear in the picker with an `(ext)` suffix.
+- Fix the dead empty-parens rendering for users with no Username.
+
+Out of scope:
+
+- Member-search beyond prefix matching (no fuzzy / substring).
+- Recency-weighted sorting of the picker results.
+- Showing channel member counts anywhere in the UI.
+- Special handling for Enterprise Grid org-shared channels (should work via the same paths, but not specifically designed around).
+- Filtering bots out of the picker (their `(not in channel)` status will be accurate; deliberate decision to leave behavior unchanged).
+
+## Design Decisions
+
+1. **Show everyone, sort members first.** Non-members aren't hidden or filtered out — they're sorted below in-channel users, in muted text, with a `(not in channel)` label. Preserves the "I can still mention them if I really want to" affordance while making accidental mentions obvious.
+
+2. **Eager fetch on channel switch with SQLite persistence and live event updates.** Channel membership is fetched via `conversations.members` on first visit (and after TTL/reconnect invalidation), persisted to SQLite, and kept fresh by handling Slack's `member_joined_channel` and `member_left_channel` events. Reconnects invalidate the active channel; a 24h TTL is the backstop for everything else.
+
+3. **External users are resolved at fetch time, not lazily.** When `conversations.members` returns a user ID we don't have, we resolve it via `users.info` immediately and cache the result. The picker never shows raw user IDs; users that fail to resolve are simply omitted.
+
+4. **No new color dimension.** External users get a `(ext)` suffix in muted text rather than a distinct accent color. Keeps the visual language to two states (in-channel = normal, not-in-channel = muted), with optional muted suffixes layered on.
+
+## Data Model
+
+### `mentionpicker.User` — extend struct
+
+In `internal/ui/mentionpicker/model.go`:
+
+```go
+type User struct {
+    ID          string
+    DisplayName string
+    Username    string
+    InChannel   bool   // false for non-members of the active channel
+    IsExternal  bool   // true for Slack Connect users from another workspace
+}
+```
+
+`InChannel` defaults to `true` for the special mentions (`@here`, `@channel`, `@everyone`). Until membership data lands for the active channel, all real users default to `InChannel = true` so the picker renders the same as today.
+
+### SQLite — new `channel_members` table
+
+```sql
+CREATE TABLE channel_members (
+    workspace_id TEXT NOT NULL,
+    channel_id   TEXT NOT NULL,
+    user_id      TEXT NOT NULL,
+    updated_at   INTEGER NOT NULL,
+    PRIMARY KEY (workspace_id, channel_id, user_id)
+);
+CREATE INDEX idx_channel_members_channel ON channel_members(workspace_id, channel_id);
+```
+
+One row per (channel, member). Single-row inserts/deletes for join/leave events. No JSON blobs.
+
+### SQLite — new `channel_membership_meta` table
+
+```sql
+CREATE TABLE channel_membership_meta (
+    workspace_id        TEXT NOT NULL,
+    channel_id          TEXT NOT NULL,
+    last_full_fetch_at  INTEGER NOT NULL,
+    PRIMARY KEY (workspace_id, channel_id)
+);
+```
+
+`last_full_fetch_at` drives the 24h TTL check. Updated only on full successful paginated fetch — never on event deltas.
+
+### `cache.User` — add `is_external` column
+
+In `internal/cache/users.go`, add a nullable column:
+
+```sql
+ALTER TABLE users ADD COLUMN is_external INTEGER NOT NULL DEFAULT 0;
+```
+
+We persist external-user resolution so we don't re-resolve every time. Inferred from `team_id != client.TeamID()` in the `users.info` response.
+
+No new fields on the `channels` table — we infer "shared channel" implicitly by whether any member resolves as external.
+
+## Fetch & Cache Lifecycle
+
+### New component: `internal/slack/membership.Manager`
+
+One instance per workspace (constructed alongside `WorkspaceContext`). Owns:
+
+- In-memory `map[channelID]*channelMembership` cache.
+- A per-channel in-flight sentinel to dedupe concurrent fetches.
+- A small `users.info` worker pool (max 4 concurrent) for external user resolution.
+
+Backed by `cache.DB` for persistence.
+
+### Lifecycle events
+
+1. **Channel switch → `Manager.EnsureFresh(channelID)`**
+   - Load from SQLite into memory if not already loaded.
+   - Check `last_full_fetch_at`:
+     - **Fresh (< 24h):** push current membership to the UI, done.
+     - **Stale or missing:** push current membership to UI immediately (avoids empty picker), then kick off a background fetch.
+
+2. **Background fetch** — paginated `client.GetUsersInConversation(channelID)` with `limit=1000` per page. After each page:
+   - Diff against in-memory set; write inserts/deletes to SQLite.
+   - For unknown user IDs (not in `wctx.UserNames`, not in `cache.User`), enqueue external resolution.
+   - Push incremental update to UI if the channel is still active.
+
+   On full completion, update `last_full_fetch_at`. If the active channel changed mid-fetch, finish writing to SQLite anyway; skip the final UI push.
+
+3. **External user resolution** — worker pool reads from a dedupe-queue of `(workspace_id, user_id)` pairs.
+   - Call `users.info`.
+   - If `team_id != client.TeamID()`, set `is_external = 1`.
+   - Write to `cache.User`, update `wctx.UserNames`, push to active picker.
+
+4. **Live events** — wire `member_joined_channel` and `member_left_channel` into the existing event dispatcher.
+   - Single-row insert/delete to SQLite + in-memory set.
+   - If joining user is unknown, enqueue external resolution.
+   - Push update to active picker if the event's channel is currently active.
+   - Do **not** update `last_full_fetch_at` on event deltas — that timestamp tracks full-fetch freshness only.
+
+5. **Websocket reconnect** — hook the existing reconnect path.
+   - Force-stale the currently active channel.
+   - Immediately call `EnsureFresh(activeChannelID)`.
+   - Other channels stay as-is; they re-validate on next visit.
+
+### UI bridge
+
+New methods on `App`:
+
+- `App.SetChannelMembership(channelID string, memberIDs []string)` — analogous to existing `App.SetUserNames`. Forwards to both compose pickers. The payload is just user IDs; the picker resolves names from the workspace user list.
+- `compose.SetActiveChannel(channelID string)` — tells the picker which channel context to use when computing `InChannel`.
+
+The picker keeps two pieces of state:
+
+- Full workspace user list (from `SetUsers`, same as today; now includes resolved external users from any shared channels we've visited).
+- Per-channel member ID set (from `SetChannelMembership`).
+
+`InChannel` and `IsExternal` are populated on the `User` slice handed to the picker, computed per channel switch / membership update:
+
+- `InChannel = userID ∈ memberIDs`.
+- `IsExternal = cache.User.IsExternal` for that user.
+- **External user visibility rule:** a user with `IsExternal = true` is **only included in the picker's user list when they are in the active channel** (i.e., when `InChannel` would be true). External users who were cached from a previous shared channel but aren't in the current channel are filtered out of the picker entirely. This avoids the misleading `(ext) (not in channel)` combination — you can't usefully mention an external user from a channel they're not in. Internal users follow the existing "show with `(not in channel)` label" rule when not in the active channel.
+
+## UI Rendering & Sort
+
+### Sort order (top to bottom)
+
+1. Special mentions matching the query: `@here`, `@channel`, `@everyone`.
+2. In-channel users matching the query, alphabetical by DisplayName (internal + external interleaved).
+3. Not-in-channel users matching the query, alphabetical by DisplayName.
+
+Tie-break is alphabetical. No recency or relevance signal today; can be added later without breaking the protocol.
+
+### `MaxVisible`
+
+Bump from 5 to **7**. Still fits comfortably above the compose box, gives room for the new mixed-class rows.
+
+### Row format
+
+Example query `@j` in a shared channel:
+
+```
+▌ jane.doe                       ← selected, in channel, internal
+  john.smith                     ← in channel, internal
+  jenny.kim (ext)                ← in channel, external
+  jordan.lee (not in channel)    ← not in channel, internal, ENTIRE ROW MUTED
+  jamal.foo (not in channel)     ← not in channel, internal, ENTIRE ROW MUTED
+```
+
+### Styles
+
+Using existing styles from `internal/ui/styles/styles.go`:
+
+| Row class | DisplayName color | Suffix | Suffix color |
+|---|---|---|---|
+| In channel, internal | `TextPrimary` | — | — |
+| In channel, external | `TextPrimary` | ` (ext)` | `TextMuted` |
+| Not in channel | `TextMuted` | ` (not in channel)` | `TextMuted` |
+| Special mention | `TextPrimary` | ` (Username)` | `TextPrimary` |
+
+### Selection treatment
+
+- Indicator `▌` in `Accent` (unchanged).
+- In-channel rows: DisplayName becomes **bold** (unchanged).
+- Not-in-channel rows: DisplayName becomes **bold + `TextPrimary`** when selected (upgrades from muted), but ` (not in channel)` suffix stays `TextMuted`. The focused row stays readable; the at-rest visual hierarchy is preserved on unselected rows.
+
+### Dead-code fix for empty parens
+
+Current at `internal/ui/mentionpicker/model.go:148`:
+
+```go
+label := fmt.Sprintf("%s (%s)", u.DisplayName, u.Username)
+```
+
+Replace with:
+
+```go
+label := u.DisplayName
+if u.Username != "" {
+    label = fmt.Sprintf("%s (%s)", u.DisplayName, u.Username)
+}
+```
+
+`(Username)` disappears for real users (where Username is empty) and is preserved for the three special mentions which legitimately set it. The `(ext)` and `(not in channel)` suffixes are appended afterward, independent of this conditional.
+
+### Filter logic
+
+Unchanged from today: prefix match on DisplayName and Username, accent-folded via `text.Fold`. The match domain still includes all users (in-channel and not). Sort the matched set per the order above, then apply `MaxVisible`.
+
+### Loading state
+
+When membership data hasn't arrived for the active channel (first switch, cache miss in-flight), every real user defaults to `InChannel = true` — picker renders the same as today. When membership data lands, picker re-renders with proper labels. No spinner; one-frame re-sort.
+
+### Width handling
+
+Long `DisplayName + (not in channel)` may overflow narrow terminals. The picker's existing width plumbing truncates row-level, so the suffix truncates with the rest. Acceptable — matches current behavior.
+
+## Failure Modes & Edge Cases
+
+**API failures:**
+
+- `conversations.members` error (network, 5xx, permission): log it, leave `last_full_fetch_at` unchanged so we retry on next visit. Picker silently degrades to "no membership data" mode (everyone shown without labels).
+- Slack 429 rate-limit: respect `Retry-After` via slack-go's built-in handling. Background fetch sleeps and resumes.
+- `users.info` fails for an external user: leave them unresolved. Picker **does not show** unresolved users (raw `Uxxxx` IDs would be worse than omission). Resolution is retried on next channel visit.
+
+**Drift:**
+
+Live events keep things current while connected. Reconnects refresh the active channel. 24h TTL is the offline-drift backstop. Up to 24h of staleness for non-active channels after long offline periods is acceptable.
+
+**Picker open during channel switch:**
+
+The picker is owned by `compose.Model`, which is tied to the active channel. Channel switch dismisses the picker as a side effect of context change. The new channel's membership is loaded via `EnsureFresh` as part of the switch handler. **Verify during implementation:** if the picker can persist across channel switches today, explicitly close it on switch.
+
+**DMs and group DMs:**
+
+`conversations.members` works on `D…` and `G…` IDs and returns implicit member lists. Treated like any other channel — no special-case code. A 1:1 DM will show 2 members in-channel and everyone else as "not in channel"; that's accurate, if visually unusual.
+
+**Workspace switch:**
+
+`Manager` is per-workspace. SQLite is workspace-scoped via the `workspace_id` column. Switching workspaces switches manager instances.
+
+**Channels we're not a member of:**
+
+User can't open a compose box for unjoined channels, so `EnsureFresh` is never called for them. No design change needed.
+
+**Migration failure:**
+
+Tables are additive — new `channel_members`, new `channel_membership_meta`, new `is_external` column with default. If migration fails, follow the existing `internal/cache/` migration error pattern. Recoverable by deleting the cache file.
+
+**Rapid channel switching (A → B → A):**
+
+In-flight sentinel prevents duplicate fetches per channel. Both fetches complete and write to SQLite. Only the currently active channel pushes UI updates. No race in visible state.
+
+**Out-of-order events after reconnect:**
+
+Events are applied as deltas — re-applying a duplicate join is idempotent (already in set), re-applying a duplicate leave on a missing user is a no-op. No correctness issue.
+
+**Members we can't render a name for:**
+
+A `member_joined_channel` event may name a user we've never seen and can't resolve (offline, `users.info` fails, deleted account, etc.). Such users sit in `channel_members` but aren't in `cache.User` / `wctx.UserNames`. The picker skips them — better to show nothing than `U07ABCDE`. Resolution is retried opportunistically on next channel visit. If they're ever rendered without a name in the message history, that's a separate codepath (the existing `UserResolver` in `cmd/slk/main.go`) and not affected by this design.
+
+## Touched Files
+
+Reasonably complete list. Exact line numbers shift during implementation.
+
+- `internal/ui/mentionpicker/model.go` — extend `User` struct, update filter sort, update view rendering (suffixes, muted styles, selection upgrade, empty-parens fix).
+- `internal/ui/compose/model.go` — add `activeChannel`, accept and store channel membership, pass it into the picker, close picker on channel switch if needed.
+- `internal/ui/app.go` — add `SetChannelMembership`, propagate to both compose pickers; thread `compose.SetActiveChannel` through channel-switch handlers.
+- `internal/slack/membership/manager.go` — new file. `Manager`, `EnsureFresh`, background fetch goroutine, in-flight sentinel, external resolution worker pool.
+- `internal/slack/client.go` — add `GetUsersInConversation` wrapper around slack-go's `GetUsersInConversationContext`.
+- `internal/slack/events.go` — add `member_joined_channel` and `member_left_channel` cases to the dispatch switch (around line 258, alongside the existing `message`, `reaction_added`, `presence_change`, etc. cases).
+- `internal/cache/migrations/` — new migration adding `channel_members`, `channel_membership_meta`, and the `is_external` column on `users`.
+- `internal/cache/users.go` — add `IsExternal` to the `User` struct and queries.
+- `internal/cache/channel_members.go` — new file. Insert / delete / list / TTL-meta queries.
+- `cmd/slk/main.go` — construct `Manager`, wire reconnect-refresh hook, wire channel-switch hook.
+
+## Testing Strategy
+
+- **Unit tests** on `Manager`:
+  - `EnsureFresh` cache hit (fresh) — no fetch.
+  - `EnsureFresh` cache miss — fetch + persist + UI push.
+  - `EnsureFresh` stale (past TTL) — fetch + persist + UI push.
+  - Concurrent `EnsureFresh` for same channel — single fetch (in-flight sentinel).
+  - Event handler: join applies delta without touching `last_full_fetch_at`.
+  - External user resolution: unknown ID → `users.info` → cache write.
+  - External user resolution failure: ID stays unresolved, not shown.
+- **Unit tests** on `mentionpicker` sort/render:
+  - Sort order with mixed in-channel / not-in-channel / external / special rows.
+  - Empty-parens fix: non-special row without Username renders no parenthetical.
+  - Selection upgrade: muted-row-when-selected renders bold + `TextPrimary` on name, muted on suffix.
+  - Loading state: when no channel membership data, every real user renders as in-channel.
+- **Integration / manual**:
+  - Open a public channel, type `@` — see members at top, non-members muted below.
+  - Open a Slack Connect channel, type `@` — see external members with `(ext)` suffix.
+  - Disconnect and reconnect — verify active channel re-fetches and picker reflects current membership.
+  - Receive a `member_joined_channel` event while picker is open — verify joined user moves to in-channel section on next render.

--- a/internal/cache/channel_members.go
+++ b/internal/cache/channel_members.go
@@ -1,0 +1,121 @@
+package cache
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// UpsertChannelMember inserts or updates a single membership row.
+// Used by member_joined_channel event deltas.
+func (db *DB) UpsertChannelMember(workspaceID, channelID, userID string, updatedAt int64) error {
+	_, err := db.conn.Exec(`
+		INSERT INTO channel_members (workspace_id, channel_id, user_id, updated_at)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT(workspace_id, channel_id, user_id) DO UPDATE SET
+			updated_at=excluded.updated_at
+	`, workspaceID, channelID, userID, updatedAt)
+	if err != nil {
+		return fmt.Errorf("upserting channel member: %w", err)
+	}
+	return nil
+}
+
+// DeleteChannelMember removes a single membership row.
+// No-op (no error) if the row doesn't exist.
+func (db *DB) DeleteChannelMember(workspaceID, channelID, userID string) error {
+	_, err := db.conn.Exec(`
+		DELETE FROM channel_members
+		WHERE workspace_id = ? AND channel_id = ? AND user_id = ?
+	`, workspaceID, channelID, userID)
+	if err != nil {
+		return fmt.Errorf("deleting channel member: %w", err)
+	}
+	return nil
+}
+
+// ListChannelMembers returns user IDs for a channel, in no guaranteed order.
+func (db *DB) ListChannelMembers(workspaceID, channelID string) ([]string, error) {
+	rows, err := db.conn.Query(`
+		SELECT user_id FROM channel_members
+		WHERE workspace_id = ? AND channel_id = ?
+	`, workspaceID, channelID)
+	if err != nil {
+		return nil, fmt.Errorf("listing channel members: %w", err)
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scanning channel member: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+// ReplaceChannelMembers atomically replaces the full member set for a
+// channel and updates last_full_fetch_at in channel_membership_meta.
+// Used by the background full-fetch completion path. fetchedAt is a
+// Unix second timestamp.
+func (db *DB) ReplaceChannelMembers(workspaceID, channelID string, userIDs []string, fetchedAt int64) error {
+	tx, err := db.conn.Begin()
+	if err != nil {
+		return fmt.Errorf("begin replace channel members: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck // committed below on success
+
+	if _, err := tx.Exec(`
+		DELETE FROM channel_members
+		WHERE workspace_id = ? AND channel_id = ?
+	`, workspaceID, channelID); err != nil {
+		return fmt.Errorf("clearing channel members: %w", err)
+	}
+
+	stmt, err := tx.Prepare(`
+		INSERT INTO channel_members (workspace_id, channel_id, user_id, updated_at)
+		VALUES (?, ?, ?, ?)
+	`)
+	if err != nil {
+		return fmt.Errorf("prepare insert: %w", err)
+	}
+	defer stmt.Close()
+	for _, uid := range userIDs {
+		if _, err := stmt.Exec(workspaceID, channelID, uid, fetchedAt); err != nil {
+			return fmt.Errorf("insert channel member %s: %w", uid, err)
+		}
+	}
+
+	if _, err := tx.Exec(`
+		INSERT INTO channel_membership_meta (workspace_id, channel_id, last_full_fetch_at)
+		VALUES (?, ?, ?)
+		ON CONFLICT(workspace_id, channel_id) DO UPDATE SET
+			last_full_fetch_at=excluded.last_full_fetch_at
+	`, workspaceID, channelID, fetchedAt); err != nil {
+		return fmt.Errorf("upserting meta: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit replace channel members: %w", err)
+	}
+	return nil
+}
+
+// GetChannelMembershipMeta returns last_full_fetch_at for a channel.
+// ok=false if no row exists (channel never fetched).
+func (db *DB) GetChannelMembershipMeta(workspaceID, channelID string) (int64, bool, error) {
+	var ts int64
+	err := db.conn.QueryRow(`
+		SELECT last_full_fetch_at FROM channel_membership_meta
+		WHERE workspace_id = ? AND channel_id = ?
+	`, workspaceID, channelID).Scan(&ts)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, false, nil
+		}
+		return 0, false, fmt.Errorf("getting channel membership meta: %w", err)
+	}
+	return ts, true, nil
+}

--- a/internal/cache/channel_members.go
+++ b/internal/cache/channel_members.go
@@ -103,6 +103,25 @@ func (db *DB) ReplaceChannelMembers(workspaceID, channelID string, userIDs []str
 	return nil
 }
 
+// ZeroChannelMembershipMeta sets last_full_fetch_at to 0 for a
+// channel without touching the channel_members table. Used by
+// membership.Manager.ForceStale on websocket reconnect to invalidate
+// freshness without wiping the persisted member list.
+//
+// No-op (no error) if the meta row doesn't exist — there's nothing
+// to invalidate, and the next full fetch will create the row.
+func (db *DB) ZeroChannelMembershipMeta(workspaceID, channelID string) error {
+	_, err := db.conn.Exec(`
+		UPDATE channel_membership_meta
+		SET last_full_fetch_at = 0
+		WHERE workspace_id = ? AND channel_id = ?
+	`, workspaceID, channelID)
+	if err != nil {
+		return fmt.Errorf("zeroing channel membership meta: %w", err)
+	}
+	return nil
+}
+
 // GetChannelMembershipMeta returns last_full_fetch_at for a channel.
 // ok=false if no row exists (channel never fetched).
 func (db *DB) GetChannelMembershipMeta(workspaceID, channelID string) (int64, bool, error) {

--- a/internal/cache/channel_members_test.go
+++ b/internal/cache/channel_members_test.go
@@ -1,0 +1,140 @@
+package cache
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestUpsertAndListChannelMember(t *testing.T) {
+	db := setupDBWithWorkspace(t)
+	defer db.Close()
+
+	if err := db.UpsertChannelMember("T1", "C1", "U1", 100); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.UpsertChannelMember("T1", "C1", "U2", 100); err != nil {
+		t.Fatal(err)
+	}
+	got, err := db.ListChannelMembers("T1", "C1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(got)
+	if len(got) != 2 || got[0] != "U1" || got[1] != "U2" {
+		t.Errorf("ListChannelMembers = %v, want [U1 U2]", got)
+	}
+}
+
+func TestUpsertChannelMemberIdempotent(t *testing.T) {
+	db := setupDBWithWorkspace(t)
+	defer db.Close()
+
+	if err := db.UpsertChannelMember("T1", "C1", "U1", 100); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.UpsertChannelMember("T1", "C1", "U1", 200); err != nil {
+		t.Fatalf("re-upsert errored: %v", err)
+	}
+	got, err := db.ListChannelMembers("T1", "C1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Errorf("expected single row after re-upsert, got %v", got)
+	}
+}
+
+func TestDeleteChannelMember(t *testing.T) {
+	db := setupDBWithWorkspace(t)
+	defer db.Close()
+
+	_ = db.UpsertChannelMember("T1", "C1", "U1", 100)
+	_ = db.UpsertChannelMember("T1", "C1", "U2", 100)
+	if err := db.DeleteChannelMember("T1", "C1", "U1"); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := db.ListChannelMembers("T1", "C1")
+	if len(got) != 1 || got[0] != "U2" {
+		t.Errorf("after delete, got %v, want [U2]", got)
+	}
+}
+
+func TestDeleteMissingChannelMemberIsNoop(t *testing.T) {
+	db := setupDBWithWorkspace(t)
+	defer db.Close()
+
+	if err := db.DeleteChannelMember("T1", "C1", "U_GONE"); err != nil {
+		t.Errorf("deleting nonexistent row should be noop, got %v", err)
+	}
+}
+
+func TestReplaceChannelMembersUpdatesMeta(t *testing.T) {
+	db := setupDBWithWorkspace(t)
+	defer db.Close()
+
+	if err := db.ReplaceChannelMembers("T1", "C1", []string{"U1", "U2", "U3"}, 12345); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := db.ListChannelMembers("T1", "C1")
+	sort.Strings(got)
+	if len(got) != 3 {
+		t.Errorf("ListChannelMembers = %v, want 3", got)
+	}
+	ts, ok, err := db.GetChannelMembershipMeta("T1", "C1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || ts != 12345 {
+		t.Errorf("meta = (%d, %v), want (12345, true)", ts, ok)
+	}
+}
+
+func TestReplaceChannelMembersReplacesNotAppends(t *testing.T) {
+	db := setupDBWithWorkspace(t)
+	defer db.Close()
+
+	_ = db.ReplaceChannelMembers("T1", "C1", []string{"U1", "U2"}, 100)
+	_ = db.ReplaceChannelMembers("T1", "C1", []string{"U2", "U3"}, 200)
+
+	got, _ := db.ListChannelMembers("T1", "C1")
+	sort.Strings(got)
+	if len(got) != 2 || got[0] != "U2" || got[1] != "U3" {
+		t.Errorf("ListChannelMembers after replace = %v, want [U2 U3]", got)
+	}
+	ts, _, _ := db.GetChannelMembershipMeta("T1", "C1")
+	if ts != 200 {
+		t.Errorf("meta last_full_fetch_at = %d, want 200", ts)
+	}
+}
+
+func TestGetChannelMembershipMetaMissing(t *testing.T) {
+	db := setupDBWithWorkspace(t)
+	defer db.Close()
+
+	_, ok, err := db.GetChannelMembershipMeta("T1", "C_UNKNOWN")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Error("expected ok=false for missing meta")
+	}
+}
+
+func TestChannelMembersScopedByWorkspace(t *testing.T) {
+	db := setupDBWithWorkspace(t)
+	defer db.Close()
+	// Add a second workspace so the FK on channels would have somewhere to point if we used it.
+	_ = db.UpsertWorkspace(Workspace{ID: "T2", Name: "Other"})
+
+	_ = db.UpsertChannelMember("T1", "C1", "U1", 100)
+	_ = db.UpsertChannelMember("T2", "C1", "U2", 100)
+
+	got1, _ := db.ListChannelMembers("T1", "C1")
+	got2, _ := db.ListChannelMembers("T2", "C1")
+	if len(got1) != 1 || got1[0] != "U1" {
+		t.Errorf("T1/C1 = %v, want [U1]", got1)
+	}
+	if len(got2) != 1 || got2[0] != "U2" {
+		t.Errorf("T2/C1 = %v, want [U2]", got2)
+	}
+}

--- a/internal/cache/channel_members_test.go
+++ b/internal/cache/channel_members_test.go
@@ -120,6 +120,36 @@ func TestGetChannelMembershipMetaMissing(t *testing.T) {
 	}
 }
 
+func TestZeroChannelMembershipMetaPreservesMembers(t *testing.T) {
+	db := setupDBWithWorkspace(t)
+	defer db.Close()
+
+	_ = db.ReplaceChannelMembers("T1", "C1", []string{"U1", "U2"}, 12345)
+	if err := db.ZeroChannelMembershipMeta("T1", "C1"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Members preserved.
+	got, _ := db.ListChannelMembers("T1", "C1")
+	if len(got) != 2 {
+		t.Errorf("members lost: %v", got)
+	}
+	// Meta zeroed.
+	ts, ok, _ := db.GetChannelMembershipMeta("T1", "C1")
+	if !ok || ts != 0 {
+		t.Errorf("meta = (%d, %v), want (0, true)", ts, ok)
+	}
+}
+
+func TestZeroChannelMembershipMetaMissingIsNoop(t *testing.T) {
+	db := setupDBWithWorkspace(t)
+	defer db.Close()
+
+	if err := db.ZeroChannelMembershipMeta("T1", "C_NEVER_FETCHED"); err != nil {
+		t.Errorf("zeroing nonexistent meta should be noop; got %v", err)
+	}
+}
+
 func TestChannelMembersScopedByWorkspace(t *testing.T) {
 	db := setupDBWithWorkspace(t)
 	defer db.Close()

--- a/internal/cache/db.go
+++ b/internal/cache/db.go
@@ -165,6 +165,24 @@ func (db *DB) migrate() error {
 	CREATE INDEX IF NOT EXISTS idx_channel_visits_recent ON channel_visits(workspace_id, last_visited DESC);
 	CREATE INDEX IF NOT EXISTS idx_thread_subs_workspace
 		ON thread_subscriptions(workspace_id, active);
+
+	CREATE TABLE IF NOT EXISTS channel_members (
+		workspace_id TEXT NOT NULL,
+		channel_id   TEXT NOT NULL,
+		user_id      TEXT NOT NULL,
+		updated_at   INTEGER NOT NULL,
+		PRIMARY KEY (workspace_id, channel_id, user_id)
+	);
+
+	CREATE TABLE IF NOT EXISTS channel_membership_meta (
+		workspace_id        TEXT NOT NULL,
+		channel_id          TEXT NOT NULL,
+		last_full_fetch_at  INTEGER NOT NULL,
+		PRIMARY KEY (workspace_id, channel_id)
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_channel_members_channel
+		ON channel_members(workspace_id, channel_id);
 	`
 
 	if _, err := db.conn.Exec(schema); err != nil {
@@ -191,6 +209,10 @@ func (db *DB) migrate() error {
 	}
 	if err := db.addColumnIfMissing("channels", "has_unread",
 		"ALTER TABLE channels ADD COLUMN has_unread INTEGER NOT NULL DEFAULT 0"); err != nil {
+		return err
+	}
+	if err := db.addColumnIfMissing("users", "is_external",
+		"ALTER TABLE users ADD COLUMN is_external INTEGER NOT NULL DEFAULT 0"); err != nil {
 		return err
 	}
 

--- a/internal/cache/db.go
+++ b/internal/cache/db.go
@@ -48,6 +48,14 @@ func New(dsn string) (*DB, error) {
 		return nil, fmt.Errorf("opening database: %w", err)
 	}
 
+	// SQLite ":memory:" databases are per-connection: each new
+	// connection in the pool gets its own empty database. Pin the
+	// pool to a single connection so concurrent writers all see the
+	// same in-memory schema. Disk-backed DSNs are unaffected.
+	if strings.HasPrefix(dsn, ":memory:") {
+		conn.SetMaxOpenConns(1)
+	}
+
 	db := &DB{conn: conn}
 	if err := db.migrate(); err != nil {
 		conn.Close()

--- a/internal/cache/db_test.go
+++ b/internal/cache/db_test.go
@@ -237,6 +237,48 @@ func TestNew_SetsBusyTimeoutOnAllPoolConnections(t *testing.T) {
 	}
 }
 
+func TestMembershipSchema(t *testing.T) {
+	db, err := New(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	// Tables exist.
+	for _, table := range []string{"channel_members", "channel_membership_meta"} {
+		var name string
+		err := db.conn.QueryRow(
+			`SELECT name FROM sqlite_master WHERE type='table' AND name=?`, table,
+		).Scan(&name)
+		if err != nil {
+			t.Errorf("table %s missing: %v", table, err)
+		}
+	}
+
+	// is_external column present on users.
+	rows, err := db.conn.Query(`PRAGMA table_info(users)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	found := false
+	for rows.Next() {
+		var cid int
+		var name, ctype string
+		var notnull, pk int
+		var dflt sql.NullString
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			t.Fatal(err)
+		}
+		if name == "is_external" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("users.is_external column missing")
+	}
+}
+
 func TestMigrate_CreatesThreadSubscriptionsTable(t *testing.T) {
 	db := setupDBWithWorkspace(t)
 	// PRAGMA table_info returns one row per column on an existing

--- a/internal/cache/users.go
+++ b/internal/cache/users.go
@@ -13,22 +13,27 @@ type User struct {
 	// slack.User.IsBot and IsAppUser). Used to bucket their DMs into
 	// the "Apps" sidebar section so they don't clutter the human DM
 	// list.
-	IsBot     bool
-	UpdatedAt int64
+	IsBot bool
+	// IsExternal is true for users whose home team_id differs from
+	// the workspace's TeamID (Slack Connect / shared-channel guests).
+	// Set by the user-resolution path; persisted so we don't re-resolve.
+	IsExternal bool
+	UpdatedAt  int64
 }
 
 func (db *DB) UpsertUser(u User) error {
 	_, err := db.conn.Exec(`
-		INSERT INTO users (id, workspace_id, name, display_name, avatar_url, presence, is_bot, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO users (id, workspace_id, name, display_name, avatar_url, presence, is_bot, is_external, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			name=excluded.name,
 			display_name=excluded.display_name,
 			avatar_url=excluded.avatar_url,
 			presence=excluded.presence,
 			is_bot=excluded.is_bot,
+			is_external=excluded.is_external,
 			updated_at=excluded.updated_at
-	`, u.ID, u.WorkspaceID, u.Name, u.DisplayName, u.AvatarURL, u.Presence, u.IsBot, u.UpdatedAt)
+	`, u.ID, u.WorkspaceID, u.Name, u.DisplayName, u.AvatarURL, u.Presence, u.IsBot, u.IsExternal, u.UpdatedAt)
 	if err != nil {
 		return fmt.Errorf("upserting user: %w", err)
 	}
@@ -38,9 +43,9 @@ func (db *DB) UpsertUser(u User) error {
 func (db *DB) GetUser(id string) (User, error) {
 	var u User
 	err := db.conn.QueryRow(`
-		SELECT id, workspace_id, name, display_name, avatar_url, presence, is_bot, updated_at
+		SELECT id, workspace_id, name, display_name, avatar_url, presence, is_bot, is_external, updated_at
 		FROM users WHERE id = ?
-	`, id).Scan(&u.ID, &u.WorkspaceID, &u.Name, &u.DisplayName, &u.AvatarURL, &u.Presence, &u.IsBot, &u.UpdatedAt)
+	`, id).Scan(&u.ID, &u.WorkspaceID, &u.Name, &u.DisplayName, &u.AvatarURL, &u.Presence, &u.IsBot, &u.IsExternal, &u.UpdatedAt)
 	if err != nil {
 		return u, fmt.Errorf("getting user: %w", err)
 	}
@@ -49,7 +54,7 @@ func (db *DB) GetUser(id string) (User, error) {
 
 func (db *DB) ListUsers(workspaceID string) ([]User, error) {
 	rows, err := db.conn.Query(`
-		SELECT id, workspace_id, name, display_name, avatar_url, presence, is_bot, updated_at
+		SELECT id, workspace_id, name, display_name, avatar_url, presence, is_bot, is_external, updated_at
 		FROM users WHERE workspace_id = ? ORDER BY display_name, name
 	`, workspaceID)
 	if err != nil {
@@ -60,7 +65,7 @@ func (db *DB) ListUsers(workspaceID string) ([]User, error) {
 	var users []User
 	for rows.Next() {
 		var u User
-		if err := rows.Scan(&u.ID, &u.WorkspaceID, &u.Name, &u.DisplayName, &u.AvatarURL, &u.Presence, &u.IsBot, &u.UpdatedAt); err != nil {
+		if err := rows.Scan(&u.ID, &u.WorkspaceID, &u.Name, &u.DisplayName, &u.AvatarURL, &u.Presence, &u.IsBot, &u.IsExternal, &u.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scanning user: %w", err)
 		}
 		users = append(users, u)

--- a/internal/cache/users_test.go
+++ b/internal/cache/users_test.go
@@ -32,6 +32,46 @@ func TestUpsertAndGetUser(t *testing.T) {
 	}
 }
 
+func TestUpsertUserPreservesIsExternal(t *testing.T) {
+	db := setupDBWithWorkspace(t)
+	defer db.Close()
+
+	u := User{
+		ID:          "U_EXT",
+		WorkspaceID: "T1",
+		Name:        "ext.user",
+		DisplayName: "External User",
+		IsExternal:  true,
+	}
+	if err := db.UpsertUser(u); err != nil {
+		t.Fatal(err)
+	}
+	got, err := db.GetUser("U_EXT")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.IsExternal {
+		t.Errorf("IsExternal not persisted: got %+v", got)
+	}
+}
+
+func TestUpsertUserDefaultsIsExternalFalse(t *testing.T) {
+	db := setupDBWithWorkspace(t)
+	defer db.Close()
+
+	u := User{ID: "U_INT", WorkspaceID: "T1", Name: "int.user", DisplayName: "Internal"}
+	if err := db.UpsertUser(u); err != nil {
+		t.Fatal(err)
+	}
+	got, err := db.GetUser("U_INT")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.IsExternal {
+		t.Errorf("IsExternal should default to false; got %+v", got)
+	}
+}
+
 func TestUpdatePresence(t *testing.T) {
 	db := setupDBWithWorkspace(t)
 	defer db.Close()

--- a/internal/slack/client.go
+++ b/internal/slack/client.go
@@ -26,6 +26,7 @@ type SlackAPI interface {
 	GetConversationHistory(params *slack.GetConversationHistoryParameters) (*slack.GetConversationHistoryResponse, error)
 	GetConversationReplies(params *slack.GetConversationRepliesParameters) ([]slack.Message, bool, string, error)
 	GetUsersContext(ctx context.Context, options ...slack.GetUsersOption) ([]slack.User, error)
+	GetUsersInConversationContext(ctx context.Context, params *slack.GetUsersInConversationParameters) ([]string, string, error)
 	GetUserInfo(user string) (*slack.User, error)
 	GetEmoji() (map[string]string, error)
 	PostMessage(channelID string, options ...slack.MsgOption) (string, string, error)
@@ -396,6 +397,55 @@ func (c *Client) GetAllPublicChannels(ctx context.Context) ([]slack.Channel, err
 	}
 
 	return allChannels, nil
+}
+
+// GetUsersInConversation returns all user IDs that are members of the
+// given conversation (channel, DM, group DM, or shared channel). Paginates
+// 1000 IDs per page. On 429 responses, sleeps the server-advised RetryAfter
+// (defaulting to 30s if zero) and retries the same page; honors ctx
+// cancellation both between iterations and during the rate-limit sleep.
+// Mirrors GetAllPublicChannels' loop structure.
+func (c *Client) GetUsersInConversation(ctx context.Context, channelID string) ([]string, error) {
+	var all []string
+	cursor := ""
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		params := &slack.GetUsersInConversationParameters{
+			ChannelID: channelID,
+			Cursor:    cursor,
+			Limit:     1000,
+		}
+
+		users, next, err := c.api.GetUsersInConversationContext(ctx, params)
+		if err != nil {
+			if rlErr, ok := err.(*slack.RateLimitedError); ok {
+				wait := rlErr.RetryAfter
+				if wait == 0 {
+					wait = 30 * time.Second
+				}
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(wait):
+				}
+				continue
+			}
+			return nil, fmt.Errorf("listing conversation members: %w", err)
+		}
+
+		all = append(all, users...)
+
+		if next == "" {
+			return all, nil
+		}
+		cursor = next
+	}
 }
 
 // JoinChannel joins a public channel via conversations.join. Returns nil on

--- a/internal/slack/client_test.go
+++ b/internal/slack/client_test.go
@@ -8,8 +8,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/slack-go/slack"
 )
@@ -131,18 +133,19 @@ func TestSendMessage_EmptyTextSendsNoBlocks(t *testing.T) {
 // mockSlackAPI implements SlackAPI for testing.
 // Function fields allow tests to override default behavior.
 type mockSlackAPI struct {
-	authTestFn               func() (*slack.AuthTestResponse, error)
-	getConversationHistoryFn func(params *slack.GetConversationHistoryParameters) (*slack.GetConversationHistoryResponse, error)
-	getConversationRepliesFn func(params *slack.GetConversationRepliesParameters) ([]slack.Message, bool, string, error)
-	getEmojiFn               func() (map[string]string, error)
-	getPermalinkContextFn    func(ctx context.Context, params *slack.PermalinkParameters) (string, error)
-	setUserPresenceContextFn func(ctx context.Context, presence string) error
-	getUserPresenceContextFn func(ctx context.Context, user string) (*slack.UserPresence, error)
-	setSnoozeContextFn       func(ctx context.Context, minutes int) (*slack.DNDStatus, error)
-	endSnoozeContextFn       func(ctx context.Context) (*slack.DNDStatus, error)
-	endDNDContextFn          func(ctx context.Context) error
-	getDNDInfoContextFn      func(ctx context.Context, user *string, options ...slack.ParamOption) (*slack.DNDStatus, error)
-	uploadFileContextFn      func(ctx context.Context, params slack.UploadFileParameters) (*slack.FileSummary, error)
+	authTestFn                      func() (*slack.AuthTestResponse, error)
+	getConversationHistoryFn        func(params *slack.GetConversationHistoryParameters) (*slack.GetConversationHistoryResponse, error)
+	getConversationRepliesFn        func(params *slack.GetConversationRepliesParameters) ([]slack.Message, bool, string, error)
+	getEmojiFn                      func() (map[string]string, error)
+	getPermalinkContextFn           func(ctx context.Context, params *slack.PermalinkParameters) (string, error)
+	setUserPresenceContextFn        func(ctx context.Context, presence string) error
+	getUserPresenceContextFn        func(ctx context.Context, user string) (*slack.UserPresence, error)
+	setSnoozeContextFn              func(ctx context.Context, minutes int) (*slack.DNDStatus, error)
+	endSnoozeContextFn              func(ctx context.Context) (*slack.DNDStatus, error)
+	endDNDContextFn                 func(ctx context.Context) error
+	getDNDInfoContextFn             func(ctx context.Context, user *string, options ...slack.ParamOption) (*slack.DNDStatus, error)
+	uploadFileContextFn             func(ctx context.Context, params slack.UploadFileParameters) (*slack.FileSummary, error)
+	getUsersInConversationContextFn func(ctx context.Context, params *slack.GetUsersInConversationParameters) ([]string, string, error)
 }
 
 func (m *mockSlackAPI) GetConversations(params *slack.GetConversationsParameters) ([]slack.Channel, string, error) {
@@ -270,6 +273,13 @@ func (m *mockSlackAPI) UploadFileContext(ctx context.Context, params slack.Uploa
 		return m.uploadFileContextFn(ctx, params)
 	}
 	return &slack.FileSummary{}, nil
+}
+
+func (m *mockSlackAPI) GetUsersInConversationContext(ctx context.Context, params *slack.GetUsersInConversationParameters) ([]string, string, error) {
+	if m.getUsersInConversationContextFn != nil {
+		return m.getUsersInConversationContextFn(ctx, params)
+	}
+	return nil, "", nil
 }
 
 func TestUploadFile_Success(t *testing.T) {
@@ -1790,5 +1800,103 @@ func TestListThreadSubscriptions_ReturnsErrorOnNotOK(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "invalid_auth") {
 		t.Errorf("error = %q, want contains \"invalid_auth\"", err.Error())
+	}
+}
+
+func TestGetUsersInConversationPaginates(t *testing.T) {
+	type page struct {
+		users []string
+		next  string
+	}
+	pages := map[string]page{
+		"":        {users: []string{"U1", "U2"}, next: "cursor2"},
+		"cursor2": {users: []string{"U3"}, next: ""},
+	}
+	var seenChannel string
+	var seenLimits []int
+	mock := &mockSlackAPI{
+		getUsersInConversationContextFn: func(ctx context.Context, params *slack.GetUsersInConversationParameters) ([]string, string, error) {
+			seenChannel = params.ChannelID
+			seenLimits = append(seenLimits, params.Limit)
+			p, ok := pages[params.Cursor]
+			if !ok {
+				t.Fatalf("unexpected cursor %q", params.Cursor)
+			}
+			return p.users, p.next, nil
+		},
+	}
+	c := &Client{api: mock}
+
+	got, err := c.GetUsersInConversation(context.Background(), "C1")
+	if err != nil {
+		t.Fatalf("GetUsersInConversation: %v", err)
+	}
+	want := []string{"U1", "U2", "U3"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	if seenChannel != "C1" {
+		t.Errorf("ChannelID = %q, want %q", seenChannel, "C1")
+	}
+	if len(seenLimits) != 2 {
+		t.Fatalf("expected 2 API calls, got %d", len(seenLimits))
+	}
+	for i, lim := range seenLimits {
+		if lim != 1000 {
+			t.Errorf("call[%d].Limit = %d, want 1000", i, lim)
+		}
+	}
+}
+
+func TestGetUsersInConversationPropagatesError(t *testing.T) {
+	wantErr := errors.New("channel_not_found")
+	mock := &mockSlackAPI{
+		getUsersInConversationContextFn: func(ctx context.Context, params *slack.GetUsersInConversationParameters) ([]string, string, error) {
+			return nil, "", wantErr
+		},
+	}
+	c := &Client{api: mock}
+
+	_, err := c.GetUsersInConversation(context.Background(), "C1")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Errorf("expected wrapped wantErr, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "listing conversation members") {
+		t.Errorf("expected 'listing conversation members' prefix, got %q", err.Error())
+	}
+}
+
+func TestGetUsersInConversationRetriesOnRateLimit(t *testing.T) {
+	var calls int
+	var seenCursors []string
+	mock := &mockSlackAPI{
+		getUsersInConversationContextFn: func(ctx context.Context, params *slack.GetUsersInConversationParameters) ([]string, string, error) {
+			calls++
+			seenCursors = append(seenCursors, params.Cursor)
+			if calls == 1 {
+				return nil, "", &slack.RateLimitedError{RetryAfter: 10 * time.Millisecond}
+			}
+			return []string{"U1", "U2"}, "", nil
+		},
+	}
+	c := &Client{api: mock}
+
+	got, err := c.GetUsersInConversation(context.Background(), "C1")
+	if err != nil {
+		t.Fatalf("GetUsersInConversation: %v", err)
+	}
+	want := []string{"U1", "U2"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 API calls (1 rate-limited + 1 retry), got %d", calls)
+	}
+	// On rate-limit, cursor must NOT advance — the retry hits the same page.
+	if seenCursors[0] != "" || seenCursors[1] != "" {
+		t.Errorf("expected both calls with empty cursor (same page retry), got %v", seenCursors)
 	}
 }

--- a/internal/slack/events.go
+++ b/internal/slack/events.go
@@ -77,6 +77,15 @@ type EventHandler interface {
 	// value as a string — for list-shaped prefs like muted_channels,
 	// Slack ships the full updated list, comma-separated.
 	OnPrefChange(name, value string)
+
+	// OnMemberJoined is delivered for member_joined_channel WS events:
+	// a user joined the conversation. For shared channels this includes
+	// external (Slack Connect) users. The receiver should persist the
+	// membership and trigger external-user resolution if the user is unknown.
+	OnMemberJoined(channelID, userID string)
+
+	// OnMemberLeft is delivered for member_left_channel WS events.
+	OnMemberLeft(channelID, userID string)
 }
 
 // wsEvent is the minimal structure for identifying a WebSocket event type.
@@ -136,6 +145,15 @@ type wsTypingEvent struct {
 	Type    string `json:"type"`
 	Channel string `json:"channel"`
 	User    string `json:"user"`
+}
+
+// wsMemberChannelEvent represents member_joined_channel /
+// member_left_channel. Both events share the same shape.
+type wsMemberChannelEvent struct {
+	Type    string `json:"type"`
+	Channel string `json:"channel"`
+	User    string `json:"user"`
+	Team    string `json:"team"`
 }
 
 // wsManualPresenceEvent represents a manual_presence_change event,
@@ -379,6 +397,22 @@ func dispatchWebSocketEvent(data []byte, handler EventHandler) {
 			return
 		}
 		handler.OnUserTyping(evt.Channel, evt.User)
+
+	case "member_joined_channel":
+		var evt wsMemberChannelEvent
+		if err := json.Unmarshal(data, &evt); err != nil {
+			return
+		}
+		debuglog.WS("member_joined_channel: channel=%s user=%s", evt.Channel, evt.User)
+		handler.OnMemberJoined(evt.Channel, evt.User)
+
+	case "member_left_channel":
+		var evt wsMemberChannelEvent
+		if err := json.Unmarshal(data, &evt); err != nil {
+			return
+		}
+		debuglog.WS("member_left_channel: channel=%s user=%s", evt.Channel, evt.User)
+		handler.OnMemberLeft(evt.Channel, evt.User)
 
 	case "channel_section_upserted":
 		var raw wsChannelSectionUpserted

--- a/internal/slack/events_test.go
+++ b/internal/slack/events_test.go
@@ -42,10 +42,18 @@ type mockEventHandler struct {
 	sectionChannelsRemoved        []string
 
 	prefChanges []prefChangeRecord
+
+	memberJoined []memberEventRecord
+	memberLeft   []memberEventRecord
 }
 
 type prefChangeRecord struct {
 	name, value string
+}
+
+type memberEventRecord struct {
+	channelID string
+	userID    string
 }
 
 type channelMarkRecord struct {
@@ -128,6 +136,13 @@ func (m *mockEventHandler) OnChannelSectionChannelsRemoved(sectionID string, cha
 }
 func (m *mockEventHandler) OnPrefChange(name, value string) {
 	m.prefChanges = append(m.prefChanges, prefChangeRecord{name, value})
+}
+
+func (m *mockEventHandler) OnMemberJoined(channelID, userID string) {
+	m.memberJoined = append(m.memberJoined, memberEventRecord{channelID, userID})
+}
+func (m *mockEventHandler) OnMemberLeft(channelID, userID string) {
+	m.memberLeft = append(m.memberLeft, memberEventRecord{channelID, userID})
 }
 
 func TestEventHandlerInterface(t *testing.T) {
@@ -623,5 +638,31 @@ func TestDispatch_PrefChange_EmptyValue(t *testing.T) {
 	}
 	if h.prefChanges[0].value != "" {
 		t.Errorf("value = %q, want empty", h.prefChanges[0].value)
+	}
+}
+
+func TestDispatchMemberJoinedChannel(t *testing.T) {
+	handler := &mockEventHandler{}
+	data := []byte(`{"type":"member_joined_channel","channel":"C1","user":"U_NEW","team":"T1"}`)
+	dispatchWebSocketEvent(data, handler)
+	if len(handler.memberJoined) != 1 {
+		t.Fatalf("expected 1 join, got %d", len(handler.memberJoined))
+	}
+	rec := handler.memberJoined[0]
+	if rec.channelID != "C1" || rec.userID != "U_NEW" {
+		t.Errorf("got %+v, want {C1 U_NEW}", rec)
+	}
+}
+
+func TestDispatchMemberLeftChannel(t *testing.T) {
+	handler := &mockEventHandler{}
+	data := []byte(`{"type":"member_left_channel","channel":"C1","user":"U_GONE","team":"T1"}`)
+	dispatchWebSocketEvent(data, handler)
+	if len(handler.memberLeft) != 1 {
+		t.Fatalf("expected 1 leave, got %d", len(handler.memberLeft))
+	}
+	rec := handler.memberLeft[0]
+	if rec.channelID != "C1" || rec.userID != "U_GONE" {
+		t.Errorf("got %+v, want {C1 U_GONE}", rec)
 	}
 }

--- a/internal/slack/membership/manager.go
+++ b/internal/slack/membership/manager.go
@@ -63,8 +63,17 @@ func New(workspaceID string, api ConversationMemberAPI, db *cache.DB, push PushF
 
 // EnsureFresh loads (if needed) cached membership for a channel,
 // pushes it to the UI, and triggers a background full-fetch if the
-// cache is missing or older than TTL. Returns immediately; fetch is
-// asynchronous.
+// cache is missing or older than TTL. The background fetch is
+// asynchronous, but the initial cache load and PushFunc invocation
+// run synchronously on the caller's goroutine.
+//
+// IMPORTANT: EnsureFresh calls PushFunc synchronously via pushSnapshot.
+// If PushFunc invokes bubbletea's Program.Send (which uses an unbuffered
+// channel in bubbletea v2), DO NOT call EnsureFresh from inside a
+// bubbletea Update handler — Send would deadlock waiting for the
+// Update goroutine to receive. Call EnsureFresh from a separate
+// goroutine in that case. Calling from a WebSocket-reader goroutine
+// or any background goroutine is safe.
 func (m *Manager) EnsureFresh(ctx context.Context, channelID string) {
 	m.loadIntoMemory(channelID)
 	m.pushSnapshot(channelID)

--- a/internal/slack/membership/manager.go
+++ b/internal/slack/membership/manager.go
@@ -1,0 +1,155 @@
+// Package membership manages per-channel member sets: SQLite-backed
+// persistence, eager fetch on channel switch, live event deltas, and
+// external (Slack Connect) user resolution.
+package membership
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/gammons/slk/internal/cache"
+)
+
+// TTL bounds how stale cached membership can be before EnsureFresh
+// triggers a background re-fetch. Spec: 24h.
+const TTL = 24 * time.Hour
+
+// ConversationMemberAPI is the slack-client subset Manager needs.
+// Decoupled from *slackclient.Client for testability.
+type ConversationMemberAPI interface {
+	GetUsersInConversation(ctx context.Context, channelID string) ([]string, error)
+}
+
+// UserResolver is the userResolver subset Manager invokes to trigger
+// external-user resolution for unknown IDs. nil-safe in early tasks;
+// wired in Task 12.
+type UserResolver interface {
+	Request(userID string)
+}
+
+// PushFunc is invoked by Manager whenever a channel's membership has
+// new data to surface to the UI. Wired in main.go to program.Send
+// with a ui.ChannelMembershipMsg.
+type PushFunc func(channelID string, memberIDs []string)
+
+// Manager owns per-channel member state for one workspace.
+type Manager struct {
+	workspaceID string
+	api         ConversationMemberAPI
+	db          *cache.DB
+	push        PushFunc
+	resolver    UserResolver
+
+	mu       sync.Mutex
+	members  map[string]map[string]struct{} // channelID -> member set
+	fetching map[string]struct{}            // in-flight sentinel by channelID
+}
+
+// New constructs a Manager bound to one workspace.
+func New(workspaceID string, api ConversationMemberAPI, db *cache.DB, push PushFunc, resolver UserResolver) *Manager {
+	return &Manager{
+		workspaceID: workspaceID,
+		api:         api,
+		db:          db,
+		push:        push,
+		resolver:    resolver,
+		members:     map[string]map[string]struct{}{},
+		fetching:    map[string]struct{}{},
+	}
+}
+
+// EnsureFresh loads (if needed) cached membership for a channel,
+// pushes it to the UI, and triggers a background full-fetch if the
+// cache is missing or older than TTL. Returns immediately; fetch is
+// asynchronous.
+func (m *Manager) EnsureFresh(ctx context.Context, channelID string) {
+	m.loadIntoMemory(channelID)
+	m.pushSnapshot(channelID)
+
+	fetchedAt, ok, err := m.db.GetChannelMembershipMeta(m.workspaceID, channelID)
+	if err != nil {
+		// Treat read error as stale — better to refetch than to wedge.
+		ok = false
+	}
+	fresh := ok && time.Since(time.Unix(fetchedAt, 0)) < TTL
+	if fresh {
+		return
+	}
+	go m.backgroundFetch(ctx, channelID)
+}
+
+// loadIntoMemory reads the cached member set into the in-memory map
+// if not already present. Safe to call repeatedly.
+func (m *Manager) loadIntoMemory(channelID string) {
+	m.mu.Lock()
+	_, have := m.members[channelID]
+	m.mu.Unlock()
+	if have {
+		return
+	}
+	ids, err := m.db.ListChannelMembers(m.workspaceID, channelID)
+	if err != nil {
+		return
+	}
+	set := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		set[id] = struct{}{}
+	}
+	m.mu.Lock()
+	if _, raced := m.members[channelID]; !raced {
+		m.members[channelID] = set
+	}
+	m.mu.Unlock()
+}
+
+// pushSnapshot calls the push callback with the current in-memory
+// member set for a channel.
+func (m *Manager) pushSnapshot(channelID string) {
+	m.mu.Lock()
+	set := m.members[channelID]
+	ids := make([]string, 0, len(set))
+	for id := range set {
+		ids = append(ids, id)
+	}
+	m.mu.Unlock()
+	if m.push != nil {
+		m.push(channelID, ids)
+	}
+}
+
+// backgroundFetch performs a single GetUsersInConversation call,
+// persists the result via cache.ReplaceChannelMembers (which bumps
+// last_full_fetch_at), updates in-memory state, and pushes to UI.
+// Deduped by per-channel in-flight sentinel.
+func (m *Manager) backgroundFetch(ctx context.Context, channelID string) {
+	m.mu.Lock()
+	if _, busy := m.fetching[channelID]; busy {
+		m.mu.Unlock()
+		return
+	}
+	m.fetching[channelID] = struct{}{}
+	m.mu.Unlock()
+	defer func() {
+		m.mu.Lock()
+		delete(m.fetching, channelID)
+		m.mu.Unlock()
+	}()
+
+	ids, err := m.api.GetUsersInConversation(ctx, channelID)
+	if err != nil {
+		return
+	}
+	now := time.Now().Unix()
+	if err := m.db.ReplaceChannelMembers(m.workspaceID, channelID, ids, now); err != nil {
+		return
+	}
+	set := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		set[id] = struct{}{}
+	}
+	m.mu.Lock()
+	m.members[channelID] = set
+	m.mu.Unlock()
+	m.pushSnapshot(channelID)
+}

--- a/internal/slack/membership/manager.go
+++ b/internal/slack/membership/manager.go
@@ -41,9 +41,10 @@ type Manager struct {
 	push        PushFunc
 	resolver    UserResolver
 
-	mu       sync.Mutex
-	members  map[string]map[string]struct{} // channelID -> member set
-	fetching map[string]struct{}            // in-flight sentinel by channelID
+	mu          sync.Mutex
+	members     map[string]map[string]struct{} // channelID -> member set
+	fetching    map[string]struct{}            // in-flight sentinel by channelID
+	lastFetched map[string]time.Time           // last successful full-fetch (in-memory, for dedup)
 }
 
 // New constructs a Manager bound to one workspace.
@@ -56,6 +57,7 @@ func New(workspaceID string, api ConversationMemberAPI, db *cache.DB, push PushF
 		resolver:    resolver,
 		members:     map[string]map[string]struct{}{},
 		fetching:    map[string]struct{}{},
+		lastFetched: map[string]time.Time{},
 	}
 }
 
@@ -128,6 +130,15 @@ func (m *Manager) backgroundFetch(ctx context.Context, channelID string) {
 		m.mu.Unlock()
 		return
 	}
+	// Also dedup against an in-memory recent-fetch timestamp: a prior
+	// goroutine may have already completed and released the sentinel
+	// before this one arrived. The DB-backed TTL check in EnsureFresh
+	// can't catch this because a flurry of concurrent EnsureFresh calls
+	// all read the (empty) meta before any one of them persists.
+	if last, ok := m.lastFetched[channelID]; ok && time.Since(last) < TTL {
+		m.mu.Unlock()
+		return
+	}
 	m.fetching[channelID] = struct{}{}
 	m.mu.Unlock()
 	defer func() {
@@ -140,6 +151,11 @@ func (m *Manager) backgroundFetch(ctx context.Context, channelID string) {
 	if err != nil {
 		return
 	}
+	if m.resolver != nil {
+		for _, id := range ids {
+			m.resolver.Request(id)
+		}
+	}
 	now := time.Now().Unix()
 	if err := m.db.ReplaceChannelMembers(m.workspaceID, channelID, ids, now); err != nil {
 		return
@@ -150,6 +166,61 @@ func (m *Manager) backgroundFetch(ctx context.Context, channelID string) {
 	}
 	m.mu.Lock()
 	m.members[channelID] = set
+	m.lastFetched[channelID] = time.Now()
 	m.mu.Unlock()
 	m.pushSnapshot(channelID)
+}
+
+// ApplyJoin records a single membership addition (from a
+// member_joined_channel event). Single-row upsert; does NOT bump
+// last_full_fetch_at — that timestamp tracks full-fetch freshness only.
+// If a UserResolver is configured, ApplyJoin invokes it for the user
+// (resolver dedupes via its inflight map; redundant calls are cheap).
+func (m *Manager) ApplyJoin(channelID, userID string) {
+	now := time.Now().Unix()
+	if err := m.db.UpsertChannelMember(m.workspaceID, channelID, userID, now); err != nil {
+		return
+	}
+	m.mu.Lock()
+	set := m.members[channelID]
+	if set == nil {
+		set = map[string]struct{}{}
+		m.members[channelID] = set
+	}
+	set[userID] = struct{}{}
+	m.mu.Unlock()
+
+	if m.resolver != nil {
+		m.resolver.Request(userID)
+	}
+	m.pushSnapshot(channelID)
+}
+
+// ApplyLeave records a single membership removal.
+func (m *Manager) ApplyLeave(channelID, userID string) {
+	if err := m.db.DeleteChannelMember(m.workspaceID, channelID, userID); err != nil {
+		return
+	}
+	m.mu.Lock()
+	if set := m.members[channelID]; set != nil {
+		delete(set, userID)
+	}
+	m.mu.Unlock()
+	m.pushSnapshot(channelID)
+}
+
+// ForceStale invalidates the freshness timestamp for a channel so the
+// next EnsureFresh will trigger a re-fetch. Called from the websocket
+// reconnect hook for the currently active channel. Preserves both the
+// in-memory and persisted member list — only the meta timestamp is
+// zeroed.
+func (m *Manager) ForceStale(channelID string) {
+	if err := m.db.ZeroChannelMembershipMeta(m.workspaceID, channelID); err != nil {
+		return
+	}
+	// Also clear the in-memory dedup window so EnsureFresh actually
+	// re-fetches even within a recent successful-fetch interval.
+	m.mu.Lock()
+	delete(m.lastFetched, channelID)
+	m.mu.Unlock()
 }

--- a/internal/slack/membership/manager_test.go
+++ b/internal/slack/membership/manager_test.go
@@ -1,0 +1,159 @@
+package membership
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gammons/slk/internal/cache"
+)
+
+// fakeMemberAPI implements ConversationMemberAPI for tests.
+type fakeMemberAPI struct {
+	mu     sync.Mutex
+	calls  int
+	result []string
+	err    error
+}
+
+func (f *fakeMemberAPI) GetUsersInConversation(ctx context.Context, channelID string) ([]string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	return f.result, f.err
+}
+
+func (f *fakeMemberAPI) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+// captureSink records ChannelMembershipMsg pushes.
+type captureSink struct {
+	mu     sync.Mutex
+	pushes []capturedPush
+}
+type capturedPush struct {
+	channelID string
+	memberIDs []string
+}
+
+func (s *captureSink) Push(channelID string, memberIDs []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := make([]string, len(memberIDs))
+	copy(cp, memberIDs)
+	s.pushes = append(s.pushes, capturedPush{channelID, cp})
+}
+func (s *captureSink) snapshot() []capturedPush {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]capturedPush, len(s.pushes))
+	copy(out, s.pushes)
+	return out
+}
+
+func newManagerForTest(t *testing.T) (*Manager, *fakeMemberAPI, *captureSink, *cache.DB) {
+	t.Helper()
+	db, err := cache.New(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = db.UpsertWorkspace(cache.Workspace{ID: "T1", Name: "Test"})
+	api := &fakeMemberAPI{}
+	sink := &captureSink{}
+	mgr := New("T1", api, db, sink.Push, nil /* userResolver */)
+	return mgr, api, sink, db
+}
+
+func TestEnsureFreshCacheHitNoFetch(t *testing.T) {
+	mgr, api, sink, db := newManagerForTest(t)
+	defer db.Close()
+	// Seed cache with recent meta.
+	_ = db.ReplaceChannelMembers("T1", "C1", []string{"U1", "U2"}, time.Now().Unix())
+
+	mgr.EnsureFresh(context.Background(), "C1")
+	// EnsureFresh kicks off background work; wait for any push.
+	waitForPush(t, sink, 1)
+
+	if api.callCount() != 0 {
+		t.Errorf("fresh cache should NOT trigger fetch; got %d calls", api.callCount())
+	}
+	pushes := sink.snapshot()
+	if len(pushes) != 1 || pushes[0].channelID != "C1" {
+		t.Errorf("expected 1 push for C1; got %+v", pushes)
+	}
+}
+
+func TestEnsureFreshCacheMissTriggersFetch(t *testing.T) {
+	mgr, api, sink, db := newManagerForTest(t)
+	defer db.Close()
+	api.result = []string{"U1", "U2", "U3"}
+
+	mgr.EnsureFresh(context.Background(), "C1")
+	waitForPush(t, sink, 1)     // initial empty push
+	waitForCallCount(t, api, 1) // fetch happens
+	waitForPush(t, sink, 2)     // post-fetch push
+
+	if api.callCount() != 1 {
+		t.Errorf("expected 1 fetch call; got %d", api.callCount())
+	}
+	pushes := sink.snapshot()
+	if len(pushes) < 2 {
+		t.Fatalf("expected >=2 pushes; got %d", len(pushes))
+	}
+	last := pushes[len(pushes)-1]
+	if len(last.memberIDs) != 3 {
+		t.Errorf("final push had %d members; want 3", len(last.memberIDs))
+	}
+
+	// Cache persisted?
+	got, _ := db.ListChannelMembers("T1", "C1")
+	if len(got) != 3 {
+		t.Errorf("expected 3 cached members; got %d", len(got))
+	}
+}
+
+func TestEnsureFreshStaleTriggersFetch(t *testing.T) {
+	mgr, api, sink, db := newManagerForTest(t)
+	defer db.Close()
+	// Seed cache as stale (yesterday).
+	stale := time.Now().Add(-25 * time.Hour).Unix()
+	_ = db.ReplaceChannelMembers("T1", "C1", []string{"U1"}, stale)
+	api.result = []string{"U1", "U2"}
+
+	mgr.EnsureFresh(context.Background(), "C1")
+	waitForPush(t, sink, 1)
+	waitForCallCount(t, api, 1)
+	waitForPush(t, sink, 2)
+
+	if api.callCount() != 1 {
+		t.Errorf("stale cache should trigger fetch; got %d calls", api.callCount())
+	}
+}
+
+// Helpers — poll briefly because the Manager fans work to goroutines.
+func waitForPush(t *testing.T, s *captureSink, n int) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if len(s.snapshot()) >= n {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d pushes; got %d", n, len(s.snapshot()))
+}
+func waitForCallCount(t *testing.T, api *fakeMemberAPI, n int) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if api.callCount() >= n {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d API calls", n)
+}

--- a/internal/slack/membership/manager_test.go
+++ b/internal/slack/membership/manager_test.go
@@ -157,3 +157,183 @@ func waitForCallCount(t *testing.T, api *fakeMemberAPI, n int) {
 	}
 	t.Fatalf("timed out waiting for %d API calls", n)
 }
+
+func TestApplyJoinPersistsAndPushes(t *testing.T) {
+	mgr, _, sink, db := newManagerForTest(t)
+	defer db.Close()
+	// Pre-seed C1 with U1 so the active set isn't empty.
+	_ = db.ReplaceChannelMembers("T1", "C1", []string{"U1"}, time.Now().Unix())
+	mgr.EnsureFresh(context.Background(), "C1")
+	waitForPush(t, sink, 1)
+
+	mgr.ApplyJoin("C1", "U_NEW")
+
+	// Persisted?
+	got, _ := db.ListChannelMembers("T1", "C1")
+	found := false
+	for _, id := range got {
+		if id == "U_NEW" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("U_NEW not persisted; cache = %v", got)
+	}
+	// Pushed?
+	waitForPush(t, sink, 2)
+	pushes := sink.snapshot()
+	last := pushes[len(pushes)-1]
+	hasNew := false
+	for _, id := range last.memberIDs {
+		if id == "U_NEW" {
+			hasNew = true
+		}
+	}
+	if !hasNew {
+		t.Errorf("U_NEW missing from push: %v", last.memberIDs)
+	}
+}
+
+func TestApplyLeaveDeletesAndPushes(t *testing.T) {
+	mgr, _, sink, db := newManagerForTest(t)
+	defer db.Close()
+	_ = db.ReplaceChannelMembers("T1", "C1", []string{"U1", "U2"}, time.Now().Unix())
+	mgr.EnsureFresh(context.Background(), "C1")
+	waitForPush(t, sink, 1)
+
+	mgr.ApplyLeave("C1", "U1")
+
+	got, _ := db.ListChannelMembers("T1", "C1")
+	for _, id := range got {
+		if id == "U1" {
+			t.Errorf("U1 still in cache after leave: %v", got)
+		}
+	}
+}
+
+func TestApplyJoinDoesNotBumpLastFullFetchAt(t *testing.T) {
+	mgr, _, _, db := newManagerForTest(t)
+	defer db.Close()
+	originalTS := int64(12345)
+	_ = db.ReplaceChannelMembers("T1", "C1", []string{"U1"}, originalTS)
+
+	mgr.ApplyJoin("C1", "U_NEW")
+
+	ts, _, _ := db.GetChannelMembershipMeta("T1", "C1")
+	if ts != originalTS {
+		t.Errorf("last_full_fetch_at = %d, want %d (deltas must not touch it)", ts, originalTS)
+	}
+}
+
+func TestForceStaleDoesNotWipePersistedMembers(t *testing.T) {
+	mgr, _, _, db := newManagerForTest(t)
+	defer db.Close()
+
+	// Seed cache without ever calling loadIntoMemory (cold in-memory).
+	_ = db.ReplaceChannelMembers("T1", "C1", []string{"U1", "U2", "U3"}, time.Now().Unix())
+
+	mgr.ForceStale("C1")
+
+	got, _ := db.ListChannelMembers("T1", "C1")
+	if len(got) != 3 {
+		t.Errorf("members wiped: %v (cold-cache regression)", got)
+	}
+	ts, _, _ := db.GetChannelMembershipMeta("T1", "C1")
+	if ts != 0 {
+		t.Errorf("meta = %d, want 0", ts)
+	}
+}
+
+func TestForceStaleCausesRefetch(t *testing.T) {
+	mgr, api, sink, db := newManagerForTest(t)
+	defer db.Close()
+	// Seed as fresh.
+	_ = db.ReplaceChannelMembers("T1", "C1", []string{"U1"}, time.Now().Unix())
+	api.result = []string{"U1", "U2"}
+
+	mgr.ForceStale("C1")
+	mgr.EnsureFresh(context.Background(), "C1")
+
+	waitForCallCount(t, api, 1)
+	waitForPush(t, sink, 2)
+}
+
+// fakeResolver records calls for the resolver-invocation test.
+type fakeResolver struct {
+	mu   sync.Mutex
+	seen []string
+}
+
+func (r *fakeResolver) Request(userID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.seen = append(r.seen, userID)
+}
+func (r *fakeResolver) snapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.seen))
+	copy(out, r.seen)
+	return out
+}
+
+func TestBackgroundFetchTriggersResolverForEachID(t *testing.T) {
+	db, _ := cache.New(":memory:")
+	defer db.Close()
+	_ = db.UpsertWorkspace(cache.Workspace{ID: "T1", Name: "Test"})
+
+	api := &fakeMemberAPI{result: []string{"U1", "U2", "U3"}}
+	sink := &captureSink{}
+	resolver := &fakeResolver{}
+	mgr := New("T1", api, db, sink.Push, resolver)
+
+	mgr.EnsureFresh(context.Background(), "C1")
+	waitForCallCount(t, api, 1)
+	waitForPush(t, sink, 2)
+
+	// Brief settle for the resolver Request calls.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if len(resolver.snapshot()) >= 3 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	seen := resolver.snapshot()
+	if len(seen) != 3 {
+		t.Fatalf("expected resolver to see 3 IDs; got %v", seen)
+	}
+	// Verify each ID is present (order not required).
+	want := map[string]bool{"U1": true, "U2": true, "U3": true}
+	for _, id := range seen {
+		if !want[id] {
+			t.Errorf("unexpected ID %s", id)
+		}
+		delete(want, id)
+	}
+	if len(want) != 0 {
+		t.Errorf("missing IDs: %v", want)
+	}
+}
+
+func TestEnsureFreshConcurrentDoesNotDuplicate(t *testing.T) {
+	mgr, api, _, db := newManagerForTest(t)
+	defer db.Close()
+	api.result = []string{"U1"}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			mgr.EnsureFresh(context.Background(), "C1")
+		}()
+	}
+	wg.Wait()
+	// Allow background goroutines to settle.
+	time.Sleep(100 * time.Millisecond)
+
+	if c := api.callCount(); c > 1 {
+		t.Errorf("expected at most 1 fetch under concurrent EnsureFresh; got %d", c)
+	}
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1603,7 +1603,18 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.compose.SetActiveChannel(msg.ID)
 		a.threadCompose.SetActiveChannel(msg.ID)
 		if a.channelMembershipFetcher != nil {
-			a.channelMembershipFetcher(msg.ID)
+			// Fire the fetcher on a fresh goroutine so it can't block
+			// the Update loop. The fetcher is fire-and-forget — results
+			// arrive later via ChannelMembershipMsg. main.go's fetcher
+			// closure ultimately calls Membership.EnsureFresh which
+			// invokes bubbletea Program.Send via pushSnapshot, and
+			// bubbletea v2's program channel is unbuffered: a Send
+			// from inside Update would deadlock waiting for the same
+			// goroutine to receive. See manager.go's EnsureFresh
+			// docs and the deadlock-regression test in app_test.go.
+			fetcher := a.channelMembershipFetcher
+			channelID := msg.ID
+			go fetcher(channelID)
 		}
 		a.statusbar.SetChannel(msg.Name)
 		a.statusbar.SetChannelType(msg.Type)

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -776,6 +776,16 @@ type App struct {
 	// sub-component's API.
 	userNames map[string]string
 
+	// externalUsers tracks which user IDs are Slack Connect / shared-channel
+	// guests. Populated by main.go via SetExternalUsers as users are
+	// resolved. Read by SetUserNames when building the mention-picker User
+	// slice so IsExternal is set on each entry.
+	externalUsers map[string]bool
+	// channelMembershipFetcher is invoked on every ChannelSelectedMsg to
+	// prompt the membership.Manager to ensure-fresh the new active channel.
+	// nil-safe.
+	channelMembershipFetcher func(channelID string)
+
 	// Last (channelID, threadTS) auto-opened from the threads view.
 	// openSelectedThreadCmd compares against these to dedup repeat calls
 	// (j/k keystrokes and ThreadsListLoadedMsg refreshes both fire
@@ -991,6 +1001,7 @@ func NewApp() *App {
 		lastSelfSendByChannel: make(map[string]time.Time),
 		threadsDirtyDebounce: 150 * time.Millisecond,
 		userNames:            map[string]string{},
+		externalUsers:        map[string]bool{},
 		statusByTeam:         map[string]workspaceStatus{},
 		lastChannelByTeam:    map[string]string{},
 		navHistory:           make(map[string]*navStack),
@@ -1550,6 +1561,11 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.messagepane.SetChannelType(msg.Type)
 
 		a.compose.SetChannel(msg.Name)
+		a.compose.SetActiveChannel(msg.ID)
+		a.threadCompose.SetActiveChannel(msg.ID)
+		if a.channelMembershipFetcher != nil {
+			a.channelMembershipFetcher(msg.ID)
+		}
 		a.statusbar.SetChannel(msg.Name)
 		a.statusbar.SetChannelType(msg.Type)
 
@@ -4786,10 +4802,39 @@ func (a *App) SetUserNames(names map[string]string) {
 			ID:          id,
 			DisplayName: displayName,
 			Username:    "",
+			IsExternal:  a.externalUsers[id],
 		})
 	}
 	a.compose.SetUsers(users)
 	a.threadCompose.SetUsers(users)
+}
+
+// SetExternalUsers replaces the set of user IDs known to be Slack
+// Connect / shared-channel guests. Sticky: subsequent SetUserNames
+// calls consult this map when building mention-picker entries.
+// Pass an empty map (or nil) to clear.
+func (a *App) SetExternalUsers(externalIDs map[string]bool) {
+	if externalIDs == nil {
+		externalIDs = map[string]bool{}
+	}
+	a.externalUsers = externalIDs
+	if len(a.userNames) > 0 {
+		a.SetUserNames(a.userNames)
+	}
+}
+
+// SetChannelMembership forwards channel-member IDs to both compose
+// pickers. Called by main.go from the membership.Manager.
+func (a *App) SetChannelMembership(channelID string, memberIDs []string) {
+	a.compose.SetChannelMembership(channelID, memberIDs)
+	a.threadCompose.SetChannelMembership(channelID, memberIDs)
+}
+
+// SetChannelMembershipFetcher registers a callback invoked on every
+// ChannelSelectedMsg with the newly active channel ID. main.go wires
+// this to membership.Manager.EnsureFresh.
+func (a *App) SetChannelMembershipFetcher(fn func(channelID string)) {
+	a.channelMembershipFetcher = fn
 }
 
 // SetCustomEmoji rebuilds the emoji entry list (built-ins + the active

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -242,8 +242,15 @@ type (
 		Channels    []sidebar.ChannelItem
 		FinderItems []channelfinder.Item
 		UserNames   map[string]string
-		UserID      string
-		CustomEmoji map[string]string
+		// ExternalUsers maps userID -> true for users this workspace
+		// considers Slack Connect / shared-channel guests. Hydrated from
+		// cache.User.IsExternal so the mention picker can flag externals
+		// at workspace-switch time, before any new userResolver lookups
+		// fire. Order matters: the App handler applies this BEFORE
+		// SetUserNames so the picker rebuild sees the external flags.
+		ExternalUsers map[string]bool
+		UserID        string
+		CustomEmoji   map[string]string
 		// SectionsProvider supplies Slack-native sidebar sections for this
 		// workspace. Nil means "use config-glob behavior" (the App's
 		// sidebar reverts to its existing name-keyed buckets).
@@ -294,8 +301,15 @@ type (
 		Channels    []sidebar.ChannelItem
 		FinderItems []channelfinder.Item
 		UserNames   map[string]string
-		UserID      string
-		CustomEmoji map[string]string
+		// ExternalUsers maps userID -> true for users this workspace
+		// considers Slack Connect / shared-channel guests. Hydrated from
+		// cache.User.IsExternal so the mention picker can flag externals
+		// on startup, before any new userResolver lookups fire. Order
+		// matters: the App handler applies this BEFORE SetUserNames so
+		// the picker rebuild sees the external flags.
+		ExternalUsers map[string]bool
+		UserID        string
+		CustomEmoji   map[string]string
 		// SectionsProvider supplies Slack-native sidebar sections for this
 		// workspace. Nil means "use config-glob behavior" (the App's
 		// sidebar reverts to its existing name-keyed buckets).
@@ -1577,6 +1591,14 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.messagepane.SetChannel(msg.Name, "")
 		a.messagepane.SetChannelType(msg.Type)
 
+		// Close any open mention picker before switching channels.
+		// SetUsers replaces the user list but does NOT re-run the
+		// picker's filter, so an open picker would render the
+		// previous channel's matches until the user typed or moved.
+		// CloseMention is nil-safe (no-op when already closed).
+		a.compose.CloseMention()
+		a.threadCompose.CloseMention()
+
 		a.compose.SetChannel(msg.Name)
 		a.compose.SetActiveChannel(msg.ID)
 		a.threadCompose.SetActiveChannel(msg.ID)
@@ -2369,6 +2391,9 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.sidebar.SetSectionsProvider(msg.SectionsProvider)
 		a.SetChannels(msg.Channels)
 		a.channelFinder.SetItems(msg.FinderItems)
+		// SetExternalUsers re-pushes user-names; calling SetUserNames
+		// last is the canonical state.
+		a.SetExternalUsers(msg.ExternalUsers)
 		a.SetUserNames(msg.UserNames)
 		a.SetCustomEmoji(msg.CustomEmoji)
 		a.currentUserID = msg.UserID
@@ -2498,6 +2523,9 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.sidebar.SetSectionsProvider(msg.SectionsProvider)
 			a.SetChannels(msg.Channels)
 			a.channelFinder.SetItems(msg.FinderItems)
+			// SetExternalUsers re-pushes user-names; calling SetUserNames
+			// last is the canonical state.
+			a.SetExternalUsers(msg.ExternalUsers)
 			a.SetUserNames(msg.UserNames)
 			a.SetCustomEmoji(msg.CustomEmoji)
 			a.currentUserID = msg.UserID

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -270,6 +270,15 @@ type (
 		TeamID   string
 		Channels []sidebar.ChannelItem
 	}
+	// ChannelMembershipMsg is published by membership.Manager when a
+	// channel's member set has been loaded, updated by a delta event, or
+	// refreshed after a TTL miss / reconnect. MemberIDs is the full member
+	// list (not a delta). May be sent for non-active channels — the App
+	// forwards to both compose pickers, which gate on activeChannelID.
+	ChannelMembershipMsg struct {
+		ChannelID string
+		MemberIDs []string
+	}
 	WorkspaceReadyMsg struct {
 		TeamID      string
 		TeamName    string
@@ -2412,6 +2421,10 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Inactive-workspace events have already updated the
 		// WorkspaceContext.Channels in cmd/slk; App.Update only mutates
 		// the active sidebar.
+
+	case ChannelMembershipMsg:
+		a.SetChannelMembership(msg.ChannelID, msg.MemberIDs)
+		return a, nil
 
 	case SpinnerTickMsg:
 		if a.loading || a.messagepane.IsLoading() {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -227,6 +227,14 @@ type (
 		DisplayName string
 		IsBot       bool
 	}
+	// UserExternalMsg flags a single user as external (Slack Connect /
+	// shared-channel guest). Emitted by the user-resolution path when a
+	// users.info response shows team_id != workspace TeamID. The App
+	// updates externalUsers and re-pushes user-list state to the pickers.
+	UserExternalMsg struct {
+		UserID     string
+		IsExternal bool
+	}
 	WorkspaceSwitchedMsg struct {
 		TeamID      string
 		TeamName    string
@@ -2308,6 +2316,20 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// orchestrated by DMNameResolvedMsg; this handler is only the
 		// in-history name patch. IsBot is carried for forward
 		// compatibility but not consumed here.
+
+	case UserExternalMsg:
+		if a.externalUsers == nil {
+			a.externalUsers = map[string]bool{}
+		}
+		if msg.IsExternal {
+			a.externalUsers[msg.UserID] = true
+		} else {
+			delete(a.externalUsers, msg.UserID)
+		}
+		if len(a.userNames) > 0 {
+			a.SetUserNames(a.userNames)
+		}
+		return a, nil
 
 	case WorkspaceSwitchedMsg:
 		if a.compose.Uploading() || a.threadCompose.Uploading() {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -4083,15 +4084,69 @@ func TestChannelMembershipMsgUpdatesPicker(t *testing.T) {
 func TestChannelSelectedInvokesMembershipFetcher(t *testing.T) {
 	app := NewApp()
 	app.activeTeamID = "T1"
+	// The App invokes the fetcher on a goroutine (see ChannelSelectedMsg
+	// handler in app.go), so use a thread-safe record + a done signal.
+	var mu sync.Mutex
 	var fetched []string
-	app.SetChannelMembershipFetcher(func(channelID string) { fetched = append(fetched, channelID) })
+	done := make(chan struct{}, 1)
+	app.SetChannelMembershipFetcher(func(channelID string) {
+		mu.Lock()
+		fetched = append(fetched, channelID)
+		mu.Unlock()
+		done <- struct{}{}
+	})
 
 	_, _ = app.Update(ChannelSelectedMsg{ID: "C42", Name: "general", Type: "channel"})
 
-	if len(fetched) != 1 || fetched[0] != "C42" {
-		t.Errorf("fetcher invoked with %v, want [C42]", fetched)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("fetcher was not invoked within 1s")
+	}
+
+	mu.Lock()
+	got := append([]string(nil), fetched...)
+	mu.Unlock()
+	if len(got) != 1 || got[0] != "C42" {
+		t.Errorf("fetcher invoked with %v, want [C42]", got)
 	}
 	if app.compose.ActiveChannel() != "C42" {
 		t.Errorf("compose active channel = %q, want C42", app.compose.ActiveChannel())
+	}
+}
+
+// TestChannelSelectedReturnsPromptlyEvenIfFetcherBlocks guards against
+// the deadlock that froze the app on first run: the fetcher closure
+// in main.go originally called Membership.EnsureFresh synchronously,
+// which transitively invoked bubbletea's Program.Send (unbuffered
+// channel in bubbletea v2) from inside the Update goroutine — Send
+// blocked waiting for itself to receive. The contract is now that
+// the fetcher must NOT block; the test simulates a misbehaving
+// fetcher that blocks until released, and asserts Update still
+// returns within a short deadline. If a future maintainer changes
+// the wiring to once-again call a blocking fetcher synchronously,
+// this test fails the deadline.
+func TestChannelSelectedReturnsPromptlyEvenIfFetcherBlocks(t *testing.T) {
+	app := NewApp()
+	app.activeTeamID = "T1"
+	release := make(chan struct{})
+	app.SetChannelMembershipFetcher(func(channelID string) {
+		// Simulate a slow fetcher (e.g., blocked on a network call
+		// or a blocking p.Send). Releases when the test allows.
+		<-release
+	})
+	defer close(release)
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = app.Update(ChannelSelectedMsg{ID: "C42", Name: "general", Type: "channel"})
+		close(done)
+	}()
+	select {
+	case <-done:
+		// Update returned promptly — fetcher was not invoked
+		// synchronously on the caller's goroutine.
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Update did not return within 100ms; fetcher is being called synchronously on the Update goroutine — risks bubbletea Send-from-Update deadlock")
 	}
 }

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -4036,6 +4036,33 @@ func TestSetExternalUsersPropagates(t *testing.T) {
 	}
 }
 
+func TestChannelMembershipMsgUpdatesPicker(t *testing.T) {
+	app := NewApp()
+	app.activeTeamID = "T1"
+	app.activeChannelID = "C1"
+	app.compose.SetActiveChannel("C1")
+	app.threadCompose.SetActiveChannel("C1")
+	app.SetUserNames(map[string]string{"U1": "alice", "U2": "bob"})
+
+	_, _ = app.Update(ChannelMembershipMsg{ChannelID: "C1", MemberIDs: []string{"U1"}})
+
+	var aliceInCh, bobInCh bool
+	for _, u := range app.compose.MentionUsers() {
+		if u.ID == "U1" {
+			aliceInCh = u.InChannel
+		}
+		if u.ID == "U2" {
+			bobInCh = u.InChannel
+		}
+	}
+	if !aliceInCh {
+		t.Error("alice should be in-channel after ChannelMembershipMsg")
+	}
+	if bobInCh {
+		t.Error("bob should be not-in-channel after ChannelMembershipMsg")
+	}
+}
+
 func TestChannelSelectedInvokesMembershipFetcher(t *testing.T) {
 	app := NewApp()
 	app.activeTeamID = "T1"

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -3988,3 +3988,66 @@ func TestChannelSelected_UnknownFreshnessWithCache_FallsToTier2(t *testing.T) {
 		t.Errorf("unknown freshness with cache: fetcher should fire once; got %d", fetchCalled)
 	}
 }
+
+func TestSetChannelMembershipForwardsToCompose(t *testing.T) {
+	app := NewApp()
+	app.activeTeamID = "T1"
+	app.activeChannelID = "C1"
+	app.compose.SetActiveChannel("C1")
+	app.threadCompose.SetActiveChannel("C1")
+	app.SetUserNames(map[string]string{"U1": "alice", "U2": "bob"})
+
+	app.SetChannelMembership("C1", []string{"U1"})
+
+	users := app.compose.MentionUsers()
+	byName := map[string]bool{}
+	for _, u := range users {
+		byName[u.DisplayName] = u.InChannel
+	}
+	if !byName["alice"] {
+		t.Error("alice should be in-channel")
+	}
+	if byName["bob"] {
+		t.Error("bob should be not-in-channel")
+	}
+}
+
+func TestSetExternalUsersPropagates(t *testing.T) {
+	app := NewApp()
+	app.activeTeamID = "T1"
+	app.SetExternalUsers(map[string]bool{"U_EXT": true})
+	app.SetUserNames(map[string]string{"U_EXT": "ext.user", "U1": "alice"})
+	app.activeChannelID = "C1"
+	app.compose.SetActiveChannel("C1")
+	app.threadCompose.SetActiveChannel("C1")
+	app.SetChannelMembership("C1", []string{"U_EXT", "U1"})
+
+	found := false
+	for _, u := range app.compose.MentionUsers() {
+		if u.ID == "U_EXT" {
+			found = true
+			if !u.IsExternal {
+				t.Error("U_EXT should be flagged IsExternal")
+			}
+		}
+	}
+	if !found {
+		t.Error("U_EXT missing from picker users")
+	}
+}
+
+func TestChannelSelectedInvokesMembershipFetcher(t *testing.T) {
+	app := NewApp()
+	app.activeTeamID = "T1"
+	var fetched []string
+	app.SetChannelMembershipFetcher(func(channelID string) { fetched = append(fetched, channelID) })
+
+	_, _ = app.Update(ChannelSelectedMsg{ID: "C42", Name: "general", Type: "channel"})
+
+	if len(fetched) != 1 || fetched[0] != "C42" {
+		t.Errorf("fetcher invoked with %v, want [C42]", fetched)
+	}
+	if app.compose.ActiveChannel() != "C42" {
+		t.Errorf("compose active channel = %q, want C42", app.compose.ActiveChannel())
+	}
+}

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -3863,6 +3863,23 @@ func TestUserResolvedMsg_DropsForOtherWorkspace(t *testing.T) {
 	}
 }
 
+func TestUserExternalMsgFlagsPickerEntry(t *testing.T) {
+	app := NewApp()
+	app.activeTeamID = "T1"
+	app.activeChannelID = "C1"
+	app.compose.SetActiveChannel("C1")
+	app.threadCompose.SetActiveChannel("C1")
+	app.SetUserNames(map[string]string{"U1": "alice"})
+
+	_, _ = app.Update(UserExternalMsg{UserID: "U1", IsExternal: true})
+
+	for _, u := range app.compose.MentionUsers() {
+		if u.ID == "U1" && !u.IsExternal {
+			t.Error("U1 should be marked IsExternal after UserExternalMsg")
+		}
+	}
+}
+
 // drainAllCmds recursively executes every cmd inside the tea.BatchMsg
 // tree returned by Update. Used to surface counter side-effects on
 // closure-bound fakes (channelFetcher, channelReadMarker). The

--- a/internal/ui/compose/model.go
+++ b/internal/ui/compose/model.go
@@ -41,6 +41,19 @@ type Model struct {
 	users           []mentionpicker.User
 	reverseNames    map[string]string // displayName -> userID
 
+	// activeChannelID is the channel currently shown in the messages
+	// pane. Drives the InChannel computation when rebuilding the
+	// derived mention-picker user list. Updated via SetActiveChannel.
+	activeChannelID string
+	// channelMembers maps channelID -> set of user IDs. We keep all
+	// channels we've seen so a rapid A→B→A switch doesn't lose state,
+	// but only the activeChannelID drives the derived picker list.
+	channelMembers map[string]map[string]struct{}
+	// channelMembersOK records whether membership data has been loaded
+	// for a channel. Used to distinguish "no members" (empty set, after
+	// load) from "not loaded yet" (default-everyone-in-channel state).
+	channelMembersOK map[string]bool
+
 	// Channel picker state. Mirrors the mention picker exactly:
 	// channelStartCol is the byte offset of the FIRST CHARACTER AFTER
 	// the trigger '#' within input.Value() (the '#' itself sits at
@@ -740,15 +753,95 @@ func (m Model) ChannelPickerView(width int) string {
 }
 
 // SetUsers provides the list of workspace users for mention autocomplete.
+// The stored list is the canonical workspace roster; the derived
+// []mentionpicker.User pushed to the embedded picker is recomputed by
+// rebuildMentionUsers, which carries IsExternal forward and computes
+// InChannel from the active channel's member set (if loaded).
 func (m *Model) SetUsers(users []mentionpicker.User) {
 	m.users = users
-	m.mentionPicker.SetUsers(users)
 	m.reverseNames = make(map[string]string)
 	for _, u := range users {
 		if u.DisplayName != "" {
 			m.reverseNames[u.DisplayName] = u.ID
 		}
 	}
+	m.rebuildMentionUsers()
+}
+
+// SetActiveChannel tells the compose model which channel context to
+// use when computing InChannel for the mention picker. Called from
+// App on every ChannelSelectedMsg. Idempotent: a no-op if the channel
+// hasn't actually changed (avoids needless picker rebuilds on the
+// hot reselect path).
+func (m *Model) SetActiveChannel(channelID string) {
+	if m.activeChannelID == channelID {
+		return
+	}
+	m.activeChannelID = channelID
+	m.rebuildMentionUsers()
+}
+
+// ActiveChannel returns the channel ID currently active for
+// mention-picker context.
+func (m *Model) ActiveChannel() string { return m.activeChannelID }
+
+// SetChannelMembership records the member set for a channel and, if
+// that channel is active, rebuilds the picker's user list. Membership
+// for non-active channels is still stored so a rapid A→B→A switch
+// doesn't lose state; only the active channel drives the visible
+// picker view.
+func (m *Model) SetChannelMembership(channelID string, memberIDs []string) {
+	set := make(map[string]struct{}, len(memberIDs))
+	for _, id := range memberIDs {
+		set[id] = struct{}{}
+	}
+	if m.channelMembers == nil {
+		m.channelMembers = map[string]map[string]struct{}{}
+	}
+	if m.channelMembersOK == nil {
+		m.channelMembersOK = map[string]bool{}
+	}
+	m.channelMembers[channelID] = set
+	m.channelMembersOK[channelID] = true
+	if channelID == m.activeChannelID {
+		m.rebuildMentionUsers()
+	}
+}
+
+// MentionUsers returns the most recent derived user list handed to
+// the embedded picker. Intended for tests.
+func (m *Model) MentionUsers() []mentionpicker.User {
+	return m.mentionPicker.Users()
+}
+
+// rebuildMentionUsers recomputes the derived []mentionpicker.User
+// for the active channel and pushes it to the embedded picker.
+//
+// Rules:
+//   - If membership data for activeChannelID is not yet loaded, every
+//     user defaults to InChannel=true (preserves today's behavior on
+//     first switch; spec's "Loading state" section).
+//   - If membership is loaded, InChannel = userID ∈ memberIDs.
+//   - External users that are NOT in the active channel are omitted
+//     entirely (spec's "External user visibility rule" — no
+//     "(ext) (not in channel)" combination).
+func (m *Model) rebuildMentionUsers() {
+	members := m.channelMembers[m.activeChannelID]
+	loaded := m.channelMembersOK[m.activeChannelID]
+
+	derived := make([]mentionpicker.User, 0, len(m.users))
+	for _, u := range m.users {
+		inCh := true
+		if loaded {
+			_, inCh = members[u.ID]
+		}
+		if u.IsExternal && !inCh {
+			continue
+		}
+		u.InChannel = inCh
+		derived = append(derived, u)
+	}
+	m.mentionPicker.SetUsers(derived)
 }
 
 // IsMentionActive returns whether the mention picker is currently showing.

--- a/internal/ui/compose/model_test.go
+++ b/internal/ui/compose/model_test.go
@@ -990,3 +990,133 @@ func TestSetWidthReservesBackgroundMargin(t *testing.T) {
 		}
 	}
 }
+
+// TestSetChannelMembershipPopulatesInChannel verifies that after
+// SetChannelMembership is called for the active channel, the derived
+// mention picker user list reflects InChannel based on the member set.
+func TestSetChannelMembershipPopulatesInChannel(t *testing.T) {
+	m := New("test")
+	m.SetUsers([]mentionpicker.User{
+		{ID: "U1", DisplayName: "alice"},
+		{ID: "U2", DisplayName: "bob"},
+		{ID: "U3", DisplayName: "carol"},
+	})
+	m.SetActiveChannel("C1")
+	m.SetChannelMembership("C1", []string{"U1", "U3"})
+
+	got := map[string]bool{}
+	for _, u := range m.MentionUsers() {
+		got[u.DisplayName] = u.InChannel
+	}
+	if !got["alice"] || got["bob"] || !got["carol"] {
+		t.Errorf("InChannel mapping wrong: %+v", got)
+	}
+}
+
+// TestSetChannelMembershipFiltersExternalNotInChannel verifies the
+// spec rule: external users not in the active channel are omitted
+// entirely (no "(ext) (not in channel)" combination).
+func TestSetChannelMembershipFiltersExternalNotInChannel(t *testing.T) {
+	m := New("test")
+	m.SetUsers([]mentionpicker.User{
+		{ID: "U1", DisplayName: "alice"},
+		{ID: "U_EXT", DisplayName: "ext.user", IsExternal: true},
+	})
+	m.SetActiveChannel("C1")
+	m.SetChannelMembership("C1", []string{"U1"}) // ext.user NOT in C1
+
+	seen := map[string]bool{}
+	for _, u := range m.MentionUsers() {
+		seen[u.DisplayName] = true
+	}
+	if !seen["alice"] {
+		t.Error("alice should be visible")
+	}
+	if seen["ext.user"] {
+		t.Error("external user not in C1 should be filtered out, not just muted")
+	}
+}
+
+// TestSetChannelMembershipIncludesExternalInChannel verifies that an
+// external user who IS in the active channel passes through with both
+// InChannel and IsExternal preserved.
+func TestSetChannelMembershipIncludesExternalInChannel(t *testing.T) {
+	m := New("test")
+	m.SetUsers([]mentionpicker.User{
+		{ID: "U_EXT", DisplayName: "ext.user", IsExternal: true},
+	})
+	m.SetActiveChannel("C1")
+	m.SetChannelMembership("C1", []string{"U_EXT"})
+
+	found := false
+	for _, u := range m.MentionUsers() {
+		if u.DisplayName == "ext.user" {
+			found = true
+			if !u.InChannel || !u.IsExternal {
+				t.Errorf("external in-channel: got InChannel=%v IsExternal=%v",
+					u.InChannel, u.IsExternal)
+			}
+		}
+	}
+	if !found {
+		t.Error("external in-channel user missing")
+	}
+}
+
+// TestSetChannelMembershipDefaultsToInChannelWhenNotLoaded verifies
+// the spec's "Loading state": before any SetChannelMembership for the
+// active channel, every user renders as in-channel (preserves the
+// pre-channel-aware behavior while membership data is in flight).
+func TestSetChannelMembershipDefaultsToInChannelWhenNotLoaded(t *testing.T) {
+	m := New("test")
+	m.SetUsers([]mentionpicker.User{
+		{ID: "U1", DisplayName: "alice"},
+	})
+	m.SetActiveChannel("C1")
+	// No SetChannelMembership call yet.
+
+	for _, u := range m.MentionUsers() {
+		if !u.InChannel {
+			t.Errorf("loading state should default InChannel=true; got %+v", u)
+		}
+	}
+}
+
+// TestSetChannelMembershipForInactiveChannelDoesNotRebuild verifies
+// that membership data arriving for a non-active channel doesn't
+// disturb the active picker view (it's still stored, but not visible).
+func TestSetChannelMembershipForInactiveChannelDoesNotRebuild(t *testing.T) {
+	m := New("test")
+	m.SetUsers([]mentionpicker.User{
+		{ID: "U1", DisplayName: "alice"},
+	})
+	m.SetActiveChannel("C1")
+	// Membership for C2 arrives but C1 is active — should not affect C1.
+	m.SetChannelMembership("C2", []string{"U_OTHER"})
+
+	// alice should still be in-channel (loading state for C1 — no C1 data yet).
+	for _, u := range m.MentionUsers() {
+		if u.DisplayName == "alice" && !u.InChannel {
+			t.Error("inactive-channel membership should not affect active picker")
+		}
+	}
+}
+
+// TestSetChannelMembershipAfterLoadingFlipsInChannel verifies that
+// once an empty member set arrives for the active channel, the
+// loading-state default is replaced with the actual data.
+func TestSetChannelMembershipAfterLoadingFlipsInChannel(t *testing.T) {
+	m := New("test")
+	m.SetUsers([]mentionpicker.User{
+		{ID: "U1", DisplayName: "alice"},
+	})
+	m.SetActiveChannel("C1")
+	// Load C1 membership with empty set — alice is NOT a member.
+	m.SetChannelMembership("C1", []string{})
+
+	for _, u := range m.MentionUsers() {
+		if u.DisplayName == "alice" && u.InChannel {
+			t.Error("after empty C1 membership loads, alice should be not-in-channel")
+		}
+	}
+}

--- a/internal/ui/emojipicker/model.go
+++ b/internal/ui/emojipicker/model.go
@@ -11,7 +11,8 @@ import (
 	"github.com/gammons/slk/internal/ui/styles"
 )
 
-// MaxVisible matches mentionpicker.MaxVisible for UX symmetry.
+// MaxVisible caps how many emoji rows are shown in the picker.
+// Independent of mentionpicker.MaxVisible.
 const MaxVisible = 5
 
 type Model struct {

--- a/internal/ui/mentionpicker/model.go
+++ b/internal/ui/mentionpicker/model.go
@@ -173,15 +173,46 @@ func (m *Model) View(width int) string {
 
 	var rows []string
 	for i, u := range m.filtered {
+		selected := i == m.selected
+
 		indicator := "  "
-		nameStyle := lipgloss.NewStyle().Foreground(styles.TextPrimary)
-		if i == m.selected {
+		if selected {
 			indicator = lipgloss.NewStyle().Foreground(styles.Accent).Render("▌ ")
+		}
+
+		// Name color: muted for not-in-channel rows at rest;
+		// upgraded to TextPrimary when selected (per spec).
+		nameColor := styles.TextPrimary
+		if !u.InChannel && !selected {
+			nameColor = styles.TextMuted
+		}
+		nameStyle := lipgloss.NewStyle().Foreground(nameColor)
+		if selected {
 			nameStyle = nameStyle.Bold(true)
 		}
 
-		label := fmt.Sprintf("%s (%s)", u.DisplayName, u.Username)
+		// Special mentions keep "(Username)" in TextPrimary (the
+		// historical, intentional behavior). Regular users get no
+		// parenthetical here (the dead empty-parens fix).
+		label := u.DisplayName
+		if u.Username != "" {
+			label = fmt.Sprintf("%s (%s)", u.DisplayName, u.Username)
+		}
+
 		row := indicator + nameStyle.Render(label)
+
+		// Suffix in TextMuted, always (even when row is selected).
+		var suffix string
+		switch {
+		case !u.InChannel:
+			suffix = " (not in channel)"
+		case u.IsExternal:
+			suffix = " (ext)"
+		}
+		if suffix != "" {
+			row += lipgloss.NewStyle().Foreground(styles.TextMuted).Render(suffix)
+		}
+
 		rows = append(rows, row)
 	}
 
@@ -191,7 +222,7 @@ func (m *Model) View(width int) string {
 		BorderStyle(lipgloss.RoundedBorder()).
 		BorderForeground(styles.Primary).
 		Background(styles.SurfaceDark).
-		Width(width - 2). // account for border
+		Width(width - 2).
 		Render(content)
 
 	return box

--- a/internal/ui/mentionpicker/model.go
+++ b/internal/ui/mentionpicker/model.go
@@ -2,6 +2,7 @@ package mentionpicker
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"charm.land/lipgloss/v2"
@@ -9,12 +10,26 @@ import (
 	"github.com/gammons/slk/internal/ui/styles"
 )
 
-const MaxVisible = 5
+const MaxVisible = 7
 
 type User struct {
 	ID          string
 	DisplayName string
 	Username    string
+	// InChannel indicates whether the user is a member of the active
+	// channel. False sorts the user into the not-in-channel tier (below
+	// in-channel users in the picker). The caller is responsible for
+	// populating this field. Special mentions (@here / @channel /
+	// @everyone) always have InChannel=true. For workspace users, the
+	// compose layer computes the value from the active channel's member
+	// set (see compose.rebuildMentionUsers); when no membership data
+	// has been loaded yet, compose defaults it to true to preserve the
+	// pre-channel-aware behavior.
+	InChannel bool
+	// IsExternal indicates a Slack Connect / shared-channel guest
+	// whose home team_id differs from the workspace TeamID. Drives
+	// the "(ext)" suffix in the picker.
+	IsExternal bool
 }
 
 type MentionResult struct {
@@ -23,9 +38,9 @@ type MentionResult struct {
 }
 
 var specialMentions = []User{
-	{ID: "special:here", DisplayName: "here", Username: "here"},
-	{ID: "special:channel", DisplayName: "channel", Username: "channel"},
-	{ID: "special:everyone", DisplayName: "everyone", Username: "everyone"},
+	{ID: "special:here", DisplayName: "here", Username: "here", InChannel: true},
+	{ID: "special:channel", DisplayName: "channel", Username: "channel", InChannel: true},
+	{ID: "special:everyone", DisplayName: "everyone", Username: "everyone", InChannel: true},
 }
 
 type Model struct {
@@ -108,26 +123,46 @@ func (m *Model) Select() *MentionResult {
 
 func (m *Model) filter() {
 	q := text.Fold(m.query)
-	var results []User
+	matches := func(u User) bool {
+		if q == "" {
+			return true
+		}
+		return strings.HasPrefix(text.Fold(u.DisplayName), q) ||
+			strings.HasPrefix(text.Fold(u.Username), q)
+	}
 
-	// Special mentions first
+	var specials, inCh, notInCh []User
 	for _, u := range specialMentions {
-		if q == "" || strings.HasPrefix(text.Fold(u.DisplayName), q) || strings.HasPrefix(text.Fold(u.Username), q) {
-			results = append(results, u)
+		if matches(u) {
+			specials = append(specials, u)
+		}
+	}
+	for _, u := range m.users {
+		if !matches(u) {
+			continue
+		}
+		if u.InChannel {
+			inCh = append(inCh, u)
+		} else {
+			notInCh = append(notInCh, u)
 		}
 	}
 
-	// Then regular users
-	for _, u := range m.users {
-		if q == "" || strings.HasPrefix(text.Fold(u.DisplayName), q) || strings.HasPrefix(text.Fold(u.Username), q) {
-			results = append(results, u)
-		}
-	}
+	sort.Slice(inCh, func(i, j int) bool {
+		return inCh[i].DisplayName < inCh[j].DisplayName
+	})
+	sort.Slice(notInCh, func(i, j int) bool {
+		return notInCh[i].DisplayName < notInCh[j].DisplayName
+	})
+
+	results := make([]User, 0, len(specials)+len(inCh)+len(notInCh))
+	results = append(results, specials...)
+	results = append(results, inCh...)
+	results = append(results, notInCh...)
 
 	if len(results) > MaxVisible {
 		results = results[:MaxVisible]
 	}
-
 	m.filtered = results
 }
 

--- a/internal/ui/mentionpicker/model.go
+++ b/internal/ui/mentionpicker/model.go
@@ -59,6 +59,12 @@ func (m *Model) SetUsers(users []User) {
 	m.users = users
 }
 
+// Users returns the user list most recently set via SetUsers.
+// Used by tests; not part of the picker's input API.
+func (m *Model) Users() []User {
+	return m.users
+}
+
 func (m *Model) Open() {
 	m.visible = true
 	m.query = ""

--- a/internal/ui/mentionpicker/model_test.go
+++ b/internal/ui/mentionpicker/model_test.go
@@ -2,6 +2,7 @@ package mentionpicker
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -214,6 +215,55 @@ func TestSpecialMentionsAlwaysInChannel(t *testing.T) {
 func TestMaxVisibleSeven(t *testing.T) {
 	if MaxVisible != 7 {
 		t.Errorf("MaxVisible = %d, want 7", MaxVisible)
+	}
+}
+
+func TestViewNoEmptyParensForRegularUser(t *testing.T) {
+	m := New()
+	m.SetUsers([]User{{ID: "U1", DisplayName: "jane.doe", InChannel: true}})
+	m.Open()
+	out := m.View(40)
+	if strings.Contains(out, "()") {
+		t.Errorf("view contains empty parens: %q", out)
+	}
+	if !strings.Contains(out, "jane.doe") {
+		t.Errorf("view missing display name: %q", out)
+	}
+}
+
+func TestViewKeepsParensForSpecialMentions(t *testing.T) {
+	m := New()
+	m.SetUsers(nil)
+	m.Open()
+	out := m.View(40)
+	for _, want := range []string{"(here)", "(channel)", "(everyone)"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("view missing %q: %q", want, out)
+		}
+	}
+}
+
+func TestViewExternalSuffix(t *testing.T) {
+	m := New()
+	m.SetUsers([]User{
+		{ID: "U1", DisplayName: "jenny.kim", InChannel: true, IsExternal: true},
+	})
+	m.Open()
+	out := m.View(60)
+	if !strings.Contains(out, "(ext)") {
+		t.Errorf("expected (ext) suffix: %q", out)
+	}
+}
+
+func TestViewNotInChannelSuffix(t *testing.T) {
+	m := New()
+	m.SetUsers([]User{
+		{ID: "U1", DisplayName: "jordan.lee", InChannel: false},
+	})
+	m.Open()
+	out := m.View(60)
+	if !strings.Contains(out, "(not in channel)") {
+		t.Errorf("expected (not in channel) suffix: %q", out)
 	}
 }
 

--- a/internal/ui/mentionpicker/model_test.go
+++ b/internal/ui/mentionpicker/model_test.go
@@ -1,6 +1,9 @@
 package mentionpicker
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestFilterByDisplayNamePrefix(t *testing.T) {
 	m := New()
@@ -59,9 +62,9 @@ func TestFilterEmptyQueryShowsAll(t *testing.T) {
 	})
 	m.Open()
 	m.SetQuery("")
-	// Empty query shows specials (3) + first users up to MaxVisible=5 total
-	if len(m.Filtered()) != 5 {
-		t.Fatalf("expected 5 filtered users (max), got %d", len(m.Filtered()))
+	// Empty query shows specials (3) + first users up to MaxVisible=7 total
+	if len(m.Filtered()) != 7 {
+		t.Fatalf("expected 7 filtered users (max), got %d", len(m.Filtered()))
 	}
 }
 
@@ -151,6 +154,66 @@ func TestSelectEmptyReturnsNil(t *testing.T) {
 	result := m.Select()
 	if result != nil {
 		t.Error("expected nil result for empty filtered list")
+	}
+}
+
+func TestFilterSortsInChannelBeforeNotInChannel(t *testing.T) {
+	m := New()
+	m.SetUsers([]User{
+		{ID: "U1", DisplayName: "alice", InChannel: false},
+		{ID: "U2", DisplayName: "bob", InChannel: true},
+		{ID: "U3", DisplayName: "charlie", InChannel: false},
+		{ID: "U4", DisplayName: "dan", InChannel: true},
+	})
+	m.Open()
+	got := m.Filtered()
+	// Special mentions match empty query too. Strip them to assert user order.
+	var names []string
+	for _, u := range got {
+		if u.ID == "U1" || u.ID == "U2" || u.ID == "U3" || u.ID == "U4" {
+			names = append(names, u.DisplayName)
+		}
+	}
+	want := []string{"bob", "dan", "alice", "charlie"}
+	if !reflect.DeepEqual(names, want) {
+		t.Errorf("user order = %v, want %v", names, want)
+	}
+}
+
+func TestFilterAlphabeticalWithinTier(t *testing.T) {
+	m := New()
+	m.SetUsers([]User{
+		{ID: "U1", DisplayName: "zoe", InChannel: true},
+		{ID: "U2", DisplayName: "alex", InChannel: true},
+		{ID: "U3", DisplayName: "mia", InChannel: true},
+	})
+	m.Open()
+	var names []string
+	for _, u := range m.Filtered() {
+		if u.ID != "" && u.ID[:1] == "U" {
+			names = append(names, u.DisplayName)
+		}
+	}
+	want := []string{"alex", "mia", "zoe"}
+	if !reflect.DeepEqual(names, want) {
+		t.Errorf("alpha order = %v, want %v", names, want)
+	}
+}
+
+func TestSpecialMentionsAlwaysInChannel(t *testing.T) {
+	m := New()
+	m.SetUsers(nil)
+	m.Open()
+	for _, u := range m.Filtered() {
+		if !u.InChannel {
+			t.Errorf("special mention %s should have InChannel=true", u.DisplayName)
+		}
+	}
+}
+
+func TestMaxVisibleSeven(t *testing.T) {
+	if MaxVisible != 7 {
+		t.Errorf("MaxVisible = %d, want 7", MaxVisible)
 	}
 }
 


### PR DESCRIPTION
## Summary

The `@`-mention picker is now channel-aware. Channel members render normally; non-members appear muted at the bottom with a ` (not in channel)` suffix; Slack Connect external users in a shared channel show a ` (ext)` suffix. The dead ` ()` empty-parens that has always trailed every workspace user in the picker is gone.

Spec: `docs/superpowers/specs/2026-05-20-mention-picker-channel-membership-design.md`.
Plan: `docs/superpowers/plans/2026-05-20-mention-picker-channel-membership.md`.

## What changed

**Data model**
- New SQLite tables `channel_members` (one row per channel/user) and `channel_membership_meta` (per-channel `last_full_fetch_at` for the 24h TTL backstop).
- New `users.is_external` column. External = `slack.User.TeamID != client.TeamID()` (Slack Connect / shared-channel guests). Set at four call sites: bootstrap users.list seed, both `resolveUser` paths, and `userResolver.Request` after a `users.info`.
- `mentionpicker.User` gains `InChannel` and `IsExternal`. Picker `filter()` produces specials → in-channel (alpha) → not-in-channel (alpha). `MaxVisible` 5 → 7.

**Fetch & cache lifecycle**
- New `internal/slack/membership.Manager`, one per workspace. Owns in-memory member-set state backed by SQLite.
- `EnsureFresh(channelID)` pushes the cached set to the UI immediately, then triggers a background `conversations.members` paginated fetch (Limit=1000, cursor-driven, 429-retry mirroring `GetAllPublicChannels`) on TTL miss / cache miss.
- `ApplyJoin` / `ApplyLeave` apply single-row deltas from `member_joined_channel` / `member_left_channel` WS events. Deltas explicitly do NOT bump `last_full_fetch_at` — that timestamp tracks full-fetch freshness only.
- `ForceStale` zeros the meta timestamp surgically (new `db.ZeroChannelMembershipMeta`) so reconnect triggers re-fetch without wiping persisted members.
- Concurrent-EnsureFresh dedup: in-flight sentinel + in-memory `lastFetched` window. The sentinel alone has a race when goroutines complete between checks; the timestamp closes it. Race detector clean across stress runs.

**External user resolution**
- The existing `userResolver` is the resolver. Its `Request(userID)` now computes `IsExternal` from `users.info` and emits `ui.UserExternalMsg`.
- Manager calls `resolver.Request(id)` for every member it sees on a fetch. Resolver's new cache-skip short-circuit (`db.GetUser` hit → return) prevents O(channel-size) `users.info` re-fires per channel switch.

**UI plumbing**
- `compose.Model` gains `activeChannelID` + per-channel member-set state. Rebuilds the derived `[]mentionpicker.User` whenever users / active channel / membership changes. Loading-state default: `InChannel = true` until membership data lands. External users not in active channel are filtered out entirely (no `(ext) (not in channel)` combo).
- `App.SetChannelMembership` / `SetExternalUsers` / `SetChannelMembershipFetcher`. `case ChannelSelectedMsg:` closes any open mention picker, sets active channel on both compose models, and fires the fetcher on a goroutine.
- `WorkspaceReadyMsg` / `WorkspaceSwitchedMsg` now carry `ExternalUsers map[string]bool`, hydrated from cache. App's handler calls `SetExternalUsers` before `SetUserNames` so picker entries get correct `IsExternal` flags on startup.

**Bug fixes folded in**
- `mentionpicker` empty-parens (`jane.doe ()`) gone for real users; preserved for special mentions.
- `cache.New` pins `MaxOpenConns(1)` for `:memory:` DSNs (SQLite per-connection schema gotcha; surfaces under concurrent writes against an in-memory test DB).

## Out of scope

Per the spec's explicit "Out of scope" list, none of these are implemented:
- Fuzzy / substring search beyond prefix.
- Recency-weighted picker sort.
- Channel member counts in the UI.
- Enterprise Grid org-shared channel special-casing.
- Filtering bots out of the picker.

## Test plan

**Automated (all passing locally):**
- [x] `go test ./... -count=1` — all 39 packages pass
- [x] `go test ./... -count=1 -race` — clean
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] Unit tests at every layer: schema migration, channel_members CRUD, `users.IsExternal` round-trip, `GetUsersInConversation` pagination + 429 retry, member event dispatch, picker filter sort, picker view rendering (suffixes, muted styles, empty-parens), compose membership integration, App propagation, Manager lifecycle (cache hit / miss / stale, deltas, ForceStale, concurrent dedup, resolver trigger), external-user MsgFlow
- [x] Deadlock-regression test: `TestChannelSelectedReturnsPromptlyEvenIfFetcherBlocks` — wires a blocking fetcher; if a future maintainer reverts the goroutine wrap, Update blocks past a 100ms deadline and the test fails

**Manual (smoke-tested by @gammons):**
- [x] App boots clean against two workspaces (one regular, one with Slack Connect channels)
- [x] First channel switch no longer deadlocks (was an unbuffered-bubbletea `Send`-from-`Update` issue in the channel-membership fetcher wiring — fixed in `193082a` and captured by the regression test above)

Open items for the reviewer / followup:
- [ ] Confirm `(ext)` rendering on a real Slack Connect channel
- [ ] Confirm muted ` (not in channel)` on a channel where the user knows some workspace folks aren't members
- [ ] Confirm `member_joined_channel` delta updates the picker live (have someone `/invite` a user)
- [ ] Confirm reconnect refresh: drop network briefly, reconnect, switch away and back to the active channel — membership refreshes silently

## Notable design decisions worth a second look

1. **`userResolver.Request` cache-skip** (`cmd/slk/main.go:248-258`). Without this, a 1000-member shared channel would fire 1000 `users.info` calls per refresh — exactly the main use case made worst. The cache hit short-circuit (after the inflight LoadOrStore, before the goroutine) makes the resolver idempotent for already-known users. A `Delete` releases the inflight slot on the cache-hit path. Ordering matters: `LoadOrStore` first, then the cache check, then `Delete` on bail — avoids the race where two concurrent callers both check (miss), both then claim a slot, and the loser silently returns.

2. **`channelMembershipFetcher` is invoked on a goroutine.** Bubbletea v2's program message channel is unbuffered (`charm.land/bubbletea/v2 tea.go:598`). Calling `Membership.EnsureFresh` synchronously from inside `case ChannelSelectedMsg:` deadlocks on its `pushSnapshot` → `p.Send(ChannelMembershipMsg)`. Comment + regression test guard against reverting this. The fetcher is semantically fire-and-forget; results arrive later via `ChannelMembershipMsg`.

3. **Lazy in-memory `lastFetched` window in addition to the in-flight sentinel.** The plan claimed the sentinel alone would dedup concurrent EnsureFresh calls. Under stress it doesn't: the fake API returns instantly, the first goroutine completes and releases the sentinel before the others reach the busy check, so they refetch. The `lastFetched` map (mu-protected, cleared by `ForceStale`) closes that race. `TestEnsureFreshConcurrentDoesNotDuplicate` is stable across `-count=20 -race`.

4. **`ForceStale` uses surgical meta-only update**, not `ReplaceChannelMembers([]string{}, 0)`. The original implementation read in-memory `cachedIDs` and called `ReplaceChannelMembers`; on cold cache this would wipe the persisted member list. New `db.ZeroChannelMembershipMeta` does a one-line `UPDATE channel_membership_meta SET last_full_fetch_at = 0`. `TestForceStaleDoesNotWipePersistedMembers` regression-tests this directly.

## Commits

Reasonably bottom-up — each commit is independently testable, none break compilation:

\`\`\`
193082a fix: deadlock on channel-switch via bubbletea unbuffered Send
f4abfd9 wire membership.Manager into workspace bootstrap
f7f378f userResolver: detect + report external users
9808bd5 membership: ApplyJoin / ApplyLeave / ForceStale + resolver trigger
bc598cf membership: Manager skeleton + EnsureFresh
5204dd6 app: thread channel-membership + external-user state to picker
0d40854 compose: per-channel mention picker membership
8b4323f mentionpicker: muted suffix rendering + empty-parens fix
6c9e555 mentionpicker: channel-aware User + members-first sort
6d0c57a slack: dispatch member_joined_channel / member_left_channel
05fecb5 slack: GetUsersInConversation paginated wrapper
07c2c86 cache: channel_members CRUD + meta queries
e7f7f29 cache: persist User.IsExternal
6313925 cache: add channel_members, channel_membership_meta, users.is_external
\`\`\`