### PR TITLE
Scroll & interaction improvements: decouple wheel/PageUp, configurable speed, scrolling thread parent, click-to-open

### DIFF
--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -682,6 +682,7 @@ func run() error {
 	app.SetWorkspaces(wsItems)
 	app.SetTypingEnabled(cfg.Animations.TypingIndicators)
 	app.SetSidebarStaleThreshold(time.Duration(cfg.Sidebar.HideInactiveAfterDays) * 24 * time.Hour)
+	app.SetMouseWheelLines(cfg.Appearance.MouseWheelLines)
 
 	// Wire theme switcher
 	app.SetThemeItems(styles.ThemeNames())

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,6 +52,10 @@ type Appearance struct {
 	// If 0 or unset, defaults to 60. The image is also bounded by the
 	// available message-pane width when narrower.
 	MaxImageCols int `toml:"max_image_cols"`
+	// MouseWheelLines controls how many lines the viewport scrolls per
+	// mouse-wheel notch. Higher = faster scroll. Defaults to 3 (typical
+	// terminal behavior). Clamped to >= 1 at load time.
+	MouseWheelLines int `toml:"mouse_wheel_lines"`
 }
 
 type Animations struct {
@@ -128,6 +132,7 @@ func Default() Config {
 			ImageProtocol:   "auto",
 			MaxImageRows:    20,
 			MaxImageCols:    60,
+			MouseWheelLines: 3,
 		},
 		Animations: Animations{
 			Enabled:          true,
@@ -172,6 +177,13 @@ func Load(path string) (Config, error) {
 		return cfg, err
 	}
 	cfg.Workspaces = resolved
+
+	// Clamp MouseWheelLines: 0 (unset, after a user supplied a partial
+	// [appearance] block without this key) and negative values both fall
+	// back to the default. >= 1 to guarantee scroll progress per notch.
+	if cfg.Appearance.MouseWheelLines < 1 {
+		cfg.Appearance.MouseWheelLines = 3
+	}
 
 	return cfg, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -149,6 +149,56 @@ func TestConfig_ImageDefaults(t *testing.T) {
 	}
 }
 
+// MouseWheelLines: default is 3, an unset/zero value is coerced to 3 on
+// Load (defends against partial [appearance] blocks), and an explicit
+// positive value passes through.
+func TestConfig_MouseWheelLines(t *testing.T) {
+	// Default value from Default().
+	if d := Default(); d.Appearance.MouseWheelLines != 3 {
+		t.Errorf("Default() mouse_wheel_lines = %d, want 3", d.Appearance.MouseWheelLines)
+	}
+
+	// Missing key in [appearance]: Load should fall back to 3.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte("[appearance]\ntheme = \"nord\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Appearance.MouseWheelLines != 3 {
+		t.Errorf("missing key: mouse_wheel_lines = %d, want 3", cfg.Appearance.MouseWheelLines)
+	}
+
+	// Explicit override passes through.
+	path2 := filepath.Join(dir, "config2.toml")
+	if err := os.WriteFile(path2, []byte("[appearance]\nmouse_wheel_lines = 7\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg2, err := Load(path2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg2.Appearance.MouseWheelLines != 7 {
+		t.Errorf("override: mouse_wheel_lines = %d, want 7", cfg2.Appearance.MouseWheelLines)
+	}
+
+	// Negative or zero explicit values are clamped to the default 3.
+	path3 := filepath.Join(dir, "config3.toml")
+	if err := os.WriteFile(path3, []byte("[appearance]\nmouse_wheel_lines = -2\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg3, err := Load(path3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg3.Appearance.MouseWheelLines != 3 {
+		t.Errorf("negative clamp: mouse_wheel_lines = %d, want 3", cfg3.Appearance.MouseWheelLines)
+	}
+}
+
 func TestConfig_ImageOverrides(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -396,6 +396,12 @@ type dragState struct {
 	lastX, lastY     int
 	moved            bool
 	autoScrollActive bool
+	// clickedMessage is set on press when ClickAt on the messages pane
+	// reported a hit on a real message row (i.e. not chrome / empty
+	// space). MouseReleaseMsg consults it: a plain click (no motion)
+	// that landed on a message opens that message's thread, mirroring
+	// the Enter keypress. Cleared by clearing the whole dragState.
+	clickedMessage bool
 }
 
 // autoScrollTickMsg is dispatched by tea.Tick while a drag is held near
@@ -1297,7 +1303,11 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				a.drag = dragState{panel: PanelMessages, pressX: px, pressY: py, lastX: px, lastY: py}
 				a.messagepane.BeginSelectionAt(py, px)
-				a.messagepane.ClickAt(py)
+				// Remember whether this press actually landed on a message
+				// row -- MouseReleaseMsg uses this to decide whether a plain
+				// click (no drag) should open the message's thread (mirrors
+				// pressing Enter on the selected message).
+				a.drag.clickedMessage = a.messagepane.ClickAt(py)
 			}
 		} else if a.threadVisible && x < a.layoutThreadEnd {
 			a.focusedPanel = PanelThread
@@ -1444,12 +1454,21 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		moved := a.drag.moved
 		panel := a.drag.panel
+		clickedMessage := a.drag.clickedMessage
 		a.drag = dragState{}
 		if !moved {
 			// Plain click — drop any previous pinned selection.
 			switch panel {
 			case PanelMessages:
 				a.messagepane.ClearSelection()
+				// Treat a click on a real message row as Enter:
+				// open that message's thread. Clicks that missed
+				// (chrome, empty space) leave the panel as-is.
+				if clickedMessage {
+					if cmd := a.openThreadForSelectedMessage(); cmd != nil {
+						cmds = append(cmds, cmd)
+					}
+				}
 			case PanelThread:
 				a.threadPanel.ClearSelection()
 			}
@@ -4093,41 +4112,52 @@ func (a *App) handleEnter() tea.Cmd {
 	}
 
 	if a.focusedPanel == PanelMessages {
-		msg, ok := a.messagepane.SelectedMessage()
-		if ok {
-			// Use the message's own TS as the thread parent.
-			// If it's already a thread reply, use its ThreadTS instead.
-			threadTS := msg.TS
-			if msg.ThreadTS != "" && msg.ThreadTS != msg.TS {
-				threadTS = msg.ThreadTS
-			}
-			a.threadVisible = true
-			a.statusbar.SetInThread(true)
-			a.focusedPanel = PanelThread
-			a.threadPanel.SetThread(msg, nil, a.activeChannelID, threadTS)
-			a.threadCompose.SetChannel("thread")
-			a.applyThreadUnreadBoundary(a.activeChannelID)
-
-			if a.threadFetcher != nil {
-				fetcher := a.threadFetcher
-				chID := a.activeChannelID
-				ts := threadTS
-				var batch []tea.Cmd
-				if a.threadCacheReader != nil {
-					if cached := a.threadCacheReader(chID, ts); len(cached) > 1 {
-						replies := cached[1:] // strip parent; reducer expects replies-only
-						batch = append(batch, func() tea.Msg {
-							return ThreadRepliesLoadedMsg{ThreadTS: ts, Replies: replies}
-						})
-					}
-				}
-				batch = append(batch, func() tea.Msg { return fetcher(chID, ts) })
-				return tea.Batch(batch...)
-			}
-		}
+		return a.openThreadForSelectedMessage()
 	}
 
 	return nil
+}
+
+// openThreadForSelectedMessage opens the thread panel for the message
+// currently selected in the channel messages pane. Mirrors the Enter
+// keypress on PanelMessages; called from both handleEnter and from the
+// click-to-open-thread path so the two entry points stay in lockstep.
+// Returns nil when there is no selected message or no threadFetcher.
+func (a *App) openThreadForSelectedMessage() tea.Cmd {
+	msg, ok := a.messagepane.SelectedMessage()
+	if !ok {
+		return nil
+	}
+	// Use the message's own TS as the thread parent.
+	// If it's already a thread reply, use its ThreadTS instead.
+	threadTS := msg.TS
+	if msg.ThreadTS != "" && msg.ThreadTS != msg.TS {
+		threadTS = msg.ThreadTS
+	}
+	a.threadVisible = true
+	a.statusbar.SetInThread(true)
+	a.focusedPanel = PanelThread
+	a.threadPanel.SetThread(msg, nil, a.activeChannelID, threadTS)
+	a.threadCompose.SetChannel("thread")
+	a.applyThreadUnreadBoundary(a.activeChannelID)
+
+	if a.threadFetcher == nil {
+		return nil
+	}
+	fetcher := a.threadFetcher
+	chID := a.activeChannelID
+	ts := threadTS
+	var batch []tea.Cmd
+	if a.threadCacheReader != nil {
+		if cached := a.threadCacheReader(chID, ts); len(cached) > 1 {
+			replies := cached[1:] // strip parent; reducer expects replies-only
+			batch = append(batch, func() tea.Msg {
+				return ThreadRepliesLoadedMsg{ThreadTS: ts, Replies: replies}
+			})
+		}
+	}
+	batch = append(batch, func() tea.Msg { return fetcher(chID, ts) })
+	return tea.Batch(batch...)
 }
 
 func (a *App) SetMode(mode Mode) {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -887,6 +887,11 @@ type App struct {
 	typingTickerOn bool
 	typingEnabled  bool
 
+	// mouseWheelLines is the number of lines the viewport scrolls per
+	// mouse-wheel notch. Plumbed from [appearance].mouse_wheel_lines.
+	// Falls back to 3 when unset (matches the pre-config behavior).
+	mouseWheelLines int
+
 	// Outbound typing
 	typingSendFn   TypingSendFunc
 	lastTypingSent time.Time
@@ -1031,6 +1036,7 @@ func NewApp() *App {
 		selfSentTSes:         make(map[string]time.Time),
 		lastSelfSendByChannel: make(map[string]time.Time),
 		threadsDirtyDebounce: 150 * time.Millisecond,
+		mouseWheelLines:      3,
 		userNames:            map[string]string{},
 		externalUsers:        map[string]bool{},
 		statusByTeam:         map[string]workspaceStatus{},
@@ -1144,11 +1150,15 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		default:
 			break
 		}
-		// Lines moved per wheel notch -- matches typical terminal behavior.
-		// Single-row panes (sidebar) still feel fine because real-world
-		// workspace lists are short and the snap-back on the next j/k
-		// restores the previously-selected channel.
-		const wheelLinesPerNotch = 3
+		// Lines moved per wheel notch -- configured via
+		// [appearance].mouse_wheel_lines (default 3, matches typical
+		// terminal behavior). Single-row panes (sidebar) still feel fine
+		// because real-world workspace lists are short and the snap-back
+		// on the next j/k restores the previously-selected channel.
+		wheelLinesPerNotch := a.mouseWheelLines
+		if wheelLinesPerNotch < 1 {
+			wheelLinesPerNotch = 1
+		}
 		x := msg.X
 		switch {
 		case x < a.layoutRailWidth:
@@ -5060,6 +5070,15 @@ func (a *App) SetThemeOverrides(overrides config.Theme) {
 // SetTypingEnabled controls whether typing indicators are shown and sent.
 func (a *App) SetTypingEnabled(enabled bool) {
 	a.typingEnabled = enabled
+}
+
+// SetMouseWheelLines configures the number of lines the viewport scrolls per
+// mouse-wheel notch. Values < 1 are coerced to 1 to guarantee scroll progress.
+func (a *App) SetMouseWheelLines(n int) {
+	if n < 1 {
+		n = 1
+	}
+	a.mouseWheelLines = n
 }
 
 // SetSidebarStaleThreshold configures auto-hiding of inactive

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1130,9 +1130,11 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if a.loading {
 			break
 		}
-		// Wheel notches move the selection like j/k rather than scrolling the
-		// viewport directly. Targets the panel under the cursor regardless of
-		// which panel currently has keyboard focus.
+		// Wheel notches scroll the viewport of the panel under the cursor
+		// WITHOUT changing the current selection -- decoupled from j/k so a
+		// user can read past a long message or browse history without losing
+		// the selected/active item. Targets the panel under the cursor
+		// regardless of which panel currently has keyboard focus.
 		up := false
 		switch msg.Button {
 		case tea.MouseWheelUp:
@@ -1142,53 +1144,47 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		default:
 			break
 		}
+		// Lines moved per wheel notch -- matches typical terminal behavior.
+		// Single-row panes (sidebar) still feel fine because real-world
+		// workspace lists are short and the snap-back on the next j/k
+		// restores the previously-selected channel.
+		const wheelLinesPerNotch = 3
 		x := msg.X
 		switch {
 		case x < a.layoutRailWidth:
-			// Workspace rail: no selection navigation here.
+			// Workspace rail: no scroll here.
 		case a.sidebarVisible && x < a.layoutSidebarEnd:
 			if up {
-				a.sidebar.MoveUp()
+				a.sidebar.ScrollUp(wheelLinesPerNotch)
 			} else {
-				a.sidebar.MoveDown()
+				a.sidebar.ScrollDown(wheelLinesPerNotch)
 			}
 		case x < a.layoutMsgEnd:
 			if a.view == ViewThreads {
 				if up {
-					a.threadsView.MoveUp()
+					a.threadsView.ScrollUp(wheelLinesPerNotch)
 				} else {
-					a.threadsView.MoveDown()
+					a.threadsView.ScrollDown(wheelLinesPerNotch)
 				}
-				cmds = append(cmds, a.openSelectedThreadCmd(true))
+				// No openSelectedThreadCmd here: pure viewport scroll
+				// does not change the highlighted thread card.
 			} else {
 				if up {
-					a.messagepane.MoveUp()
-					// Mirror j/k: when selection hits the top, backfill older history.
-					if a.messagepane.AtTop() && !a.fetchingOlder && a.olderMessagesFetcher != nil {
-						a.fetchingOlder = true
-						a.messagepane.SetLoading(true)
-						chID := a.activeChannelID
-						oldestTS := a.messagepane.OldestTS()
-						fetcher := a.olderMessagesFetcher
-						// Kick the spinner tick: if a.loading is already
-						// false (workspace fully loaded), no tick is alive
-						// and the glyph would freeze on its last frame.
-						cmds = append(cmds, tea.Tick(100*time.Millisecond, func(time.Time) tea.Msg {
-							return SpinnerTickMsg{}
-						}))
-						cmds = append(cmds, func() tea.Msg {
-							return fetcher(chID, oldestTS)
-						})
+					a.messagepane.ScrollUp(wheelLinesPerNotch)
+					// Backfill older history when the viewport hits the
+					// top (selection-based AtTop check moved to handleUp).
+					if cmd := a.maybeFetchOlderHistory(a.messagepane.ViewportAtTop()); cmd != nil {
+						cmds = append(cmds, cmd)
 					}
 				} else {
-					a.messagepane.MoveDown()
+					a.messagepane.ScrollDown(wheelLinesPerNotch)
 				}
 			}
 		case a.threadVisible && x < a.layoutThreadEnd:
 			if up {
-				a.threadPanel.MoveUp()
+				a.threadPanel.ScrollUp(wheelLinesPerNotch)
 			} else {
-				a.threadPanel.MoveDown()
+				a.threadPanel.ScrollDown(wheelLinesPerNotch)
 			}
 		}
 
@@ -2967,16 +2963,24 @@ func (a *App) handleNormalMode(msg tea.KeyMsg) tea.Cmd {
 		}
 
 	case key.Matches(msg, a.keys.PageUp):
-		a.scrollFocusedPanel(-a.pageSize())
+		if cmd := a.scrollFocusedPanel(-a.pageSize()); cmd != nil {
+			return cmd
+		}
 
 	case key.Matches(msg, a.keys.PageDown):
-		a.scrollFocusedPanel(a.pageSize())
+		if cmd := a.scrollFocusedPanel(a.pageSize()); cmd != nil {
+			return cmd
+		}
 
 	case key.Matches(msg, a.keys.HalfPageUp):
-		a.scrollFocusedPanel(-a.halfPageSize())
+		if cmd := a.scrollFocusedPanel(-a.halfPageSize()); cmd != nil {
+			return cmd
+		}
 
 	case key.Matches(msg, a.keys.HalfPageDown):
-		a.scrollFocusedPanel(a.halfPageSize())
+		if cmd := a.scrollFocusedPanel(a.halfPageSize()); cmd != nil {
+			return cmd
+		}
 
 	case key.Matches(msg, a.keys.Help):
 		a.help.SetEntries(help.FromKeyMap(a.keys))
@@ -3862,24 +3866,11 @@ func (a *App) handleUp() tea.Cmd {
 			return a.openSelectedThreadCmd(true)
 		}
 		a.messagepane.MoveUp()
-		// If at top, fetch older messages
-		if a.messagepane.AtTop() && !a.fetchingOlder && a.olderMessagesFetcher != nil {
-			a.fetchingOlder = true
-			a.messagepane.SetLoading(true)
-			chID := a.activeChannelID
-			oldestTS := a.messagepane.OldestTS()
-			fetcher := a.olderMessagesFetcher
-			// Kick the spinner tick: if a.loading is already false
-			// (workspace fully loaded), no tick is alive and the glyph
-			// would freeze on its last frame.
-			return tea.Batch(
-				tea.Tick(100*time.Millisecond, func(time.Time) tea.Msg {
-					return SpinnerTickMsg{}
-				}),
-				func() tea.Msg {
-					return fetcher(chID, oldestTS)
-				},
-			)
+		// If selection reached the top, fetch older messages. The
+		// viewport-based path (wheel / PageUp) is handled by
+		// scrollFocusedPanel via the same helper.
+		if cmd := a.maybeFetchOlderHistory(a.messagepane.AtTop()); cmd != nil {
+			return cmd
 		}
 	case PanelThread:
 		a.threadPanel.MoveUp()
@@ -3957,65 +3948,79 @@ func (a *App) panelAt(x, y int) (panel Panel, paneX, paneY int, ok bool) {
 	return PanelWorkspace, 0, 0, false
 }
 
-// scrollFocusedPanel scrolls the focused panel by delta lines (negative = up).
-// Half-page scrolls (ctrl+u / ctrl+d) advance the SELECTION as well as the
-// viewport: previously they moved only the viewport, leaving `selected`
-// behind, so the next j/k snapped the viewport back to where the user
-// started -- effectively undoing the page jump. Moving by N selection
-// steps fixes that and also exercises sidebar's threads-row transition
-// logic naturally.
-func (a *App) scrollFocusedPanel(delta int) {
+// scrollFocusedPanel scrolls the focused panel by delta lines (negative = up)
+// WITHOUT advancing selection. This is the keyboard equivalent of the mouse
+// wheel: PageUp/PageDown/Ctrl+U/Ctrl+D move the viewport only; the selected
+// message/channel stays put (and may scroll off-screen). The next j/k will
+// snap the viewport back to keep the (still-)selected item visible because
+// hasSnapped == true but snappedSelection != selected once selection moves.
+//
+// On a scroll-up that lands the messages-pane viewport at the very top, this
+// also triggers a fetch of older channel history -- the same UX the
+// selection-based AtTop path provides via handleUp.
+func (a *App) scrollFocusedPanel(delta int) tea.Cmd {
 	if delta == 0 {
-		return
+		return nil
 	}
-	steps := delta
-	if steps < 0 {
-		steps = -steps
+	n := delta
+	if n < 0 {
+		n = -n
 	}
 	switch a.focusedPanel {
 	case PanelSidebar:
 		if delta < 0 {
-			for i := 0; i < steps; i++ {
-				a.sidebar.MoveUp()
-			}
+			a.sidebar.ScrollUp(n)
 		} else {
-			for i := 0; i < steps; i++ {
-				a.sidebar.MoveDown()
-			}
+			a.sidebar.ScrollDown(n)
 		}
 	case PanelMessages:
 		if a.view == ViewThreads {
 			if delta < 0 {
-				for i := 0; i < steps; i++ {
-					a.threadsView.MoveUp()
-				}
+				a.threadsView.ScrollUp(n)
 			} else {
-				for i := 0; i < steps; i++ {
-					a.threadsView.MoveDown()
-				}
+				a.threadsView.ScrollDown(n)
 			}
 		} else {
 			if delta < 0 {
-				for i := 0; i < steps; i++ {
-					a.messagepane.MoveUp()
-				}
-			} else {
-				for i := 0; i < steps; i++ {
-					a.messagepane.MoveDown()
-				}
+				a.messagepane.ScrollUp(n)
+				return a.maybeFetchOlderHistory(a.messagepane.ViewportAtTop())
 			}
+			a.messagepane.ScrollDown(n)
 		}
 	case PanelThread:
 		if delta < 0 {
-			for i := 0; i < steps; i++ {
-				a.threadPanel.MoveUp()
-			}
+			a.threadPanel.ScrollUp(n)
 		} else {
-			for i := 0; i < steps; i++ {
-				a.threadPanel.MoveDown()
-			}
+			a.threadPanel.ScrollDown(n)
 		}
 	}
+	return nil
+}
+
+// maybeFetchOlderHistory kicks off a backfill of older channel history when
+// `atTop` is true, no fetch is already in flight, and a fetcher is wired up.
+// Returns nil otherwise. Centralizes the spinner-tick + fetch-cmd batching
+// previously duplicated across handleUp / the mouse-wheel handler / page-up.
+func (a *App) maybeFetchOlderHistory(atTop bool) tea.Cmd {
+	if !atTop || a.fetchingOlder || a.olderMessagesFetcher == nil {
+		return nil
+	}
+	a.fetchingOlder = true
+	a.messagepane.SetLoading(true)
+	chID := a.activeChannelID
+	oldestTS := a.messagepane.OldestTS()
+	fetcher := a.olderMessagesFetcher
+	// Kick the spinner tick: if a.loading is already false (workspace
+	// fully loaded), no tick is alive and the glyph would freeze on its
+	// last frame.
+	return tea.Batch(
+		tea.Tick(100*time.Millisecond, func(time.Time) tea.Msg {
+			return SpinnerTickMsg{}
+		}),
+		func() tea.Msg {
+			return fetcher(chID, oldestTS)
+		},
+	)
 }
 
 // openQuitConfirm raises the centered "Quit slk?" overlay. Called from

--- a/internal/ui/app_olderfetch_spinner_test.go
+++ b/internal/ui/app_olderfetch_spinner_test.go
@@ -57,3 +57,53 @@ func TestHandleUp_BackfillEmitsSpinnerTick(t *testing.T) {
 		t.Fatal("expected fetchingOlder=true after dispatch")
 	}
 }
+
+// PageUp / wheel-up at the top of the messages pane (viewport scrolled all
+// the way up, regardless of where selection sits) must also kick off an
+// older-history backfill -- otherwise users can never load history without
+// also moving selection. Defends the issue-#23 "scroll past long messages"
+// fix path through scrollFocusedPanel.
+func TestScrollFocusedPanel_BackfillAtViewportTop(t *testing.T) {
+	app := NewApp()
+	app.activeChannelID = "C1"
+	app.focusedPanel = PanelMessages
+	app.view = ViewChannels
+	app.loading = false
+	app.fetchingOlder = false
+	app.layoutMsgHeight = 20
+
+	app.messagepane.SetMessages([]messages.MessageItem{
+		{TS: "1.0", UserName: "alice", Text: "first"},
+		{TS: "2.0", UserName: "bob", Text: "second"},
+	})
+
+	called := false
+	app.SetOlderMessagesFetcher(func(channelID, oldestTS string) tea.Msg {
+		called = true
+		return nil
+	})
+
+	// PageUp -> scrollFocusedPanel(-pageSize). With only 2 messages the
+	// viewport is already at the top, so this should immediately trigger
+	// the backfill path via ViewportAtTop().
+	cmd := app.scrollFocusedPanel(-app.pageSize())
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd from PageUp at top of viewport")
+	}
+	got := drainBatch(cmd)
+	var sawSpinner bool
+	for _, m := range got {
+		if _, ok := m.(SpinnerTickMsg); ok {
+			sawSpinner = true
+		}
+	}
+	if !sawSpinner {
+		t.Fatalf("expected SpinnerTickMsg from PageUp backfill, got %#v", got)
+	}
+	if !called {
+		t.Fatal("expected fetcher cmd to have been dispatched from PageUp")
+	}
+	if !app.fetchingOlder {
+		t.Fatal("expected fetchingOlder=true after PageUp dispatch")
+	}
+}

--- a/internal/ui/app_selection_test.go
+++ b/internal/ui/app_selection_test.go
@@ -115,6 +115,114 @@ func TestApp_PlainClickDoesNotCopy(t *testing.T) {
 	}
 }
 
+// A plain click (no drag) on a message row opens that message's thread
+// view, mirroring the Enter keypress. Defends the click-to-open-thread
+// behavior so it stays in lockstep with handleEnter's PanelMessages
+// branch via the shared openThreadForSelectedMessage helper.
+func TestApp_PlainClickOnMessageOpensThread(t *testing.T) {
+	a := newTestAppWithMessages(t)
+	a.activeChannelID = "C1"
+
+	fetchedCh := ""
+	fetchedTS := ""
+	a.SetThreadFetcher(func(channelID, threadTS string) tea.Msg {
+		fetchedCh = channelID
+		fetchedTS = threadTS
+		return ThreadRepliesLoadedMsg{ThreadTS: threadTS, Replies: nil}
+	})
+
+	pressX := a.layoutSidebarEnd + 2
+	// pane-local y=3 (terminal y=4 minus 1-row panel border) lands on
+	// the first message row past the 2-row chrome. newTestAppWithMessages
+	// seeds 2 messages with selection at index 1 (the bottom message --
+	// SetMessages defaults selection to the newest); clicking row 3
+	// should select message index 0 and open its thread.
+	pressY := 4
+	_, _ = a.Update(tea.MouseClickMsg{X: pressX, Y: pressY, Button: tea.MouseLeft})
+	_, cmd := a.Update(tea.MouseReleaseMsg{X: pressX, Y: pressY, Button: tea.MouseLeft})
+	if cmd == nil {
+		t.Fatal("click-release on a message must return a non-nil cmd (open-thread fetch)")
+	}
+	_ = drainBatch(cmd)
+
+	if !a.threadVisible {
+		t.Error("threadVisible = false after click; want true")
+	}
+	if a.focusedPanel != PanelThread {
+		t.Errorf("focusedPanel = %v after click; want PanelThread", a.focusedPanel)
+	}
+	if fetchedCh != "C1" {
+		t.Errorf("threadFetcher called with channel %q; want C1", fetchedCh)
+	}
+	// The first message has TS "1.0"; clicking it should open thread with
+	// that TS as the parent.
+	if fetchedTS != "1.0" {
+		t.Errorf("threadFetcher called with threadTS %q; want 1.0", fetchedTS)
+	}
+}
+
+// A click that lands on the channel header chrome (above the first
+// message) must NOT open a thread -- chrome clicks are no-ops. Defends
+// the ClickAt(returns bool) plumbing.
+func TestApp_PlainClickOnChromeDoesNotOpenThread(t *testing.T) {
+	a := newTestAppWithMessages(t)
+	a.activeChannelID = "C1"
+
+	called := false
+	a.SetThreadFetcher(func(channelID, threadTS string) tea.Msg {
+		called = true
+		return ThreadRepliesLoadedMsg{ThreadTS: threadTS, Replies: nil}
+	})
+
+	pressX := a.layoutSidebarEnd + 2
+	// pane-local y=0 (terminal y=1 minus 1-row panel border) lands on
+	// the channel header inside the messages pane chrome -- chrome
+	// occupies pane-local rows 0..chromeHeight-1.
+	pressY := 1
+	_, _ = a.Update(tea.MouseClickMsg{X: pressX, Y: pressY, Button: tea.MouseLeft})
+	_, cmd := a.Update(tea.MouseReleaseMsg{X: pressX, Y: pressY, Button: tea.MouseLeft})
+
+	for _, m := range drainBatch(cmd) {
+		if _, ok := m.(ThreadRepliesLoadedMsg); ok {
+			t.Fatal("click on chrome must not dispatch a thread fetch")
+		}
+	}
+	if called {
+		t.Fatal("threadFetcher called on chrome click")
+	}
+	if a.threadVisible {
+		t.Error("threadVisible = true after chrome click; want false")
+	}
+}
+
+// A drag (motion between press and release) must NOT open a thread --
+// the user is text-selecting, not navigating. Defends the moved-vs-clicked
+// gate in the MouseReleaseMsg handler.
+func TestApp_DragDoesNotOpenThread(t *testing.T) {
+	a := newTestAppWithMessages(t)
+	a.activeChannelID = "C1"
+
+	called := false
+	a.SetThreadFetcher(func(channelID, threadTS string) tea.Msg {
+		called = true
+		return ThreadRepliesLoadedMsg{ThreadTS: threadTS, Replies: nil}
+	})
+
+	pressX := a.layoutSidebarEnd + 2
+	pressY := 4
+	_, _ = a.Update(tea.MouseClickMsg{X: pressX, Y: pressY, Button: tea.MouseLeft})
+	// Any motion between press and release flags a drag.
+	_, _ = a.Update(tea.MouseMotionMsg{X: pressX + 5, Y: pressY, Button: tea.MouseLeft})
+	_, _ = a.Update(tea.MouseReleaseMsg{X: pressX + 5, Y: pressY, Button: tea.MouseLeft})
+
+	if called {
+		t.Fatal("threadFetcher called after a drag; drags must not open threads")
+	}
+	if a.threadVisible {
+		t.Error("threadVisible = true after drag; want false")
+	}
+}
+
 func TestApp_CopiedMsgShowsToastAndSchedulesClear(t *testing.T) {
 	a := newTestAppWithMessages(t)
 	_, cmd := a.Update(statusbar.CopiedMsg{N: 7})

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -1382,9 +1382,12 @@ func TestApp_DuplicateMessageEventDoesNotDoubleAppend(t *testing.T) {
 	}
 }
 
-// Defends Bug B: ctrl+u / ctrl+d must move the selection, not just the
-// viewport. Otherwise a subsequent j/k snaps back to the original spot.
-func TestApp_HalfPageScrollAdvancesSelection(t *testing.T) {
+// Half-page scroll (ctrl+u / ctrl+d) and PageUp/PageDown are now decoupled
+// from selection: they move the viewport only. The selected message stays
+// put -- so a subsequent j/k will snap the viewport back to keep selection
+// visible, which is the expected behavior once the user explicitly invokes
+// selection navigation. This test pins that contract.
+func TestApp_HalfPageScrollMovesViewportNotSelection(t *testing.T) {
 	app := NewApp()
 	app.activeChannelID = "C1"
 	app.focusedPanel = PanelMessages
@@ -1397,19 +1400,34 @@ func TestApp_HalfPageScrollAdvancesSelection(t *testing.T) {
 		})
 	}
 	app.messagepane.SetMessages(items)
-	// Provide a sane layout height so halfPageSize() returns > 1.
+	// Provide a sane layout so halfPageSize() returns > 1.
 	app.layoutMsgHeight = 20
+	// Force one render so yOffset snaps to keep the bottom selection visible
+	// (SetMessages defaults selection to the last message). Without this,
+	// yOffset is still 0 and ScrollUp would clamp with no observable effect.
+	_ = app.messagepane.View(80, 20)
 
 	startIdx := app.messagepane.SelectedIndex()
+	startOff := app.messagepane.YOffset()
+
 	app.scrollFocusedPanel(-app.halfPageSize()) // ctrl+u
-	upIdx := app.messagepane.SelectedIndex()
-	if upIdx >= startIdx {
-		t.Errorf("ctrl+u should decrease selection; start=%d after=%d", startIdx, upIdx)
+	if got := app.messagepane.SelectedIndex(); got != startIdx {
+		t.Errorf("ctrl+u must NOT change selection; start=%d after=%d", startIdx, got)
 	}
+	upOff := app.messagepane.YOffset()
+	if upOff >= startOff {
+		t.Errorf("ctrl+u should decrease yOffset; start=%d after=%d", startOff, upOff)
+	}
+
 	app.scrollFocusedPanel(app.halfPageSize()) // ctrl+d
-	downIdx := app.messagepane.SelectedIndex()
-	if downIdx <= upIdx {
-		t.Errorf("ctrl+d should increase selection; before=%d after=%d", upIdx, downIdx)
+	if got := app.messagepane.SelectedIndex(); got != startIdx {
+		t.Errorf("ctrl+d must NOT change selection; start=%d after=%d", startIdx, got)
+	}
+	// Force a render so View() clamps yOffset against actual content height.
+	_ = app.messagepane.View(80, 20)
+	downOff := app.messagepane.YOffset()
+	if downOff <= upOff {
+		t.Errorf("ctrl+d should increase yOffset; before=%d after=%d", upOff, downOff)
 	}
 }
 

--- a/internal/ui/messages/model.go
+++ b/internal/ui/messages/model.go
@@ -1949,11 +1949,15 @@ func convertSixelMap(in map[int]imgrender.SixelEntry) map[int]sixelEntry {
 // y returned by App.panelAt, which is measured from the panel's top border —
 // so y=0..chromeHeight-1 is the channel header / separator chrome and
 // y=chromeHeight onward is message content). Selects the message at that
-// position; clicks in the chrome are ignored.
-func (m *Model) ClickAt(y int) {
+// position; clicks in the chrome are ignored. Returns true when the click
+// landed on a real message row (selection was either updated or already
+// matched the hit), false when the click missed -- callers use the bool to
+// distinguish "clicked a message" from "clicked empty space" so that
+// click-to-open-thread doesn't fire on chrome / dead-space clicks.
+func (m *Model) ClickAt(y int) bool {
 	contentY := y - m.chromeHeight
 	if contentY < 0 {
-		return // click on chrome (header / separator) — ignore
+		return false // click on chrome (header / separator) — ignore
 	}
 	absoluteY := contentY + m.yOffset
 
@@ -1970,10 +1974,11 @@ func (m *Model) ClickAt(y int) {
 				m.selected = entry.msgIdx
 				m.dirty()
 			}
-			return
+			return true
 		}
 		currentLine += entry.height
 	}
+	return false
 }
 
 // HitTest returns the message index, attachment index, and Slack file

--- a/internal/ui/messages/model.go
+++ b/internal/ui/messages/model.go
@@ -861,6 +861,21 @@ func (m *Model) AtTop() bool {
 	return m.selected == 0 && len(m.messages) > 0
 }
 
+// ViewportAtTop reports whether the viewport is scrolled to the very top of
+// the message stream. Used by the app layer to trigger older-history backfill
+// on a wheel-up / PageUp gesture that scrolls the viewport without moving
+// selection (selection-based backfill goes through AtTop()).
+func (m *Model) ViewportAtTop() bool {
+	return m.yOffset == 0 && len(m.messages) > 0
+}
+
+// YOffset returns the current viewport scroll offset (first visible line
+// index inside the flattened message buffer). Exposed for tests and the
+// debug overlay; do not use for navigation -- call ScrollUp/ScrollDown.
+func (m *Model) YOffset() int {
+	return m.yOffset
+}
+
 func (m *Model) PrependMessages(msgs []MessageItem) {
 	if len(msgs) == 0 {
 		return

--- a/internal/ui/sidebar/model.go
+++ b/internal/ui/sidebar/model.go
@@ -667,6 +667,9 @@ func (m *Model) MoveUp() {
 }
 
 // ScrollUp moves the viewport up by n rows without changing the selection.
+// Marks the current cursor as already-snapped so View() leaves yOffset alone
+// on the next render -- prevents the snap branch from yanking the viewport
+// back to keep the (unchanged) selection visible.
 func (m *Model) ScrollUp(n int) {
 	if n <= 0 {
 		return
@@ -675,16 +678,26 @@ func (m *Model) ScrollUp(n int) {
 	if m.yOffset < 0 {
 		m.yOffset = 0
 	}
+	m.snappedSelection = m.cursor
+	m.hasSnapped = true
 	m.dirty()
 }
 
-// ScrollDown moves the viewport down by n rows. The next View() clamps to the
-// max valid offset for the current content height.
+// ScrollDown moves the viewport down by n rows. View() clamps to the
+// max valid offset for the current content height. See ScrollUp for the
+// snap-guard rationale.
 func (m *Model) ScrollDown(n int) {
 	if n > 0 {
 		m.yOffset += n
+		m.snappedSelection = m.cursor
+		m.hasSnapped = true
 		m.dirty()
 	}
+}
+
+// ViewportAtTop reports whether the sidebar viewport is scrolled to the top.
+func (m *Model) ViewportAtTop() bool {
+	return m.yOffset == 0
 }
 
 func (m *Model) GoToTop() {

--- a/internal/ui/thread/model.go
+++ b/internal/ui/thread/model.go
@@ -133,8 +133,6 @@ type Model struct {
 	chromeCacheValid    bool
 	chromeWidth         int
 	chromeReplyCount    int
-	chromeParentTS      string
-	chromeParentText    string
 	chromeUserNamesV    uint64 // version of the userNames map at build time
 	chromeChannelNamesV uint64 // version of the channelNames map at build time
 
@@ -1154,8 +1152,8 @@ func (m *Model) View(height, width int) string {
 	// at the top of m.viewContent so it scrolls with the replies (a long
 	// parent must not pin and block the reply area). Chrome is only the
 	// header line + a single border separator; everything else moved into
-	// the viewport. chromeParentTS/chromeParentText are kept on the struct
-	// for legacy callers but no longer participate in the cache key.
+	// the viewport, so parent identity no longer participates in the
+	// chrome cache key.
 	if !m.chromeCacheValid ||
 		m.chromeWidth != width ||
 		m.chromeReplyCount != chromeReplyCount ||

--- a/internal/ui/thread/model.go
+++ b/internal/ui/thread/model.go
@@ -16,6 +16,7 @@ import (
 	imgpkg "github.com/gammons/slk/internal/image"
 	"github.com/gammons/slk/internal/ui/imgrender"
 	"github.com/gammons/slk/internal/ui/messages"
+	"github.com/gammons/slk/internal/ui/scrollbar"
 	"github.com/gammons/slk/internal/ui/selection"
 	"github.com/gammons/slk/internal/ui/styles"
 )
@@ -1149,13 +1150,15 @@ func (m *Model) View(height, width int) string {
 	// infrequently — chrome is rebuilt rarely, so the comparison cost is
 	// negligible and invalidation discipline is easier to get wrong.
 	chromeReplyCount := len(m.replies)
-	parentTS := m.parent.TS
-	parentText := m.parent.Text
+	// Chrome no longer contains the parent message -- the parent now lives
+	// at the top of m.viewContent so it scrolls with the replies (a long
+	// parent must not pin and block the reply area). Chrome is only the
+	// header line + a single border separator; everything else moved into
+	// the viewport. chromeParentTS/chromeParentText are kept on the struct
+	// for legacy callers but no longer participate in the cache key.
 	if !m.chromeCacheValid ||
 		m.chromeWidth != width ||
 		m.chromeReplyCount != chromeReplyCount ||
-		m.chromeParentTS != parentTS ||
-		m.chromeParentText != parentText ||
 		m.chromeUserNamesV != m.userNamesV ||
 		m.chromeChannelNamesV != m.channelNamesV {
 		replyLabel := "replies"
@@ -1173,18 +1176,11 @@ func (m *Model) View(height, width int) string {
 			Background(styles.Background).
 			Foreground(styles.Border).
 			Render(strings.Repeat("-", width))
-		// v1: discard parent flushes — parent attachments are rare
-		// in the chrome-cached path and threading kitty flushes through
-		// the chromeCache lifecycle adds complexity. Reply flushes are
-		// captured below in the per-reply cache loop.
-		parentContent, _, _ := m.renderThreadMessage(m.parent, width, m.userNames, m.channelNames, false)
-		m.chromeCache = header + "\n" + separator + "\n" + parentContent + "\n" + separator
+		m.chromeCache = header + "\n" + separator
 		m.chromeHeight = lipgloss.Height(m.chromeCache)
 		m.chromeCacheValid = true
 		m.chromeWidth = width
 		m.chromeReplyCount = chromeReplyCount
-		m.chromeParentTS = parentTS
-		m.chromeParentText = parentText
 		m.chromeUserNamesV = m.userNamesV
 		m.chromeChannelNamesV = m.channelNamesV
 	}
@@ -1200,14 +1196,48 @@ func (m *Model) View(height, width int) string {
 	}
 	m.lastViewHeight = replyAreaHeight
 
+	// Render the parent message once -- it now lives at the top of the
+	// scrollable viewContent (chrome only carries the header + separator).
+	// We discard the parent's image flushes and reaction-hit rects in v1:
+	// parent attachments are rare and threading flushes through the cache
+	// lifecycle adds complexity; reply flushes and hit rects ARE captured
+	// in the per-reply loop below.
+	parentContent, _, _ := m.renderThreadMessage(m.parent, width, m.userNames, m.channelNames, false)
+	parentSeparator := lipgloss.NewStyle().
+		Width(width).
+		Background(styles.Background).
+		Foreground(styles.Border).
+		Render(strings.Repeat("─", width))
+	parentBlock := parentContent + "\n" + parentSeparator
+	parentBlockHeight := lipgloss.Height(parentBlock)
+
 	if len(m.replies) == 0 {
+		emptyHeight := replyAreaHeight - parentBlockHeight
+		if emptyHeight < 1 {
+			emptyHeight = 1
+		}
 		empty := lipgloss.NewStyle().
 			Width(width).
-			Height(replyAreaHeight).
+			Height(emptyHeight).
 			Background(styles.Background).
 			Foreground(styles.TextMuted).
 			Render("No replies yet")
-		result := chrome + "\n" + empty
+		// Push parent + placeholder through the viewport so a parent
+		// taller than the pane still scrolls. The scrollbar overlay
+		// reflects the parent's own height.
+		emptyContent := parentBlock + "\n" + empty
+		emptyTotalLines := lipgloss.Height(emptyContent)
+		m.vp.SetWidth(width)
+		m.vp.SetHeight(replyAreaHeight)
+		m.vp.KeyMap = viewport.KeyMap{}
+		m.vp.SetContent(emptyContent)
+		visibleLines := strings.Split(m.vp.View(), "\n")
+		visibleLines = scrollbar.Overlay(
+			visibleLines, width,
+			emptyTotalLines, m.vp.YOffset(), replyAreaHeight,
+			styles.Background, styles.Border, styles.Primary,
+		)
+		result := chrome + "\n" + strings.Join(visibleLines, "\n")
 		return lipgloss.NewStyle().Width(width).Height(height).MaxHeight(height).Background(styles.Background).Render(result)
 	}
 
@@ -1329,10 +1359,16 @@ func (m *Model) View(height, width int) string {
 		}
 		landmarkInserted := false
 
-		var allRows []string
+		// viewContent begins with the parent message block so the parent
+		// scrolls together with the replies. entryOffsets / selectedStartLine
+		// / m.totalLines are built in parent-inclusive coordinates from here
+		// on -- the snap-to-selection math and reaction-hit translation
+		// both index into viewContent and so naturally account for the
+		// parent prefix without further adjustment.
+		allRows := []string{parentBlock}
 		startLine := 0
 		endLine := 0
-		currentLine := 0
+		currentLine := parentBlockHeight
 		// kittyFlushBuf collects per-image kitty APC upload bytes for
 		// every cached entry (the thread cache holds only the open
 		// thread's replies — typically a handful — so we don't bother
@@ -1490,7 +1526,16 @@ func (m *Model) View(height, width int) string {
 		m.vp.SetContent(m.applySelectionOverlay(m.viewContent))
 	}
 
-	result := chrome + "\n" + m.vp.View()
+	// Scrollbar overlay on the right edge of the scrollable area. Chrome
+	// (header + separator) is left alone since it does not scroll. Same
+	// pattern as messages.Model.View().
+	visibleLines := strings.Split(m.vp.View(), "\n")
+	visibleLines = scrollbar.Overlay(
+		visibleLines, width,
+		m.totalLines, m.vp.YOffset(), replyAreaHeight,
+		styles.Background, styles.Border, styles.Primary,
+	)
+	result := chrome + "\n" + strings.Join(visibleLines, "\n")
 	return lipgloss.NewStyle().Width(width).Height(height).MaxHeight(height).Background(styles.Background).Render(result)
 }
 

--- a/internal/ui/thread/model.go
+++ b/internal/ui/thread/model.go
@@ -174,6 +174,13 @@ type Model struct {
 	// at the moment the thread is opened.
 	unreadBoundaryTS string
 
+	// snappedSelection lets View() avoid re-snapping vp.YOffset back to the
+	// selected reply on every render. While snappedSelection == selected,
+	// mouse-wheel / programmatic scrolls (ScrollUp/ScrollDown) are preserved
+	// across renders -- mirrors the same convention used by messages.Model.
+	snappedSelection int
+	hasSnapped       bool
+
 	// version increments on every state change that could alter View() output.
 	version int64
 
@@ -593,21 +600,34 @@ func (m *Model) SelectByIndex(i int) {
 
 // MoveUp moves the selection cursor up one reply.
 // ScrollUp scrolls the thread viewport up by n lines without changing the
-// selected reply.
+// selected reply. Marks the current selection as already-snapped so View()
+// won't pull the viewport back to keep selection visible on the next render.
 func (m *Model) ScrollUp(n int) {
 	if n > 0 {
 		m.vp.ScrollUp(n)
+		m.snappedSelection = m.selected
+		m.hasSnapped = true
 		m.dirty()
 	}
 }
 
 // ScrollDown scrolls the thread viewport down by n lines without changing the
-// selected reply.
+// selected reply. Marks the current selection as already-snapped so View()
+// won't pull the viewport back on the next render.
 func (m *Model) ScrollDown(n int) {
 	if n > 0 {
 		m.vp.ScrollDown(n)
+		m.snappedSelection = m.selected
+		m.hasSnapped = true
 		m.dirty()
 	}
+}
+
+// ViewportAtTop reports whether the thread viewport is scrolled to the top.
+// Used by the app layer to detect a wheel-up / PageUp that hit the top of the
+// reply stream (cosmetic only -- no thread backfill exists today).
+func (m *Model) ViewportAtTop() bool {
+	return m.vp.YOffset() == 0
 }
 
 func (m *Model) MoveUp() {
@@ -1404,12 +1424,20 @@ func (m *Model) View(height, width int) string {
 	m.vp.KeyMap = viewport.KeyMap{}
 	m.vp.SetContent(m.viewContent)
 
-	// Scroll to keep selected item visible
-	if m.selectedEndLine > m.vp.YOffset()+m.vp.Height() {
-		m.vp.SetYOffset(m.selectedEndLine - m.vp.Height())
-	}
-	if m.selectedStartLine < m.vp.YOffset() {
-		m.vp.SetYOffset(m.selectedStartLine)
+	// Scroll to keep selected item visible -- but only when the selection
+	// has actually changed since the last snap. This lets the mouse wheel
+	// (or programmatic ScrollUp/Down) move the viewport away from the
+	// selected reply without the next render yanking it back. Mirrors the
+	// same guard used in messages.Model.View().
+	if !m.hasSnapped || m.snappedSelection != m.selected {
+		if m.selectedEndLine > m.vp.YOffset()+m.vp.Height() {
+			m.vp.SetYOffset(m.selectedEndLine - m.vp.Height())
+		}
+		if m.selectedStartLine < m.vp.YOffset() {
+			m.vp.SetYOffset(m.selectedStartLine)
+		}
+		m.snappedSelection = m.selected
+		m.hasSnapped = true
 	}
 
 	// Populate the per-frame reaction-hit slice in pane-local

--- a/internal/ui/thread/model_test.go
+++ b/internal/ui/thread/model_test.go
@@ -1,6 +1,7 @@
 package thread
 
 import (
+	"fmt"
 	stdimage "image"
 	"strings"
 	"testing"
@@ -605,5 +606,80 @@ func TestHitTestReaction_NoHitsWithoutReactions(t *testing.T) {
 	}
 	if _, _, ok := m.HitTestReaction(0, 0); ok {
 		t.Error("HitTestReaction with no reactions should always return ok=false")
+	}
+}
+
+// Parent message now lives at the top of the scrollable viewContent (not
+// pinned in chrome). This means: (1) chromeHeight no longer counts the
+// parent rows, (2) the parent shows up in viewContent above the replies,
+// (3) ScrollDown moves the parent out of view, leaving the replies. Pins
+// the issue-#23 follow-up: a long parent must not block the reply area.
+func TestThreadView_ParentScrollsWithReplies(t *testing.T) {
+	m := New()
+	parent := messages.MessageItem{
+		TS:       "1.0",
+		UserName: "alice",
+		// A long parent body that spans multiple wrapped lines.
+		Text:      strings.Repeat("LONGPARENT ", 30),
+		Timestamp: "10:30 AM",
+	}
+	replies := []messages.MessageItem{
+		{TS: "2.0", UserName: "bob", Text: "REPLY_MARKER one", Timestamp: "10:31 AM"},
+		{TS: "3.0", UserName: "carol", Text: "REPLY_MARKER two", Timestamp: "10:32 AM"},
+	}
+	m.SetThread(parent, replies, "C1", "1.0")
+	_ = m.View(40, 60)
+
+	// Chrome is just header + separator now -- exactly 2 visual rows.
+	if m.chromeHeight != 2 {
+		t.Errorf("chromeHeight = %d, want 2 (header + separator only)", m.chromeHeight)
+	}
+
+	// viewContent must start with the parent block (LONGPARENT) BEFORE
+	// the first reply marker. Find the first occurrence of each and
+	// assert ordering inside viewContent.
+	pIdx := strings.Index(m.viewContent, "LONGPARENT")
+	rIdx := strings.Index(m.viewContent, "REPLY_MARKER")
+	if pIdx < 0 {
+		t.Fatal("viewContent missing parent body")
+	}
+	if rIdx < 0 {
+		t.Fatal("viewContent missing reply marker")
+	}
+	if pIdx >= rIdx {
+		t.Errorf("parent (idx %d) must precede first reply (idx %d) in viewContent", pIdx, rIdx)
+	}
+
+	// entryOffsets[0] is now offset by the parent block's height -- not 0
+	// as in the old layout. Defends the math used by snap + reaction-hit
+	// translation + ClickAt.
+	if len(m.entryOffsets) == 0 || m.entryOffsets[0] == 0 {
+		t.Errorf("entryOffsets[0] = %v, want > 0 (parent block precedes first reply)", m.entryOffsets)
+	}
+}
+
+// Thread reply area gets a scrollbar overlay when content exceeds the
+// visible height -- matches the messages-pane convention. Defends the
+// fix for the "replies view has no scrollbar" report.
+func TestThreadView_HasScrollbarWhenOverflowing(t *testing.T) {
+	m := New()
+	parent := messages.MessageItem{TS: "1.0", UserName: "alice", Text: "p"}
+	// Many short replies so the total content easily exceeds a 10-row pane.
+	var replies []messages.MessageItem
+	for i := 0; i < 30; i++ {
+		replies = append(replies, messages.MessageItem{
+			TS:       fmt.Sprintf("%d.0", i+2),
+			UserName: "bob",
+			Text:     fmt.Sprintf("reply %d", i),
+		})
+	}
+	m.SetThread(parent, replies, "C1", "1.0")
+
+	view := m.View(40, 10)
+	// Scrollbar uses '│' (track) and '█' (thumb). With 30 replies in a
+	// 10-row pane, totalLines >> pane height, so scrollbar.Overlay
+	// definitely draws.
+	if !strings.ContainsRune(view, '│') && !strings.ContainsRune(view, '█') {
+		t.Fatalf("expected scrollbar glyph in overflowing thread view; got:\n%s", view)
 	}
 }

--- a/internal/ui/thread/selection_test.go
+++ b/internal/ui/thread/selection_test.go
@@ -20,10 +20,20 @@ func newTestThread() *Model {
 }
 
 // firstContentY returns the smallest pane-local viewportY that lands on
-// reply content (past the chrome — header + separator + parent message
-// + separator). Used by tests rather than hard-coding the chrome height
-// because the parent's render width / wrap can change it.
-func firstContentY(m *Model) int { return m.chromeHeight }
+// reply content. Chrome is now just `header + separator`, and the parent
+// message lives at the top of the scrollable viewContent (it scrolls with
+// replies so a long parent does not block them). m.entryOffsets[0] is the
+// line index of the first reply inside viewContent, which equals the
+// parent block's height. Pane-local row = chromeHeight + entryOffsets[0]
+// minus the viewport's YOffset. Tests start at YOffset=0 (newTestThread
+// calls View once and selection isn't moved), so we don't subtract YOffset
+// here.
+func firstContentY(m *Model) int {
+	if len(m.entryOffsets) == 0 {
+		return m.chromeHeight
+	}
+	return m.chromeHeight + m.entryOffsets[0] - m.vp.YOffset()
+}
 
 func TestThreadSelection_BeginExtendEnd(t *testing.T) {
 	m := newTestThread()
@@ -89,19 +99,24 @@ func TestThreadSelection_ScrollHintForDrag(t *testing.T) {
 	if h < 2 {
 		t.Skip("test height too small")
 	}
-	// A row sitting inside the chrome should be treated as "above the
-	// top edge" so an upward drag continues to auto-scroll.
+	// A row sitting inside the chrome (header / separator) should be
+	// treated as "above the top edge" so an upward drag continues to
+	// auto-scroll. Chrome is now just header+separator -- the parent
+	// message has moved into the scrollable content.
 	if got := m.ScrollHintForDrag(0); got != -1 {
 		t.Errorf("chrome row: want -1 (treated as above top edge) got %d", got)
 	}
-	// First content row is the top edge.
-	if got := m.ScrollHintForDrag(firstContentY(m)); got != -1 {
-		t.Errorf("top: want -1 got %d", got)
+	// The first row of the scrollable area IS the top edge -- this lands
+	// at the start of the parent message block now (parent scrolls).
+	if got := m.ScrollHintForDrag(m.chromeHeight); got != -1 {
+		t.Errorf("top of scrollable: want -1 got %d", got)
 	}
-	if got := m.ScrollHintForDrag(firstContentY(m) + h - 1); got != +1 {
+	// Bottom edge of the reply area.
+	if got := m.ScrollHintForDrag(m.chromeHeight + h - 1); got != +1 {
 		t.Errorf("bottom: want +1 got %d", got)
 	}
-	if got := m.ScrollHintForDrag(firstContentY(m) + h/2); got != 0 {
+	// Middle of the reply area.
+	if got := m.ScrollHintForDrag(m.chromeHeight + h/2); got != 0 {
 		t.Errorf("middle: want 0 got %d", got)
 	}
 }

--- a/internal/ui/threadsview/model.go
+++ b/internal/ui/threadsview/model.go
@@ -301,8 +301,10 @@ func (m *Model) GoToBottom() {
 }
 
 // ScrollUp moves the viewport up n lines without changing the selection.
-// Resetting hasSnapped lets the next selection move re-snap to keep the
-// selection visible (sidebar uses the same convention).
+// Marks the current selection as already-snapped so the next View() leaves
+// yOffset alone -- otherwise the snap would yank the viewport back to keep
+// the (unchanged) selection visible, undoing the scroll. The next selection
+// move (j/k/click) will re-snap naturally because snappedSelection != selected.
 func (m *Model) ScrollUp(n int) {
 	if n <= 0 {
 		return
@@ -311,20 +313,27 @@ func (m *Model) ScrollUp(n int) {
 	if m.yOffset < 0 {
 		m.yOffset = 0
 	}
-	m.hasSnapped = false
+	m.snappedSelection = m.selected
+	m.hasSnapped = true
 	m.dirty()
 }
 
 // ScrollDown moves the viewport down n lines without changing the
 // selection. View() clamps yOffset against the actual content height.
-// Resetting hasSnapped lets the next selection move re-snap.
+// Marks the current selection as already-snapped (see ScrollUp).
 func (m *Model) ScrollDown(n int) {
 	if n <= 0 {
 		return
 	}
 	m.yOffset += n
-	m.hasSnapped = false
+	m.snappedSelection = m.selected
+	m.hasSnapped = true
 	m.dirty()
+}
+
+// ViewportAtTop reports whether the viewport is scrolled to the very top.
+func (m *Model) ViewportAtTop() bool {
+	return m.yOffset == 0 && len(m.summaries) > 0
 }
 
 // ClickAt selects the thread card whose visual row contains rowY, where


### PR DESCRIPTION
## Summary

Four related improvements to scroll mechanics and click handling. Fully fixes #23.

### 1. Decouple wheel + PageUp/Dn scroll from selection (`f51400a`)

Mouse wheel, PageUp/PageDown, and Ctrl+U/Ctrl+D now move the **viewport only** — selection stays put. `j`/`k`/arrows/`g`/`G` continue to drive selection (and pull the viewport along). The snap-guard plumbing already existed on every panel; this just wires it to user gestures.

Wheel-up / PageUp at the messages-pane top still triggers the older-history backfill via a new `maybeFetchOlderHistory` helper (also reused by `handleUp`).

### 2. Configurable mouse wheel speed (`9c3808d`)

New `[appearance].mouse_wheel_lines` TOML setting (default `3`, clamped `>= 1`):

```toml
[appearance]
mouse_wheel_lines = 7
```

### 3. Thread parent scrolls with replies + reply-area scrollbar (`129d47d`)

The parent message used to be pinned in the thread chrome and could consume the entire pane when long, blocking the replies. It now lives at the top of `m.viewContent` and scrolls together with the replies. Chrome shrinks to just the `Thread N replies` header + a single separator. Adds the `scrollbar.Overlay` glyph (consistent with the messages pane) to the thread reply area.

### 4. Click message opens thread (`4a1a204`)

A plain left-click on a real message row in the channel pane opens that message's thread, identical to pressing Enter. `messages.Model.ClickAt` returns a bool so chrome / empty-space clicks are no-ops; drags still copy text and do not open a thread. The Enter and click paths share one `openThreadForSelectedMessage` helper.

Fixes #23.

## Test Plan

Automated coverage added on this branch:

- `TestApp_HalfPageScrollMovesViewportNotSelection` — ctrl+u/d move yOffset, not selection.
- `TestScrollFocusedPanel_BackfillAtViewportTop` — PageUp at top fires backfill.
- `TestConfig_MouseWheelLines` — default, missing-key fallback, override, negative clamp.
- `TestThreadView_ParentScrollsWithReplies` — chromeHeight is 2, parent precedes first reply in viewContent, `entryOffsets[0] > 0`.
- `TestThreadView_HasScrollbarWhenOverflowing` — scrollbar glyph present when replies overflow.
- `TestApp_PlainClickOnMessageOpensThread`
- `TestApp_PlainClickOnChromeDoesNotOpenThread`
- `TestApp_DragDoesNotOpenThread`

Manual smoke test recommended:

- [ ] Wheel through a long channel; selection stays put, scrollbar tracks position
- [ ] PageDown / Ctrl+D in messages pane; viewport advances without selection skipping
- [ ] Open a thread with a tall parent; scroll the parent fully into view
- [ ] Click a message in the channel; the thread for that message opens
- [ ] Drag-select text inside the channel; clipboard receives selection, no thread opens
- [ ] Click on the channel header chrome; nothing happens
- [ ] Add `mouse_wheel_lines = 7` under `[appearance]` in config.toml, restart, verify faster scroll

```
go build ./... && go vet ./... && go test ./...
```

all clean.
