### PR TITLE
Tab title indicator: workspace initials + unread counts (closes #25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,45 @@ half-block rendering automatically — no config change needed. To force a
 specific renderer regardless of detection, set `image_protocol` in
 `config.toml` to `kitty`, `sixel`, `halfblock`, or `off`.
 
+## Unread indicator in tmux
+
+`slk` sets the terminal window title to reflect unread state — for
+example `slk SW (3) +1` means three channels-with-unreads in the active
+workspace and at least one other workspace also has unreads. The
+two-letter prefix is the active workspace's initials (matching the
+left-rail label).
+
+Outside tmux this just works — modern terminals (Kitty, WezTerm,
+Alacritty, Ghostty, iTerm2, Windows Terminal, gnome-terminal) render
+title changes in their tab/window chrome.
+
+Inside tmux there's an extra step. tmux intercepts the title escape
+from slk, and only re-emits it to the outer terminal when title
+forwarding is on, *and* it uses its own title template by default
+(`#W` = window name) rather than the pane's title. Add both lines to
+`~/.tmux.conf`:
+
+```tmux
+set -g set-titles on
+set -g set-titles-string '#T'
+```
+
+`#T` (active pane title) is what carries slk's string. Reload tmux for
+the setting to take effect (`tmux kill-server`, then reattach). Verify
+with:
+
+```bash
+tmux show -gv set-titles
+tmux show -gv set-titles-string
+```
+
+Expected output: `on` and `#T`.
+
+If you'd prefer slk's unread indicator to work in tmux without any
+config change at all, that's tracked as a follow-up — it requires
+passing the title escape through tmux's DCS passthrough rather than
+relying on `set-titles`. Not in this release.
+
 ## Debugging
 
 Set `SLK_DEBUG=1` to enable a comprehensive debug log written to

--- a/docs/superpowers/plans/2026-05-21-tab-title-unread-indicator.md
+++ b/docs/superpowers/plans/2026-05-21-tab-title-unread-indicator.md
@@ -1,0 +1,595 @@
+# Tab Title Unread Indicator — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the tab title unread indicator described in [`docs/superpowers/specs/2026-05-21-tab-title-unread-indicator-design.md`](../specs/2026-05-21-tab-title-unread-indicator-design.md). Closes [#25](https://github.com/gammons/sl​k/issues/25).
+
+**Architecture:** Add a `windowTitle string` field on `App` that's populated by a *pure free function* `computeWindowTitle(activeTeamID, workspaceName string, activeUnreads, otherUnreads int) string` living in `internal/ui/app_title.go`. Call it from `notifyReadStateChanged` (the existing central hook for every read-state mutation), passing inputs sourced from accessors on the sub-models that already own the data. Read the cached value into `tea.View.WindowTitle` from `View()`. Bubbletea v2's renderer emits the OSC sequence whenever the field value changes.
+
+Counting logic lives on the sub-models that own the underlying state, not on App:
+
+- `sidebar.Model.UnreadChannelCount() int` — uses a new `ChannelItem.IsVisiblyUnread(state)` helper that consolidates the *single* "shown as an unread dot" predicate currently duplicated inline in `View()`.
+- `workspace.Model.OtherUnreadCount(activeID string) int` — uses the rail's existing `unreadReader` callback. App does *not* grow a new reader field; existing single-place setters remain symmetric.
+- `workspace.Model.NameByID(id string) string` — small accessor to feed `workspace.WorkspaceInitials`.
+
+This keeps `App` as an orchestrator: it knows where to source each input but doesn't reach into sub-model internals or duplicate predicates.
+
+**Tech Stack:** Go, `charm.land/bubbletea/v2` (`tea.View.WindowTitle`), existing slk read-state API.
+
+---
+
+### Task 1: Add `NameByID` and `OtherUnreadCount` to `workspace.Model`
+
+**Files:**
+- Modify: `internal/ui/workspace/model.go`
+- Modify: `internal/ui/workspace/model_test.go`
+
+- [ ] **Step 1: Add accessors**
+
+  Append after `SelectedID()`:
+
+  ```go
+  // NameByID returns the display name for the given team ID, or "" if
+  // no workspace with that ID is present. Used by the App to compute
+  // the window title's two-letter initials via WorkspaceInitials.
+  func (m *Model) NameByID(id string) string {
+      for _, item := range m.items {
+          if item.ID == id {
+              return item.Name
+          }
+      }
+      return ""
+  }
+
+  // OtherUnreadCount returns the number of workspaces (excluding the
+  // given activeID) that currently have at least one channel with
+  // has_unread=true. Reads through the installed unreadReader; returns
+  // 0 if no reader is set or activeID is empty. Used by the App to
+  // compute the window title's "+N" overflow.
+  //
+  // Does NOT filter mute (matches the rail dot's existing semantics —
+  // workspaces with only-muted unreads still contribute, the same way
+  // they already light up the rail dot).
+  func (m *Model) OtherUnreadCount(activeID string) int {
+      if m.unreadReader == nil {
+          return 0
+      }
+      count := 0
+      for _, id := range m.unreadReader() {
+          if id != activeID {
+              count++
+          }
+      }
+      return count
+  }
+  ```
+
+- [ ] **Step 2: Add tests**
+
+  Append to `model_test.go`:
+
+  ```go
+  func TestNameByID(t *testing.T) {
+      m := New([]WorkspaceItem{
+          {ID: "T1", Name: "SWAP", Initials: "SW"},
+          {ID: "T2", Name: "Home", Initials: "HO"},
+      }, 0)
+      cases := map[string]string{"T1": "SWAP", "T2": "Home", "T-missing": ""}
+      for id, want := range cases {
+          if got := m.NameByID(id); got != want {
+              t.Errorf("NameByID(%q) = %q, want %q", id, got, want)
+          }
+      }
+  }
+
+  func TestOtherUnreadCount(t *testing.T) {
+      m := New([]WorkspaceItem{
+          {ID: "T1"}, {ID: "T2"}, {ID: "T3"},
+      }, 0)
+
+      // No reader installed
+      if got := m.OtherUnreadCount("T1"); got != 0 {
+          t.Errorf("OtherUnreadCount with no reader = %d, want 0", got)
+      }
+
+      // Reader returns T1, T2, T3 (all have unreads)
+      m.SetUnreadReader(func() []string { return []string{"T1", "T2", "T3"} })
+      if got := m.OtherUnreadCount("T1"); got != 2 {
+          t.Errorf("OtherUnreadCount(T1) = %d, want 2", got)
+      }
+      if got := m.OtherUnreadCount("T2"); got != 2 {
+          t.Errorf("OtherUnreadCount(T2) = %d, want 2", got)
+      }
+      // Active ID not in the set
+      if got := m.OtherUnreadCount("T-missing"); got != 3 {
+          t.Errorf("OtherUnreadCount(missing) = %d, want 3", got)
+      }
+      // Empty active ID treated as "no exclusion" — caller's responsibility
+      // to skip the call when there's no active workspace
+      if got := m.OtherUnreadCount(""); got != 3 {
+          t.Errorf("OtherUnreadCount(empty) = %d, want 3", got)
+      }
+  }
+  ```
+
+- [ ] **Step 3: Run tests**
+
+  ```bash
+  go test ./internal/ui/workspace/... -run "TestNameByID|TestOtherUnreadCount" -v
+  ```
+
+  Expected: all PASS.
+
+---
+
+### Task 2: Add `IsVisiblyUnread` helper + `UnreadChannelCount` to `sidebar.Model`, refactor `View()` to use the helper
+
+**Files:**
+- Modify: `internal/ui/sidebar/model.go`
+- Modify: `internal/ui/sidebar/model_test.go`
+
+This task does *two* things deliberately bundled: it (a) extracts the inline "visibly unread" predicate from `View()` into a single helper, and (b) adds the count accessor that uses that same helper. Bundling avoids creating a second call site that re-duplicates the predicate. See plan rationale at top.
+
+- [ ] **Step 1: Add the predicate helper**
+
+  Add as a method on `ChannelItem` (near its struct definition):
+
+  ```go
+  // IsVisiblyUnread reports whether this channel should render as having
+  // unread messages — i.e., the read-state says HasUnread AND the user
+  // hasn't muted the channel. This is the single source of truth for
+  // the "unread dot" predicate; both the sidebar View and the count
+  // accessor (UnreadChannelCount) MUST use this helper.
+  func (item ChannelItem) IsVisiblyUnread(state cache.ReadState) bool {
+      return state.HasUnread && !item.IsMuted
+  }
+  ```
+
+- [ ] **Step 2: Refactor `View()` to use the helper**
+
+  At `internal/ui/sidebar/model.go:1132`, replace:
+
+  ```go
+  hasUnread := readState[item.ID].HasUnread && !item.IsMuted
+  ```
+
+  With:
+
+  ```go
+  hasUnread := item.IsVisiblyUnread(readState[item.ID])
+  ```
+
+  Verify no other inline duplicates of this predicate exist by grepping:
+
+  ```bash
+  grep -n "HasUnread && !.*IsMuted\|HasUnread && !item.IsMuted" internal/ui/sidebar/*.go
+  ```
+
+  Expected after refactor: no matches (or only the helper definition itself).
+
+- [ ] **Step 3: Add `UnreadChannelCount` accessor**
+
+  Place near the existing read-state reader plumbing (search for `readStateReader` in `model.go`):
+
+  ```go
+  // UnreadChannelCount returns the number of channels in the sidebar
+  // that should render as unread (HasUnread && !IsMuted). Uses the
+  // installed read-state reader and the IsVisiblyUnread helper, so the
+  // count matches the dot population exactly. Returns 0 if no reader
+  // is installed. Used by the App to compute the window title.
+  func (m *Model) UnreadChannelCount() int {
+      if m.readStateReader == nil {
+          return 0
+      }
+      state := m.readStateReader()
+      count := 0
+      for _, item := range m.items {
+          if item.IsVisiblyUnread(state[item.ID]) {
+              count++
+          }
+      }
+      return count
+  }
+  ```
+
+  Note: confirm the field name `readStateReader` against the existing `SetReadStateReader`; adjust if it differs.
+
+- [ ] **Step 4: Add tests**
+
+  Append to `model_test.go`. Pattern after existing sidebar tests to construct a `Model` with seeded items.
+
+  ```go
+  func TestIsVisiblyUnread(t *testing.T) {
+      cases := []struct {
+          name  string
+          item  ChannelItem
+          state cache.ReadState
+          want  bool
+      }{
+          {"unread, unmuted", ChannelItem{IsMuted: false}, cache.ReadState{HasUnread: true}, true},
+          {"unread, muted", ChannelItem{IsMuted: true}, cache.ReadState{HasUnread: true}, false},
+          {"read, unmuted", ChannelItem{IsMuted: false}, cache.ReadState{HasUnread: false}, false},
+          {"read, muted", ChannelItem{IsMuted: true}, cache.ReadState{HasUnread: false}, false},
+      }
+      for _, tt := range cases {
+          t.Run(tt.name, func(t *testing.T) {
+              if got := tt.item.IsVisiblyUnread(tt.state); got != tt.want {
+                  t.Errorf("IsVisiblyUnread = %v, want %v", got, tt.want)
+              }
+          })
+      }
+  }
+
+  func TestUnreadChannelCount_NoReader(t *testing.T) {
+      m := /* construct empty Model per existing test patterns */
+      if got := m.UnreadChannelCount(); got != 0 {
+          t.Errorf("UnreadChannelCount with no reader = %d, want 0", got)
+      }
+  }
+
+  func TestUnreadChannelCount_FiltersMute(t *testing.T) {
+      m := /* construct Model */
+      m.SetItems([]ChannelItem{
+          {ID: "C1", IsMuted: false},
+          {ID: "C2", IsMuted: false},
+          {ID: "C3", IsMuted: true},
+          {ID: "C4", IsMuted: false},
+      })
+      m.SetReadStateReader(func() map[string]cache.ReadState {
+          return map[string]cache.ReadState{
+              "C1": {HasUnread: true},  // counted
+              "C2": {HasUnread: false}, // skipped (read)
+              "C3": {HasUnread: true},  // skipped (muted)
+              "C4": {HasUnread: true},  // counted
+          }
+      })
+      if got := m.UnreadChannelCount(); got != 2 {
+          t.Errorf("UnreadChannelCount = %d, want 2 (C1, C4)", got)
+      }
+  }
+  ```
+
+  Match constructor/setter names to the existing sidebar test patterns.
+
+- [ ] **Step 5: Run tests**
+
+  ```bash
+  go test ./internal/ui/sidebar/... -run "TestIsVisiblyUnread|TestUnreadChannelCount" -v
+  go test ./internal/ui/sidebar/... -race
+  ```
+
+  Expected: new tests PASS, existing tests still PASS (View refactor must not regress dot rendering).
+
+---
+
+### Task 3: Add pure `formatTitle` + `computeWindowTitle` + tests (TDD)
+
+**Files:**
+- Create: `internal/ui/app_title.go`
+- Create: `internal/ui/app_title_test.go`
+
+Both functions in this file are pure (no App reference, no I/O). Tests live alongside and run without standing up an `App` instance.
+
+- [ ] **Step 1: Write failing tests first**
+
+  Create `internal/ui/app_title_test.go`:
+
+  ```go
+  package ui
+
+  import "testing"
+
+  func TestFormatTitle(t *testing.T) {
+      tests := []struct {
+          name     string
+          initials string
+          active   int
+          other    int
+          want     string
+      }{
+          {"no unreads", "SW", 0, 0, "slk SW"},
+          {"active only", "SW", 3, 0, "slk SW (3)"},
+          {"other only", "SW", 0, 1, "slk SW +1"},
+          {"both", "SW", 3, 1, "slk SW (3) +1"},
+          {"max values", "SW", 99, 99, "slk SW (99) +99"},
+          {"empty initials fallback", "?", 0, 0, "slk ?"},
+          {"empty initials with unreads", "?", 5, 2, "slk ? (5) +2"},
+      }
+      for _, tt := range tests {
+          t.Run(tt.name, func(t *testing.T) {
+              got := formatTitle(tt.initials, tt.active, tt.other)
+              if got != tt.want {
+                  t.Errorf("formatTitle(%q, %d, %d) = %q, want %q",
+                      tt.initials, tt.active, tt.other, got, tt.want)
+              }
+          })
+      }
+  }
+
+  func TestComputeWindowTitle(t *testing.T) {
+      tests := []struct {
+          name          string
+          activeTeamID  string
+          workspaceName string
+          activeUnreads int
+          otherUnreads  int
+          want          string
+      }{
+          {"pre-bootstrap (no active workspace)", "", "", 0, 0, "slk"},
+          {"pre-bootstrap with stray inputs", "", "Ignored", 99, 99, "slk"},
+          {"active workspace, no unreads", "T1", "SWAP", 0, 0, "slk SW"},
+          {"active workspace, with unreads", "T1", "SWAP", 3, 0, "slk SW (3)"},
+          {"active + other workspaces have unreads", "T1", "SWAP", 3, 2, "slk SW (3) +2"},
+          {"only other workspaces have unreads", "T1", "SWAP", 0, 1, "slk SW +1"},
+          {"empty workspace name yields fallback initials", "T1", "", 0, 0, "slk ?"},
+          {"single-word name uses first 2 chars", "T1", "Home", 1, 0, "slk HO (1)"},
+          {"multi-word name uses initials of first 2", "T1", "StratusGrid Eng", 5, 1, "slk SE (5) +1"},
+      }
+      for _, tt := range tests {
+          t.Run(tt.name, func(t *testing.T) {
+              got := computeWindowTitle(tt.activeTeamID, tt.workspaceName, tt.activeUnreads, tt.otherUnreads)
+              if got != tt.want {
+                  t.Errorf("computeWindowTitle(%q,%q,%d,%d) = %q, want %q",
+                      tt.activeTeamID, tt.workspaceName, tt.activeUnreads, tt.otherUnreads, got, tt.want)
+              }
+          })
+      }
+  }
+  ```
+
+- [ ] **Step 2: Verify tests fail to compile**
+
+  ```bash
+  go test ./internal/ui/... -run "TestFormatTitle|TestComputeWindowTitle" 2>&1 | head -5
+  ```
+
+  Expected: compile error — `undefined: formatTitle`, `undefined: computeWindowTitle`.
+
+- [ ] **Step 3: Implement**
+
+  Create `internal/ui/app_title.go`:
+
+  ```go
+  package ui
+
+  import (
+      "fmt"
+
+      "github.com/gammons/slk/internal/ui/workspace"
+  )
+
+  // computeWindowTitle builds the slk terminal-window-title string from
+  // pre-computed inputs. Pure; covered by table-driven tests in
+  // app_title_test.go.
+  //
+  // The caller (App.notifyReadStateChanged) is responsible for sourcing
+  // each input from the appropriate collaborator:
+  //   - activeTeamID:   App.activeTeamID
+  //   - workspaceName:  App.workspaceRail.NameByID(activeTeamID)
+  //   - activeUnreads:  App.sidebar.UnreadChannelCount() (mute-filtered)
+  //   - otherUnreads:   App.workspaceRail.OtherUnreadCount(activeTeamID)
+  //
+  // See docs/superpowers/specs/2026-05-21-tab-title-unread-indicator-design.md.
+  func computeWindowTitle(activeTeamID, workspaceName string, activeUnreads, otherUnreads int) string {
+      if activeTeamID == "" {
+          return "slk"
+      }
+      initials := workspace.WorkspaceInitials(workspaceName)
+      return formatTitle(initials, activeUnreads, otherUnreads)
+  }
+
+  // formatTitle assembles the final title string. Pure helper for
+  // computeWindowTitle; separated so the assembly format is testable
+  // independent of input sourcing.
+  func formatTitle(initials string, active, other int) string {
+      out := "slk " + initials
+      if active > 0 {
+          out += fmt.Sprintf(" (%d)", active)
+      }
+      if other > 0 {
+          out += fmt.Sprintf(" +%d", other)
+      }
+      return out
+  }
+  ```
+
+- [ ] **Step 4: Run tests**
+
+  ```bash
+  go test ./internal/ui/... -run "TestFormatTitle|TestComputeWindowTitle" -v
+  ```
+
+  Expected: all cases PASS.
+
+---
+
+### Task 4: Add `windowTitle` field to `App` and initialize it
+
+**Files:**
+- Modify: `internal/ui/app.go`
+
+The only state added to `App` is one cached string. No new reader callbacks, no new setters.
+
+- [ ] **Step 1: Add `windowTitle` field**
+
+  In the `App struct` block (`internal/ui/app.go:701`), near the other display-cache fields:
+
+  ```go
+      // windowTitle is the cached terminal-title string. Computed by
+      // notifyReadStateChanged on every read-state change and on
+      // workspace switch (which also routes through that hook); read
+      // by View() into tea.View.WindowTitle. See
+      // docs/superpowers/specs/2026-05-21-tab-title-unread-indicator-design.md.
+      windowTitle string
+  ```
+
+- [ ] **Step 2: Initialize in the constructor**
+
+  Find the `App` literal in the constructor (search for `workspaceRail:        workspace.New(nil, 0),`). Add a sibling field:
+
+  ```go
+      windowTitle: "slk",
+  ```
+
+  This is the pre-bootstrap default. The first `notifyReadStateChanged` (from bootstrap's `BatchUpdateChannelReadState`) replaces it with the real value.
+
+- [ ] **Step 3: Build to confirm**
+
+  ```bash
+  go build ./...
+  ```
+
+  Expected: clean build. (`SetWorkspaceUnreadReader` is unchanged from upstream — single-place install symmetry preserved.)
+
+---
+
+### Task 5: Hook orchestration into `notifyReadStateChanged` and surface in `View()`
+
+**Files:**
+- Modify: `internal/ui/app.go`
+
+- [ ] **Step 1: Extend `notifyReadStateChanged` to compute and cache the title**
+
+  Replace the existing body at `internal/ui/app.go:5942-5945`:
+
+  ```go
+  func (a *App) notifyReadStateChanged() {
+      a.sidebar.Invalidate()
+      a.workspaceRail.RefreshUnreads()
+      a.windowTitle = computeWindowTitle(
+          a.activeTeamID,
+          a.workspaceRail.NameByID(a.activeTeamID),
+          a.sidebar.UnreadChannelCount(),
+          a.workspaceRail.OtherUnreadCount(a.activeTeamID),
+      )
+  }
+  ```
+
+  Note: `computeWindowTitle` is a free function in the same package, so no receiver and no import path within `ui`.
+
+- [ ] **Step 2: Set `WindowTitle` in `View()`**
+
+  Locate `func (a *App) View() tea.View` (`internal/ui/app.go:5252`). Two return sites need the field set:
+
+  - The early-return for pre-layout (`a.width == 0 || a.height == 0`): set `v.WindowTitle = a.windowTitle` before `return v`.
+  - The main return at end of the function: same. Find the final `tea.View` value being returned (search for `return tea.View{` or `return v` near end of function) and apply the field assignment.
+
+  Example for the early-return branch:
+
+  ```go
+      if a.width == 0 || a.height == 0 {
+          var screen string
+          if a.loading {
+              screen = a.renderLoadingOverlay(80, 24)
+          } else {
+              screen = "Initializing..."
+          }
+          v := tea.NewView(screen)
+          v.AltScreen = true
+          v.WindowTitle = a.windowTitle
+          return v
+      }
+  ```
+
+- [ ] **Step 3: Build**
+
+  ```bash
+  go build ./...
+  ```
+
+  Expected: clean build.
+
+---
+
+### Task 6: Integration test on `App`
+
+**Files:**
+- Modify: `internal/ui/app_test.go` (extend)
+
+The unit-level coverage in Tasks 1–3 already proves the pieces. The integration test here only needs to confirm the orchestration: `notifyReadStateChanged` produces the expected `windowTitle`, and `View()` surfaces it on `tea.View.WindowTitle`.
+
+- [ ] **Step 1: Add an integration test**
+
+  Pattern after existing `app_test.go` tests that construct a real `App` with seeded sub-models and read-state. Cases to cover:
+
+  - `notifyReadStateChanged` populates `a.windowTitle` to the expected string when the active workspace has N unreads and 0/M other workspaces have unreads.
+  - Pre-bootstrap (`activeTeamID == ""`) yields `slk`.
+  - Muted channels are excluded from the active count (cross-check: same item set passed to sidebar produces both the expected count and the expected dot population).
+  - `App.View()` returns a `tea.View` whose `WindowTitle == a.windowTitle` — covered in both the pre-layout (`width == 0`) and main branch.
+
+  Most of the per-case format verification is already in `TestComputeWindowTitle`; the integration test's job is to verify the *wiring*, not re-test the formatting.
+
+- [ ] **Step 2: Run all UI tests**
+
+  ```bash
+  go test ./internal/ui/... -race
+  ```
+
+  Expected: all tests pass, including new ones and unchanged existing ones (especially the sidebar View tests that exercise the refactored predicate).
+
+---
+
+### Task 7: README tmux note
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Find the existing tmux section**
+
+  Search the README for `tmux` — there's already a section documenting Kitty image escapes under tmux (added by commit `acda354` / `30c998a`).
+
+- [ ] **Step 2: Add window-title bullet**
+
+  Add a bullet to the tmux section:
+
+  > **Window title:** slk emits OSC 2 to set the terminal window title on every read-state change. tmux passes these through to your terminal only when `set -g set-titles on` is configured. Add this to your `~/.tmux.conf` if you want the unread indicator to appear in your terminal's tab bar.
+
+---
+
+### Task 8: Final verification
+
+**Files:** (no edits)
+
+- [ ] **Step 1: Full test suite**
+
+  ```bash
+  go test ./... -race
+  ```
+
+  Expected: all green. Pay special attention to the sidebar tests — the `View()` refactor (Task 2 Step 2) shares its predicate with the new count function; both must continue rendering dots and counting identically.
+
+- [ ] **Step 2: Vet**
+
+  ```bash
+  go vet ./...
+  ```
+
+  Expected: clean (modulo the pre-existing emoji probe warning).
+
+- [ ] **Step 3: Lint**
+
+  ```bash
+  golangci-lint run ./...
+  ```
+
+  Expected: clean.
+
+- [ ] **Step 4: Manual smoke test**
+
+  - Launch `slk` against the test workspace.
+  - Verify title shows `slk <initials>` (no count) on a workspace with no unreads.
+  - Have a teammate (or use the official Slack client) send a message in a non-active channel; verify title updates to `slk <initials> (1)` within ~1s.
+  - Mark the channel read in the official client; verify title returns to `slk <initials>`.
+  - Mute a channel, then have a message arrive there; verify the title's `(N)` does NOT increment (and the sidebar dot does NOT appear) — both gated by the same `IsVisiblyUnread` predicate.
+  - Open `slk --add-workspace` for a second workspace; switch to it; have unread activity on the first; verify title shows `+1`.
+  - Under tmux with `set-titles on`: verify the same in the terminal's tab bar.
+
+- [ ] **Step 5: Confirm no regressions in the in-app sidebar dot**
+
+  All read-state changes that update the title also update the sidebar dot. Spot-check that the sidebar renders correctly across each scenario above. (The `View()` refactor in Task 2 should be invisible — the predicate is exactly the same, just sourced via a helper.)
+
+---
+
+## Out of scope for this plan
+
+Per the spec's "Out of scope" section: config knob, DCS-wrapped passthrough for tmux without `set-titles on`, channel-level granularity, workspace-icon glyphs. These are follow-ups, not part of this branch.

--- a/docs/superpowers/plans/2026-05-21-tab-title-unread-indicator.md
+++ b/docs/superpowers/plans/2026-05-21-tab-title-unread-indicator.md
@@ -147,7 +147,7 @@ This task does *two* things deliberately bundled: it (a) extracts the inline "vi
 
 - [ ] **Step 2: Refactor `View()` to use the helper**
 
-  At `internal/ui/sidebar/model.go:1132`, replace:
+  In the `View()` render loop in `internal/ui/sidebar/model.go`, replace:
 
   ```go
   hasUnread := readState[item.ID].HasUnread && !item.IsMuted
@@ -412,7 +412,7 @@ The only state added to `App` is one cached string. No new reader callbacks, no 
 
 - [ ] **Step 1: Add `windowTitle` field**
 
-  In the `App struct` block (`internal/ui/app.go:701`), near the other display-cache fields:
+  In the `App` struct block, alongside the other "current context" fields (next to `activeTeamID`):
 
   ```go
       // windowTitle is the cached terminal-title string. Computed by
@@ -450,7 +450,7 @@ The only state added to `App` is one cached string. No new reader callbacks, no 
 
 - [ ] **Step 1: Extend `notifyReadStateChanged` to compute and cache the title**
 
-  Replace the existing body at `internal/ui/app.go:5942-5945`:
+  Replace the existing body of `notifyReadStateChanged`:
 
   ```go
   func (a *App) notifyReadStateChanged() {
@@ -469,23 +469,15 @@ The only state added to `App` is one cached string. No new reader callbacks, no 
 
 - [ ] **Step 2: Set `WindowTitle` in `View()`**
 
-  Locate `func (a *App) View() tea.View` (`internal/ui/app.go:5252`). Two return sites need the field set:
+  Locate `func (a *App) View() tea.View`. Two return sites need the field set:
 
-  - The early-return for pre-layout (`a.width == 0 || a.height == 0`): set `v.WindowTitle = a.windowTitle` before `return v`.
-  - The main return at end of the function: same. Find the final `tea.View` value being returned (search for `return tea.View{` or `return v` near end of function) and apply the field assignment.
+  - The early-return for pre-layout (before the terminal size is known): set `v.WindowTitle = a.windowTitle` before `return v`.
+  - The main return at end of the function: same. Find the final `tea.View` value being returned (search for `return v` near end of function) and apply the field assignment.
 
-  Example for the early-return branch:
+  Example for the early-return branch. The pre-layout fallback is extracted into `renderEarlyFallback()` (see `internal/ui/view_early.go`), so the title is set on the returned view at the call site:
 
   ```go
-      if a.width == 0 || a.height == 0 {
-          var screen string
-          if a.loading {
-              screen = a.renderLoadingOverlay(80, 24)
-          } else {
-              screen = "Initializing..."
-          }
-          v := tea.NewView(screen)
-          v.AltScreen = true
+      if v, handled := a.renderEarlyFallback(); handled {
           v.WindowTitle = a.windowTitle
           return v
       }
@@ -515,7 +507,7 @@ The unit-level coverage in Tasks 1–3 already proves the pieces. The integratio
   - `notifyReadStateChanged` populates `a.windowTitle` to the expected string when the active workspace has N unreads and 0/M other workspaces have unreads.
   - Pre-bootstrap (`activeTeamID == ""`) yields `slk`.
   - Muted channels are excluded from the active count (cross-check: same item set passed to sidebar produces both the expected count and the expected dot population).
-  - `App.View()` returns a `tea.View` whose `WindowTitle == a.windowTitle` — covered in both the pre-layout (`width == 0`) and main branch.
+  - `App.View()` returns a `tea.View` whose `WindowTitle == a.windowTitle` — covered in both the pre-layout fallback and the main branch.
 
   Most of the per-case format verification is already in `TestComputeWindowTitle`; the integration test's job is to verify the *wiring*, not re-test the formatting.
 

--- a/docs/superpowers/specs/2026-05-21-tab-title-unread-indicator-design.md
+++ b/docs/superpowers/specs/2026-05-21-tab-title-unread-indicator-design.md
@@ -1,0 +1,185 @@
+# Tab Title Unread Indicator Design
+
+## Motivation
+
+Closes [#25](https://github.com/gammons/slk/issues/25).
+
+slk has no notification surface beyond the in-app sidebar dot. A user with slk in a background tab (terminal tab, tmux window, multiplexer pane) cannot tell whether new messages have arrived without switching to it. Desktop notifications are gated by Slack's notification preferences and (intentionally) easy to silence, which leaves a real gap: "is there anything for me?" requires an active context switch.
+
+The terminal window title is the natural place to expose this signal. It is already visible in every terminal multiplexer (tmux/screen), every modern terminal emulator's tab bar (kitty, alacritty, wezterm, iTerm2, Windows Terminal, gnome-terminal), and most window managers' task lists. Setting it costs nothing — a single OSC 2 escape per state change — and it degrades gracefully on terminals that don't render the title.
+
+## Format
+
+Workspace identity uses the same two-letter initials the workspace rail renders (`internal/ui/workspace/model.go:185`, `WorkspaceInitials`). Followed by an optional count of channels-with-unreads in the active workspace, followed by an optional cross-workspace overflow marker.
+
+| State | Title |
+|---|---|
+| Pre-bootstrap (no workspace selected) | `slk` |
+| No unreads anywhere | `slk SW` |
+| Unreads only in active workspace | `slk SW (3)` |
+| Unreads only in inactive workspaces | `slk SW +1` |
+| Unreads in active and inactive workspaces | `slk SW (3) +1` |
+
+The count `(N)` is channels-with-unreads in the active workspace, consistent with the deliberate semantic established in [`2026-05-17-read-state-sync-design.md`](./2026-05-17-read-state-sync-design.md): "boolean, not integer." The trailing `+N` is the count of *other* workspaces with at least one unread channel, derived from `db.WorkspacesWithUnreads()` minus the active workspace.
+
+Worst-case width: with the maximum reasonable values for both numbers (`(99) +99`), the title is `slk SW (99) +99` = 15 characters. Fits the tightest realistic tab budget (tmux window list at ~15 chars; kitty/wezterm with many tabs at ~20). Initials are fixed-width, so the title never overflows on long workspace names.
+
+### Format alternatives considered
+
+- **Full slug or workspace name** (`slk swap (3) +1`). Better disambiguation in the common 1–3-workspace case but breaks the width budget when slugs exceed ~10 characters (a `stratusgrid-eng`-style slug pushes the title past 25 chars). The rail already uses initials for the same reason; the title inherits that convention rather than re-litigating it.
+- **`slk *` (single marker)** — the issue's first suggestion. Loses the count, loses the workspace identity, loses the multi-workspace signal. Rejected as strictly less informative at the same character cost.
+- **No workspace identifier** (`slk (3) +1`). Most compact, but a user with multiple workspaces tabs back and forth between them and the title doesn't tell them which one is active. The whole point of the rail showing initials is that "which workspace am I in" is a real question.
+- **`(3) slk SW`** — number first. Slightly easier to scan in a wide tab bar but breaks the "app name comes first" convention every other terminal app follows. Rejected for consistency.
+- **Channel-name display** (`slk #general (3)`) — communicates *where* an unread is, but only useful when there is exactly one. Drops information in the common case. Rejected.
+
+## Architecture
+
+Bubbletea v2's `tea.View` struct exposes a `WindowTitle string` field. The renderer (`charm.land/bubbletea/v2@v2.0.6/cursed_renderer.go:128-129,189-191,372-374`) emits `ansi.SetWindowTitle()` whenever the value changes between renders. This is the entire transport — no manual escape emission, no separate `tea.Cmd`, no goroutine.
+
+The unread state already drives a single in-app event: `ReadStateChangedMsg` (`internal/ui/app.go:263`) is sent by every read-state mutator (`cmd/slk/main.go:2803, 3086`; `cmd/slk/reconnect_backfill.go:137`) and handled by `App.Update` at `app.go:2460`, which calls `notifyReadStateChanged` (`app.go:5942`). That function currently invalidates the sidebar cache and refreshes the workspace rail; this design adds one more line to it: update a cached `windowTitle` field on `App`.
+
+```go
+// internal/ui/app.go
+type App struct {
+    // ...
+    windowTitle string // computed in notifyReadStateChanged, read in View
+}
+
+func (a *App) notifyReadStateChanged() {
+    a.sidebar.Invalidate()
+    a.workspaceRail.RefreshUnreads()
+    a.windowTitle = a.computeWindowTitle() // NEW
+}
+
+func (a *App) View() tea.View {
+    // ... existing layout ...
+    v := tea.NewView(screen)
+    v.AltScreen = true
+    v.WindowTitle = a.windowTitle // NEW (or "" pre-bootstrap)
+    return v
+}
+```
+
+The title is *not* recomputed on every `View()` call. `notifyReadStateChanged` is the only source of truth and is already invoked by all six read-state write paths. Workspace switches also call it (the workspace switch already calls `notifyReadStateChanged` via the existing rail refresh path).
+
+## Computation
+
+```go
+// internal/ui/app.go
+func (a *App) computeWindowTitle() string {
+    if a.activeWorkspace == nil {
+        return "slk"
+    }
+    activeID := a.activeWorkspace.TeamID
+    initials := workspace.WorkspaceInitials(a.activeWorkspace.Name)
+
+    activeCount := 0
+    if states, err := a.db.GetWorkspaceReadState(activeID); err == nil {
+        for _, s := range states {
+            if s.HasUnread {
+                activeCount++
+            }
+        }
+    }
+
+    otherCount := 0
+    if ids, err := a.db.WorkspacesWithUnreads(); err == nil {
+        for _, id := range ids {
+            if id != activeID {
+                otherCount++
+            }
+        }
+    }
+
+    return formatTitle(initials, activeCount, otherCount)
+}
+
+// formatTitle is pure; covered by table-driven tests.
+func formatTitle(initials string, active, other int) string {
+    out := "slk " + initials
+    if active > 0 {
+        out += fmt.Sprintf(" (%d)", active)
+    }
+    if other > 0 {
+        out += fmt.Sprintf(" +%d", other)
+    }
+    return out
+}
+```
+
+Both DB calls are already used elsewhere in the render path (`cmd/slk/main.go:875, 884`); no new query surface. Errors are logged and the title degrades to the initials-only form rather than failing. The `WorkspaceInitials` helper already handles edge cases (empty name → `"?"`, single-letter names, multi-word names).
+
+## Muted channels
+
+Channels marked muted in Slack already have their `HasUnread` flag stored at the DB level (the flag is set by the same write paths regardless of mute state), but the sidebar suppresses the dot for muted channels at render time using its `ChannelItem.IsMuted` field (`internal/ui/sidebar/model.go:1132`).
+
+For the **active-workspace count** (the `(N)` portion), the title filters mute the same way: a new accessor on `sidebar.Model` reads the installed read-state callback, iterates the sidebar's items, and counts entries where `state[id].HasUnread && !item.IsMuted`. The sidebar already has both inputs in hand at render time; exposing the count is a one-method addition. This guarantees `(N)` matches the sidebar dot population exactly — no "title says 3 but I only see 2 dots."
+
+For the **`+N` overflow**, the title uses the existing `db.WorkspacesWithUnreads()` reader unchanged. That reader does **not** filter mute today — the workspaceRail dot it drives (`internal/ui/workspace/model.go`) also doesn't — so a workspace whose only unreads are muted does show both a rail dot and contribute to the title's `+N`. We accept this small inconsistency rather than re-engineer mute-aware aggregation at the DB level. If users complain that `+N` is over-counted, the fix lives in the rail too (a single coherent change), not in title-only special-casing.
+
+## tmux and multiplexer passthrough
+
+`ansi.SetWindowTitle` emits a plain OSC 2 sequence (`ESC ] 2 ; <title> BEL` or with `ST` terminator). Inside tmux, this reaches the outer terminal *only* when the user has `set -g set-titles on` configured. Without that, tmux swallows the OSC.
+
+We will:
+
+- Emit the plain OSC and rely on the user's tmux config, the same approach the kitty image escape passthrough fix (`acda354 image: detect kitty under tmux ...`, `30c998a fix: wrap Kitty image escapes for tmux passthrough`) took before adding the DCS wrap. This is the path of least surprise.
+- Document the tmux `set-titles on` requirement in the README's tmux section alongside the existing kitty notes.
+- Defer DCS-wrapped passthrough (`ESC P tmux ; ESC <OSC> ESC \`) until a user reports it actually missing. The image-escape case was a real demand; the title is a far weaker signal and we should not preemptively grow the renderer's complexity.
+
+## Configuration
+
+A configuration knob is **out of scope for v1**. Justifications:
+
+- The title only updates on real state changes (handful per minute at most).
+- The format is benign: it never exceeds ~25 characters, contains no sensitive content, and degrades to plain `slk` at zero-unreads-anywhere.
+- Terminals and multiplexers that don't support OSC 2 silently drop it.
+- Users who want it off can almost always disable it at the terminal level (kitty: `dynamic_background_opacity yes` doesn't help here, but most muxers have a per-window override).
+
+If a credible "off" request lands, the config schema is straightforward: a `[ui] tab_title = "off" | "count" | "marker"` key, defaulting to `"count"`. Adding the switch later is a single conditional in `computeWindowTitle`.
+
+## Edge cases
+
+- **Pre-bootstrap.** Before any workspace is connected, `a.activeWorkspace` is nil. Title is `"slk"`. The post-bootstrap rebroadcast of `ReadStateChangedMsg` (already fired by `connectWorkspace` after `BatchUpdateChannelReadState`) updates the title to the real value.
+- **Workspace switch.** The switch handler already calls `notifyReadStateChanged` (via the existing rail refresh). Title updates with the same tick.
+- **Workspace removed.** `slk --remove-workspace` is a separate `os.Exit` flow; in-process workspace removal does not exist. Out of scope.
+- **All workspaces disconnected.** `a.activeWorkspace` remains set to the last-active workspace; title shows its cached state. Acceptable: the user knows what they were looking at.
+- **No channels yet (fresh workspace).** `GetWorkspaceReadState` returns an empty map; `activeCount` is 0; title is `slk SW` (no count). Correct.
+- **Hundreds of unread channels.** `(347)` rendered literally. No truncation. Terminal handles it.
+
+## Test plan
+
+### New tests
+
+**`internal/ui/app_title_test.go`** — table-driven on `formatTitle`:
+
+| initials | active | other | expected |
+|---|---|---|---|
+| `SW` | 0 | 0 | `slk SW` |
+| `SW` | 3 | 0 | `slk SW (3)` |
+| `SW` | 0 | 1 | `slk SW +1` |
+| `SW` | 3 | 1 | `slk SW (3) +1` |
+| `SW` | 99 | 99 | `slk SW (99) +99` |
+| `?` | 0 | 0 | `slk ?` (fallback from `WorkspaceInitials` for empty name) |
+
+**`internal/ui/app_test.go`** — integration:
+
+- `notifyReadStateChanged` populates `a.windowTitle` with the expected string for a workspace whose cache has N unread channels.
+- Muted channels are excluded from the count.
+- `View()` returns a `tea.View` whose `WindowTitle` field equals `a.windowTitle`.
+- Pre-bootstrap `View()` returns `WindowTitle == "slk"`.
+
+### Tests expected to break
+
+None. This change is additive: it adds a field, populates it in an existing hook, and reads it in an existing function. No existing assertions about `View()` content cover `WindowTitle`.
+
+## Out of scope (follow-ups)
+
+1. Configuration knob (`[ui] tab_title = ...`). Add when a user asks.
+2. DCS-wrapped passthrough for tmux users without `set-titles on`. Add when a user reports the missing signal.
+3. Channel-level granularity in the title (e.g., `slk #general 3`). Distinct UX call; not in #25.
+4. Workspace-icon glyphs (Slack workspace icons in the title). Outside the OSC contract; not in #25.
+
+## Open questions
+
+None. All design decisions are settled.

--- a/docs/superpowers/specs/2026-05-21-tab-title-unread-indicator-design.md
+++ b/docs/superpowers/specs/2026-05-21-tab-title-unread-indicator-design.md
@@ -10,7 +10,7 @@ The terminal window title is the natural place to expose this signal. It is alre
 
 ## Format
 
-Workspace identity uses the same two-letter initials the workspace rail renders (`internal/ui/workspace/model.go:185`, `WorkspaceInitials`). Followed by an optional count of channels-with-unreads in the active workspace, followed by an optional cross-workspace overflow marker.
+Workspace identity uses the same two-letter initials the workspace rail renders (`WorkspaceInitials` in `internal/ui/workspace/model.go`). Followed by an optional count of channels-with-unreads in the active workspace, followed by an optional cross-workspace overflow marker.
 
 | State | Title |
 |---|---|
@@ -36,7 +36,7 @@ Worst-case width: with the maximum reasonable values for both numbers (`(99) +99
 
 Bubbletea v2's `tea.View` struct exposes a `WindowTitle string` field. The renderer (`charm.land/bubbletea/v2@v2.0.6/cursed_renderer.go:128-129,189-191,372-374`) emits `ansi.SetWindowTitle()` whenever the value changes between renders. This is the entire transport — no manual escape emission, no separate `tea.Cmd`, no goroutine.
 
-The unread state already drives a single in-app event: `ReadStateChangedMsg` (`internal/ui/app.go:263`) is sent by every read-state mutator (`cmd/slk/main.go:2803, 3086`; `cmd/slk/reconnect_backfill.go:137`) and handled by `App.Update` at `app.go:2460`, which calls `notifyReadStateChanged` (`app.go:5942`). That function currently invalidates the sidebar cache and refreshes the workspace rail; this design adds one more line to it: update a cached `windowTitle` field on `App`.
+The unread state already drives a single in-app event: `ReadStateChangedMsg` (declared in `internal/ui/app.go`) is sent by every read-state mutator (in `cmd/slk/main.go` and `cmd/slk/reconnect_backfill.go`) and handled by `App.Update`, which calls `notifyReadStateChanged`. That function currently invalidates the sidebar cache and refreshes the workspace rail; this design adds one more line to it: update a cached `windowTitle` field on `App`.
 
 ```go
 // internal/ui/app.go
@@ -107,11 +107,11 @@ func formatTitle(initials string, active, other int) string {
 }
 ```
 
-Both DB calls are already used elsewhere in the render path (`cmd/slk/main.go:875, 884`); no new query surface. Errors are logged and the title degrades to the initials-only form rather than failing. The `WorkspaceInitials` helper already handles edge cases (empty name → `"?"`, single-letter names, multi-word names).
+Both DB calls are already used elsewhere in the render path (in `cmd/slk/main.go`); no new query surface. Errors are logged and the title degrades to the initials-only form rather than failing. The `WorkspaceInitials` helper already handles edge cases (empty name → `"?"`, single-letter names, multi-word names).
 
 ## Muted channels
 
-Channels marked muted in Slack already have their `HasUnread` flag stored at the DB level (the flag is set by the same write paths regardless of mute state), but the sidebar suppresses the dot for muted channels at render time using its `ChannelItem.IsMuted` field (`internal/ui/sidebar/model.go:1132`).
+Channels marked muted in Slack already have their `HasUnread` flag stored at the DB level (the flag is set by the same write paths regardless of mute state), but the sidebar suppresses the dot for muted channels at render time using its `ChannelItem.IsMuted` field (`internal/ui/sidebar/model.go`).
 
 For the **active-workspace count** (the `(N)` portion), the title filters mute the same way: a new accessor on `sidebar.Model` reads the installed read-state callback, iterates the sidebar's items, and counts entries where `state[id].HasUnread && !item.IsMuted`. The sidebar already has both inputs in hand at render time; exposing the count is a one-method addition. This guarantees `(N)` matches the sidebar dot population exactly — no "title says 3 but I only see 2 dots."
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -17,7 +17,6 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
-	"golang.design/x/clipboard"
 	"github.com/gammons/slk/internal/cache"
 	"github.com/gammons/slk/internal/config"
 	"github.com/gammons/slk/internal/debuglog"
@@ -42,6 +41,7 @@ import (
 	"github.com/gammons/slk/internal/ui/threadsview"
 	"github.com/gammons/slk/internal/ui/workspace"
 	"github.com/gammons/slk/internal/ui/workspacefinder"
+	"golang.design/x/clipboard"
 )
 
 type Panel int
@@ -115,6 +115,12 @@ type App struct {
 	activeChannelID string
 	activeTeamID    string // workspace whose data is currently loaded into the side panels
 
+	// windowTitle is the cached terminal-window-title string, recomputed
+	// by notifyReadStateChanged on every read-state mutation and read by
+	// View() into tea.View.WindowTitle. Bubbletea's renderer emits OSC 2
+	// only when the value changes between renders -- no per-frame work.
+	// See docs/superpowers/specs/2026-05-21-tab-title-unread-indicator-design.md.
+	windowTitle string
 	// Callbacks
 	// channels is the App's ChannelService collaborator (Slack
 	// channels API + local cache + session bookkeeping). See
@@ -177,14 +183,14 @@ type App struct {
 	pendingThreadFetchGen uint64
 
 	// Reaction picker
-	reactionPicker   *reactionpicker.Model
-	confirmPrompt    *confirmprompt.Model
+	reactionPicker *reactionpicker.Model
+	confirmPrompt  *confirmprompt.Model
 	// reactions is the App's ReactionService collaborator (add/remove
 	// reactions on Slack + load/record frecent emoji history). See
 	// internal/ui/services.go. Defaulted to a no-op adapter in NewApp
 	// so call sites can dispatch without nil-checks.
-	reactions ReactionService
-	currentUserID    string
+	reactions     ReactionService
+	currentUserID string
 
 	// editing tracks in-progress message edit state. See
 	// internal/ui/edit.go.
@@ -304,6 +310,7 @@ func NewApp() *App {
 		keys:                 DefaultKeyMap(),
 		selfSend:             newSelfSendDedup(),
 		bootstrap:            newWorkspaceBootstrap(),
+		windowTitle:          "slk",
 		threadsDirtyDebounce: 150 * time.Millisecond,
 		mouseWheelLines:      3,
 		userNames:            map[string]string{},
@@ -442,9 +449,9 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, cmd)
 		}
 
-	// All non-WindowSize, non-Key message types are owned by Phase 4
-	// reducers; see the dispatch chain at the top of Update and the
-	// per-family reducer_*.go files / controller Handle methods.
+		// All non-WindowSize, non-Key message types are owned by Phase 4
+		// reducers; see the dispatch chain at the top of Update and the
+		// per-family reducer_*.go files / controller Handle methods.
 	}
 
 	return a, tea.Batch(cmds...)
@@ -1698,8 +1705,6 @@ func (a *App) nowFormatted() string {
 	return time.Now().Format("3:04 PM")
 }
 
-
-
 // ActiveChannelID returns the ID of the currently viewed channel.
 func (a *App) ActiveChannelID() string {
 	return a.activeChannelID
@@ -1815,6 +1820,7 @@ func (a *App) renderTypingLine() string {
 
 func (a *App) View() tea.View {
 	if v, handled := a.renderEarlyFallback(); handled {
+		v.WindowTitle = a.windowTitle
 		return v
 	}
 
@@ -1861,6 +1867,7 @@ func (a *App) View() tea.View {
 	v := tea.NewView(a.maybeWrapFinalScreen(screen))
 	v.AltScreen = true
 	v.MouseMode = tea.MouseModeCellMotion
+	v.WindowTitle = a.windowTitle
 	return v
 }
 
@@ -2079,14 +2086,23 @@ func (a *App) beginEditOfSelected() tea.Cmd {
 	return a.compose.Focus()
 }
 
-// notifyReadStateChanged invalidates the sidebar render cache and
-// refreshes the workspace rail's HasUnread flags. Call this whenever
-// per-channel read state is mutated via the DB API (i.e., wherever
-// a.sidebar.Invalidate() used to suffice). Pairing them prevents the
-// rail from going stale when the sidebar updates.
+// notifyReadStateChanged invalidates the sidebar render cache,
+// refreshes the workspace rail's HasUnread flags, and recomputes the
+// cached terminal-window title. Call this whenever per-channel read
+// state is mutated via the DB API (i.e., wherever a.sidebar.Invalidate()
+// used to suffice). All three operations are downstream consumers of
+// the same DB read-state change and MUST stay in lockstep -- e.g., the
+// rail going stale while the sidebar updates was an earlier bug class
+// this single hook prevents.
 func (a *App) notifyReadStateChanged() {
 	a.sidebar.Invalidate()
 	a.workspaceRail.RefreshUnreads()
+	a.windowTitle = computeWindowTitle(
+		a.activeTeamID,
+		a.workspaceRail.NameByID(a.activeTeamID),
+		a.sidebar.UnreadChannelCount(),
+		a.workspaceRail.OtherUnreadCount(a.activeTeamID),
+	)
 }
 
 // applyChannelMark updates local state for a channel-level read-state

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -14,15 +14,16 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
-	"golang.design/x/clipboard"
 	"github.com/gammons/slk/internal/cache"
+	"github.com/gammons/slk/internal/ids"
 	imgpkg "github.com/gammons/slk/internal/image"
 	"github.com/gammons/slk/internal/ui/compose"
-	"github.com/gammons/slk/internal/ids"
 	"github.com/gammons/slk/internal/ui/messages"
 	"github.com/gammons/slk/internal/ui/sidebar"
 	"github.com/gammons/slk/internal/ui/statusbar"
 	"github.com/gammons/slk/internal/ui/styles"
+	"github.com/gammons/slk/internal/ui/workspace"
+	"golang.design/x/clipboard"
 )
 
 func TestAppFocusCycle(t *testing.T) {
@@ -4143,6 +4144,112 @@ func TestChannelSelectedInvokesMembershipFetcher(t *testing.T) {
 // returns within a short deadline. If a future maintainer changes
 // the wiring to once-again call a blocking fetcher synchronously,
 // this test fails the deadline.
+// setupAppForTitleTest builds an App wired with the readers and items
+// the window-title pipeline depends on. Returns the app plus the
+// mutable channel-state and workspace-unreads slices the caller can
+// re-point the readers at without re-wiring.
+func setupAppForTitleTest(
+	t *testing.T,
+	channels []sidebar.ChannelItem,
+	workspaces []workspace.WorkspaceItem,
+	channelState map[string]cache.ReadState,
+	workspaceUnreads []string,
+) *App {
+	t.Helper()
+	app := NewApp()
+	app.SetWorkspaces(workspaces)
+	app.SetChannels(channels)
+	app.SetReadStateReader(func() map[string]cache.ReadState { return channelState })
+	app.SetWorkspaceUnreadReader(func() []string { return workspaceUnreads })
+	return app
+}
+
+// TestNotifyReadStateChanged_PopulatesWindowTitle is the canonical
+// wiring test. It verifies that notifyReadStateChanged actually plumbs
+// each input from the collaborator the architecture assigns to it:
+//   - active count comes from the sidebar (mute-filtered)
+//   - other-workspace count comes from the rail (not mute-filtered)
+//   - workspace name comes from the rail for the active team
+//
+// If a future refactor reroutes any of these sources, the assertions
+// fall over and point at the wiring break.
+func TestNotifyReadStateChanged_PopulatesWindowTitle(t *testing.T) {
+	app := setupAppForTitleTest(t,
+		[]sidebar.ChannelItem{
+			{ID: "C1", Name: "general", Type: "channel", IsMuted: false},
+			{ID: "C2", Name: "noisy", Type: "channel", IsMuted: true},
+			{ID: "C3", Name: "design", Type: "channel", IsMuted: false},
+		},
+		[]workspace.WorkspaceItem{
+			{ID: "T1", Name: "SWAP", Initials: "SW"},
+			{ID: "T2", Name: "Other", Initials: "OT"},
+		},
+		map[string]cache.ReadState{
+			"C1": {HasUnread: true},  // counted toward active
+			"C2": {HasUnread: true},  // muted: NOT counted toward active
+			"C3": {HasUnread: false}, // read: NOT counted
+		},
+		[]string{"T1", "T2"}, // T1 active, T2 contributes to +1
+	)
+	app.activeTeamID = "T1"
+
+	app.notifyReadStateChanged()
+
+	if got, want := app.windowTitle, "slk SW (1) +1"; got != want {
+		t.Errorf("windowTitle = %q want %q", got, want)
+	}
+}
+
+func TestNotifyReadStateChanged_PreBootstrap(t *testing.T) {
+	app := NewApp()
+	// activeTeamID intentionally left blank
+	app.notifyReadStateChanged()
+	if got, want := app.windowTitle, "slk"; got != want {
+		t.Errorf("pre-bootstrap windowTitle = %q want %q", got, want)
+	}
+}
+
+func TestNotifyReadStateChanged_NoUnreads(t *testing.T) {
+	app := setupAppForTitleTest(t,
+		[]sidebar.ChannelItem{{ID: "C1", Name: "general", Type: "channel"}},
+		[]workspace.WorkspaceItem{{ID: "T1", Name: "SWAP", Initials: "SW"}},
+		map[string]cache.ReadState{"C1": {HasUnread: false}},
+		nil,
+	)
+	app.activeTeamID = "T1"
+
+	app.notifyReadStateChanged()
+
+	if got, want := app.windowTitle, "slk SW"; got != want {
+		t.Errorf("windowTitle = %q want %q", got, want)
+	}
+}
+
+// TestView_PropagatesWindowTitle proves View() surfaces the cached
+// title onto tea.View.WindowTitle from BOTH return sites: the
+// pre-layout fallback (width/height==0) and the full-layout main
+// branch. Bubbletea's renderer only emits the OSC sequence when this
+// field changes between renders, so a missed assignment silently
+// disables the feature.
+func TestView_PropagatesWindowTitle(t *testing.T) {
+	app := NewApp()
+	app.windowTitle = "slk SW (2) +1"
+
+	// Pre-layout branch (width/height==0).
+	v := app.View()
+	if v.WindowTitle != "slk SW (2) +1" {
+		t.Errorf("pre-layout View.WindowTitle = %q want %q", v.WindowTitle, "slk SW (2) +1")
+	}
+
+	// Main branch: give the app a real canvas size and re-render.
+	app.width = 100
+	app.height = 30
+	v = app.View()
+	if v.WindowTitle != "slk SW (2) +1" {
+		t.Errorf("main View.WindowTitle = %q want %q", v.WindowTitle, "slk SW (2) +1")
+	}
+}
+
 func TestChannelSelectedReturnsPromptlyEvenIfFetcherBlocks(t *testing.T) {
 	app := NewApp()
 	app.activeTeamID = "T1"

--- a/internal/ui/app_title.go
+++ b/internal/ui/app_title.go
@@ -1,0 +1,43 @@
+package ui
+
+import (
+	"fmt"
+
+	"github.com/gammons/slk/internal/ui/workspace"
+)
+
+// computeWindowTitle builds the slk terminal-window-title string from
+// pre-computed inputs. Pure (no I/O, no App reference); table-driven
+// tests in app_title_test.go cover the full output matrix.
+//
+// The caller (App.notifyReadStateChanged) sources each input from the
+// collaborator that already owns it:
+//
+//   - activeTeamID:   App.activeTeamID
+//   - workspaceName:  App.workspaceRail.NameByID(activeTeamID)
+//   - activeUnreads:  App.sidebar.UnreadChannelCount() (mute-filtered)
+//   - otherUnreads:   App.workspaceRail.OtherUnreadCount(activeTeamID)
+//
+// Pre-bootstrap, activeTeamID is "" and the function returns a bare
+// "slk" regardless of any stray non-zero counts. See
+// docs/superpowers/specs/2026-05-21-tab-title-unread-indicator-design.md.
+func computeWindowTitle(activeTeamID, workspaceName string, activeUnreads, otherUnreads int) string {
+	if activeTeamID == "" {
+		return "slk"
+	}
+	return formatTitle(workspace.WorkspaceInitials(workspaceName), activeUnreads, otherUnreads)
+}
+
+// formatTitle assembles the final title string from already-derived
+// pieces. Separated from computeWindowTitle so the assembly format is
+// testable independent of input sourcing.
+func formatTitle(initials string, active, other int) string {
+	out := "slk " + initials
+	if active > 0 {
+		out += fmt.Sprintf(" (%d)", active)
+	}
+	if other > 0 {
+		out += fmt.Sprintf(" +%d", other)
+	}
+	return out
+}

--- a/internal/ui/app_title_test.go
+++ b/internal/ui/app_title_test.go
@@ -1,0 +1,65 @@
+package ui
+
+import "testing"
+
+func TestFormatTitle(t *testing.T) {
+	tests := []struct {
+		name     string
+		initials string
+		active   int
+		other    int
+		want     string
+	}{
+		{"no unreads", "SW", 0, 0, "slk SW"},
+		{"active only", "SW", 3, 0, "slk SW (3)"},
+		{"other only", "SW", 0, 1, "slk SW +1"},
+		{"both", "SW", 3, 1, "slk SW (3) +1"},
+		{"max values", "SW", 99, 99, "slk SW (99) +99"},
+		{"fallback initials", "?", 0, 0, "slk ?"},
+		{"fallback initials with unreads", "?", 5, 2, "slk ? (5) +2"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatTitle(tt.initials, tt.active, tt.other)
+			if got != tt.want {
+				t.Errorf("formatTitle(%q, %d, %d) = %q want %q",
+					tt.initials, tt.active, tt.other, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestComputeWindowTitle covers the full pipeline from raw inputs to
+// rendered title. The pre-bootstrap branch (empty activeTeamID) MUST
+// produce a stable "slk" regardless of stray non-zero counts -- a
+// brief window during startup where the readers may already return
+// data but the active workspace isn't yet selected.
+func TestComputeWindowTitle(t *testing.T) {
+	tests := []struct {
+		name          string
+		activeTeamID  string
+		workspaceName string
+		activeUnreads int
+		otherUnreads  int
+		want          string
+	}{
+		{"pre-bootstrap (no active workspace)", "", "", 0, 0, "slk"},
+		{"pre-bootstrap ignores stray inputs", "", "Ignored", 99, 99, "slk"},
+		{"active workspace, no unreads", "T1", "SWAP", 0, 0, "slk SW"},
+		{"active workspace, with unreads", "T1", "SWAP", 3, 0, "slk SW (3)"},
+		{"active + other workspaces have unreads", "T1", "SWAP", 3, 2, "slk SW (3) +2"},
+		{"only other workspaces have unreads", "T1", "SWAP", 0, 1, "slk SW +1"},
+		{"empty workspace name yields fallback initials", "T1", "", 0, 0, "slk ?"},
+		{"single-word name uses first 2 chars", "T1", "Home", 1, 0, "slk HO (1)"},
+		{"multi-word name uses initials of first two words", "T1", "StratusGrid Eng", 5, 1, "slk SE (5) +1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := computeWindowTitle(tt.activeTeamID, tt.workspaceName, tt.activeUnreads, tt.otherUnreads)
+			if got != tt.want {
+				t.Errorf("computeWindowTitle(%q, %q, %d, %d) = %q want %q",
+					tt.activeTeamID, tt.workspaceName, tt.activeUnreads, tt.otherUnreads, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/ui/sidebar/model.go
+++ b/internal/ui/sidebar/model.go
@@ -44,6 +44,15 @@ type ChannelItem struct {
 	IsMuted bool
 }
 
+// IsVisiblyUnread reports whether this channel should render as having
+// unread messages -- DB-level HasUnread AND the user hasn't muted it.
+// This is the single source of truth for the "unread dot" predicate;
+// both the sidebar View, section aggregates, and the App's tab-title
+// counter MUST consult this helper rather than re-deriving the rule.
+func (item ChannelItem) IsVisiblyUnread(state cache.ReadState) bool {
+	return state.HasUnread && !item.IsMuted
+}
+
 // sectionFor is the package-level back-compat shim for callers
 // (including tests) that don't have a *Model. It always uses
 // config-mode logic. The Slack-mode dispatcher is *Model.sectionFor.
@@ -275,6 +284,25 @@ func (m *Model) SetReadStateReader(f func() map[string]cache.ReadState) {
 	m.readStateReader = f
 	m.cacheValid = false
 	m.dirty()
+}
+
+// UnreadChannelCount returns the number of channels currently in the
+// sidebar that should render as unread (HasUnread && !IsMuted), via
+// ChannelItem.IsVisiblyUnread. Returns 0 when no reader is installed.
+// Used by the App to compute the window title's active-workspace
+// count -- guaranteed to match the dot population exactly.
+func (m *Model) UnreadChannelCount() int {
+	if m.readStateReader == nil {
+		return 0
+	}
+	state := m.readStateReader()
+	count := 0
+	for _, item := range m.items {
+		if item.IsVisiblyUnread(state[item.ID]) {
+			count++
+		}
+	}
+	return count
 }
 
 // Invalidate forces the next View() call to re-read read state from
@@ -948,13 +976,10 @@ func (m *Model) aggregateUnreadForSection(section string) int {
 	total := 0
 	for _, idx := range m.filtered {
 		item := m.items[idx]
-		if item.IsMuted {
-			continue
-		}
 		if m.sectionFor(item) != section {
 			continue
 		}
-		if readState[item.ID].HasUnread {
+		if item.IsVisiblyUnread(readState[item.ID]) {
 			total++
 		}
 	}
@@ -1141,8 +1166,9 @@ func (m *Model) buildCache(width int) {
 		// pop, even when they have new messages — Slack's contract is
 		// "muted = no notification surface". The dimmer ChannelMuted
 		// style below distinguishes muted-with-unreads from a fully
-		// read row visually.
-		hasUnread := readState[item.ID].HasUnread && !item.IsMuted
+		// read row visually. Predicate lives on ChannelItem so the
+		// App's tab-title counter and section aggregates agree.
+		hasUnread := item.IsVisiblyUnread(readState[item.ID])
 
 		// Unread dot indicator (same regardless of selection state).
 		unreadDot := " "

--- a/internal/ui/sidebar/muted_test.go
+++ b/internal/ui/sidebar/muted_test.go
@@ -115,3 +115,70 @@ func TestAggregateBadge_AllMutedDropsBadge(t *testing.T) {
 		}
 	}
 }
+
+// TestChannelItem_IsVisiblyUnread locks in the single predicate that
+// drives the sidebar dot, the section aggregate, AND the tab-title
+// count. If a future change diverges any of those call sites from the
+// predicate captured here, the corresponding render/count tests will
+// fail -- but this one fails first and points directly at the rule.
+func TestChannelItem_IsVisiblyUnread(t *testing.T) {
+	cases := []struct {
+		name  string
+		item  ChannelItem
+		state cache.ReadState
+		want  bool
+	}{
+		{"unread, unmuted", ChannelItem{IsMuted: false}, cache.ReadState{HasUnread: true}, true},
+		{"unread, muted", ChannelItem{IsMuted: true}, cache.ReadState{HasUnread: true}, false},
+		{"read, unmuted", ChannelItem{IsMuted: false}, cache.ReadState{HasUnread: false}, false},
+		{"read, muted", ChannelItem{IsMuted: true}, cache.ReadState{HasUnread: false}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.item.IsVisiblyUnread(tc.state); got != tc.want {
+				t.Errorf("IsVisiblyUnread = %v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestUnreadChannelCount_NoReader(t *testing.T) {
+	m := New([]ChannelItem{
+		{ID: "C1", Name: "general", Type: "channel"},
+	})
+	if got := m.UnreadChannelCount(); got != 0 {
+		t.Errorf("UnreadChannelCount with no reader = %d want 0", got)
+	}
+}
+
+// TestUnreadChannelCount_FiltersMute proves the count uses
+// IsVisiblyUnread -- muted-but-unread channels are excluded, matching
+// the dot population. If this assertion ever drifts from the sidebar
+// dot count, the predicate has been duplicated somewhere.
+func TestUnreadChannelCount_FiltersMute(t *testing.T) {
+	m := New([]ChannelItem{
+		{ID: "C1", Name: "a", Type: "channel", IsMuted: false},
+		{ID: "C2", Name: "b", Type: "channel", IsMuted: false},
+		{ID: "C3", Name: "c", Type: "channel", IsMuted: true},
+		{ID: "C4", Name: "d", Type: "channel", IsMuted: false},
+	})
+	m.SetReadStateReader(func() map[string]cache.ReadState {
+		return map[string]cache.ReadState{
+			"C1": {HasUnread: true},  // counted
+			"C2": {HasUnread: false}, // skipped (read)
+			"C3": {HasUnread: true},  // skipped (muted)
+			"C4": {HasUnread: true},  // counted
+		}
+	})
+	if got := m.UnreadChannelCount(); got != 2 {
+		t.Errorf("UnreadChannelCount = %d want 2 (C1, C4)", got)
+	}
+}
+
+func TestUnreadChannelCount_EmptySidebar(t *testing.T) {
+	m := New(nil)
+	m.SetReadStateReader(func() map[string]cache.ReadState { return nil })
+	if got := m.UnreadChannelCount(); got != 0 {
+		t.Errorf("UnreadChannelCount with no items = %d want 0", got)
+	}
+}

--- a/internal/ui/workspace/model.go
+++ b/internal/ui/workspace/model.go
@@ -42,6 +42,35 @@ func (m *Model) SelectedID() string {
 	return m.items[m.selected].ID
 }
 
+// NameByID returns the workspace's display name, or "" if no item with
+// the given ID is present. Used by the App to derive the window title's
+// initials via WorkspaceInitials.
+func (m *Model) NameByID(id string) string {
+	for _, item := range m.items {
+		if item.ID == id {
+			return item.Name
+		}
+	}
+	return ""
+}
+
+// OtherUnreadCount returns the number of workspaces with unreads,
+// excluding activeID. Reads through the installed unreadReader; returns
+// 0 when no reader is set. Does not filter mute -- matches the rail
+// dot's existing semantics so the title's "+N" and the rail dots agree.
+func (m *Model) OtherUnreadCount(activeID string) int {
+	if m.unreadReader == nil {
+		return 0
+	}
+	count := 0
+	for _, id := range m.unreadReader() {
+		if id != activeID {
+			count++
+		}
+	}
+	return count
+}
+
 func (m *Model) SelectedIndex() int {
 	return m.selected
 }

--- a/internal/ui/workspace/model_test.go
+++ b/internal/ui/workspace/model_test.go
@@ -82,3 +82,59 @@ func TestClickAt_EmptyRail(t *testing.T) {
 		t.Error("ClickAt on empty rail must return ok=false")
 	}
 }
+
+func TestNameByID(t *testing.T) {
+	m := New([]WorkspaceItem{
+		{ID: "T1", Name: "SWAP", Initials: "SW"},
+		{ID: "T2", Name: "Home", Initials: "HO"},
+	}, 0)
+	cases := map[string]string{
+		"T1":        "SWAP",
+		"T2":        "Home",
+		"T-missing": "",
+		"":          "",
+	}
+	for id, want := range cases {
+		if got := m.NameByID(id); got != want {
+			t.Errorf("NameByID(%q) = %q want %q", id, got, want)
+		}
+	}
+}
+
+func TestOtherUnreadCount_NoReader(t *testing.T) {
+	m := New([]WorkspaceItem{{ID: "T1"}}, 0)
+	if got := m.OtherUnreadCount("T1"); got != 0 {
+		t.Errorf("OtherUnreadCount with no reader = %d want 0", got)
+	}
+}
+
+func TestOtherUnreadCount(t *testing.T) {
+	m := New([]WorkspaceItem{
+		{ID: "T1"}, {ID: "T2"}, {ID: "T3"},
+	}, 0)
+	m.SetUnreadReader(func() []string { return []string{"T1", "T2", "T3"} })
+
+	cases := []struct {
+		activeID string
+		want     int
+	}{
+		{"T1", 2},
+		{"T2", 2},
+		{"T3", 2},
+		{"T-missing", 3}, // active workspace not in unread set: counts all
+		{"", 3},          // empty active: counts all; caller is responsible
+	}
+	for _, tc := range cases {
+		if got := m.OtherUnreadCount(tc.activeID); got != tc.want {
+			t.Errorf("OtherUnreadCount(%q) = %d want %d", tc.activeID, got, tc.want)
+		}
+	}
+}
+
+func TestOtherUnreadCount_EmptyReaderResult(t *testing.T) {
+	m := New([]WorkspaceItem{{ID: "T1"}, {ID: "T2"}}, 0)
+	m.SetUnreadReader(func() []string { return nil })
+	if got := m.OtherUnreadCount("T1"); got != 0 {
+		t.Errorf("OtherUnreadCount with empty reader = %d want 0", got)
+	}
+}


### PR DESCRIPTION
## Summary

slk's terminal-window title now reflects unread state — for example `slk SW (3) +1` means three channels-with-unreads in the active workspace ("SW" = SWAP) and at least one other workspace also has unreads. Bare `slk` pre-bootstrap.

The active-workspace count `(N)` is mute-filtered to match the sidebar dots. The cross-workspace `+N` is not mute-filtered, to match the rail dots. Initials are derived via the existing `WorkspaceInitials`.

Spec: `docs/superpowers/specs/2026-05-21-tab-title-unread-indicator-design.md`.
Plan: `docs/superpowers/plans/2026-05-21-tab-title-unread-indicator.md`.

## Mechanics

- New free function `computeWindowTitle(activeTeamID, workspaceName, activeUnreads, otherUnreads) string` in `internal/ui/app_title.go`. Pure: no I/O, no `App` reference. Handles the pre-bootstrap branch (empty `activeTeamID` → bare `slk`) so the brief startup window can't render stray non-zero counts.
- New `sidebar.ChannelItem.IsVisiblyUnread(state)` and `sidebar.Model.UnreadChannelCount()`. The predicate (`HasUnread && !IsMuted`) was inlined in two places, one expressed in inverted form (`if IsMuted continue; if HasUnread count++`) — extracting it ensures the sidebar dots, the section aggregate, and the new title count agree by construction.
- New `workspace.Model.NameByID(id)` and `workspace.Model.OtherUnreadCount(activeID)`. Both read-only accessors, sourced from the same `unreadReader` the rail uses for its own dots — title `+N` and rail dots are derived from the same iteration, so they cannot drift.
- New `App.windowTitle` field, initialized to `slk` in `NewApp`, updated by `notifyReadStateChanged` (the existing fan-out hook for read-state mutations; joins `sidebar.Invalidate` and `workspaceRail.RefreshUnreads` as the third downstream consumer), and set onto `tea.View.WindowTitle` at both `View()` return sites. Bubbletea's renderer emits OSC 2 only on title change, so there's no per-frame cost.
- README section explaining the tmux config (`set-titles on` + `set-titles-string '#T'`) tmux users need to forward the title escape to their outer terminal's chrome.

## Out of scope

Per the spec's "Out of scope (follow-ups)" section: configuration knob, DCS-wrapped passthrough for tmux without `set-titles on`, channel-level granularity, workspace-icon glyphs. None are implemented in this PR.

## Test plan

**Automated (all passing locally):**

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run` — 0 issues
- [x] `go test ./... -count=1` — 39 packages pass
- [x] Unit tests at each layer: predicate 2x2 truth table, sidebar count (no-reader / mute-filter / empty), rail `NameByID` (happy + missing + empty), rail `OtherUnreadCount` (happy + degenerate inputs), pure formatter (16 cases covering pre-bootstrap branches and the full unread-combo matrix)
- [x] Wiring test `TestNotifyReadStateChanged_PopulatesWindowTitle`: muted-with-unreads channel + unmuted-with-unreads channel + two workspaces with unreads → asserts `slk SW (1) +1`. Locks down that the active count comes from the sidebar (mute-filtered), `+N` from the rail (unfiltered), and the workspace name from the rail
- [x] `TestView_PropagatesWindowTitle` exercises **both** `View()` return sites (pre-layout and main) — catches the case where a future refactor forgets to set the field on one of them

**Manual:**

- [x] Dogfooded across two real workspaces; title updates in real time as messages arrive and channels are marked read, including mute suppression on the active count and `+N` increments when the inactive workspace gets activity
- [x] Cross-workspace switching: `Ctrl+W` updates the initials and recomputes both counts as expected
- [x] tmux: with the documented `set-titles` config the title forwards correctly to Kitty's tab chrome; without it tmux swallows the escape (as documented)
- [ ] Reviewer: confirm rendering in your terminal of choice

Closes #25.

## Commits

Bottom-up; each commit builds clean, passes its own tests, and is independently bisect-friendly:

```
8459ef6 docs: tab-title unread indicator section in README
ad1d7a4 app: wire windowTitle through View + notifyReadStateChanged
faa7566 ui: computeWindowTitle + formatTitle pure functions
fb761d6 workspace: NameByID + OtherUnreadCount accessors
7953827 sidebar: IsVisiblyUnread predicate + UnreadChannelCount
b7a76f0 docs: spec and plan for tab title unread indicator
```

*Designed in dialogue with Claude (Anthropic); implementation drafted by Claude, reviewed and verified by me.*