### PR TITLE
fix: drop VS16 carve-out from emoji glyph rule

### DIFF
--- a/internal/emoji/render_test.go
+++ b/internal/emoji/render_test.go
@@ -12,7 +12,7 @@ func TestResolveShortcodesInText(t *testing.T) {
 		{"single safe emoji", "look :smile: here", "look 😄  here"},
 		{"single unsafe (ZWJ) emoji stays text", "pride :rainbow_flag: month", "pride :rainbow_flag: month"},
 		{"unsafe with slack hyphen form", "pride :rainbow-flag: month", "pride :rainbow-flag: month"},
-		{"VS16 emoji renders", "love :heart: you", "love ❤️  you"},
+		{"VS16 emoji stays as shortcode", "love :heart: you", "love :heart: you"},
 		{"unknown shortcode passes through", "wat :nope: lol", "wat :nope: lol"},
 		{"multiple safe", "hi :smile: and :fire:", "hi 😄  and 🔥 "},
 		{"safe + unsafe mixed", "ok :smile: :rainbow_flag: done", "ok 😄  :rainbow_flag: done"},

--- a/internal/emoji/shouldrender.go
+++ b/internal/emoji/shouldrender.go
@@ -2,20 +2,20 @@ package emoji
 
 import "strings"
 
-// vs16 is U+FE0F, the variation selector that forces emoji presentation
-// for the preceding base codepoint. VS16 is well-supported across
-// terminal fonts because no glyph composition is required — the
-// terminal merely picks the emoji-presentation form of a single base
-// codepoint that the font already has.
-const vs16 rune = 0xFE0F
-
 // ShouldRenderUnicode reports whether the resolved Unicode form of an
-// emoji is composition-safe to render as a glyph. Returns true iff the
-// string contains exactly one base codepoint, or exactly one base
-// codepoint followed by VS16. Multi-codepoint sequences (ZWJ,
-// regional-indicator flag pairs, skin-tone modifiers) return false
-// because terminal font support for composition is inconsistent and
-// the resulting visual-width disagreement breaks slk's layout.
+// emoji is safe to render as a glyph. Returns true iff the string
+// contains exactly one codepoint. Any multi-codepoint sequence —
+// including base+VS16 (`❤️`, `⚠️`, `🌩️`), ZWJ sequences,
+// regional-indicator flag pairs, and skin-tone modifiers — returns
+// false.
+//
+// VS16 (U+FE0F) was previously treated as a "safe composition" but
+// field experience disagreed: many terminal+font combos render
+// VS16-anchored emoji from the legacy blocks (U+2600-2BFF and
+// U+1F300-1F5FF) at a different visual width than lipgloss reports,
+// breaking border alignment. Dropping the VS16 carve-out is the
+// pragmatic tradeoff: lose the colorful presentation for `:heart:`,
+// `:warning:`, `:lightning:`, etc., gain reliable layout.
 //
 // Trailing whitespace is ignored — kyokomi/emoji's Sprint appends a
 // trailing space after each resolved emoji and callers occasionally
@@ -26,12 +26,5 @@ func ShouldRenderUnicode(s string) bool {
 		return false
 	}
 	runes := []rune(s)
-	switch len(runes) {
-	case 1:
-		return true
-	case 2:
-		return runes[1] == vs16
-	default:
-		return false
-	}
+	return len(runes) == 1
 }

--- a/internal/emoji/shouldrender_test.go
+++ b/internal/emoji/shouldrender_test.go
@@ -15,10 +15,12 @@ func TestShouldRenderUnicode(t *testing.T) {
 		// Single non-emoji codepoint (rule is structural; harmless).
 		{"single ascii letter", "a", true},
 		{"single misc symbol", "\u2603", true},
-		// Single base codepoint + VS16 (well-supported composition).
-		{"heart + VS16", "\u2764\uFE0F", true},
-		{"warning + VS16", "\u26A0\uFE0F", true},
-		{"flag base + VS16", "\U0001F3F3\uFE0F", true},
+		// Single base codepoint + VS16. Previously rendered as glyph;
+		// now falls back to shortcode because font support for
+		// VS16 emoji presentation in legacy blocks is inconsistent.
+		{"heart + VS16", "\u2764\uFE0F", false},
+		{"warning + VS16", "\u26A0\uFE0F", false},
+		{"flag base + VS16", "\U0001F3F3\uFE0F", false},
 		// Multi-codepoint composition (the cases the bug is about).
 		{"ZWJ pride flag", "\U0001F3F3\uFE0F\u200D\U0001F308", false},
 		{"ZWJ family", "\U0001F468\u200D\U0001F469\u200D\U0001F467", false},

--- a/internal/ui/reactionpicker/glyph_render_test.go
+++ b/internal/ui/reactionpicker/glyph_render_test.go
@@ -59,12 +59,13 @@ func TestViewOverlayPreservesFireGlyph(t *testing.T) {
 	}
 }
 
-// TestPickerRendersHeartGlyph guards that VS16-anchored emoji
-// (single base + U+FE0F) DO render as a glyph. This is the case
-// that the picker's previous len(runes)==1 rule incorrectly
-// excluded — surfacing it again was a key win of the
-// ShouldRenderUnicode-based rule.
-func TestPickerRendersHeartGlyph(t *testing.T) {
+// TestPickerFallsBackForVS16Emoji guards that VS16-anchored emoji
+// (single base + U+FE0F) now fall back to :name: text rather than
+// rendering the Unicode glyph. Many terminal+font combos render
+// VS16 emoji from legacy blocks at a different visual width than
+// lipgloss reports, breaking border alignment; the shortcode form
+// is layout-safe.
+func TestPickerFallsBackForVS16Emoji(t *testing.T) {
 	m := New()
 	m.SetFrecentEmoji([]EmojiEntry{})
 	m.Open("Cxxx", "1.0", nil)
@@ -72,8 +73,11 @@ func TestPickerRendersHeartGlyph(t *testing.T) {
 		m.HandleKey(string(ch))
 	}
 	view := m.View(120)
-	if !strings.Contains(view, "\u2764\uFE0F") {
-		t.Errorf("rendered picker does NOT contain ❤️ glyph (VS16-anchored) for :heart: search")
+	if !strings.Contains(view, ":heart:") {
+		t.Errorf("rendered picker does NOT contain literal :heart: text for VS16-anchored emoji")
+	}
+	if strings.Contains(view, "\u2764\uFE0F") {
+		t.Errorf("rendered picker contains ❤️ Unicode glyph; expected :heart: text fallback")
 	}
 }
 


### PR DESCRIPTION
## Summary

Tightens \`emoji.ShouldRenderUnicode\` to render Unicode only for
strings of exactly one codepoint. Any multi-codepoint sequence —
including base+VS16 pairs (\`❤️\`, \`⚠️\`, \`🌩️\`), ZWJ sequences,
regional-indicator flag pairs, and skin-tone modifiers — falls back
to readable \`:shortcode:\` text.

## Why

The previous rule (#30) allowed base+VS16 pairs through to the
Unicode glyph path on the theory that VS16 "doesn't require
composition." Field experience shows that's wrong: many terminal+font
combos render VS16 emoji from the legacy blocks (U+2600-2BFF and
U+1F300-1F5FF) at a different visual width than lipgloss reports,
breaking border alignment exactly like the ZWJ cases.

Confirmed examples that broke borders before this PR:

- \`:lightning:\` → U+1F329 + U+FE0F (cloud with lightning)
- \`:heart:\` → U+2764 + U+FE0F
- \`:warning:\` → U+26A0 + U+FE0F
- \`:flag_white:\` → U+1F3F3 + U+FE0F (and any other lone-flag base)

User-confirmed in production: this PR fixes 100% of the remaining
emoji-related width breaks.

## Trade-off

Reactions, picker, and inline message body emoji for VS16-anchored
codepoints lose their colorful glyph and show the readable shortcode
instead. Pure single-codepoint modern-block emoji (🔥 🌈 🎉 🚀 🙌
🌮 🍷 etc.) are unaffected.

## Test Plan

- [x] \`go test ./...\` — all packages pass
- [x] Manual: \`:lightning:\`, \`:heart:\`, \`:warning:\` in body and reactions all render as shortcode text; no border breaks
- [x] Manual: \`:fire:\`, \`:rainbow:\`, \`:tada:\`, \`:rocket:\` still render as colorful glyphs
- [x] Manual: picker shows colorful glyphs for single-codepoint emoji, shortcodes for VS16/ZWJ/flag/skin-tone

🤖 Generated with [opencode](https://opencode.ai)