### PR TITLE
fix: emoji shortcode fallback + lipgloss canvas wide-char preservation

### DIFF
--- a/docs/superpowers/plans/2026-05-24-emoji-shortcode-fallback.md
+++ b/docs/superpowers/plans/2026-05-24-emoji-shortcode-fallback.md
@@ -1,0 +1,700 @@
+# Emoji Shortcode Fallback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop slk from rendering composition-fragile emoji (ZWJ sequences, flag pairs, skin-tone modifiers) as Unicode glyphs. Fall back to readable `:shortcode:` text whenever the resolved Unicode form is more than one base codepoint + optional VS16. Fixes the right-border-breaks-on-emoji bug in kitty/ghostty without requiring users to set an env var.
+
+**Architecture:** Single shared classifier (`emoji.ShouldRenderUnicode`) used at every shortcode→Unicode resolution site (message-pane reaction pills, thread-pane reaction pills, reaction picker, message body text). The rule: render Unicode iff the string is exactly one codepoint, OR one codepoint followed by VS16 (U+FE0F). Everything else is shown as its `:name:` form.
+
+**Tech Stack:** Go 1.21+, `github.com/kyokomi/emoji/v2`, `charm.land/lipgloss/v2`. Reuses existing `internal/emoji/` package.
+
+**Spec:** `docs/superpowers/specs/2026-05-24-emoji-shortcode-fallback-design.md`
+
+---
+
+## Task 1: Add ShouldRenderUnicode helper with truth-table tests
+
+**Files:**
+- Create: `internal/emoji/shouldrender.go`
+- Create: `internal/emoji/shouldrender_test.go`
+
+- [ ] **Step 1.1: Write the failing tests**
+
+Create `internal/emoji/shouldrender_test.go`:
+
+```go
+package emoji
+
+import "testing"
+
+func TestShouldRenderUnicode(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		want    bool
+	}{
+		// Single codepoint, emoji presentation.
+		{"single emoji raised hands", "\U0001F64C", true}, // 🙌
+		{"single emoji rainbow", "\U0001F308", true},      // 🌈
+		{"single emoji fire", "\U0001F525", true},          // 🔥
+		// Single non-emoji codepoint (rule is structural; harmless).
+		{"single ascii letter", "a", true},
+		{"single misc symbol", "\u2603", true}, // ☃
+		// Single base codepoint + VS16 (well-supported composition).
+		{"heart + VS16", "\u2764\uFE0F", true},        // ❤️
+		{"warning + VS16", "\u26A0\uFE0F", true},      // ⚠️
+		{"flag base + VS16", "\U0001F3F3\uFE0F", true}, // 🏳️ (white flag alone)
+		// Multi-codepoint composition (the cases the bug is about).
+		{"ZWJ pride flag", "\U0001F3F3\uFE0F\u200D\U0001F308", false}, // 🏳️‍🌈
+		{"ZWJ family", "\U0001F468\u200D\U0001F469\u200D\U0001F467", false}, // 👨‍👩‍👧
+		{"regional indicator pair US", "\U0001F1FA\U0001F1F8", false}, // 🇺🇸
+		{"skin-tone modifier", "\U0001F44D\U0001F3FD", false},          // 👍🏽
+		{"base + VS16 + extra codepoint", "\u2764\uFE0F\u200D\U0001F525", false}, // ❤️‍🔥
+		// Edge cases.
+		{"empty string", "", false},
+		{"two ascii letters", "ab", false},
+		// Defensive: callers occasionally pass kyokomi's trailing-space
+		// form. The helper trims trailing whitespace before classifying.
+		{"single emoji with trailing space", "\U0001F308 ", true},
+		{"ZWJ with trailing space", "\U0001F3F3\uFE0F\u200D\U0001F308 ", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ShouldRenderUnicode(c.input)
+			if got != c.want {
+				t.Errorf("ShouldRenderUnicode(%q) = %v, want %v", c.input, got, c.want)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 1.2: Run tests to verify they fail**
+
+Run: `cd /home/grant/local_code/slk && go test ./internal/emoji -run TestShouldRenderUnicode -v`
+Expected: FAIL with "undefined: ShouldRenderUnicode" (or equivalent build error).
+
+- [ ] **Step 1.3: Implement the helper**
+
+Create `internal/emoji/shouldrender.go`:
+
+```go
+package emoji
+
+import "strings"
+
+// vs16 is U+FE0F, the variation selector that forces emoji presentation
+// for the preceding base codepoint. VS16 is well-supported across
+// terminal fonts because no glyph composition is required — the
+// terminal merely picks the emoji-presentation form of a single base
+// codepoint that the font already has.
+const vs16 rune = 0xFE0F
+
+// ShouldRenderUnicode reports whether the resolved Unicode form of an
+// emoji is composition-safe to render as a glyph. Returns true iff the
+// string contains exactly one base codepoint, or exactly one base
+// codepoint followed by VS16. Multi-codepoint sequences (ZWJ,
+// regional-indicator flag pairs, skin-tone modifiers) return false
+// because terminal font support for composition is inconsistent and
+// the resulting visual-width disagreement breaks slk's layout.
+//
+// Trailing whitespace is ignored — kyokomi/emoji's Sprint appends a
+// trailing space after each resolved emoji and callers occasionally
+// pass that form. Empty strings (after trim) return false.
+func ShouldRenderUnicode(s string) bool {
+	s = strings.TrimRight(s, " \t")
+	if s == "" {
+		return false
+	}
+	runes := []rune(s)
+	switch len(runes) {
+	case 1:
+		return true
+	case 2:
+		return runes[1] == vs16
+	default:
+		return false
+	}
+}
+```
+
+- [ ] **Step 1.4: Run tests to verify they pass**
+
+Run: `cd /home/grant/local_code/slk && go test ./internal/emoji -run TestShouldRenderUnicode -v`
+Expected: All 17 sub-tests PASS.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+cd /home/grant/local_code/slk && git add internal/emoji/shouldrender.go internal/emoji/shouldrender_test.go && git commit -m "feat(emoji): ShouldRenderUnicode classifier
+
+Returns true for emoji strings that are exactly one base codepoint
+or one base codepoint + VS16. Multi-codepoint sequences (ZWJ, flag
+pairs, skin-tone modifiers) return false because terminal font
+support is inconsistent and width disagreement breaks layout.
+
+Centralizes the rule that future reaction-pill / picker / body-text
+sites will share. See docs/superpowers/specs/2026-05-24-emoji-
+shortcode-fallback-design.md."
+```
+
+---
+
+## Task 2: Wire helper into message-pane reaction pills
+
+**Files:**
+- Modify: `internal/ui/messages/model.go:1635` (the reaction-pill loop)
+
+The reaction pill currently does:
+```go
+emojiStr := emojiutil.Sprint(":" + emojiutil.StripSkinTone(r.Emoji) + ":")
+pillText := fmt.Sprintf("%s%d", emojiStr, r.Count)
+```
+
+After: resolve via kyokomi, classify with `ShouldRenderUnicode`. If unsafe, fall back to the shortcode text.
+
+- [ ] **Step 2.1: Read the surrounding context to confirm imports and helper names**
+
+Run: `cd /home/grant/local_code/slk && rg -n 'emojiutil\.|kyoemoji\.|kyokomi/emoji' internal/ui/messages/model.go`
+
+Expected: `emojiutil "github.com/gammons/slk/internal/emoji"` is already imported. No other kyokomi import; the kyokomi import was removed in the debug-instrumentation phase.
+
+- [ ] **Step 2.2: Add the kyokomi import back**
+
+Edit `internal/ui/messages/model.go` (top of import block, restoring the alias used elsewhere):
+
+```go
+import (
+    // ... existing imports ...
+    emojiutil "github.com/gammons/slk/internal/emoji"
+    kyoemoji "github.com/kyokomi/emoji/v2"
+    // ... other existing imports ...
+)
+```
+
+Run: `cd /home/grant/local_code/slk && goimports -l -w internal/ui/messages/model.go || true`
+
+- [ ] **Step 2.3: Change the reaction-pill resolution**
+
+Locate the reaction-pill loop (around line 1635). Replace the two lines that build `emojiStr` and `pillText` with the per-emoji classifier:
+
+```go
+// Resolve the shortcode to Unicode and check whether the resolved
+// form is composition-safe. Multi-codepoint sequences (ZWJ flags,
+// skin tones, regional-indicator pairs) render as broken glyphs in
+// many terminal fonts and break right-border alignment; in those
+// cases we display the readable :shortcode: text instead. See
+// internal/emoji/shouldrender.go for the rule.
+nameForLookup := emojiutil.StripSkinTone(r.Emoji)
+resolved := kyoemoji.Sprint(":" + nameForLookup + ":")
+var emojiStr string
+if emojiutil.ShouldRenderUnicode(resolved) {
+    emojiStr = resolved
+} else {
+    emojiStr = ":" + nameForLookup + ":"
+}
+pillText := fmt.Sprintf("%s%d", emojiStr, r.Count)
+```
+
+- [ ] **Step 2.4: Run all messages tests**
+
+Run: `cd /home/grant/local_code/slk && go test ./internal/ui/messages/...`
+Expected: PASS. (TestViewLineWidths_* tests still pass because plain text widths are trivially consistent.)
+
+- [ ] **Step 2.5: Build the whole project**
+
+Run: `cd /home/grant/local_code/slk && go build ./...`
+Expected: success, no output.
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+cd /home/grant/local_code/slk && git add internal/ui/messages/model.go && git commit -m "fix(reactions): fall back to :shortcode: for composition-fragile emoji
+
+Message-pane reaction pills now route the resolved Unicode through
+ShouldRenderUnicode. Multi-codepoint sequences (ZWJ flags like
+:rainbow-flag:, skin-toned reactions, regional-indicator flag
+pairs) display as readable :name: text instead of broken glyphs
+that desync slk's right-border alignment.
+
+Single-codepoint emoji and VS16-anchored emoji continue to render
+as Unicode glyphs."
+```
+
+---
+
+## Task 3: Apply same change to thread-pane reaction pills
+
+**Files:**
+- Modify: `internal/ui/thread/model.go:1595` (mirror of message-pane logic)
+
+- [ ] **Step 3.1: Restore the kyokomi import in thread/model.go**
+
+Run: `cd /home/grant/local_code/slk && rg -n 'kyokomi/emoji' internal/ui/thread/model.go`
+
+If no match, add it to the import block (restoring the original alias used before the debug phase):
+
+```go
+import (
+    // ... existing imports ...
+    "github.com/gammons/slk/internal/debuglog"
+    emojiutil "github.com/gammons/slk/internal/emoji"
+    kyoemoji "github.com/kyokomi/emoji/v2"
+    // ... other existing imports ...
+)
+```
+
+- [ ] **Step 3.2: Update the reaction-pill resolution at line 1595**
+
+Replace the existing two lines that build `emojiStr` and `pillText` with the same per-emoji classifier used in Task 2:
+
+```go
+nameForLookup := emojiutil.StripSkinTone(r.Emoji)
+resolved := kyoemoji.Sprint(":" + nameForLookup + ":")
+var emojiStr string
+if emojiutil.ShouldRenderUnicode(resolved) {
+    emojiStr = resolved
+} else {
+    emojiStr = ":" + nameForLookup + ":"
+}
+pillText := fmt.Sprintf("%s%d", emojiStr, r.Count)
+```
+
+- [ ] **Step 3.3: Run thread tests and build**
+
+Run: `cd /home/grant/local_code/slk && go test ./internal/ui/thread/... && go build ./...`
+Expected: PASS, then build success.
+
+- [ ] **Step 3.4: Commit**
+
+```bash
+cd /home/grant/local_code/slk && git add internal/ui/thread/model.go && git commit -m "fix(thread): apply shortcode fallback to thread reaction pills
+
+Mirror of the message-pane fix in the previous commit. Same
+ShouldRenderUnicode rule for thread reactions."
+```
+
+---
+
+## Task 4: Replace picker's len(runes)==1 rule with ShouldRenderUnicode
+
+**Files:**
+- Modify: `internal/ui/reactionpicker/model.go:50-67` (buildEmojiList — strip trailing space when storing Unicode)
+- Modify: `internal/ui/reactionpicker/model.go:340-351` (the picker rendering check)
+
+The picker's existing rule excludes ALL multi-codepoint emoji, which silently hides every colorful VS16-anchored emoji (`:heart:` ❤️, `:warning:` ⚠️, etc.). Switching to `ShouldRenderUnicode` will surface those.
+
+A precondition: the picker currently stores the raw kyokomi `unicode` value in `EmojiEntry.Unicode`, which includes a trailing space (`"🌈 "`). `ShouldRenderUnicode` trims trailing whitespace defensively but it's cleaner to strip at load time so the stored value is the pure glyph.
+
+- [ ] **Step 4.1: Add slkemoji import alias to reactionpicker**
+
+Run: `cd /home/grant/local_code/slk && rg -n 'gammons/slk/internal/emoji' internal/ui/reactionpicker/model.go`
+
+If absent, add to the import block:
+
+```go
+import (
+    // ... existing imports ...
+    slkemoji "github.com/gammons/slk/internal/emoji"
+    // ... other existing ...
+)
+```
+
+(slkemoji is the alias already used elsewhere in this file — verify with `rg slkemoji internal/ui/reactionpicker/model.go`. If a different alias is used, match it.)
+
+- [ ] **Step 4.2: Strip trailing space when storing the built-in Unicode**
+
+In `buildEmojiList` (around line 55), change:
+
+```go
+m.allEmoji = append(m.allEmoji, EmojiEntry{Name: name, Unicode: unicode})
+```
+
+to:
+
+```go
+m.allEmoji = append(m.allEmoji, EmojiEntry{Name: name, Unicode: strings.TrimRight(unicode, " ")})
+```
+
+(`strings` is already imported; verify.)
+
+- [ ] **Step 4.3: Replace the picker rendering test**
+
+In the row-rendering loop (around line 347), change:
+
+```go
+if len([]rune(entry.Unicode)) == 1 {
+    line = entry.Unicode + " " + entry.Name
+} else {
+    line = ":" + entry.Name + ":"
+}
+```
+
+to:
+
+```go
+// Use the shared composition-safety classifier instead of the
+// stricter len(runes)==1 rule. The previous rule excluded all
+// VS16-anchored colorful emoji (❤️, ⚠️, 🏳️ etc.) by accident.
+if slkemoji.ShouldRenderUnicode(entry.Unicode) {
+    line = entry.Unicode + " " + entry.Name
+} else {
+    line = ":" + entry.Name + ":"
+}
+```
+
+- [ ] **Step 4.4: Update the explanatory comment block above the if/else**
+
+Replace the existing comment (lines 340-345) with:
+
+```go
+// Display Unicode emoji when the resolved form is composition-safe
+// (single base codepoint, optionally + VS16). Multi-codepoint
+// sequences (ZWJ, regional-indicator flags, skin tones) render as
+// broken glyphs in many terminal fonts and corrupt the picker's
+// width arithmetic. See internal/emoji/shouldrender.go.
+```
+
+- [ ] **Step 4.5: Run picker tests + build**
+
+Run: `cd /home/grant/local_code/slk && go test ./internal/ui/reactionpicker/... && go build ./...`
+Expected: PASS, then build success.
+
+- [ ] **Step 4.6: Commit**
+
+```bash
+cd /home/grant/local_code/slk && git add internal/ui/reactionpicker/model.go && git commit -m "fix(picker): use ShouldRenderUnicode (surfaces VS16 emoji)
+
+Picker previously gated emoji display on len(runes)==1, which
+correctly excluded ZWJ sequences and flag pairs but also
+accidentally excluded every colorful VS16-anchored emoji (:heart:,
+:warning:, :white_check_mark:, etc.). Users were seeing the
+picker as a sea of black-and-white symbols.
+
+Switching to ShouldRenderUnicode surfaces VS16 emoji as glyphs
+while keeping the original protection against ZWJ/flag/skin-tone
+sequences. Also trims kyokomi's trailing space when loading
+built-ins so the stored Unicode is the pure glyph."
+```
+
+---
+
+## Task 5: Body-text path — per-shortcode resolution
+
+**Files:**
+- Modify: `internal/ui/messages/render.go:561-565` (the emoji line in renderInlineFormatting)
+- Create: `internal/emoji/render.go` (the per-shortcode resolution helper)
+- Create: `internal/emoji/render_test.go`
+
+The current body-text path calls `emoji.Sprint(text)` which scans `text` in one pass and substitutes every shortcode. To apply `ShouldRenderUnicode` per-shortcode we need a scanner that resolves each match individually.
+
+- [ ] **Step 5.1: Write failing tests for the new helper**
+
+Create `internal/emoji/render_test.go`:
+
+```go
+package emoji
+
+import "testing"
+
+func TestResolveShortcodesInText(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"no shortcodes", "hello world", "hello world"},
+		{"single safe emoji", "look :smile: here", "look 😄  here"},
+		{"single unsafe (ZWJ) emoji stays text", "pride :rainbow_flag: month", "pride :rainbow_flag: month"},
+		{"unsafe with slack hyphen form", "pride :rainbow-flag: month", "pride :rainbow-flag: month"},
+		{"VS16 emoji renders", "love :heart: you", "love ❤️  you"},
+		{"unknown shortcode passes through", "wat :nope: lol", "wat :nope: lol"},
+		{"multiple safe", "hi :smile: and :fire:", "hi 😄  and 🔥 "},
+		{"safe + unsafe mixed", "ok :smile: :rainbow_flag: done", "ok 😄  :rainbow_flag: done"},
+		{"adjacent shortcodes", ":smile::fire:", "😄 🔥 "},
+		{"empty", "", ""},
+		{"colons only", "::", "::"},
+		{"single colon", "a:b", "a:b"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ResolveShortcodesInText(c.input)
+			if got != c.want {
+				t.Errorf("ResolveShortcodesInText(%q) = %q, want %q", c.input, got, c.want)
+			}
+		})
+	}
+}
+```
+
+Note: kyokomi appends a trailing space to each resolved emoji (`":smile:"` → `"😄 "`). The expected strings include that space to match kyokomi's behavior, so body-text rendering before/after the change emits the same visible text for the safe cases. The unsafe cases leave the shortcode literally as it appeared in input.
+
+- [ ] **Step 5.2: Run tests to verify they fail**
+
+Run: `cd /home/grant/local_code/slk && go test ./internal/emoji -run TestResolveShortcodesInText -v`
+Expected: FAIL with "undefined: ResolveShortcodesInText".
+
+- [ ] **Step 5.3: Implement ResolveShortcodesInText**
+
+Create `internal/emoji/render.go`:
+
+```go
+package emoji
+
+import (
+	"regexp"
+
+	kyoemoji "github.com/kyokomi/emoji/v2"
+)
+
+// shortcodeRe matches Slack-style emoji shortcodes embedded in text:
+// a colon, a name made of letters/digits/_/+/-, then a closing colon.
+// Anchored by the colons; non-greedy isn't needed because the inner
+// class disallows colons. Matches what Slack permits in custom emoji
+// names plus the kyokomi built-in set.
+var shortcodeRe = regexp.MustCompile(`:[A-Za-z0-9_+\-]+:`)
+
+// ResolveShortcodesInText substitutes safe Slack-style :shortcode:
+// sequences in s with their Unicode glyphs (matching kyokomi/emoji's
+// trailing-space behavior for byte-for-byte parity with the previous
+// emoji.Sprint(text) call). Shortcodes whose resolved Unicode form
+// fails ShouldRenderUnicode (ZWJ sequences, flag pairs, skin-tone
+// modifiers) are left as the literal :name: text so they render as
+// readable shortcodes instead of broken glyphs.
+//
+// Unknown shortcodes pass through unchanged (kyokomi returns the
+// input verbatim for unrecognized names).
+func ResolveShortcodesInText(s string) string {
+	return shortcodeRe.ReplaceAllStringFunc(s, func(match string) string {
+		resolved := kyoemoji.Sprint(match)
+		if resolved == match {
+			// Unrecognized shortcode; pass through.
+			return match
+		}
+		if ShouldRenderUnicode(resolved) {
+			return resolved
+		}
+		return match
+	})
+}
+```
+
+- [ ] **Step 5.4: Run tests to verify they pass**
+
+Run: `cd /home/grant/local_code/slk && go test ./internal/emoji -run TestResolveShortcodesInText -v`
+Expected: All 12 sub-tests PASS.
+
+- [ ] **Step 5.5: Update the body-text call site**
+
+Edit `internal/ui/messages/render.go`. Around line 561-565, change:
+
+```go
+// Emoji shortcodes: :red_circle: -> 🔴
+// Strip skin-tone modifier suffixes from shortcodes first; toned
+// emoji render inconsistently across terminals and break alignment.
+text = emojiutil.Sprint(emojiutil.StripSkinToneFromText(text))
+```
+
+to:
+
+```go
+// Emoji shortcodes: :red_circle: -> 🔴, but only when the resolved
+// Unicode form is composition-safe (single codepoint or VS16-
+// anchored). ZWJ sequences, flag pairs, and skin-tone modifiers
+// stay as readable :shortcode: text — they break terminal
+// width arithmetic on many fonts. See internal/emoji/shouldrender.go.
+//
+// StripSkinToneFromText runs first because skin-toned shortcodes
+// (e.g. :wave_tone3:) should resolve as their base name (:wave:),
+// not be left as literal text.
+text = emojiutil.ResolveShortcodesInText(emojiutil.StripSkinToneFromText(text))
+```
+
+- [ ] **Step 5.6: Run messages tests + build**
+
+Run: `cd /home/grant/local_code/slk && go test ./internal/ui/messages/... && go build ./...`
+Expected: PASS, then build success.
+
+- [ ] **Step 5.7: Commit**
+
+```bash
+cd /home/grant/local_code/slk && git add internal/emoji/render.go internal/emoji/render_test.go internal/ui/messages/render.go && git commit -m "fix(body): apply shortcode fallback to inline message-body emoji
+
+Adds ResolveShortcodesInText that scans body text for :shortcode:
+runs, resolves each via kyokomi, and substitutes the Unicode glyph
+only when ShouldRenderUnicode passes. Multi-codepoint sequences
+(ZWJ, flag pairs, skin-tone modifiers) embedded in message bodies
+now render as readable :shortcode: text instead of broken glyphs.
+
+Preserves kyokomi's trailing-space behavior for byte-for-byte
+parity with the previous emoji.Sprint(text) call on the safe-path."
+```
+
+---
+
+## Task 6: Cleanup — remove all debug instrumentation
+
+**Files:**
+- Delete: `internal/emoji/sprint.go` (SLK_NO_EMOJI env-var wrapper)
+- Delete: `internal/emoji/test_helpers.go` (SetWidthMapForTest — only used by the debug test)
+- Delete: `internal/ui/messages/width_repro_test.go` (debug test that never reproduced)
+- Delete: `slk-frame-dump.txt` (one-off dump from the investigation)
+- Modify: `internal/ui/messages/model.go` (remove debugCheckModal)
+- Modify: `internal/ui/view_messages.go` (remove debugDumpLineWidths, dumpFrameIfRequested, per-stage logging)
+- Modify: `internal/ui/sidebar/model.go` (revert emojiutil.Sprint → kyoemoji.Sprint with the imports it had)
+
+- [ ] **Step 6.1: Delete debug files**
+
+```bash
+cd /home/grant/local_code/slk
+rm internal/emoji/sprint.go
+rm internal/emoji/test_helpers.go
+rm internal/ui/messages/width_repro_test.go
+rm -f slk-frame-dump.txt slk-debug.log
+```
+
+- [ ] **Step 6.2: Remove debugCheckModal from internal/ui/messages/model.go**
+
+Search for the function:
+
+```bash
+cd /home/grant/local_code/slk && rg -n 'debugCheckModal' internal/ui/messages/model.go
+```
+
+Two hits expected: the function definition (around line 1289 region) and one or more call sites. Delete the function (the `func debugCheckModal(...)` block and its `// debugCheckModal ...` doc comment). Delete all call sites (`debugCheckModal("messages.View:...", visible)` lines).
+
+After deletion:
+- The `ansi.StringWidth` import in `messages/model.go` may still be needed for other code (the file already used it before debug instrumentation; verify with `rg ansi\. internal/ui/messages/model.go`).
+- The `debuglog` import may no longer be needed in `messages/model.go` (it was added for the debug path). Verify with `rg debuglog internal/ui/messages/model.go`; if no other uses, remove the import.
+
+- [ ] **Step 6.3: Revert internal/ui/view_messages.go**
+
+The current file has:
+- `dumpFrameIfRequested` function
+- `debugDumpLineWidths` function
+- Per-stage `debugDumpLineWidths(...)` calls inside `renderMessagesTop`
+- `"os"`, `"strings"`, `"github.com/charmbracelet/x/ansi"`, `"github.com/gammons/slk/internal/debuglog"` imports added for the above
+
+Restore to the pre-debug state. The file should look like:
+
+```go
+package ui
+
+import (
+	"charm.land/lipgloss/v2"
+
+	"github.com/gammons/slk/internal/ui/messages"
+	"github.com/gammons/slk/internal/ui/styles"
+)
+```
+
+(plus the existing top-of-file comment block — leave that untouched.)
+
+And in `renderMessagesTop`, restore the body to:
+
+```go
+func (a *App) renderMessagesTop(msgWidth, msgBorder, topHeight, msgContentHeight int, topPanelVersion, topLayoutKey int64, msgFocused bool) string {
+	c := &a.renderCache.msgTop
+	if c.hit(topPanelVersion, msgWidth, topHeight, topLayoutKey) {
+		return c.output
+	}
+	topBorderStyle := styles.UnfocusedBorder.Width(msgWidth).
+		BorderTop(true).BorderLeft(true).BorderRight(true).BorderBottom(false)
+	if msgFocused {
+		topBorderStyle = styles.FocusedBorder.Width(msgWidth).
+			BorderTop(true).BorderLeft(true).BorderRight(true).BorderBottom(false)
+	}
+	msgView := a.messagepane.View(msgContentHeight, msgWidth-2)
+	msgView = messages.ReapplyBgAfterResets(msgView, messages.BgANSI())
+	out := exactSize(
+		topBorderStyle.Render(msgView),
+		msgWidth+msgBorder, topHeight,
+	)
+	c.store(out, topPanelVersion, msgWidth, topHeight, topLayoutKey)
+	return out
+}
+```
+
+Delete the `dumpFrameIfRequested` and `debugDumpLineWidths` helpers entirely.
+
+- [ ] **Step 6.4: Revert sidebar's emojiutil.Sprint to kyoemoji.Sprint**
+
+In `internal/ui/sidebar/model.go`, around line 1348, the call was changed from `kyoemoji.Sprint(token)` to `emojiutil.Sprint(token)` during the debug phase. Revert it:
+
+```go
+rendered := kyoemoji.Sprint(token)
+```
+
+And restore the import block to include `kyoemoji "github.com/kyokomi/emoji/v2"` and remove the now-unused `emojiutil` import (verify it's not used elsewhere in the file with `rg emojiutil internal/ui/sidebar/model.go`).
+
+(The sidebar section-header emojis use the kyokomi codemap directly and intentionally fall back to literal `:shortcode:` text when unknown. We don't apply ShouldRenderUnicode here because section headers are user-configured and out of scope for this fix. A future task can extend it if needed.)
+
+- [ ] **Step 6.5: Build the whole project**
+
+Run: `cd /home/grant/local_code/slk && go build ./...`
+Expected: success, no output. If imports complain, run `goimports -w` on the modified files.
+
+- [ ] **Step 6.6: Run the full test suite**
+
+Run: `cd /home/grant/local_code/slk && go test ./...`
+Expected: All tests PASS.
+
+- [ ] **Step 6.7: Run linter**
+
+Run: `cd /home/grant/local_code/slk && golangci-lint run ./internal/emoji/... ./internal/ui/messages/... ./internal/ui/thread/... ./internal/ui/reactionpicker/... ./internal/ui/sidebar/... ./internal/ui/view_messages.go`
+
+Expected: no findings. If there are findings, fix them inline.
+
+- [ ] **Step 6.8: Commit cleanup**
+
+```bash
+cd /home/grant/local_code/slk && git add -A && git commit -m "chore: remove emoji-width investigation debug artifacts
+
+Reverts the temporary instrumentation added during the emoji-
+width root-cause hunt:
+- SLK_NO_EMOJI env-var passthrough wrapper (internal/emoji/sprint.go)
+- SetWidthMapForTest helper (internal/emoji/test_helpers.go)
+- width_repro_test.go (never reproduced; superseded by ShouldRenderUnicode tests)
+- debugCheckModal + debugDumpLineWidths + dumpFrameIfRequested helpers
+- per-stage line-width logging in renderMessagesTop
+- frame dump and debug log files
+
+Sidebar's section-header emoji call reverts to kyoemoji.Sprint
+(same behavior as before the investigation)."
+```
+
+---
+
+## Task 7: End-to-end verification
+
+**Files:** none — manual smoke + final commit log review.
+
+- [ ] **Step 7.1: Read the commit log**
+
+Run: `cd /home/grant/local_code/slk && git log --oneline -10`
+
+Expected: spec commit (`docs: spec — emoji shortcode fallback`), then six fix/cleanup commits in this order:
+1. `feat(emoji): ShouldRenderUnicode classifier`
+2. `fix(reactions): fall back to :shortcode: for composition-fragile emoji`
+3. `fix(thread): apply shortcode fallback to thread reaction pills`
+4. `fix(picker): use ShouldRenderUnicode (surfaces VS16 emoji)`
+5. `fix(body): apply shortcode fallback to inline message-body emoji`
+6. `chore: remove emoji-width investigation debug artifacts`
+
+- [ ] **Step 7.2: Diff against `main` (or whatever the integration branch is)**
+
+Run: `cd /home/grant/local_code/slk && git diff main --stat`
+
+Expected: new files `internal/emoji/shouldrender.go`, `internal/emoji/shouldrender_test.go`, `internal/emoji/render.go`, `internal/emoji/render_test.go`, `docs/superpowers/specs/2026-05-24-emoji-shortcode-fallback-design.md`, `docs/superpowers/plans/2026-05-24-emoji-shortcode-fallback.md`. Modifications to `internal/ui/messages/model.go`, `internal/ui/messages/render.go`, `internal/ui/thread/model.go`, `internal/ui/reactionpicker/model.go`, `internal/ui/sidebar/model.go`. NO modifications to `internal/ui/view_messages.go` net of the debug additions (it should match `main`).
+
+- [ ] **Step 7.3: User smoke test**
+
+Hand off to the human partner. Manual checks:
+
+1. Open the self-DM with the `:rainbow-flag:` reaction. The reaction pill should now show `:rainbow-flag: 1` (text). The right border on that row should align with surrounding rows.
+2. Open any message with a single-codepoint reaction (`:fire:`, `:smile:`, etc.). The pill should still show the colorful emoji glyph followed by the count.
+3. Open a message with a VS16 reaction (`:heart:`, `:warning:`). The pill should show the colorful emoji glyph.
+4. Open the reaction picker on any message. Confirm VS16 emojis (`:heart:`, `:warning:`, `:white_check_mark:` etc.) are now visible as colorful glyphs (previously hidden as `:name:` text). ZWJ sequences (`:rainbow-flag:`, `:family:`) continue to show as shortcode text.
+5. Confirm `SLK_DEBUG=1 slk` does NOT produce any `slk-frame-dump.txt` (the dumper was removed) and the debug log no longer contains `emoji-width` entries (instrumentation removed).
+
+Once smoke checks pass, the plan is complete.

--- a/docs/superpowers/specs/2026-05-24-emoji-shortcode-fallback-design.md
+++ b/docs/superpowers/specs/2026-05-24-emoji-shortcode-fallback-design.md
@@ -1,0 +1,162 @@
+# Emoji shortcode fallback for composition-fragile sequences
+
+## Problem
+
+Reactions and inline message-body emojis whose Unicode form is a
+multi-codepoint sequence (ZWJ sequences, regional-indicator flag
+pairs, skin-tone modifiers, VS16-anchored compositions) corrupt slk's
+TUI layout when the user's terminal font cannot compose the sequence
+into a single combined glyph.
+
+Concretely observed in kitty + ghostty with their default font stack:
+the pride flag emoji `🏳️‍🌈` (U+1F3F3 U+FE0F U+200D U+1F308) is
+treated by lipgloss/displaywidth as a width-2 grapheme cluster, but
+the terminal font draws the parts as two separate glyphs (white flag
++ rainbow). The cursor advance and the physical pixel rendering
+disagree, and slk's right border lands one column off on the affected
+row. Bug reproduces with `:rainbow-flag:` reactions in any DM/channel.
+
+The root cause is fundamentally outside slk: it is a disagreement
+between three layers (Unicode width tables, terminal width tables,
+font glyph coverage). slk cannot fix the terminal or the font. What
+slk CAN do is decline to render compositionally fragile emoji as
+glyphs, and instead show their Slack-style `:shortcode:` text. Plain
+ASCII text has no width ambiguity.
+
+Precedent: `internal/ui/reactionpicker/model.go:340-351` already does
+this, with an explanatory comment. The rule it uses
+(`len([]rune(unicode)) == 1`) is over-restrictive — it excludes all
+VS16-anchored emoji (`❤️`, `⚠️`, `🏳️`) which most terminal fonts
+DO render correctly. The picker is consequently missing nearly all
+its colorful emoji in the user's terminal.
+
+## Solution
+
+Add a single shared helper that classifies any resolved Unicode emoji
+string as "safe to render as a glyph" or "must fall back to text
+shortcode". The rule:
+
+> Render as glyph iff the string is exactly one codepoint, OR exactly
+> two codepoints where the second is VS16 (U+FE0F). Otherwise render
+> the `:shortcode:` text.
+
+VS16 is well-supported: it merely tells the terminal to use
+emoji-presentation for a single base codepoint, no composition
+required. The composition-fragile cases (ZWJ, regional indicators,
+skin tones) all involve more than one base codepoint and are the ones
+that misbehave when a font lacks the combined glyph.
+
+Apply at every site that resolves shortcode → Unicode for display:
+
+- `internal/ui/messages/model.go:1635` — message-pane reaction pill
+- `internal/ui/thread/model.go:1595` — thread-pane reaction pill
+- `internal/ui/reactionpicker/model.go:347` — picker list (replaces
+  the over-restrictive `len(runes)==1` test, surfacing more colorful
+  emoji)
+- `internal/ui/messages/render.go:564` — message body inline emoji.
+  The current single `emoji.Sprint(text)` call replaces every
+  shortcode in one pass. To apply the per-emoji rule, replace it with
+  a scan that resolves each `:name:` individually: keep the
+  shortcode text when the resolved Unicode fails the rule, swap in
+  the Unicode glyph when it passes.
+
+## Helper API
+
+`internal/emoji/shouldrender.go`:
+
+```go
+// ShouldRenderUnicode reports whether the rendered Unicode form of
+// an emoji is composition-safe: exactly one codepoint, or one
+// codepoint followed by VS16 (U+FE0F). Multi-codepoint sequences
+// (ZWJ, regional-indicator flag pairs, skin-tone modifiers) are
+// rejected because terminal font support for composition is
+// inconsistent and visual width disagreement breaks slk's layout.
+//
+// Callers that resolve a :shortcode: via kyokomi/emoji should use
+// this to decide whether to render the Unicode glyph or keep the
+// shortcode as readable text.
+func ShouldRenderUnicode(unicode string) bool
+```
+
+The implementation walks runes with a tiny state machine; no
+allocations. Empty string returns false.
+
+Truth-table tests in `internal/emoji/shouldrender_test.go` cover:
+
+- single emoji (`🙌` → true)
+- single non-emoji codepoint (`a` → true; harmless edge case)
+- emoji + VS16 (`❤️` → true)
+- non-emoji + VS16 (`#️` → true; rule is structural, not semantic)
+- ZWJ sequence (`🏳️‍🌈` → false)
+- regional indicator pair (`🇺🇸` → false)
+- skin-tone modifier (`👍🏽` → false)
+- text + VS16 + extra codepoint (false)
+- empty string (false)
+
+## Body-text rewrite
+
+The current body-text path is a single `emoji.Sprint(text)` call that
+substitutes every `:shortcode:` in one pass via kyokomi's internal
+scanner. Per-emoji control requires us to resolve emojis one at a
+time. Plan:
+
+1. Add a helper in `internal/emoji/` that scans a string for
+   `:shortcode:` runs, resolves each via the existing codemap +
+   custom-emoji map, applies `ShouldRenderUnicode` to the resolved
+   value, and emits either the Unicode glyph (with kyokomi's
+   trailing-space behavior preserved for compatibility) or the
+   literal shortcode.
+2. `renderInlineFormatting` calls the new helper instead of
+   `emoji.Sprint`.
+3. Custom workspace emoji (`emoji.BuildEntries` / `SetCustomEmoji`)
+   continue to resolve via the existing alias-chain machinery; the
+   resolved Unicode is fed through `ShouldRenderUnicode` like any
+   other.
+
+## Cleanup of debugging artifacts
+
+The investigation that led to this design left several temporary
+additions that must be reverted before shipping:
+
+- `internal/emoji/sprint.go` — the `SLK_NO_EMOJI` env-var wrapper.
+  Delete the file; the new fix is the proper solution.
+- `internal/emoji/test_helpers.go` — `SetWidthMapForTest`. Keep if
+  the new tests use it; otherwise delete.
+- `internal/ui/messages/model.go` — `debugCheckModal` helper.
+  Remove.
+- `internal/ui/view_messages.go` — `debugDumpLineWidths`,
+  `dumpFrameIfRequested`, the per-stage instrumentation in
+  `renderMessagesTop`. Remove. Restore the original imports.
+- `internal/ui/messages/width_repro_test.go` — rewrite as an
+  assertion that ZWJ-reaction messages no longer corrupt borders
+  (using the new helper); or delete if redundant with the helper's
+  truth-table tests.
+- All call sites that switched from `emoji.Sprint` (kyokomi) to
+  `emojiutil.Sprint` (the SLK_NO_EMOJI wrapper) get updated to call
+  the new resolution helper. Restore unused-import cleanups.
+
+## Out of scope
+
+- A probe-based detection that asks the terminal "do you actually
+  compose this ZWJ sequence into a single glyph?" — desirable but
+  hard (DSR-style probing only reports cursor advance, which equals
+  the displaywidth value regardless of glyph coverage). Filed as a
+  follow-up after this ships.
+- Detecting and fixing the underlying lipgloss/displaywidth ZWJ
+  miscount — upstream issue.
+- Replacing kyokomi's trailing-space behavior — orthogonal.
+
+## Acceptance
+
+- Reaction pill containing `:rainbow-flag:` no longer breaks the
+  right border on any row.
+- Reaction picker shows colorful emoji for `:heart:`, `:warning:`,
+  `:rainbow:`, and other VS16-class emoji (previously hidden by the
+  over-restrictive `len(runes)==1` rule).
+- Reaction pills containing skin-toned, ZWJ-composed, or flag
+  emoji render as readable shortcodes instead of broken glyphs.
+- Message body containing inline `:rainbow-flag:` etc. no longer
+  breaks borders.
+- All existing tests pass. New truth-table tests for
+  `ShouldRenderUnicode` pass.
+- All temporary debug instrumentation removed.

--- a/internal/emoji/render.go
+++ b/internal/emoji/render.go
@@ -1,0 +1,38 @@
+package emoji
+
+import (
+	"regexp"
+
+	kyoemoji "github.com/kyokomi/emoji/v2"
+)
+
+// shortcodeRe matches Slack-style emoji shortcodes embedded in text:
+// a colon, a name made of letters/digits/_/+/-, then a closing colon.
+// Anchored by the colons; non-greedy isn't needed because the inner
+// class disallows colons. Matches what Slack permits in custom emoji
+// names plus the kyokomi built-in set.
+var shortcodeRe = regexp.MustCompile(`:[A-Za-z0-9_+\-]+:`)
+
+// ResolveShortcodesInText substitutes safe Slack-style :shortcode:
+// sequences in s with their Unicode glyphs (matching kyokomi/emoji's
+// trailing-space behavior for byte-for-byte parity with the previous
+// emoji.Sprint(text) call). Shortcodes whose resolved Unicode form
+// fails ShouldRenderUnicode (ZWJ sequences, flag pairs, skin-tone
+// modifiers) are left as the literal :name: text so they render as
+// readable shortcodes instead of broken glyphs.
+//
+// Unknown shortcodes pass through unchanged (kyokomi returns the
+// input verbatim for unrecognized names).
+func ResolveShortcodesInText(s string) string {
+	return shortcodeRe.ReplaceAllStringFunc(s, func(match string) string {
+		resolved := kyoemoji.Sprint(match)
+		if resolved == match {
+			// Unrecognized shortcode; pass through.
+			return match
+		}
+		if ShouldRenderUnicode(resolved) {
+			return resolved
+		}
+		return match
+	})
+}

--- a/internal/emoji/render_test.go
+++ b/internal/emoji/render_test.go
@@ -1,0 +1,32 @@
+package emoji
+
+import "testing"
+
+func TestResolveShortcodesInText(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"no shortcodes", "hello world", "hello world"},
+		{"single safe emoji", "look :smile: here", "look 😄  here"},
+		{"single unsafe (ZWJ) emoji stays text", "pride :rainbow_flag: month", "pride :rainbow_flag: month"},
+		{"unsafe with slack hyphen form", "pride :rainbow-flag: month", "pride :rainbow-flag: month"},
+		{"VS16 emoji renders", "love :heart: you", "love ❤️  you"},
+		{"unknown shortcode passes through", "wat :nope: lol", "wat :nope: lol"},
+		{"multiple safe", "hi :smile: and :fire:", "hi 😄  and 🔥 "},
+		{"safe + unsafe mixed", "ok :smile: :rainbow_flag: done", "ok 😄  :rainbow_flag: done"},
+		{"adjacent shortcodes", ":smile::fire:", "😄 🔥 "},
+		{"empty", "", ""},
+		{"colons only", "::", "::"},
+		{"single colon", "a:b", "a:b"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ResolveShortcodesInText(c.input)
+			if got != c.want {
+				t.Errorf("ResolveShortcodesInText(%q) = %q, want %q", c.input, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/emoji/shouldrender.go
+++ b/internal/emoji/shouldrender.go
@@ -1,0 +1,37 @@
+package emoji
+
+import "strings"
+
+// vs16 is U+FE0F, the variation selector that forces emoji presentation
+// for the preceding base codepoint. VS16 is well-supported across
+// terminal fonts because no glyph composition is required — the
+// terminal merely picks the emoji-presentation form of a single base
+// codepoint that the font already has.
+const vs16 rune = 0xFE0F
+
+// ShouldRenderUnicode reports whether the resolved Unicode form of an
+// emoji is composition-safe to render as a glyph. Returns true iff the
+// string contains exactly one base codepoint, or exactly one base
+// codepoint followed by VS16. Multi-codepoint sequences (ZWJ,
+// regional-indicator flag pairs, skin-tone modifiers) return false
+// because terminal font support for composition is inconsistent and
+// the resulting visual-width disagreement breaks slk's layout.
+//
+// Trailing whitespace is ignored — kyokomi/emoji's Sprint appends a
+// trailing space after each resolved emoji and callers occasionally
+// pass that form. Empty strings (after trim) return false.
+func ShouldRenderUnicode(s string) bool {
+	s = strings.TrimRight(s, " \t")
+	if s == "" {
+		return false
+	}
+	runes := []rune(s)
+	switch len(runes) {
+	case 1:
+		return true
+	case 2:
+		return runes[1] == vs16
+	default:
+		return false
+	}
+}

--- a/internal/emoji/shouldrender_test.go
+++ b/internal/emoji/shouldrender_test.go
@@ -1,0 +1,43 @@
+package emoji
+
+import "testing"
+
+func TestShouldRenderUnicode(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		// Single codepoint, emoji presentation.
+		{"single emoji raised hands", "\U0001F64C", true},
+		{"single emoji rainbow", "\U0001F308", true},
+		{"single emoji fire", "\U0001F525", true},
+		// Single non-emoji codepoint (rule is structural; harmless).
+		{"single ascii letter", "a", true},
+		{"single misc symbol", "\u2603", true},
+		// Single base codepoint + VS16 (well-supported composition).
+		{"heart + VS16", "\u2764\uFE0F", true},
+		{"warning + VS16", "\u26A0\uFE0F", true},
+		{"flag base + VS16", "\U0001F3F3\uFE0F", true},
+		// Multi-codepoint composition (the cases the bug is about).
+		{"ZWJ pride flag", "\U0001F3F3\uFE0F\u200D\U0001F308", false},
+		{"ZWJ family", "\U0001F468\u200D\U0001F469\u200D\U0001F467", false},
+		{"regional indicator pair US", "\U0001F1FA\U0001F1F8", false},
+		{"skin-tone modifier", "\U0001F44D\U0001F3FD", false},
+		{"base + VS16 + extra codepoint", "\u2764\uFE0F\u200D\U0001F525", false},
+		// Edge cases.
+		{"empty string", "", false},
+		{"two ascii letters", "ab", false},
+		// Defensive: callers occasionally pass kyokomi's trailing-space form.
+		{"single emoji with trailing space", "\U0001F308 ", true},
+		{"ZWJ with trailing space", "\U0001F3F3\uFE0F\u200D\U0001F308 ", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ShouldRenderUnicode(c.input)
+			if got != c.want {
+				t.Errorf("ShouldRenderUnicode(%q) = %v, want %v", c.input, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/ui/messages/model.go
+++ b/internal/ui/messages/model.go
@@ -18,7 +18,7 @@ import (
 	"github.com/gammons/slk/internal/ui/scrollbar"
 	"github.com/gammons/slk/internal/ui/selection"
 	"github.com/gammons/slk/internal/ui/styles"
-	emoji "github.com/kyokomi/emoji/v2"
+	kyoemoji "github.com/kyokomi/emoji/v2"
 )
 
 type MessageItem struct {
@@ -1268,6 +1268,53 @@ func (m *Model) OldestTS() string {
 // buildCache and partialRebuild share. Computing them once per
 // (width, theme) avoids re-allocating identical lipgloss styles per
 // message during the per-message render loop.
+// debugCheckModal logs any line whose visible width differs from the
+// majority width across the slice. Used to surface the off-by-one
+// emoji-width bug seen in the field. No-op when SLK_DEBUG is unset.
+func debugCheckModal(stage string, lines []string) {
+	if !debuglog.Enabled() {
+		return
+	}
+	if len(lines) <= 1 {
+		return
+	}
+	widths := make([]int, len(lines))
+	counts := make(map[int]int, 4)
+	for i, ln := range lines {
+		w := ansi.StringWidth(ln)
+		widths[i] = w
+		counts[w]++
+	}
+	modal, modalCount := 0, 0
+	for w, n := range counts {
+		if n > modalCount {
+			modal, modalCount = w, n
+		}
+	}
+	if modalCount == len(lines) {
+		return
+	}
+	for i, w := range widths {
+		if w == modal {
+			continue
+		}
+		plain := ansi.Strip(lines[i])
+		if len(plain) > 200 {
+			plain = plain[:200] + "..."
+		}
+		// Dump full raw bytes (including ANSI) so we can inspect exactly
+		// what the line contains. Limit to 600 bytes to keep log readable.
+		raw := lines[i]
+		if len(raw) > 600 {
+			raw = raw[:600] + "...<truncated>"
+		}
+		debuglog.General("[emoji-width] stage=%s modal=%d line=%d visW=%d diff=%+d plain=%q",
+			stage, modal, i, w, w-modal, plain)
+		debuglog.General("[emoji-width-raw] stage=%s line=%d raw=%q",
+			stage, i, raw)
+	}
+}
+
 type cacheStyles struct {
 	borderFill   lipgloss.Style
 	borderInvis  lipgloss.Style
@@ -1632,7 +1679,23 @@ func (m *Model) renderMessagePlain(msg MessageItem, width int, avatarStr string,
 			// base emoji at a well-known width. Skin-toned glyphs render
 			// inconsistently across terminals and tend to break border
 			// alignment regardless of how we measure them.
-			emojiStr := emoji.Sprint(":" + emojiutil.StripSkinTone(r.Emoji) + ":")
+			//
+			// Resolve the shortcode to Unicode and check whether the
+			// resolved form is composition-safe. Multi-codepoint
+			// sequences (ZWJ flags, regional-indicator flag pairs,
+			// any residual skin-tone modifiers) render as broken
+			// glyphs in many terminal fonts and break right-border
+			// alignment; in those cases we display the readable
+			// :shortcode: text instead. See
+			// internal/emoji/shouldrender.go for the rule.
+			nameForLookup := emojiutil.StripSkinTone(r.Emoji)
+			resolved := kyoemoji.Sprint(":" + nameForLookup + ":")
+			var emojiStr string
+			if emojiutil.ShouldRenderUnicode(resolved) {
+				emojiStr = resolved
+			} else {
+				emojiStr = ":" + nameForLookup + ":"
+			}
 			pillText := fmt.Sprintf("%s%d", emojiStr, r.Count)
 			var style lipgloss.Style
 			if isSelected && m.reactionNavActive && i == m.reactionNavIndex {
@@ -2678,11 +2741,21 @@ func (m *Model) View(height, width int) string {
 		visible = m.applySelectionOverlay(visible, overrodeFirst, overrodeLast)
 	}
 
+	// TEMP debug instrumentation (#emoji-width-investigation): check
+	// per-stage width consistency. Modal-width assertion: log any line
+	// whose width differs from the majority.
+	debugCheckModal("messages.View:pre-selectionOverlay", visible)
+
+	// (selection overlay already applied above; re-check after it)
+	debugCheckModal("messages.View:post-selectionOverlay", visible)
+
 	// Overlay a 1-col scrollbar on the right of the message area when content
 	// exceeds the visible height. Chrome (header + separator) is left alone
 	// since it does not scroll.
 	visible = scrollbar.Overlay(visible, width, m.totalLines, m.yOffset, msgAreaHeight,
 		styles.Background, styles.Border, styles.Primary)
+
+	debugCheckModal("messages.View:post-scrollbar", visible)
 
 	return chrome + "\n" + strings.Join(visible, "\n")
 }

--- a/internal/ui/messages/model.go
+++ b/internal/ui/messages/model.go
@@ -1268,53 +1268,6 @@ func (m *Model) OldestTS() string {
 // buildCache and partialRebuild share. Computing them once per
 // (width, theme) avoids re-allocating identical lipgloss styles per
 // message during the per-message render loop.
-// debugCheckModal logs any line whose visible width differs from the
-// majority width across the slice. Used to surface the off-by-one
-// emoji-width bug seen in the field. No-op when SLK_DEBUG is unset.
-func debugCheckModal(stage string, lines []string) {
-	if !debuglog.Enabled() {
-		return
-	}
-	if len(lines) <= 1 {
-		return
-	}
-	widths := make([]int, len(lines))
-	counts := make(map[int]int, 4)
-	for i, ln := range lines {
-		w := ansi.StringWidth(ln)
-		widths[i] = w
-		counts[w]++
-	}
-	modal, modalCount := 0, 0
-	for w, n := range counts {
-		if n > modalCount {
-			modal, modalCount = w, n
-		}
-	}
-	if modalCount == len(lines) {
-		return
-	}
-	for i, w := range widths {
-		if w == modal {
-			continue
-		}
-		plain := ansi.Strip(lines[i])
-		if len(plain) > 200 {
-			plain = plain[:200] + "..."
-		}
-		// Dump full raw bytes (including ANSI) so we can inspect exactly
-		// what the line contains. Limit to 600 bytes to keep log readable.
-		raw := lines[i]
-		if len(raw) > 600 {
-			raw = raw[:600] + "...<truncated>"
-		}
-		debuglog.General("[emoji-width] stage=%s modal=%d line=%d visW=%d diff=%+d plain=%q",
-			stage, modal, i, w, w-modal, plain)
-		debuglog.General("[emoji-width-raw] stage=%s line=%d raw=%q",
-			stage, i, raw)
-	}
-}
-
 type cacheStyles struct {
 	borderFill   lipgloss.Style
 	borderInvis  lipgloss.Style
@@ -2741,21 +2694,11 @@ func (m *Model) View(height, width int) string {
 		visible = m.applySelectionOverlay(visible, overrodeFirst, overrodeLast)
 	}
 
-	// TEMP debug instrumentation (#emoji-width-investigation): check
-	// per-stage width consistency. Modal-width assertion: log any line
-	// whose width differs from the majority.
-	debugCheckModal("messages.View:pre-selectionOverlay", visible)
-
-	// (selection overlay already applied above; re-check after it)
-	debugCheckModal("messages.View:post-selectionOverlay", visible)
-
 	// Overlay a 1-col scrollbar on the right of the message area when content
 	// exceeds the visible height. Chrome (header + separator) is left alone
 	// since it does not scroll.
 	visible = scrollbar.Overlay(visible, width, m.totalLines, m.yOffset, msgAreaHeight,
 		styles.Background, styles.Border, styles.Primary)
-
-	debugCheckModal("messages.View:post-scrollbar", visible)
 
 	return chrome + "\n" + strings.Join(visible, "\n")
 }

--- a/internal/ui/messages/render.go
+++ b/internal/ui/messages/render.go
@@ -11,7 +11,6 @@ import (
 	"github.com/charmbracelet/x/ansi"
 	emojiutil "github.com/gammons/slk/internal/emoji"
 	"github.com/gammons/slk/internal/ui/styles"
-	"github.com/kyokomi/emoji/v2"
 	"github.com/rivo/uniseg"
 )
 
@@ -559,10 +558,16 @@ func renderInlineFormatting(text string, userNames map[string]string, channelNam
 		return mentionStyle().Render("@" + name)
 	})
 
-	// Emoji shortcodes: :red_circle: -> 🔴
-	// Strip skin-tone modifier suffixes from shortcodes first; toned
-	// emoji render inconsistently across terminals and break alignment.
-	text = emoji.Sprint(emojiutil.StripSkinToneFromText(text))
+	// Emoji shortcodes: :red_circle: -> 🔴, but only when the resolved
+	// Unicode form is composition-safe (single codepoint or VS16-
+	// anchored). ZWJ sequences, flag pairs, and skin-tone modifiers
+	// stay as readable :shortcode: text — they break terminal width
+	// arithmetic on many fonts. See internal/emoji/shouldrender.go.
+	//
+	// StripSkinToneFromText runs first because skin-toned shortcodes
+	// (e.g. :wave_tone3:) should resolve as their base name (:wave:)
+	// rather than be left as literal text.
+	text = emojiutil.ResolveShortcodesInText(emojiutil.StripSkinToneFromText(text))
 
 	return text
 }

--- a/internal/ui/overlay/overlay.go
+++ b/internal/ui/overlay/overlay.go
@@ -29,13 +29,28 @@ var kittyPlaceholderPrefix = string(image.PlaceholderRune)
 // frame re-emits the placeholder cells, re-creating the placement
 // without any image-state plumbing. Issue #18.
 func DimmedOverlay(width, height int, background string, box string, dimPercent float64) string {
-	// Step 1: Render background to canvas and dim all cells
+	// Step 1: Render background to canvas and dim all cells.
+	//
+	// Wide characters (emoji, CJK) need two pieces of care:
+	//
+	//   1. Continuation cells (Width==0 at column X+1 after a wide
+	//      char at column X) are layout placeholders, not real
+	//      content; skip them so we don't redundantly process them.
+	//
+	//   2. lipgloss's canvas has a quirk where calling SetCell(x, y,
+	//      cell) on a wide-char position that ALREADY contains that
+	//      wide char destroys the glyph (the canvas seems to drop the
+	//      preserved continuation column). CellAt returns a live
+	//      pointer into the canvas's internal cell storage, so
+	//      mutating cell.Style.{Bg,Fg} in-place propagates without
+	//      any SetCell call — and avoids the wide-char drop. Use that
+	//      path here; do not call SetCell.
 	canvas := lipgloss.NewCanvas(width, height)
 	canvas.Compose(lipgloss.NewLayer(background))
 	for y := 0; y < height; y++ {
 		for x := 0; x < width; x++ {
 			cell := canvas.CellAt(x, y)
-			if cell == nil {
+			if cell == nil || cell.Width == 0 {
 				continue
 			}
 			if strings.HasPrefix(cell.Content, kittyPlaceholderPrefix) {
@@ -53,7 +68,7 @@ func DimmedOverlay(width, height int, background string, box string, dimPercent 
 			if cell.Style.Fg != nil {
 				cell.Style.Fg = lipgloss.Darken(cell.Style.Fg, dimPercent)
 			}
-			canvas.SetCell(x, y, cell)
+			// Intentionally NO canvas.SetCell here — see comment above.
 		}
 	}
 
@@ -77,13 +92,23 @@ func DimmedOverlay(width, height int, background string, box string, dimPercent 
 	modalCanvas := lipgloss.NewCanvas(modalW, modalH)
 	modalCanvas.Compose(lipgloss.NewLayer(box))
 
-	// Step 4: Copy modal cells onto output canvas
+	// Step 4: Copy modal cells onto output canvas.
+	//
+	// Wide characters (emoji, CJK) occupy two grid columns. lipgloss's
+	// canvas reports the wide cell at column X with Width=2 and a
+	// CONTINUATION cell at column X+1 with Content="" Width=0. The
+	// continuation cell is a layout placeholder, not real content;
+	// calling SetCell on it would overwrite the second column of the
+	// wide glyph with empty content, erasing the emoji visually.
+	// Skip Width==0 cells so the wide character that already landed
+	// at column X stays intact across both of its columns.
 	for my := 0; my < modalH; my++ {
 		for mx := 0; mx < modalW; mx++ {
 			cell := modalCanvas.CellAt(mx, my)
-			if cell != nil {
-				outCanvas.SetCell(startX+mx, startY+my, cell)
+			if cell == nil || cell.Width == 0 {
+				continue
 			}
+			outCanvas.SetCell(startX+mx, startY+my, cell)
 		}
 	}
 

--- a/internal/ui/overlay/overlay_widechar_test.go
+++ b/internal/ui/overlay/overlay_widechar_test.go
@@ -1,0 +1,46 @@
+package overlay
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDimmedOverlayPreservesWideCharacter guards the fix for the
+// reaction-picker-shows-no-color-emoji bug. Composing a modal that
+// contains a wide character (emoji 🔥, also CJK glyphs etc.) used to
+// strip the glyph because the step-4 cell-copy loop called SetCell on
+// the wide character's continuation column with an empty-content cell,
+// overwriting the second column of the wide glyph.
+func TestDimmedOverlayPreservesWideCharacter(t *testing.T) {
+	background := strings.Repeat(strings.Repeat(" ", 40)+"\n", 10)
+	box := "🔥 fire"
+	out := DimmedOverlay(40, 10, background, box, 0.5)
+	if !strings.Contains(out, "\U0001F525") {
+		t.Errorf("DimmedOverlay output does NOT contain 🔥; cell-by-cell copy is dropping wide-character glyphs")
+		t.Logf("output (first 200 bytes): %q", truncate(out, 200))
+	}
+}
+
+// TestDimmedOverlayPreservesWideCharsInBackground guards that the
+// SAME bug doesn't bite the step-1 dim-background pass. Even if the
+// modal doesn't overlap a wide char in the background, the dim loop
+// used to call SetCell on every cell — which (lipgloss bug) destroys
+// wide-char glyphs even when called with the same cell back at the
+// same position. Fix: mutate cell colors in-place via the live
+// pointer CellAt returns; don't call SetCell at all.
+func TestDimmedOverlayPreservesWideCharsInBackground(t *testing.T) {
+	background := "🔥 burning\n" + strings.Repeat(strings.Repeat(" ", 40)+"\n", 9)
+	box := "x" // tiny modal positioned in the middle; the emoji row stays uncovered
+	out := DimmedOverlay(40, 10, background, box, 0.5)
+	if !strings.Contains(out, "\U0001F525") {
+		t.Errorf("DimmedOverlay background-dim pass dropped the 🔥 glyph from the un-modaled row")
+		t.Logf("output (first 200 bytes): %q", truncate(out, 200))
+	}
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/internal/ui/reactionpicker/glyph_render_test.go
+++ b/internal/ui/reactionpicker/glyph_render_test.go
@@ -1,0 +1,77 @@
+package reactionpicker
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPickerRendersFireGlyph guards the composition-safe emoji
+// fallback fix at /home/grant/local_code/slk/docs/superpowers/specs/2026-05-24-emoji-shortcode-fallback-design.md.
+// Opens the picker, types "fire", renders the frame, and asserts the
+// 🔥 glyph (U+1F525) is present in the output — confirming the
+// picker did NOT fall back to literal ":fire:" text for a simple
+// single-codepoint emoji.
+//
+// Regression target: the picker's previous len(runes)==1 rule also
+// reported true for :fire: so this test would have passed before too.
+// What it really guards is the broader ShouldRenderUnicode wiring:
+// if a future refactor accidentally hides single-codepoint emoji
+// behind the shortcode fallback, this test fails.
+func TestPickerRendersFireGlyph(t *testing.T) {
+	m := New()
+	m.SetFrecentEmoji([]EmojiEntry{})
+	m.Open("Cxxx", "1.0", nil)
+	for _, ch := range "fire" {
+		m.HandleKey(string(ch))
+	}
+	view := m.View(120)
+	if !strings.Contains(view, "\U0001F525") {
+		t.Errorf("rendered picker does NOT contain 🔥 glyph for :fire: search")
+		lines := strings.Split(view, "\n")
+		for i, ln := range lines {
+			if i > 20 {
+				break
+			}
+			t.Logf("line %d: %q", i, ln)
+		}
+	}
+}
+
+// TestPickerRendersHeartGlyph guards that VS16-anchored emoji
+// (single base + U+FE0F) DO render as a glyph. This is the case
+// that the picker's previous len(runes)==1 rule incorrectly
+// excluded — surfacing it again was a key win of the
+// ShouldRenderUnicode-based rule.
+func TestPickerRendersHeartGlyph(t *testing.T) {
+	m := New()
+	m.SetFrecentEmoji([]EmojiEntry{})
+	m.Open("Cxxx", "1.0", nil)
+	for _, ch := range "heart" {
+		m.HandleKey(string(ch))
+	}
+	view := m.View(120)
+	if !strings.Contains(view, "\u2764\uFE0F") {
+		t.Errorf("rendered picker does NOT contain ❤️ glyph (VS16-anchored) for :heart: search")
+	}
+}
+
+// TestPickerFallsBackForZWJSequence guards the OTHER side of the
+// fix: composition-fragile emoji (ZWJ sequences, here the pride
+// flag) must fall back to the literal :name: text, NOT render as
+// the broken-glyph Unicode sequence.
+func TestPickerFallsBackForZWJSequence(t *testing.T) {
+	m := New()
+	m.SetFrecentEmoji([]EmojiEntry{})
+	m.Open("Cxxx", "1.0", nil)
+	for _, ch := range "rainbow_f" {
+		m.HandleKey(string(ch))
+	}
+	view := m.View(120)
+	if !strings.Contains(view, ":rainbow_flag:") {
+		t.Errorf("rendered picker does NOT contain literal :rainbow_flag: for ZWJ-sequence emoji")
+	}
+	// And it must NOT contain the actual ZWJ pride flag glyph.
+	if strings.Contains(view, "\U0001F3F3\uFE0F\u200D\U0001F308") {
+		t.Errorf("rendered picker contains 🏳️‍🌈 Unicode glyph; expected :rainbow_flag: text fallback")
+	}
+}

--- a/internal/ui/reactionpicker/glyph_render_test.go
+++ b/internal/ui/reactionpicker/glyph_render_test.go
@@ -37,6 +37,28 @@ func TestPickerRendersFireGlyph(t *testing.T) {
 	}
 }
 
+// TestViewOverlayPreservesFireGlyph guards that going through
+// ViewOverlay (which uses lipgloss.NewCanvas cell-by-cell compositing)
+// preserves the wide emoji glyph. Caught a real bug where the canvas
+// overlay path was dropping wide-character cells.
+func TestViewOverlayPreservesFireGlyph(t *testing.T) {
+	m := New()
+	m.SetFrecentEmoji([]EmojiEntry{})
+	m.Open("Cxxx", "1.0", nil)
+	for _, ch := range "fire" {
+		m.HandleKey(string(ch))
+	}
+	background := strings.Repeat(" \n", 30)
+	overlaid := m.ViewOverlay(120, 30, background)
+	if !strings.Contains(overlaid, "\U0001F525") {
+		t.Errorf("ViewOverlay output does NOT contain 🔥 glyph (canvas/overlay compositing stripped it)")
+		// Compare against View() output to confirm it's the overlay path
+		view := m.View(120)
+		hasFireInView := strings.Contains(view, "\U0001F525")
+		t.Logf("View() contains 🔥: %v (if true, bug is in ViewOverlay/DimmedOverlay)", hasFireInView)
+	}
+}
+
 // TestPickerRendersHeartGlyph guards that VS16-anchored emoji
 // (single base + U+FE0F) DO render as a glyph. This is the case
 // that the picker's previous len(runes)==1 rule incorrectly

--- a/internal/ui/reactionpicker/model.go
+++ b/internal/ui/reactionpicker/model.go
@@ -58,7 +58,7 @@ func (m *Model) buildEmojiList() {
 			continue
 		}
 		seen[name] = true
-		m.allEmoji = append(m.allEmoji, EmojiEntry{Name: name, Unicode: unicode})
+		m.allEmoji = append(m.allEmoji, EmojiEntry{Name: name, Unicode: strings.TrimRight(unicode, " ")})
 	}
 
 	sort.Slice(m.allEmoji, func(i, j int) bool {
@@ -337,14 +337,14 @@ func (m *Model) renderBox(termWidth int) string {
 	var resultRows []string
 	for i := start; i < end; i++ {
 		entry := list[i]
-		// Display Unicode emoji only for single-codepoint characters.
-		// Multi-codepoint emoji (skin tones, ZWJ sequences, flags) have
-		// terminal widths that disagree with go-runewidth, breaking borders.
-		// runewidth.StringWidth() is unreliable for these — it returns 2
-		// for skin tone variants that render as 4 cells. Rune count is
-		// the reliable signal: 1 rune = predictable width, 2+ = problematic.
+		// Display Unicode emoji when the resolved form is composition-
+		// safe (single base codepoint, optionally + VS16). Multi-
+		// codepoint sequences (ZWJ, regional-indicator flags, skin
+		// tones) render as broken glyphs in many terminal fonts and
+		// corrupt the picker's width arithmetic. See
+		// internal/emoji/shouldrender.go.
 		var line string
-		if len([]rune(entry.Unicode)) == 1 {
+		if slkemoji.ShouldRenderUnicode(entry.Unicode) {
 			line = entry.Unicode + " " + entry.Name
 		} else {
 			line = ":" + entry.Name + ":"

--- a/internal/ui/thread/model.go
+++ b/internal/ui/thread/model.go
@@ -11,7 +11,6 @@ import (
 	"github.com/charmbracelet/x/ansi"
 	"github.com/gammons/slk/internal/debuglog"
 	emojiutil "github.com/gammons/slk/internal/emoji"
-	emoji "github.com/kyokomi/emoji/v2"
 
 	imgpkg "github.com/gammons/slk/internal/image"
 	"github.com/gammons/slk/internal/ui/imgrender"
@@ -19,6 +18,7 @@ import (
 	"github.com/gammons/slk/internal/ui/scrollbar"
 	"github.com/gammons/slk/internal/ui/selection"
 	"github.com/gammons/slk/internal/ui/styles"
+	kyoemoji "github.com/kyokomi/emoji/v2"
 )
 
 var thickLeftBorder = lipgloss.Border{Left: "▌"}
@@ -1592,7 +1592,23 @@ func (m *Model) renderThreadMessage(msg messages.MessageItem, width int, userNam
 			// base emoji at a well-known width. Skin-toned glyphs render
 			// inconsistently across terminals and tend to break border
 			// alignment regardless of how we measure them.
-			emojiStr := emoji.Sprint(":" + emojiutil.StripSkinTone(r.Emoji) + ":")
+			//
+			// Resolve the shortcode to Unicode and check whether the
+			// resolved form is composition-safe. Multi-codepoint
+			// sequences (ZWJ flags, regional-indicator flag pairs,
+			// any residual skin-tone modifiers) render as broken
+			// glyphs in many terminal fonts and break right-border
+			// alignment; in those cases we display the readable
+			// :shortcode: text instead. Mirror of the message-pane
+			// fix; see internal/emoji/shouldrender.go.
+			nameForLookup := emojiutil.StripSkinTone(r.Emoji)
+			resolved := kyoemoji.Sprint(":" + nameForLookup + ":")
+			var emojiStr string
+			if emojiutil.ShouldRenderUnicode(resolved) {
+				emojiStr = resolved
+			} else {
+				emojiStr = ":" + nameForLookup + ":"
+			}
 			pillText := fmt.Sprintf("%s%d", emojiStr, r.Count)
 			var style lipgloss.Style
 			if isSelected && m.reactionNavActive && i == m.reactionNavIndex {


### PR DESCRIPTION
## Summary

Fixes the right-border-breaks-on-emoji bug observed in kitty/ghostty:
ZWJ-sequence emoji (like the pride flag) caused message-pane row widths to
desync from slk's layout, breaking the border and selection highlight on
affected rows.

Root cause was twofold:

1. **Composition-fragile emoji.** Multi-codepoint emoji sequences (ZWJ
   flags, regional-indicator flag pairs, skin-tone modifiers, VS16-anchored
   compositions where the font lacks the combined glyph) render at
   visual widths that disagree with what \`lipgloss\`/\`displaywidth\`
   reports. slk has no general way to detect this from the terminal, so
   the fix declines to render those forms as glyphs and shows their
   \`:shortcode:\` text instead.

2. **Lipgloss canvas wide-character drop** in \`DimmedOverlay\` (surfaced
   when the picker change started letting more emoji through to the
   canvas-overlay path). \`canvas.SetCell\` destroys wide-character
   glyphs when called on the continuation column or on the wide cell's
   own position. This was making every emoji in the reaction picker
   invisible.

## Changes

- New \`internal/emoji.ShouldRenderUnicode\` classifier: single codepoint
  or single codepoint + VS16 returns true; multi-codepoint sequences
  return false. Truth-table tests.
- New \`internal/emoji.ResolveShortcodesInText\` for body-text inline
  emoji that resolves each shortcode individually and applies the rule.
- Wired into message-pane reaction pills, thread-pane reaction pills,
  reaction picker (replaces the over-strict \`len(runes)==1\` rule —
  which was also hiding all VS16-anchored colorful emoji from the
  picker), and message-body inline emoji.
- Fixed \`DimmedOverlay\` cell-copy loops to skip continuation cells
  and avoid \`SetCell\` round-trips that drop wide chars.

## Test Plan

- [x] \`go test ./...\` — all packages pass
- [x] Manual: reaction pill for \`:rainbow-flag:\` renders as text, right
  border aligned with surrounding rows
- [x] Manual: simple emoji reactions (\`:fire:\`, \`:smile:\`) still
  render as colorful glyphs
- [x] Manual: VS16 emoji (\`:heart:\`, \`:warning:\`) render as colorful
  glyphs
- [x] Manual: reaction picker now shows colorful emoji glyphs (was
  showing all as monochrome text)
- [x] Manual: body text inline \`:rainbow-flag:\` stays as shortcode

## Spec / Plan

- spec: \`docs/superpowers/specs/2026-05-24-emoji-shortcode-fallback-design.md\`
- plan: \`docs/superpowers/plans/2026-05-24-emoji-shortcode-fallback.md\`

🤖 Generated with [opencode](https://opencode.ai)