### PR TITLE
feat(thread): show date dividers between replies on different days

### DIFF
--- a/internal/ui/messages/model.go
+++ b/internal/ui/messages/model.go
@@ -1559,9 +1559,9 @@ func (m *Model) buildCache(width int) {
 	var lastDate string
 	newMsgLandmarkInserted := false
 	for i, msg := range m.messages {
-		msgDate := dateFromTS(msg.TS)
+		msgDate := DateFromTS(msg.TS)
 		if msgDate != "" && msgDate != lastDate {
-			label := formatDateSeparator(msgDate)
+			label := FormatDateSeparator(msgDate)
 			sepStr := "── " + label + " ──"
 			sep := lipgloss.NewStyle().Background(styles.Background).Foreground(styles.TextMuted).Bold(true).
 				Width(width).Align(lipgloss.Center).
@@ -3000,7 +3000,11 @@ func (m *Model) applySelectionOverlay(visible []string, skipFirst, skipLast bool
 	return visible
 }
 
-func dateFromTS(ts string) string {
+// DateFromTS returns the local-day date string ("2006-01-02") for a
+// Slack timestamp (e.g. "1700000000.000100"), or "" if the TS can't be
+// parsed. Exported so the thread pane can reuse the same day-boundary
+// computation that drives the channel pane's date separators.
+func DateFromTS(ts string) string {
 	parts := strings.SplitN(ts, ".", 2)
 	if len(parts) == 0 {
 		return ""
@@ -3012,7 +3016,12 @@ func dateFromTS(ts string) string {
 	return time.Unix(sec, 0).Format("2006-01-02")
 }
 
-func formatDateSeparator(dateStr string) string {
+// FormatDateSeparator turns a "2006-01-02" date string into the
+// human-readable label used in day-divider rows ("Today", "Yesterday",
+// a weekday name within the last week, or a fully-qualified date).
+// Exported so the thread pane renders identical labels to the channel
+// pane.
+func FormatDateSeparator(dateStr string) string {
 	d, err := time.Parse("2006-01-02", dateStr)
 	if err != nil {
 		return dateStr

--- a/internal/ui/thread/model.go
+++ b/internal/ui/thread/model.go
@@ -1393,6 +1393,23 @@ func (m *Model) View(height, width int) string {
 		}
 		landmarkInserted := false
 
+		// Day-divider style for "── Today ──" / "── Yesterday ──" /
+		// weekday / fully-qualified date rows inserted between replies on
+		// different local days. Mirrors the channel pane's date separator
+		// (see internal/ui/messages/model.go: buildCache). Like
+		// replySeparator and newLandmark, these rows live OUTSIDE any
+		// cache entry so selection overlay and extraction skip them
+		// naturally. lastDate is seeded from the parent so the divider
+		// only fires when a reply lands on a day different from the
+		// parent's day.
+		dateSeparatorStyle := lipgloss.NewStyle().
+			Width(width).
+			Background(styles.Background).
+			Foreground(styles.TextMuted).
+			Bold(true).
+			Align(lipgloss.Center)
+		lastDate := messages.DateFromTS(m.parent.TS)
+
 		// viewContent begins with the parent message block so the parent
 		// scrolls together with the replies. entryOffsets / selectedStartLine
 		// / m.totalLines are built in parent-inclusive coordinates from here
@@ -1421,6 +1438,23 @@ func (m *Model) View(height, width int) string {
 		m.entryOffsets = m.entryOffsets[:0]
 
 		for i, e := range m.cache {
+			// Insert a centered day-divider row when this reply's local
+			// day differs from the previous one (seeded with the parent's
+			// day). Sits ABOVE both the unread landmark and the reply
+			// itself so users see e.g. "── Yesterday ──" before any
+			// replies from yesterday — matching the channel pane's
+			// behavior. Falls through silently when the TS can't be
+			// parsed.
+			if i < len(m.replies) {
+				replyDate := messages.DateFromTS(m.replies[i].TS)
+				if replyDate != "" && replyDate != lastDate {
+					divider := dateSeparatorStyle.Render("── " + messages.FormatDateSeparator(replyDate) + " ──")
+					allRows = append(allRows, divider)
+					currentLine++
+					lastDate = replyDate
+				}
+			}
+
 			// Insert the new-reply landmark before the first reply whose
 			// TS exceeds the unread boundary. We check this BEFORE
 			// recording the entry offset so the landmark sits above

--- a/internal/ui/thread/model_test.go
+++ b/internal/ui/thread/model_test.go
@@ -154,6 +154,60 @@ func TestViewRendersContent(t *testing.T) {
 	}
 }
 
+// TestViewInsertsDateSeparatorAcrossDays asserts that the thread view
+// inserts a centered date-divider row above a reply whose local day
+// differs from the parent's, and that no divider is emitted when every
+// reply lands on the parent's day. Mirrors the channel pane's
+// day-boundary divider so threads that span days are legible at a
+// glance.
+func TestViewInsertsDateSeparatorAcrossDays(t *testing.T) {
+	const parentTS = "1700000000.000000" // 2023-11-14 22:13:20 UTC
+	// 48 hours later — guaranteed to land on a different LOCAL day in
+	// every timezone, so the assertion is timezone-independent.
+	const dayLaterTS = "1700172800.000000"
+	// Same minute as the parent — same local day in every timezone.
+	const sameDayTS = "1700000060.000000"
+
+	parentDateLabel := messages.FormatDateSeparator(messages.DateFromTS(parentTS))
+	laterDateLabel := messages.FormatDateSeparator(messages.DateFromTS(dayLaterTS))
+	if parentDateLabel == laterDateLabel {
+		t.Fatalf("test fixture broken: parent (%q) and later (%q) resolved to the same label", parentDateLabel, laterDateLabel)
+	}
+
+	// Case 1: reply spans into a new day -> divider for the later day
+	// must appear; the parent's own day must NOT appear as a divider
+	// (the parent sits in its own chrome block, not a divider row).
+	m := New()
+	parent := messages.MessageItem{TS: parentTS, UserName: "alice", Text: "parent", Timestamp: "10:30 PM"}
+	replies := []messages.MessageItem{
+		{TS: sameDayTS, UserName: "bob", Text: "same-day reply", Timestamp: "10:31 PM"},
+		{TS: dayLaterTS, UserName: "carol", Text: "next-day reply", Timestamp: "10:33 PM"},
+	}
+	m.SetThread(parent, replies, "C1", parentTS)
+
+	plain := ansi.Strip(m.View(40, 80))
+	if !strings.Contains(plain, laterDateLabel) {
+		t.Errorf("expected view to contain day-divider label %q for reply on a later day; got:\n%s", laterDateLabel, plain)
+	}
+	if strings.Contains(plain, "── "+parentDateLabel+" ──") {
+		t.Errorf("did not expect a date divider for the parent's own day (%q); got:\n%s", parentDateLabel, plain)
+	}
+	// Sanity: the centered divider is bracketed by box-drawing dashes.
+	if !strings.Contains(plain, "── "+laterDateLabel+" ──") {
+		t.Errorf("expected centered divider \"── %s ──\"; got:\n%s", laterDateLabel, plain)
+	}
+
+	// Case 2: every reply on the parent's day -> no divider at all.
+	m2 := New()
+	m2.SetThread(parent, []messages.MessageItem{
+		{TS: sameDayTS, UserName: "bob", Text: "same-day reply", Timestamp: "10:31 PM"},
+	}, "C1", parentTS)
+	plain2 := ansi.Strip(m2.View(40, 80))
+	if strings.Contains(plain2, "── "+parentDateLabel+" ──") || strings.Contains(plain2, "── "+laterDateLabel+" ──") {
+		t.Errorf("did not expect any date divider when all replies share the parent's day; got:\n%s", plain2)
+	}
+}
+
 func TestUpdateMessageInPlace_Found(t *testing.T) {
 	m := New()
 	parent := messages.MessageItem{TS: "P1", Text: "parent"}


### PR DESCRIPTION
Closes #27.

The thread reply pane rendered only a time-of-day timestamp on each reply (e.g. `10:31 AM`), so a thread that spanned days gave no way to tell when a reply actually landed. This mirrors the channel pane's existing day-boundary divider (`── Today ──` / `── Yesterday ──` / weekday / fully-qualified date) so threads stay legible at a glance.

## Change

- Export `DateFromTS` and `FormatDateSeparator` from `internal/ui/messages` so both panes share one implementation of the day label.
- In `thread.Model.View`, seed `lastDate` from the parent's TS and insert a centered `── <label> ──` row above any reply whose local day differs from the previous one. Seeding from the parent means:
  - No divider appears above the parent itself (it has its own chrome block).
  - No divider appears above the first reply when it shares the parent's day.
- Divider rows live **outside** any cache entry — same convention already used by `replySeparator` and the unread `── new ──` landmark — so selection overlay/extraction skip them naturally, and reaction hit-rect translation (which keys off `entryOffsets`) continues to work unchanged.

## Test

Added `TestViewInsertsDateSeparatorAcrossDays` (`internal/ui/thread/model_test.go`):

- Builds a thread where one reply is 48h after the parent — guaranteed to land on a different local day in every timezone, so the assertion is TZ-independent.
- Asserts the next-day divider label appears in the rendered view.
- Asserts no divider for the parent's own day (the parent sits in its chrome block, not a divider row).
- Second case: every reply on the parent's day → no divider emitted.

## Verification

- `go test ./...` — all packages pass.
- `go vet ./...` — clean.