### PR TITLE
feat: Ctrl+N new message picker (DM + group DM)

### DIFF
--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -917,6 +917,33 @@ func run() error {
 				// off the Update goroutine.
 				wctx.Membership.EnsureFresh(context.Background(), string(channelID))
 			},
+			OpenConversation: func(userIDs []string, requestID uint64) tea.Cmd {
+				wctx := router.Active()
+				if wctx == nil {
+					return func() tea.Msg {
+						return ui.NewMessageFailedMsg{
+							RequestID: requestID,
+							Err:       fmt.Errorf("no active workspace"),
+						}
+					}
+				}
+				client := wctx.Client
+				return func() tea.Msg {
+					channelID, alreadyOpen, err := client.OpenConversation(ctx, userIDs)
+					if err != nil {
+						return ui.NewMessageFailedMsg{
+							RequestID: requestID,
+							Err:       err,
+						}
+					}
+					return ui.NewMessageOpenedMsg{
+						ChannelID:   channelID,
+						AlreadyOpen: alreadyOpen,
+						UserIDs:     userIDs,
+						RequestID:   requestID,
+					}
+				}
+			},
 			Fetch: func(channelID ids.ChannelID, channelName string) tea.Msg {
 				chIDStr := string(channelID)
 				wctx := router.Active()

--- a/docs/superpowers/plans/2026-05-25-ansi-palette-themes.md
+++ b/docs/superpowers/plans/2026-05-25-ansi-palette-themes.md
@@ -1,0 +1,1077 @@
+# ANSI-palette themes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add two built-in themes (`ansi-dark`, `ansi-light`) that use ANSI 16 color codes so slk inherits the user's terminal palette.
+
+**Architecture:** Three coordinated changes to `internal/ui/messages/render.go` plus two theme entries in `internal/ui/styles/themes.go`. (1) Teach `bgANSIFor`/`fgANSIFor` to emit native ANSI 16 / 256 escapes for `ansi.BasicColor`/`ansi.IndexedColor` colors so palette inheritance reaches slk's hand-rolled escape path. (2) Add a grammar-aware SGR bg-parameter substitution helper that correctly handles short ANSI params like `"40"` without colliding with 256-color sub-arguments. (3) Wire that helper into `RepaintBgToSelectionTint`. Then add two theme entries using `"0"`–`"15"` ANSI 16 number strings.
+
+**Tech Stack:** Go, `charm.land/lipgloss/v2`, `github.com/charmbracelet/x/ansi`, `image/color`.
+
+**Spec:** `docs/superpowers/specs/2026-05-25-ansi-palette-themes-design.md`
+
+---
+
+## File structure
+
+- **Modify** `internal/ui/messages/render.go`
+  - `bgANSIFor` / `fgANSIFor`: type-switch on `color.Color` to emit basic ANSI / 256 / truecolor variants.
+  - New unexported helper `substituteBgSGR(s, fromParam, toParam string) string` — grammar-aware substitution that walks `\x1b[…m` SGR sequences and replaces bg tokens whose stringified form equals `fromParam` with `toParam`. Knows about `48;5;N` and `48;2;R;G;B` so the `N` and `R/G/B` arguments are never matched against `fromParam`.
+  - `RepaintBgToSelectionTint`: switch from `strings.ReplaceAll` to the new helper.
+
+- **Modify** `internal/ui/messages/render_test.go`
+  - Add tests for the three changes above.
+
+- **Modify** `internal/ui/styles/themes.go`
+  - Add two map entries to `builtinThemes`: `"ansi-dark"` and `"ansi-light"`.
+
+- **Modify** `internal/ui/styles/themes_test.go`
+  - Add tests asserting both themes registered, have all required color fields, and that values resolve to `ansi.BasicColor`.
+
+- **Modify** `wiki/Configuration.md`
+  - Short subsection in the themes area describing the new themes.
+
+- **Modify** `README.md`
+  - Update theme count.
+
+---
+
+## Task 1: ANSI-aware `bgANSIFor` / `fgANSIFor`
+
+**Files:**
+- Modify: `internal/ui/messages/render.go:348-358`
+- Test: `internal/ui/messages/render_test.go`
+
+**Why:** Today these functions always emit `\x1b[48;2;R;G;Bm` truecolor. For a theme that uses `ansi.BasicColor`, this loses the "this is ANSI red" signal and the user's terminal palette is bypassed (truecolor escapes are not palette-translated). Type-switching on the color preserves palette inheritance.
+
+- [ ] **Step 1.1: Write the failing test**
+
+Append to `internal/ui/messages/render_test.go`:
+
+```go
+// TestBgANSIForBasicColor asserts that bgANSIFor emits native ANSI 16
+// background escapes (e.g. "\x1b[41m") for ansi.BasicColor instead of
+// degrading to truecolor. Native ANSI 16 escapes are required for the
+// terminal palette to be honored — truecolor escapes always bypass it.
+func TestBgANSIForBasicColor(t *testing.T) {
+	cases := []struct {
+		name string
+		c    ansi.BasicColor
+		want string
+	}{
+		{"black", 0, "\x1b[40m"},
+		{"red", 1, "\x1b[41m"},
+		{"white", 7, "\x1b[47m"},
+		{"bright black", 8, "\x1b[100m"},
+		{"bright red", 9, "\x1b[101m"},
+		{"bright white", 15, "\x1b[107m"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := bgANSIFor(tc.c)
+			if got != tc.want {
+				t.Errorf("bgANSIFor(%d) = %q, want %q", tc.c, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFgANSIForBasicColor: symmetric for foreground.
+func TestFgANSIForBasicColor(t *testing.T) {
+	cases := []struct {
+		name string
+		c    ansi.BasicColor
+		want string
+	}{
+		{"black", 0, "\x1b[30m"},
+		{"red", 1, "\x1b[31m"},
+		{"white", 7, "\x1b[37m"},
+		{"bright black", 8, "\x1b[90m"},
+		{"bright red", 9, "\x1b[91m"},
+		{"bright white", 15, "\x1b[97m"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := fgANSIFor(tc.c)
+			if got != tc.want {
+				t.Errorf("fgANSIFor(%d) = %q, want %q", tc.c, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBgFgANSIForIndexedColor asserts ANSI 256 emission for ansi.IndexedColor.
+func TestBgFgANSIForIndexedColor(t *testing.T) {
+	if got := bgANSIFor(ansi.IndexedColor(42)); got != "\x1b[48;5;42m" {
+		t.Errorf("bgANSIFor(IndexedColor(42)) = %q, want %q", got, "\x1b[48;5;42m")
+	}
+	if got := fgANSIFor(ansi.IndexedColor(200)); got != "\x1b[38;5;200m" {
+		t.Errorf("fgANSIFor(IndexedColor(200)) = %q, want %q", got, "\x1b[38;5;200m")
+	}
+}
+
+// TestBgFgANSIForRGBA is a regression guard: truecolor emission is unchanged
+// for existing hex-based themes.
+func TestBgFgANSIForRGBA(t *testing.T) {
+	c := color.RGBA{R: 26, G: 26, B: 46, A: 0xff}
+	if got := bgANSIFor(c); got != "\x1b[48;2;26;26;46m" {
+		t.Errorf("bgANSIFor(RGBA) = %q, want %q", got, "\x1b[48;2;26;26;46m")
+	}
+	if got := fgANSIFor(c); got != "\x1b[38;2;26;26;46m" {
+		t.Errorf("fgANSIFor(RGBA) = %q, want %q", got, "\x1b[38;2;26;26;46m")
+	}
+}
+```
+
+You will need to ensure `image/color` is imported in `render_test.go`. Add it if missing:
+
+```go
+import (
+	"image/color"
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+)
+```
+
+- [ ] **Step 1.2: Run the new tests to verify they fail**
+
+Run:
+```bash
+go test ./internal/ui/messages/ -run 'TestBgANSIForBasicColor|TestFgANSIForBasicColor|TestBgFgANSIForIndexedColor|TestBgFgANSIForRGBA' -v
+```
+
+Expected: `TestBgFgANSIForRGBA` PASSES (existing behavior). `TestBgANSIForBasicColor`, `TestFgANSIForBasicColor`, `TestBgFgANSIForIndexedColor` all FAIL with output showing `\x1b[48;2;…;…;…m` instead of the expected `\x1b[41m`/`\x1b[48;5;42m` style.
+
+- [ ] **Step 1.3: Implement the type-switch**
+
+Replace `bgANSIFor` and `fgANSIFor` in `internal/ui/messages/render.go:348-358` with:
+
+```go
+// bgANSIFor returns the ANSI background-color escape for c.
+// For ansi.BasicColor it emits the native 16-color SGR (\x1b[40m–\x1b[47m,
+// \x1b[100m–\x1b[107m) so the user's terminal palette is honored.
+// For ansi.IndexedColor it emits the 256-color form (\x1b[48;5;Nm).
+// Otherwise it falls back to truecolor (\x1b[48;2;R;G;Bm).
+func bgANSIFor(c color.Color) string {
+	switch v := c.(type) {
+	case ansi.BasicColor:
+		if v < 8 {
+			return fmt.Sprintf("\x1b[%dm", 40+int(v))
+		}
+		if v < 16 {
+			return fmt.Sprintf("\x1b[%dm", 100+int(v-8))
+		}
+		// out-of-range BasicColor: fall through to RGBA
+	case ansi.IndexedColor:
+		return fmt.Sprintf("\x1b[48;5;%dm", int(v))
+	}
+	r, g, b, _ := c.RGBA()
+	return fmt.Sprintf("\x1b[48;2;%d;%d;%dm", r>>8, g>>8, b>>8)
+}
+
+// fgANSIFor returns the ANSI foreground-color escape for c.
+// See bgANSIFor for the type-switch rationale.
+func fgANSIFor(c color.Color) string {
+	switch v := c.(type) {
+	case ansi.BasicColor:
+		if v < 8 {
+			return fmt.Sprintf("\x1b[%dm", 30+int(v))
+		}
+		if v < 16 {
+			return fmt.Sprintf("\x1b[%dm", 90+int(v-8))
+		}
+	case ansi.IndexedColor:
+		return fmt.Sprintf("\x1b[38;5;%dm", int(v))
+	}
+	r, g, b, _ := c.RGBA()
+	return fmt.Sprintf("\x1b[38;2;%d;%d;%dm", r>>8, g>>8, b>>8)
+}
+```
+
+- [ ] **Step 1.4: Run the tests to verify they pass**
+
+Run:
+```bash
+go test ./internal/ui/messages/ -run 'TestBgANSIForBasicColor|TestFgANSIForBasicColor|TestBgFgANSIForIndexedColor|TestBgFgANSIForRGBA' -v
+```
+
+Expected: all 4 tests PASS.
+
+- [ ] **Step 1.5: Run the full package test to catch any regression**
+
+Run:
+```bash
+go test ./internal/ui/messages/
+```
+
+Expected: PASS. If existing tests fail, investigate — most likely a snapshot test that compared truecolor output against new ANSI output for some non-hex value (unlikely given current themes are all hex, but worth confirming).
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+git add internal/ui/messages/render.go internal/ui/messages/render_test.go
+git commit -m "feat(render): emit native ANSI escapes for BasicColor/IndexedColor
+
+bgANSIFor and fgANSIFor now type-switch on the input color. For
+ansi.BasicColor they emit native 16-color SGR (\x1b[41m etc.) so the
+user's terminal palette is honored. For ansi.IndexedColor they emit
+the 256-color form. Existing hex/RGBA themes still emit truecolor
+unchanged.
+
+Prep for #35 ANSI-palette themes."
+```
+
+---
+
+## Task 2: Grammar-aware SGR bg-parameter substitution helper
+
+**Files:**
+- Modify: `internal/ui/messages/render.go` (add new helper near `bgSGRParams`)
+- Test: `internal/ui/messages/render_test.go`
+
+**Why:** `RepaintBgToSelectionTint` currently uses `strings.ReplaceAll(s, fromParams, toParams)`. With truecolor source params like `"48;2;26;26;46"`, collisions with rendered text are extremely unlikely. With ANSI 16 source params like `"40"`, collisions are common — any literal `"40"` in a timestamp, username, or message body would be corrupted. A naive boundary check is also unsafe because `38;5;40` (256-color FG index 40) contains a `40` that must NOT be matched as a bg basic-color.
+
+The fix is a grammar-aware walker that tokenizes SGR parameter lists, treating `38;5;N`, `38;2;R;G;B`, `48;5;N`, `48;2;R;G;B` as multi-param tokens, then substitutes any bg token whose stringified form equals `from`.
+
+- [ ] **Step 2.1: Write the failing test**
+
+Append to `internal/ui/messages/render_test.go`:
+
+```go
+// TestSubstituteBgSGR exercises the grammar-aware bg-parameter
+// substitution. The helper must:
+//   (1) substitute the param when it stands alone (\x1b[40m)
+//   (2) substitute the param within a bundled SGR (\x1b[1;31;40m)
+//   (3) NOT corrupt literal digits in non-SGR content
+//   (4) NOT match the param value inside a 256-color sub-argument
+//       (\x1b[38;5;40m is an FG index 40, not a bg basic 40)
+//   (5) leave the string unchanged when from == to
+func TestSubstituteBgSGR(t *testing.T) {
+	const to = "48;2;100;100;200"
+
+	cases := []struct {
+		name string
+		in   string
+		from string
+		want string
+	}{
+		{
+			name: "standalone ANSI bg",
+			in:   "\x1b[40mhello\x1b[m",
+			from: "40",
+			want: "\x1b[" + to + "mhello\x1b[m",
+		},
+		{
+			name: "bundled SGR with ANSI bg",
+			in:   "\x1b[1;31;40mbold red on black\x1b[m",
+			from: "40",
+			want: "\x1b[1;31;" + to + "mbold red on black\x1b[m",
+		},
+		{
+			name: "literal 40 in content is not touched",
+			in:   "page 40 of 100\x1b[40mtinted\x1b[m",
+			from: "40",
+			want: "page 40 of 100\x1b[" + to + "mtinted\x1b[m",
+		},
+		{
+			name: "256-color FG index 40 is not touched",
+			in:   "\x1b[38;5;40mfg only\x1b[m",
+			from: "40",
+			want: "\x1b[38;5;40mfg only\x1b[m",
+		},
+		{
+			name: "256-color FG index 40 alongside bg 40 — only bg substituted",
+			in:   "\x1b[38;5;40;40mfg256 bg basic\x1b[m",
+			from: "40",
+			want: "\x1b[38;5;40;" + to + "mfg256 bg basic\x1b[m",
+		},
+		{
+			name: "truecolor bg substring substitution",
+			in:   "\x1b[48;2;26;26;46mhello\x1b[m",
+			from: "48;2;26;26;46",
+			want: "\x1b[" + to + "mhello\x1b[m",
+		},
+		{
+			name: "truecolor bg within bundled SGR",
+			in:   "\x1b[1;38;2;255;255;255;48;2;26;26;46mtext\x1b[m",
+			from: "48;2;26;26;46",
+			want: "\x1b[1;38;2;255;255;255;" + to + "mtext\x1b[m",
+		},
+		{
+			name: "no match leaves string unchanged",
+			in:   "\x1b[31mred fg only\x1b[m",
+			from: "40",
+			want: "\x1b[31mred fg only\x1b[m",
+		},
+		{
+			name: "from == to is a no-op",
+			in:   "\x1b[40mhello\x1b[m",
+			from: "40",
+			// to passed = "40" same as from
+			want: "\x1b[40mhello\x1b[m",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			useTo := to
+			if tc.name == "from == to is a no-op" {
+				useTo = "40"
+			}
+			got := substituteBgSGR(tc.in, tc.from, useTo)
+			if got != tc.want {
+				t.Errorf("substituteBgSGR(%q, %q, %q) = %q, want %q",
+					tc.in, tc.from, useTo, got, tc.want)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2.2: Run the new test to verify it fails**
+
+Run:
+```bash
+go test ./internal/ui/messages/ -run 'TestSubstituteBgSGR' -v
+```
+
+Expected: FAIL with `undefined: substituteBgSGR`.
+
+- [ ] **Step 2.3: Implement `substituteBgSGR`**
+
+Add this helper to `internal/ui/messages/render.go` immediately below `bgSGRParams` (around line 346):
+
+```go
+// substituteBgSGR walks s, finds every SGR sequence (\x1b[...m), tokenizes
+// its parameter list with awareness of extended-color groups (38;5;N,
+// 38;2;R;G;B, 48;5;N, 48;2;R;G;B), and substitutes any bg-token whose
+// stringified form equals from with to. Non-SGR text and SGR sequences
+// that don't contain a matching bg token are passed through unchanged.
+//
+// Grammar awareness matters because a bg token can be a single param
+// ("40"–"47", "100"–"107") that may otherwise collide with arbitrary
+// digit substrings — both inside non-SGR content and as arguments to
+// 256-color FG codes like "38;5;40". Splitting on ";" without grammar
+// knowledge would corrupt those.
+//
+// If from == to the input is returned unchanged.
+func substituteBgSGR(s, from, to string) string {
+	if from == "" || from == to {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	i := 0
+	for i < len(s) {
+		start := strings.Index(s[i:], "\x1b[")
+		if start < 0 {
+			b.WriteString(s[i:])
+			break
+		}
+		// Copy plain text before the escape verbatim.
+		b.WriteString(s[i : i+start])
+		seqStart := i + start
+		// Find the terminating 'm'. SGR parameters are digits and ';';
+		// anything else (e.g. another '\x1b') means this isn't a well-formed
+		// SGR sequence and we bail back to plain copy.
+		j := seqStart + 2
+		for j < len(s) && s[j] != 'm' {
+			c := s[j]
+			if c != ';' && (c < '0' || c > '9') {
+				break
+			}
+			j++
+		}
+		if j >= len(s) || s[j] != 'm' {
+			// Not an SGR; copy "\x1b[" and continue scanning past it.
+			b.WriteString("\x1b[")
+			i = seqStart + 2
+			continue
+		}
+		// s[seqStart+2:j] is the param list, s[j] == 'm'.
+		params := splitSGRParams(s[seqStart+2 : j])
+		out := make([]string, 0, len(params))
+		for _, p := range params {
+			if p.isBg && p.text == from {
+				out = append(out, to)
+			} else {
+				out = append(out, p.text)
+			}
+		}
+		b.WriteString("\x1b[")
+		b.WriteString(strings.Join(out, ";"))
+		b.WriteString("m")
+		i = j + 1
+	}
+	return b.String()
+}
+
+// sgrParam is one logical SGR parameter. For extended-color groups
+// (38;5;N, 38;2;R;G;B, 48;5;N, 48;2;R;G;B) text contains the joined
+// form (e.g. "48;5;40" or "48;2;26;26;46") and isBg is true for any
+// bg variant. For single parameters text is just the number (e.g.
+// "40", "1", "31") and isBg is true only when the number is in the
+// basic bg range (40–47, 100–107).
+type sgrParam struct {
+	text string
+	isBg bool
+}
+
+// splitSGRParams tokenizes an SGR parameter list with awareness of
+// extended-color sub-sequences so a "40" appearing as an argument to
+// "38;5" is not mistaken for a standalone bg-black token.
+func splitSGRParams(params string) []sgrParam {
+	if params == "" {
+		return nil
+	}
+	parts := strings.Split(params, ";")
+	out := make([]sgrParam, 0, len(parts))
+	for i := 0; i < len(parts); i++ {
+		p := parts[i]
+		switch p {
+		case "38", "48":
+			isBg := p == "48"
+			// Look ahead for "5;N" or "2;R;G;B".
+			if i+1 < len(parts) {
+				switch parts[i+1] {
+				case "5":
+					if i+2 < len(parts) {
+						out = append(out, sgrParam{
+							text: strings.Join(parts[i:i+3], ";"),
+							isBg: isBg,
+						})
+						i += 2
+						continue
+					}
+				case "2":
+					if i+4 < len(parts) {
+						out = append(out, sgrParam{
+							text: strings.Join(parts[i:i+5], ";"),
+							isBg: isBg,
+						})
+						i += 4
+						continue
+					}
+				}
+			}
+			// Malformed — treat as a bare param so we don't drop data.
+			out = append(out, sgrParam{text: p, isBg: false})
+		default:
+			out = append(out, sgrParam{
+				text: p,
+				isBg: isBasicBgParam(p),
+			})
+		}
+	}
+	return out
+}
+
+// isBasicBgParam reports whether s is a single SGR parameter representing
+// a basic 16-color background: "40"–"47" or "100"–"107".
+func isBasicBgParam(s string) bool {
+	switch s {
+	case "40", "41", "42", "43", "44", "45", "46", "47",
+		"100", "101", "102", "103", "104", "105", "106", "107":
+		return true
+	}
+	return false
+}
+```
+
+- [ ] **Step 2.4: Run the test to verify it passes**
+
+Run:
+```bash
+go test ./internal/ui/messages/ -run 'TestSubstituteBgSGR' -v
+```
+
+Expected: all 9 sub-tests PASS.
+
+- [ ] **Step 2.5: Run full package tests**
+
+Run:
+```bash
+go test ./internal/ui/messages/
+```
+
+Expected: PASS.
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add internal/ui/messages/render.go internal/ui/messages/render_test.go
+git commit -m "feat(render): grammar-aware SGR bg-param substitution helper
+
+substituteBgSGR tokenizes SGR parameter lists with awareness of
+extended-color sub-sequences (38;5;N, 38;2;R;G;B, 48;5;N, 48;2;R;G;B)
+and substitutes only complete bg tokens. This makes safe substitution
+of short ANSI bg params like \"40\" possible without corrupting
+collateral digits in content or 256-color sub-arguments.
+
+Prep for #35 ANSI-palette themes."
+```
+
+---
+
+## Task 3: Wire `substituteBgSGR` into `RepaintBgToSelectionTint`
+
+**Files:**
+- Modify: `internal/ui/messages/render.go:327-334`
+- Test: `internal/ui/messages/render_test.go`
+
+**Why:** With the helper in place, the selection-tint repainter can safely substitute even short ANSI params.
+
+- [ ] **Step 3.1: Write an end-to-end failing test**
+
+Append to `internal/ui/messages/render_test.go`:
+
+```go
+// TestRepaintBgToSelectionTintWithANSITheme exercises the integration
+// of substituteBgSGR via RepaintBgToSelectionTint when the theme uses
+// an ANSI 16 background. We apply ansi-dark so styles.Background is
+// ansi.BasicColor(0) → BgANSI() == "\x1b[40m". The repaint must
+// substitute the bundled "40" param without corrupting either literal
+// content or 256-color sub-arguments.
+func TestRepaintBgToSelectionTintWithANSITheme(t *testing.T) {
+	// Apply ansi-dark; restore dark afterward.
+	styles.Apply("ansi-dark", config.Theme{})
+	t.Cleanup(func() { styles.Apply("dark", config.Theme{}) })
+
+	if BgANSI() != "\x1b[40m" {
+		t.Fatalf("precondition: expected BgANSI() == \"\\x1b[40m\", got %q", BgANSI())
+	}
+
+	// Build a synthetic rendered string mixing: plain text containing
+	// the digit "40", a bundled SGR with bg 40, and a 256-color FG that
+	// includes "40" as its index (must NOT be substituted).
+	in := "see line 40\x1b[1;31;40mbold red on black\x1b[m and \x1b[38;5;40mfg256\x1b[m"
+	out := RepaintBgToSelectionTint(in, true)
+
+	// "line 40" plain digits must survive.
+	if !strings.Contains(out, "see line 40") {
+		t.Errorf("plain digit run was corrupted: %q", out)
+	}
+	// The bundled bg "40" must be replaced.
+	if strings.Contains(out, "\x1b[1;31;40m") {
+		t.Errorf("expected bundled bg 40 to be substituted, got %q", out)
+	}
+	// The 256-color FG with index 40 must be intact.
+	if !strings.Contains(out, "\x1b[38;5;40m") {
+		t.Errorf("expected 256-color FG index 40 to remain intact, got %q", out)
+	}
+}
+
+// TestRepaintBgToSelectionTintBackwardCompat asserts no behavior change
+// for truecolor themes — substituting a long, unique RGB param.
+func TestRepaintBgToSelectionTintBackwardCompat(t *testing.T) {
+	styles.Apply("dark", config.Theme{})
+	bg := BgANSI()
+	// We don't know the exact params; just verify a string carrying
+	// that exact bg escape gets substituted and a string with no bg
+	// escape passes through unchanged.
+	withBg := "prefix" + bg + "tinted\x1b[m suffix"
+	got := RepaintBgToSelectionTint(withBg, true)
+	if got == withBg {
+		t.Errorf("expected substitution to occur for dark theme bg")
+	}
+	noBg := "no escape here"
+	if got := RepaintBgToSelectionTint(noBg, true); got != noBg {
+		t.Errorf("expected pass-through for string with no bg escape, got %q", got)
+	}
+}
+```
+
+Make sure these imports are present at the top of `render_test.go`:
+
+```go
+import (
+	"image/color"
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/gammons/slk/internal/config"
+	"github.com/gammons/slk/internal/ui/styles"
+)
+```
+
+- [ ] **Step 3.2: Run the tests to verify they fail**
+
+Run:
+```bash
+go test ./internal/ui/messages/ -run 'TestRepaintBgToSelectionTintWithANSITheme|TestRepaintBgToSelectionTintBackwardCompat' -v
+```
+
+Expected outcomes:
+- `TestRepaintBgToSelectionTintWithANSITheme` FAILS — either `BgANSI()` precondition fails because `ansi-dark` theme doesn't exist yet (we'll add it in Task 4) **OR** the substitution corrupts the 256-color sub-argument. *Note:* this test depends on `ansi-dark` being registered. If you're running Task 3 before Task 4, this test will fail at the precondition step. That's expected — re-run after Task 4 lands and it will exercise the integration.
+- `TestRepaintBgToSelectionTintBackwardCompat` likely PASSES already since `strings.ReplaceAll` works fine for long truecolor params.
+
+If `TestRepaintBgToSelectionTintWithANSITheme` is blocked by the missing theme, **skip Step 3.4's verification of this specific test for now and revisit after Task 4**. Steps 3.3 (the implementation) can still be done now.
+
+- [ ] **Step 3.3: Replace `RepaintBgToSelectionTint`**
+
+In `internal/ui/messages/render.go:327-334`, replace the body:
+
+```go
+func RepaintBgToSelectionTint(s string, focused bool) string {
+	from := bgSGRParams(BgANSI())
+	to := bgSGRParams(SelectionTintBgANSI(focused))
+	if from == "" || from == to {
+		return s
+	}
+	return substituteBgSGR(s, from, to)
+}
+```
+
+The signature, exported name, and high-level contract are unchanged. Only the substitution mechanism inside the function changes.
+
+- [ ] **Step 3.4: Run backward-compat test to verify behavior preserved**
+
+Run:
+```bash
+go test ./internal/ui/messages/ -run 'TestRepaintBgToSelectionTintBackwardCompat' -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 3.5: Run full package tests**
+
+Run:
+```bash
+go test ./internal/ui/messages/
+```
+
+Expected: PASS. `TestRepaintBgToSelectionTintWithANSITheme` will still fail until Task 4 registers `ansi-dark`. Note this as a known gap to revisit after Task 4.
+
+- [ ] **Step 3.6: Commit**
+
+```bash
+git add internal/ui/messages/render.go internal/ui/messages/render_test.go
+git commit -m "refactor(render): use grammar-aware substitution in RepaintBgToSelectionTint
+
+Switch from strings.ReplaceAll on the bg-param substring to
+substituteBgSGR, which understands SGR token grammar. Behaviorally
+identical for truecolor themes; required for safe substitution when
+the theme uses short ANSI 16 bg params.
+
+Prep for #35 ANSI-palette themes."
+```
+
+---
+
+## Task 4: Add `ansi-dark` theme
+
+**Files:**
+- Modify: `internal/ui/styles/themes.go`
+- Test: `internal/ui/styles/themes_test.go`
+
+- [ ] **Step 4.1: Write the failing test**
+
+Append to `internal/ui/styles/themes_test.go`:
+
+```go
+// TestANSIDarkThemeRegistered asserts the ansi-dark theme is present
+// in the theme switcher and that every color field is populated with
+// a value that resolves to ansi.BasicColor — confirming the theme
+// will inherit the user's terminal palette rather than emit truecolor.
+func TestANSIDarkThemeRegistered(t *testing.T) {
+	names := ThemeNames()
+	found := false
+	for _, n := range names {
+		if n == "ANSI Dark" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected \"ANSI Dark\" in ThemeNames, got %v", names)
+	}
+
+	c := lookupTheme("ansi-dark")
+	required := map[string]string{
+		"Primary":     c.Primary,
+		"Accent":      c.Accent,
+		"Warning":     c.Warning,
+		"Error":       c.Error,
+		"Background":  c.Background,
+		"Surface":     c.Surface,
+		"SurfaceDark": c.SurfaceDark,
+		"Text":        c.Text,
+		"TextMuted":   c.TextMuted,
+		"Border":      c.Border,
+	}
+	for name, val := range required {
+		if val == "" {
+			t.Errorf("ansi-dark.%s is empty", name)
+			continue
+		}
+		col := lipgloss.Color(val)
+		if _, ok := col.(ansi.BasicColor); !ok {
+			t.Errorf("ansi-dark.%s = %q resolves to %T, want ansi.BasicColor",
+				name, val, col)
+		}
+	}
+}
+```
+
+Add imports to `themes_test.go` if not already present:
+
+```go
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/gammons/slk/internal/config"
+)
+```
+
+- [ ] **Step 4.2: Run the test to verify it fails**
+
+Run:
+```bash
+go test ./internal/ui/styles/ -run TestANSIDarkThemeRegistered -v
+```
+
+Expected: FAIL — theme not in `ThemeNames()`.
+
+- [ ] **Step 4.3: Add the theme entry**
+
+In `internal/ui/styles/themes.go`, add this entry to the `builtinThemes` map. The existing themes are grouped by family rather than strictly alphabetical, so just pick a sensible location — at the end of the map literal is fine. The key is `"ansi-dark"` (lowercase, hyphenated). The struct literal uses ANSI 16 number strings:
+
+```go
+"ansi-dark": {
+	Name: "ANSI Dark",
+	Colors: ThemeColors{
+		// All values are ANSI 16 color numbers ("0"–"15"). They are
+		// passed through lipgloss.Color() which returns ansi.BasicColor,
+		// so rendering uses native 16-color SGR escapes and inherits the
+		// user's terminal palette.
+		Primary:     "4",  // blue
+		Accent:      "6",  // cyan
+		Warning:     "3",  // yellow
+		Error:       "1",  // red
+		Background:  "0",  // black
+		Surface:     "8",  // bright black (slightly lifted panel bg)
+		SurfaceDark: "0",  // black (matches background)
+		Text:        "15", // bright white
+		TextMuted:   "8",  // bright black
+		Border:      "8",  // bright black
+	},
+},
+```
+
+- [ ] **Step 4.4: Run the test to verify it passes**
+
+Run:
+```bash
+go test ./internal/ui/styles/ -run TestANSIDarkThemeRegistered -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 4.5: Re-run the Task 3 integration test**
+
+Run:
+```bash
+go test ./internal/ui/messages/ -run TestRepaintBgToSelectionTintWithANSITheme -v
+```
+
+Expected: PASS. The integration test from Task 3 now has its prerequisite theme and exercises the full ANSI substitution path.
+
+- [ ] **Step 4.6: Run all tests in the affected packages**
+
+Run:
+```bash
+go test ./internal/ui/styles/ ./internal/ui/messages/
+```
+
+Expected: PASS.
+
+- [ ] **Step 4.7: Commit**
+
+```bash
+git add internal/ui/styles/themes.go internal/ui/styles/themes_test.go
+git commit -m "feat(themes): add ansi-dark theme
+
+Uses ANSI 16 color numbers (\"0\"–\"15\") for every theme color so
+rendering inherits the user's terminal palette via native 16-color
+SGR escapes. Resolves the dark half of #35."
+```
+
+---
+
+## Task 5: Add `ansi-light` theme
+
+**Files:**
+- Modify: `internal/ui/styles/themes.go`
+- Test: `internal/ui/styles/themes_test.go`
+
+- [ ] **Step 5.1: Write the failing test**
+
+Append to `internal/ui/styles/themes_test.go`:
+
+```go
+// TestANSILightThemeRegistered: mirror of TestANSIDarkThemeRegistered
+// for the light variant.
+func TestANSILightThemeRegistered(t *testing.T) {
+	names := ThemeNames()
+	found := false
+	for _, n := range names {
+		if n == "ANSI Light" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected \"ANSI Light\" in ThemeNames, got %v", names)
+	}
+
+	c := lookupTheme("ansi-light")
+	required := map[string]string{
+		"Primary":     c.Primary,
+		"Accent":      c.Accent,
+		"Warning":     c.Warning,
+		"Error":       c.Error,
+		"Background":  c.Background,
+		"Surface":     c.Surface,
+		"SurfaceDark": c.SurfaceDark,
+		"Text":        c.Text,
+		"TextMuted":   c.TextMuted,
+		"Border":      c.Border,
+	}
+	for name, val := range required {
+		if val == "" {
+			t.Errorf("ansi-light.%s is empty", name)
+			continue
+		}
+		col := lipgloss.Color(val)
+		if _, ok := col.(ansi.BasicColor); !ok {
+			t.Errorf("ansi-light.%s = %q resolves to %T, want ansi.BasicColor",
+				name, val, col)
+		}
+	}
+}
+```
+
+- [ ] **Step 5.2: Run the test to verify it fails**
+
+Run:
+```bash
+go test ./internal/ui/styles/ -run TestANSILightThemeRegistered -v
+```
+
+Expected: FAIL — theme not registered.
+
+- [ ] **Step 5.3: Add the theme entry**
+
+In `internal/ui/styles/themes.go`, add immediately after the `ansi-dark` entry:
+
+```go
+"ansi-light": {
+	Name: "ANSI Light",
+	Colors: ThemeColors{
+		// Same ANSI-16-only constraint as ansi-dark; values chosen for
+		// readability on light terminal backgrounds.
+		Primary:     "4",  // blue
+		Accent:      "6",  // cyan
+		Warning:     "3",  // yellow
+		Error:       "1",  // red
+		Background:  "15", // bright white
+		Surface:     "7",  // white (slightly muted panel bg)
+		SurfaceDark: "7",  // white
+		Text:        "0",  // black
+		TextMuted:   "8",  // bright black (grey)
+		Border:      "8",  // bright black
+	},
+},
+```
+
+- [ ] **Step 5.4: Run the test to verify it passes**
+
+Run:
+```bash
+go test ./internal/ui/styles/ -run TestANSILightThemeRegistered -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5.5: Run the full project test suite**
+
+Run:
+```bash
+go test ./...
+```
+
+Expected: PASS. Watch for any unrelated tests that might brittle-match against the theme count or theme list.
+
+- [ ] **Step 5.6: Build the binary to confirm no compile errors**
+
+Run:
+```bash
+go build ./...
+```
+
+Expected: clean build.
+
+- [ ] **Step 5.7: Commit**
+
+```bash
+git add internal/ui/styles/themes.go internal/ui/styles/themes_test.go
+git commit -m "feat(themes): add ansi-light theme
+
+Light-terminal counterpart to ansi-dark. Uses ANSI 16 color numbers
+so the user's terminal palette is honored. Resolves #35."
+```
+
+---
+
+## Task 6: Documentation — `wiki/Configuration.md`
+
+**Files:**
+- Modify: `wiki/Configuration.md`
+
+- [ ] **Step 6.1: Read the current themes section**
+
+Run:
+```bash
+grep -n "theme" wiki/Configuration.md | head -20
+```
+
+Identify the section that lists built-in themes or describes theme selection. The new content should slot in there.
+
+- [ ] **Step 6.2: Add the ANSI-themes subsection**
+
+Add the following block after the existing list of built-in themes (find the right anchor in the file; if there's a built-in themes list, append; if not, add after the line that introduces the `[appearance] theme = "..."` config key):
+
+```markdown
+### Terminal-palette themes (`ansi-dark`, `ansi-light`)
+
+Two built-in themes use ANSI 16 color codes exclusively rather than
+fixed RGB values. They inherit the user's terminal color palette, so
+changing your terminal colorscheme (light/dark, solarized,
+accessibility palettes, etc.) immediately changes slk's UI colors to
+match.
+
+```toml
+[appearance]
+theme = "ansi-dark"   # or "ansi-light"
+```
+
+Pick the variant whose background matches your terminal's background.
+
+**Trade-off:** selection-row highlights and compose-input tints are
+still computed as RGB approximations, so the tint regions of those
+elements use truecolor rather than your palette. The rest of the UI
+honors the palette.
+```
+
+- [ ] **Step 6.3: Sanity-check the diff**
+
+Run:
+```bash
+git diff wiki/Configuration.md
+```
+
+Confirm the addition is in a sensible place, headers nest correctly under the existing structure, and the fenced code block doesn't accidentally break a parent fenced block.
+
+- [ ] **Step 6.4: Commit**
+
+```bash
+git add wiki/Configuration.md
+git commit -m "docs(wiki): document ansi-dark and ansi-light themes (#35)"
+```
+
+---
+
+## Task 7: Documentation — `README.md` theme count + final verification
+
+**Files:**
+- Modify: `README.md:17` and `README.md:30`
+
+The README currently says "35+ built-in themes" at line 17 and "12 themes" at line 30 (the 12 figure is stale — the codebase currently ships 34 builtins; this PR brings it to 36). Update both to a single accurate count.
+
+- [ ] **Step 7.1: Verify current theme count programmatically**
+
+Run:
+```bash
+go test ./internal/ui/styles/ -run 'TestANSIDarkThemeRegistered|TestANSILightThemeRegistered' -v
+```
+
+Then count themes:
+```bash
+grep -c '^\s"[a-z]' internal/ui/styles/themes.go
+```
+
+Confirm the count is 36. If the count differs from expectations, recount manually before editing the README — do not blindly trust a stale number.
+
+- [ ] **Step 7.2: Update `README.md:17`**
+
+Find the line: `- **Pretty.** 35+ built-in themes, lipgloss-styled panels, ...`
+
+Replace `35+` with `36` (or whatever the verified count is). Same line, no other changes.
+
+- [ ] **Step 7.3: Update `README.md:30`**
+
+Find the line: `- 12 themes + drop-in custom themes, live theme switcher`
+
+Replace `12 themes` with `36 themes` (or the verified count).
+
+- [ ] **Step 7.4: Final full build + test**
+
+Run:
+```bash
+go build ./... && go test ./...
+```
+
+Expected: clean build, all tests pass.
+
+- [ ] **Step 7.5: Manual verification (palette inheritance)**
+
+This step requires a terminal and a human:
+
+1. Build and run slk: `go run ./cmd/slk`.
+2. Open the theme switcher: `Ctrl+y`.
+3. Select `ANSI Dark`.
+4. Note the colors of: sidebar borders (border), unread counts (primary or accent), error messages (error), warnings (warning).
+5. **Without quitting slk**, change your terminal emulator's color scheme to a visibly different palette (e.g., switch iTerm/Alacritty/kitty from default to Solarized or vice versa).
+6. Trigger a re-render in slk (resize the window, switch channels, etc.).
+7. The colors noted in step 4 should now reflect the new palette — e.g., "red" is now solarized-red, not standard #FF0000 red.
+
+If colors did NOT change, the palette-inheritance path is broken — investigate `bgANSIFor`/`fgANSIFor` and confirm the new themes' colors resolve to `ansi.BasicColor` at runtime (a debug print in `styles.Apply` will confirm).
+
+Also visually inspect: selection highlight (`j`/`k` to move cursor) — the tint should look reasonable on the ANSI background. Note that the tint itself is a truecolor RGB; it doesn't need to inherit palette.
+
+- [ ] **Step 7.6: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): bump theme count for ansi-dark/ansi-light (#35)"
+```
+
+- [ ] **Step 7.7: Inspect commit history before opening PR**
+
+Run:
+```bash
+git log --oneline -10
+```
+
+Confirm the commit sequence is clean and each commit message accurately reflects its diff. If anything looks off, rebase interactively before opening the PR.
+
+---
+
+## Plan self-review summary
+
+- **Spec coverage:** All four spec sections (Required code changes 1-3, Tests, Documentation) map to Tasks 1-7. The optional `mixColors` ANSI-awareness and single-`terminal` theme were explicitly listed as Out of scope in the spec and are correctly absent from the plan.
+- **Test coverage:**
+  - Task 1: `TestBgANSIForBasicColor`, `TestFgANSIForBasicColor`, `TestBgFgANSIForIndexedColor`, `TestBgFgANSIForRGBA`.
+  - Task 2: `TestSubstituteBgSGR` with 9 sub-cases including all the collision scenarios from the spec.
+  - Task 3: `TestRepaintBgToSelectionTintWithANSITheme` (integration), `TestRepaintBgToSelectionTintBackwardCompat` (regression).
+  - Tasks 4-5: `TestANSIDarkThemeRegistered`, `TestANSILightThemeRegistered`.
+- **Type/name consistency:** `substituteBgSGR` referenced in Task 3 implementation matches Task 2 definition. `sgrParam`, `splitSGRParams`, `isBasicBgParam` are defined once in Task 2. Theme keys `"ansi-dark"` / `"ansi-light"` and display names `"ANSI Dark"` / `"ANSI Light"` used consistently across Tasks 4, 5, 6, 7.
+- **Cross-task dependency:** `TestRepaintBgToSelectionTintWithANSITheme` (Task 3) depends on the `ansi-dark` theme registered in Task 4. This is called out explicitly in Step 3.2 and re-verified in Step 4.5.

--- a/docs/superpowers/plans/2026-05-25-new-message-feature.md
+++ b/docs/superpowers/plans/2026-05-25-new-message-feature.md
@@ -1,0 +1,48 @@
+# New Message Feature Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `Ctrl+N` modal picker that lets the user start a DM (1 recipient) or group DM / MPIM (2–8 recipients) via Slack's `conversations.open` API, then switches to the opened channel and focuses the compose box.
+
+**Architecture:** New `internal/ui/newmessagepicker` package mirrors the existing `channelfinder` pattern (centered modal overlay, fuzzy filter, scrollbar). Selection state holds a multi-select pill bar; submit dispatches a new `ChannelService.OpenConversation` method that wraps slack-go's `OpenConversationContext`. The reducer tracks an in-flight `RequestID` so an Esc during the network round-trip abandons the result cleanly.
+
+**Tech Stack:** Go 1.26, charm.land/bubbletea v2, charm.land/lipgloss v2, github.com/slack-go/slack v0.23.0, standard `go test`.
+
+**Spec:** `docs/superpowers/specs/2026-05-25-new-message-feature-design.md`
+
+---
+
+## Task Files
+
+Each task file is self-contained — exact paths, full code, expected test output, commit message. Tasks build bottom-up; later tasks depend on the surfaces created by earlier ones.
+
+| # | Task | File |
+|---|---|---|
+| 1 | Slack client: `OpenConversation` wrapper + mock | [tasks/task-01-slack-client.md](2026-05-25-new-message-feature/task-01-slack-client.md) |
+| 2 | `newmessagepicker` package skeleton (`Model`, `User`, `Open/Close/IsVisible`) | [tasks/task-02-picker-skeleton.md](2026-05-25-new-message-feature/task-02-picker-skeleton.md) |
+| 3 | Filter & rank pure functions | [tasks/task-03-picker-filter.md](2026-05-25-new-message-feature/task-03-picker-filter.md) |
+| 4 | Navigation + multi-select toggle (Space/Tab) + MPIM cap | [tasks/task-04-picker-selection.md](2026-05-25-new-message-feature/task-04-picker-selection.md) |
+| 5 | Submit & cancel semantics (`Result`, Enter/Esc/Backspace-at-col-0) | [tasks/task-05-picker-submit.md](2026-05-25-new-message-feature/task-05-picker-submit.md) |
+| 6 | Picker view rendering (`View`, `ViewOverlay`) | [tasks/task-06-picker-view.md](2026-05-25-new-message-feature/task-06-picker-view.md) |
+| 7 | Mode constant + message types + Ctrl+N keybind | [tasks/task-07-mode-and-msgs.md](2026-05-25-new-message-feature/task-07-mode-and-msgs.md) |
+| 8 | `ChannelService.OpenConversation` interface + adapter | [tasks/task-08-channel-service.md](2026-05-25-new-message-feature/task-08-channel-service.md) |
+| 9 | App wiring: picker field, mode handler, overlay composite | [tasks/task-09-app-wiring.md](2026-05-25-new-message-feature/task-09-app-wiring.md) |
+| 10 | User list + recency snapshot on modal open | [tasks/task-10-user-list-recency.md](2026-05-25-new-message-feature/task-10-user-list-recency.md) |
+| 11 | Reducer: submit dispatch + in-flight tracking + cancel | [tasks/task-11-reducer.md](2026-05-25-new-message-feature/task-11-reducer.md) |
+| 12 | Cache hydration on `AlreadyOpen=false` + post-open `ChannelSelectedMsg` + `ModeInsert` | [tasks/task-12-cache-hydration.md](2026-05-25-new-message-feature/task-12-cache-hydration.md) |
+| 13 | `cmd/slk/main.go`: production `OpenConversation` closure | [tasks/task-13-main-wiring.md](2026-05-25-new-message-feature/task-13-main-wiring.md) |
+| 14 | End-to-end test + manual verification + final commit | [tasks/task-14-e2e.md](2026-05-25-new-message-feature/task-14-e2e.md) |
+
+## Conventions used in every task file
+
+- **Files** block lists exact paths the task touches.
+- Every step shows exact code or exact command + expected output.
+- Tests are written FIRST, run to confirm they fail, then the implementation makes them pass.
+- Each task ends with a commit step.
+- Type names, function signatures, and field names are consistent across tasks. The canonical names are in [naming.md](2026-05-25-new-message-feature/naming.md).
+
+## Execution
+
+Once a task is complete (tests pass + commit landed), proceed to the next task. Do not skip tasks — later tasks assume the earlier surfaces exist with the exact signatures defined.
+
+After Task 14, the feature is shippable. No follow-up tasks are required; any improvements (MPIM-derived recency, user-list refresh while modal open, etc.) are out of scope for this plan per the spec's Non-Goals section.

--- a/docs/superpowers/plans/2026-05-25-new-message-feature/naming.md
+++ b/docs/superpowers/plans/2026-05-25-new-message-feature/naming.md
@@ -1,0 +1,67 @@
+# Canonical names used across all tasks
+
+Refer to this file when a task uses a name that's defined in a different task. **Do not improvise alternative names** — later tasks reference these exactly.
+
+## Slack client layer (Task 1)
+
+- `slackclient.Client.OpenConversation(ctx context.Context, userIDs []string) (channelID string, alreadyOpen bool, err error)`
+- `slackclient.SlackAPI.OpenConversationContext(ctx, *slack.OpenConversationParameters) (*slack.Channel, bool, bool, error)` — already in slack-go; we add it to our local interface
+- Mock field: `openConversationContextFn func(ctx context.Context, params *slack.OpenConversationParameters) (*slack.Channel, bool, bool, error)`
+
+## Picker package (Tasks 2–6)
+
+- Package: `newmessagepicker`
+- Import path: `github.com/gammons/slk/internal/ui/newmessagepicker`
+- `Model` struct
+- `User` struct: `{ID, DisplayName, Username string; IsExternal bool; Recency int64}`
+- `Result` struct: `{UserIDs []string}` — non-nil with at least one ID when the user submits
+- Public methods on `*Model`: `SetUsers([]User)`, `SetCurrentUserID(string)`, `Open()`, `Close()`, `IsVisible() bool`, `HandleKey(string) *Result`, `View(termWidth int) string`, `ViewOverlay(termWidth, termHeight int, background string) string`
+- Constant: `MaxRecipients = 8`
+
+## UI layer (Tasks 7, 9)
+
+- Mode constant: `ModeNewMessage` (added to `internal/ui/mode.go`)
+- Mode display string: `"NEW MSG"`
+- KeyMap field: `NewMessage` with default binding `ctrl+n`
+- App field: `newMessagePicker newmessagepicker.Model`
+- App field: `newMessageInFlightID uint64` — monotonic counter; 0 means no in-flight request
+- App field: `newMessageCancelled bool` — set true when user Escs during in-flight
+
+## Message types (Task 7)
+
+Added to `internal/ui/msgs.go`:
+
+- `EnterNewMessageMsg struct{}` — dispatched when user presses Ctrl+N in `ModeNormal`
+- `NewMessageOpenedMsg struct{ ChannelID string; AlreadyOpen bool; UserIDs []string; RequestID uint64 }` — service result, success
+- `NewMessageFailedMsg struct{ RequestID uint64; Err error }` — service result, error
+
+> `ConversationOpenedMsg` already exists in `msgs.go:198` for unrelated WS events. Do not reuse its name.
+
+## Service layer (Task 8)
+
+Added to `internal/ui/services.go`:
+
+- `ChannelService.OpenConversation(userIDs []string, requestID uint64) tea.Cmd`
+- `ChannelServiceFuncs.OpenConversation func(userIDs []string, requestID uint64) tea.Cmd`
+
+## Reducer (Tasks 11, 12)
+
+- File: `internal/ui/reducer_new_message.go`
+- Reducer var: `reduceNewMessage reducerFunc`
+- Registered in `app.go`'s `dispatchReducers(...)` call after `reduceWorkspace`
+
+## Test fixtures
+
+- `internal/ui/newmessagepicker/model_test.go` — uses a `testUsers()` helper that returns 5–6 representative users
+- `internal/slack/client_test.go` — extends existing `mockSlackAPI` with `openConversationContextFn`
+- `internal/ui/reducer_new_message_test.go` — uses `services_helpers_test.go` patterns
+
+## Commit message style
+
+```
+feat(new-message): <one-line summary>
+
+<optional body>
+```
+
+Use `feat(new-message)` for all task commits so the feature is easy to identify in `git log`.

--- a/docs/superpowers/plans/2026-05-25-new-message-feature/task-01-slack-client.md
+++ b/docs/superpowers/plans/2026-05-25-new-message-feature/task-01-slack-client.md
@@ -1,0 +1,255 @@
+# Task 1: Slack client `OpenConversation` wrapper
+
+**Goal:** Add `Client.OpenConversation` that wraps slack-go's `OpenConversationContext`. Defends inputs (1 ≤ N ≤ 8 user IDs), filters out the current user defensively, and returns the channel ID + `alreadyOpen` flag.
+
+**Files:**
+- Modify: `internal/slack/client.go` (interface + new method)
+- Modify: `internal/slack/client_test.go` (mock field + tests)
+
+---
+
+- [ ] **Step 1: Add a failing test for the 1-user (IM) happy path**
+
+Open `internal/slack/client_test.go`. Find the `mockSlackAPI` struct definition (around line 133) and add a new field at the bottom of the field list:
+
+```go
+	openConversationContextFn       func(ctx context.Context, params *slack.OpenConversationParameters) (*slack.Channel, bool, bool, error)
+```
+
+At the end of the file, append the mock method:
+
+```go
+func (m *mockSlackAPI) OpenConversationContext(ctx context.Context, params *slack.OpenConversationParameters) (*slack.Channel, bool, bool, error) {
+	if m.openConversationContextFn != nil {
+		return m.openConversationContextFn(ctx, params)
+	}
+	return nil, false, false, nil
+}
+```
+
+Then add this test at the end of the file:
+
+```go
+func TestOpenConversation_SingleUserReturnsIMChannelID(t *testing.T) {
+	mock := &mockSlackAPI{
+		openConversationContextFn: func(ctx context.Context, params *slack.OpenConversationParameters) (*slack.Channel, bool, bool, error) {
+			if len(params.Users) != 1 || params.Users[0] != "U123" {
+				t.Errorf("expected Users=[U123], got %v", params.Users)
+			}
+			if !params.ReturnIM {
+				t.Error("expected ReturnIM=true")
+			}
+			return &slack.Channel{
+				GroupConversation: slack.GroupConversation{
+					Conversation: slack.Conversation{ID: "D456"},
+				},
+			}, false, false, nil
+		},
+	}
+	c := &Client{api: mock}
+
+	channelID, alreadyOpen, err := c.OpenConversation(context.Background(), []string{"U123"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if channelID != "D456" {
+		t.Errorf("expected channelID=D456, got %q", channelID)
+	}
+	if alreadyOpen {
+		t.Error("expected alreadyOpen=false")
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```
+go test ./internal/slack/ -run TestOpenConversation_SingleUserReturnsIMChannelID -v
+```
+
+Expected: build fails with `mockSlackAPI does not implement SlackAPI (missing method OpenConversationContext)` OR `c.OpenConversation undefined`. Either way it must not pass.
+
+- [ ] **Step 3: Add `OpenConversationContext` to the `SlackAPI` interface**
+
+In `internal/slack/client.go`, add a line to the `SlackAPI` interface (after line 46, before the closing brace at line 47):
+
+```go
+	OpenConversationContext(ctx context.Context, params *slack.OpenConversationParameters) (*slack.Channel, bool, bool, error)
+```
+
+- [ ] **Step 4: Add `Client.OpenConversation` method**
+
+In `internal/slack/client.go`, after the `SendMessage` method (which ends at line 640), insert:
+
+```go
+// OpenConversation opens (or returns) a direct message channel (1 user)
+// or a multi-person direct message / MPIM (2-8 users). Idempotent:
+// when the conversation already exists, Slack returns it with
+// alreadyOpen=true.
+//
+// Defends inputs: rejects 0 users or more than 8. Slack's hard cap on
+// MPIM size is 9 participants total, so up to 8 OTHER user IDs.
+func (c *Client) OpenConversation(ctx context.Context, userIDs []string) (channelID string, alreadyOpen bool, err error) {
+	if len(userIDs) == 0 {
+		return "", false, fmt.Errorf("OpenConversation: at least one user ID required")
+	}
+	if len(userIDs) > 8 {
+		return "", false, fmt.Errorf("OpenConversation: at most 8 user IDs allowed (got %d)", len(userIDs))
+	}
+	ch, _, alreadyOpen, err := c.api.OpenConversationContext(ctx, &slack.OpenConversationParameters{
+		Users:    userIDs,
+		ReturnIM: true,
+	})
+	if err != nil {
+		return "", false, fmt.Errorf("OpenConversation: %w", err)
+	}
+	return ch.ID, alreadyOpen, nil
+}
+```
+
+- [ ] **Step 5: Run the test to confirm it passes**
+
+```
+go test ./internal/slack/ -run TestOpenConversation_SingleUserReturnsIMChannelID -v
+```
+
+Expected: `PASS`.
+
+- [ ] **Step 6: Add tests for the remaining 5 cases**
+
+Append these tests to `internal/slack/client_test.go`:
+
+```go
+func TestOpenConversation_MultipleUsersReturnsMPIMChannelID(t *testing.T) {
+	mock := &mockSlackAPI{
+		openConversationContextFn: func(ctx context.Context, params *slack.OpenConversationParameters) (*slack.Channel, bool, bool, error) {
+			if len(params.Users) != 3 {
+				t.Errorf("expected 3 users, got %d", len(params.Users))
+			}
+			return &slack.Channel{
+				GroupConversation: slack.GroupConversation{
+					Conversation: slack.Conversation{ID: "G789"},
+				},
+			}, false, false, nil
+		},
+	}
+	c := &Client{api: mock}
+
+	channelID, _, err := c.OpenConversation(context.Background(), []string{"U1", "U2", "U3"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if channelID != "G789" {
+		t.Errorf("expected channelID=G789, got %q", channelID)
+	}
+}
+
+func TestOpenConversation_EmptyUserIDsReturnsErrorWithoutAPICall(t *testing.T) {
+	called := false
+	mock := &mockSlackAPI{
+		openConversationContextFn: func(ctx context.Context, params *slack.OpenConversationParameters) (*slack.Channel, bool, bool, error) {
+			called = true
+			return nil, false, false, nil
+		},
+	}
+	c := &Client{api: mock}
+
+	_, _, err := c.OpenConversation(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for empty userIDs")
+	}
+	if called {
+		t.Error("API should not have been called")
+	}
+}
+
+func TestOpenConversation_TooManyUserIDsReturnsErrorWithoutAPICall(t *testing.T) {
+	called := false
+	mock := &mockSlackAPI{
+		openConversationContextFn: func(ctx context.Context, params *slack.OpenConversationParameters) (*slack.Channel, bool, bool, error) {
+			called = true
+			return nil, false, false, nil
+		},
+	}
+	c := &Client{api: mock}
+
+	nine := []string{"U1", "U2", "U3", "U4", "U5", "U6", "U7", "U8", "U9"}
+	_, _, err := c.OpenConversation(context.Background(), nine)
+	if err == nil {
+		t.Fatal("expected error for 9 userIDs")
+	}
+	if called {
+		t.Error("API should not have been called")
+	}
+}
+
+func TestOpenConversation_APIErrorIsWrapped(t *testing.T) {
+	mock := &mockSlackAPI{
+		openConversationContextFn: func(ctx context.Context, params *slack.OpenConversationParameters) (*slack.Channel, bool, bool, error) {
+			return nil, false, false, fmt.Errorf("rate_limited")
+		},
+	}
+	c := &Client{api: mock}
+
+	_, _, err := c.OpenConversation(context.Background(), []string{"U1"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "OpenConversation") {
+		t.Errorf("expected error to be wrapped with OpenConversation prefix, got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "rate_limited") {
+		t.Errorf("expected error to contain underlying message, got %q", err.Error())
+	}
+}
+
+func TestOpenConversation_AlreadyOpenFlagPropagates(t *testing.T) {
+	mock := &mockSlackAPI{
+		openConversationContextFn: func(ctx context.Context, params *slack.OpenConversationParameters) (*slack.Channel, bool, bool, error) {
+			return &slack.Channel{
+				GroupConversation: slack.GroupConversation{
+					Conversation: slack.Conversation{ID: "D1"},
+				},
+			}, false, true, nil
+		},
+	}
+	c := &Client{api: mock}
+
+	_, alreadyOpen, err := c.OpenConversation(context.Background(), []string{"U1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !alreadyOpen {
+		t.Error("expected alreadyOpen=true")
+	}
+}
+```
+
+If `strings` isn't already imported in the test file, add it to the import block at the top.
+
+- [ ] **Step 7: Run all new tests**
+
+```
+go test ./internal/slack/ -run TestOpenConversation -v
+```
+
+Expected: 5 tests, all PASS.
+
+- [ ] **Step 8: Run the full slack package test suite to confirm no regressions**
+
+```
+go test ./internal/slack/
+```
+
+Expected: `ok  github.com/gammons/slk/internal/slack`.
+
+- [ ] **Step 9: Commit**
+
+```
+git add internal/slack/client.go internal/slack/client_test.go
+git commit -m "feat(new-message): add Client.OpenConversation wrapper
+
+Wraps slack-go's OpenConversationContext for the upcoming new-message
+modal. Validates input (1-8 user IDs), forwards the alreadyOpen flag,
+and wraps API errors with an OpenConversation: prefix."
+```

--- a/docs/superpowers/plans/2026-05-25-new-message-feature/task-02-picker-skeleton.md
+++ b/docs/superpowers/plans/2026-05-25-new-message-feature/task-02-picker-skeleton.md
@@ -1,0 +1,218 @@
+# Task 2: `newmessagepicker` package skeleton
+
+**Goal:** Create the package with the bare types (`User`, `Model`, `Result`) and the visibility methods (`Open`, `Close`, `IsVisible`, `SetUsers`, `SetCurrentUserID`). No filtering or rendering yet.
+
+**Files:**
+- Create: `internal/ui/newmessagepicker/model.go`
+- Create: `internal/ui/newmessagepicker/model_test.go`
+
+---
+
+- [ ] **Step 1: Create the test file with the open/close tests (these will fail to compile until Step 2)**
+
+Write `internal/ui/newmessagepicker/model_test.go`:
+
+```go
+package newmessagepicker
+
+import "testing"
+
+func testUsers() []User {
+	return []User{
+		{ID: "U1", DisplayName: "Alice Chen", Username: "alice", Recency: 500},
+		{ID: "U2", DisplayName: "Bob Singh", Username: "bob", Recency: 400},
+		{ID: "U3", DisplayName: "Carla Diaz", Username: "carla", Recency: 300},
+		{ID: "U4", DisplayName: "Dan Evans", Username: "dan", Recency: 200},
+		{ID: "U5", DisplayName: "Eva Frank", Username: "eva", IsExternal: true, Recency: 100},
+	}
+}
+
+func TestNew_NotVisibleByDefault(t *testing.T) {
+	m := New()
+	if m.IsVisible() {
+		t.Error("expected new model to not be visible")
+	}
+}
+
+func TestOpen_MakesVisible(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	if !m.IsVisible() {
+		t.Error("expected Open() to make model visible")
+	}
+}
+
+func TestClose_HidesModel(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	m.Close()
+	if m.IsVisible() {
+		t.Error("expected Close() to hide model")
+	}
+}
+
+func TestOpen_ResetsState(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	// Simulate dirty state from a previous session.
+	m.query = "old query"
+	m.selected["U1"] = struct{}{}
+	m.highlight = 3
+
+	m.Close()
+	m.Open()
+
+	if m.query != "" {
+		t.Errorf("expected empty query after Open, got %q", m.query)
+	}
+	if len(m.selected) != 0 {
+		t.Errorf("expected empty selection after Open, got %d entries", len(m.selected))
+	}
+	if m.highlight != 0 {
+		t.Errorf("expected highlight=0 after Open, got %d", m.highlight)
+	}
+}
+
+func TestSetCurrentUserID_ExcludesSelfFromList(t *testing.T) {
+	users := testUsers()
+	m := New()
+	m.SetCurrentUserID("U2") // Bob is "self"
+	m.SetUsers(users)
+	m.Open()
+
+	for _, idx := range m.filtered {
+		if m.users[idx].ID == "U2" {
+			t.Error("self user U2 should not appear in filtered list")
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Create the model file**
+
+Write `internal/ui/newmessagepicker/model.go`:
+
+```go
+// Package newmessagepicker is the Ctrl+N modal that lets the user
+// start a DM (one recipient) or group DM / MPIM (2-8 recipients).
+//
+// The model is a self-contained Bubble Tea sub-model mirroring the
+// channelfinder package: a fuzzy filter over a user list with a
+// pill-bar multi-select layered on top. Submission returns a Result
+// carrying the chosen user IDs; the caller (the App's mode handler)
+// is responsible for dispatching the conversations.open call.
+package newmessagepicker
+
+// MaxRecipients is Slack's hard cap on the number of OTHER users in
+// a multi-person direct message (MPIM). Slack itself caps total
+// MPIM participants at 9, so up to 8 other users plus self.
+const MaxRecipients = 8
+
+// User is one row in the picker's list. DisplayName is the
+// human-friendly name shown to the user; Username is the Slack handle
+// (without the leading @). Recency is the unix-second timestamp of
+// the most recent activity tied to this user; higher values sort
+// earlier under empty-query and break ties under a query. IsExternal
+// drives the [ext] tag in the rendered row.
+type User struct {
+	ID          string
+	DisplayName string
+	Username    string
+	IsExternal  bool
+	Recency     int64
+}
+
+// Result is returned by HandleKey when the user submits the picker.
+// UserIDs is the list of recipients to pass to conversations.open;
+// it always contains at least one ID when non-nil.
+type Result struct {
+	UserIDs []string
+}
+
+// Model is the picker's state. Constructed with New() and held on the
+// App while ModeNewMessage is active.
+type Model struct {
+	users         []User
+	filtered      []int // indices into users matching query + not-self
+	query         string
+	selected      map[string]struct{} // user IDs in the pill bar
+	highlight     int                 // index into filtered
+	visible       bool
+	currentUserID string
+}
+
+// New constructs an empty picker. SetUsers and (optionally)
+// SetCurrentUserID should be called before Open.
+func New() Model {
+	return Model{
+		selected: map[string]struct{}{},
+	}
+}
+
+// SetUsers replaces the user list the picker filters over.
+// Does not trigger a re-filter; that happens on Open.
+func (m *Model) SetUsers(users []User) {
+	m.users = users
+}
+
+// SetCurrentUserID configures which user ID represents "self" so the
+// picker can hide it from the list (a user cannot start a DM with
+// themselves via this flow). May be called once at app start.
+func (m *Model) SetCurrentUserID(userID string) {
+	m.currentUserID = userID
+}
+
+// Open shows the picker and resets per-session state: query, pill
+// selection, highlight, and recomputes the filtered list.
+func (m *Model) Open() {
+	m.visible = true
+	m.query = ""
+	m.selected = map[string]struct{}{}
+	m.highlight = 0
+	m.filter()
+}
+
+// Close hides the picker. Does not clear users; Open will re-filter.
+func (m *Model) Close() {
+	m.visible = false
+}
+
+// IsVisible reports whether the picker is currently open.
+func (m Model) IsVisible() bool {
+	return m.visible
+}
+
+// filter is a placeholder until Task 3. For now it just includes
+// every user except self. Order is the natural users-slice order.
+func (m *Model) filter() {
+	m.filtered = m.filtered[:0]
+	for i, u := range m.users {
+		if u.ID == m.currentUserID {
+			continue
+		}
+		m.filtered = append(m.filtered, i)
+	}
+}
+```
+
+- [ ] **Step 3: Run the tests**
+
+```
+go test ./internal/ui/newmessagepicker/ -v
+```
+
+Expected: 5 tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```
+git add internal/ui/newmessagepicker/
+git commit -m "feat(new-message): add newmessagepicker package skeleton
+
+Adds User, Result, Model types with Open/Close/IsVisible semantics
+and a placeholder filter that excludes the current user. Real
+filtering arrives in the next task."
+```

--- a/docs/superpowers/plans/2026-05-25-new-message-feature/task-03-picker-filter.md
+++ b/docs/superpowers/plans/2026-05-25-new-message-feature/task-03-picker-filter.md
@@ -1,0 +1,323 @@
+# Task 3: Filter & rank pure functions
+
+**Goal:** Replace the placeholder `filter()` with the real one: prefix > substring > subsequence match tiers, recency tie-break, alpha tie-break, empty-query shows all users by recency then alpha. Filtering happens over `display_name` and `username` (the `@handle`) case-insensitively.
+
+**Files:**
+- Create: `internal/ui/newmessagepicker/filter.go`
+- Modify: `internal/ui/newmessagepicker/model.go` (delete placeholder `filter`, add field for the rune-typing API)
+- Modify: `internal/ui/newmessagepicker/model_test.go` (add tests)
+
+---
+
+- [ ] **Step 1: Add the failing filter tests**
+
+Append to `internal/ui/newmessagepicker/model_test.go`:
+
+```go
+func TestFilter_EmptyQuerySortsByRecencyDesc(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers()) // Alice=500, Bob=400, Carla=300, Dan=200, Eva=100
+	m.Open()
+
+	if len(m.filtered) != 5 {
+		t.Fatalf("expected 5 users, got %d", len(m.filtered))
+	}
+	wantOrder := []string{"U1", "U2", "U3", "U4", "U5"}
+	for i, want := range wantOrder {
+		got := m.users[m.filtered[i]].ID
+		if got != want {
+			t.Errorf("position %d: want %s, got %s", i, want, got)
+		}
+	}
+}
+
+func TestFilter_EmptyQueryTieBreaksAlphabetically(t *testing.T) {
+	users := []User{
+		{ID: "U1", DisplayName: "Charlie", Username: "c", Recency: 100},
+		{ID: "U2", DisplayName: "Alice", Username: "a", Recency: 100},
+		{ID: "U3", DisplayName: "Bob", Username: "b", Recency: 100},
+	}
+	m := New()
+	m.SetUsers(users)
+	m.Open()
+
+	wantOrder := []string{"U2", "U3", "U1"} // Alice, Bob, Charlie
+	for i, want := range wantOrder {
+		got := m.users[m.filtered[i]].ID
+		if got != want {
+			t.Errorf("position %d: want %s, got %s", i, want, got)
+		}
+	}
+}
+
+func TestFilter_PrefixBeatsSubstring(t *testing.T) {
+	users := []User{
+		{ID: "U1", DisplayName: "Marcus", Username: "marcus", Recency: 100},
+		{ID: "U2", DisplayName: "Alice Marketing", Username: "amark", Recency: 999},
+	}
+	m := New()
+	m.SetUsers(users)
+	m.Open()
+	m.setQuery("mar")
+
+	if len(m.filtered) != 2 {
+		t.Fatalf("expected 2 matches, got %d", len(m.filtered))
+	}
+	if m.users[m.filtered[0]].ID != "U1" {
+		t.Errorf("prefix match should come first, got %s", m.users[m.filtered[0]].ID)
+	}
+}
+
+func TestFilter_SubstringBeatsSubsequence(t *testing.T) {
+	users := []User{
+		{ID: "U1", DisplayName: "Stephanie", Username: "steph", Recency: 100},   // contains "eph"
+		{ID: "U2", DisplayName: "Edward Phillips", Username: "ep", Recency: 999}, // subseq e-p-h
+	}
+	m := New()
+	m.SetUsers(users)
+	m.Open()
+	m.setQuery("eph")
+
+	if m.filtered[0] != 0 {
+		t.Errorf("substring match should rank first, got user at index %d", m.filtered[0])
+	}
+}
+
+func TestFilter_CaseInsensitive(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	m.setQuery("ALICE")
+
+	if len(m.filtered) == 0 {
+		t.Fatal("expected at least 1 match for ALICE")
+	}
+	if m.users[m.filtered[0]].ID != "U1" {
+		t.Errorf("expected Alice (U1) as first match, got %s", m.users[m.filtered[0]].ID)
+	}
+}
+
+func TestFilter_MatchesUsernameHandle(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	m.setQuery("dan") // Dan Evans has Username="dan"
+
+	if len(m.filtered) == 0 {
+		t.Fatal("expected match for handle 'dan'")
+	}
+	if m.users[m.filtered[0]].ID != "U4" {
+		t.Errorf("expected Dan (U4) as first match, got %s", m.users[m.filtered[0]].ID)
+	}
+}
+
+func TestFilter_NoMatchesReturnsEmpty(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	m.setQuery("xyzqq")
+
+	if len(m.filtered) != 0 {
+		t.Errorf("expected 0 matches for unmatchable query, got %d", len(m.filtered))
+	}
+}
+
+func TestFilter_ExcludesSelfEvenOnMatch(t *testing.T) {
+	users := testUsers()
+	m := New()
+	m.SetCurrentUserID("U1") // Alice is self
+	m.SetUsers(users)
+	m.Open()
+	m.setQuery("alice")
+
+	for _, idx := range m.filtered {
+		if m.users[idx].ID == "U1" {
+			t.Error("self user should be excluded even when query matches")
+		}
+	}
+}
+
+func TestFilter_RecencyTieBreaksWithinSameTier(t *testing.T) {
+	users := []User{
+		{ID: "U1", DisplayName: "alice older", Username: "a1", Recency: 100},
+		{ID: "U2", DisplayName: "alice newer", Username: "a2", Recency: 999},
+	}
+	m := New()
+	m.SetUsers(users)
+	m.Open()
+	m.setQuery("alice") // both prefix-match
+
+	if m.users[m.filtered[0]].ID != "U2" {
+		t.Errorf("higher-recency match should come first, got %s", m.users[m.filtered[0]].ID)
+	}
+}
+```
+
+- [ ] **Step 2: Add `setQuery` test helper to the model**
+
+In `internal/ui/newmessagepicker/model.go`, add this method after `filter()`:
+
+```go
+// setQuery is a test helper: replaces the query and refilters. The
+// real keystroke API in Task 4 will go through HandleKey.
+func (m *Model) setQuery(q string) {
+	m.query = q
+	m.highlight = 0
+	m.filter()
+}
+```
+
+- [ ] **Step 3: Run tests to confirm they fail**
+
+```
+go test ./internal/ui/newmessagepicker/ -v
+```
+
+Expected: the new tests FAIL — the placeholder filter doesn't honor `query`, recency, or tiering. Older tests still pass.
+
+- [ ] **Step 4: Create `filter.go` with the real ranking**
+
+Write `internal/ui/newmessagepicker/filter.go`:
+
+```go
+package newmessagepicker
+
+import (
+	"sort"
+	"strings"
+)
+
+// filter rebuilds m.filtered from m.users honoring the current query,
+// the current-user exclusion, and the ranking rules:
+//
+//  1. Match tier (only when query non-empty):
+//     0 = prefix on display name OR username
+//     1 = substring on display name OR username
+//     2 = subsequence on display name OR username
+//     Non-matchers are dropped.
+//  2. Recency DESC.
+//  3. DisplayName ASC (case-insensitive).
+//
+// Empty query: include all users (minus self) sorted by Recency DESC
+// then DisplayName ASC.
+func (m *Model) filter() {
+	m.filtered = m.filtered[:0]
+	q := strings.ToLower(m.query)
+
+	if q == "" {
+		for i, u := range m.users {
+			if u.ID == m.currentUserID {
+				continue
+			}
+			m.filtered = append(m.filtered, i)
+		}
+		sort.SliceStable(m.filtered, func(i, j int) bool {
+			return m.lessNoQuery(m.filtered[i], m.filtered[j])
+		})
+		return
+	}
+
+	type match struct {
+		idx  int
+		tier int
+	}
+	var matches []match
+	for i, u := range m.users {
+		if u.ID == m.currentUserID {
+			continue
+		}
+		tier, ok := matchTier(u, q)
+		if !ok {
+			continue
+		}
+		matches = append(matches, match{idx: i, tier: tier})
+	}
+
+	sort.SliceStable(matches, func(i, j int) bool {
+		a, b := matches[i], matches[j]
+		if a.tier != b.tier {
+			return a.tier < b.tier
+		}
+		ua, ub := m.users[a.idx], m.users[b.idx]
+		if ua.Recency != ub.Recency {
+			return ua.Recency > ub.Recency
+		}
+		return strings.ToLower(ua.DisplayName) < strings.ToLower(ub.DisplayName)
+	})
+
+	for _, mm := range matches {
+		m.filtered = append(m.filtered, mm.idx)
+	}
+}
+
+// matchTier returns (tier, true) if u matches q on either its
+// DisplayName or its Username. tier 0 = prefix, 1 = substring,
+// 2 = subsequence. q is expected to already be lower-cased.
+func matchTier(u User, q string) (int, bool) {
+	name := strings.ToLower(u.DisplayName)
+	handle := strings.ToLower(u.Username)
+	if strings.HasPrefix(name, q) || strings.HasPrefix(handle, q) {
+		return 0, true
+	}
+	if strings.Contains(name, q) || strings.Contains(handle, q) {
+		return 1, true
+	}
+	if isSubsequence(name, q) || isSubsequence(handle, q) {
+		return 2, true
+	}
+	return 0, false
+}
+
+// isSubsequence reports whether every rune of q appears in s in
+// order. Both inputs are expected to already be lower-cased.
+func isSubsequence(s, q string) bool {
+	qi := 0
+	qrunes := []rune(q)
+	if len(qrunes) == 0 {
+		return true
+	}
+	for _, r := range s {
+		if qi >= len(qrunes) {
+			break
+		}
+		if r == qrunes[qi] {
+			qi++
+		}
+	}
+	return qi == len(qrunes)
+}
+
+// lessNoQuery is the comparator used when the query is empty:
+// Recency DESC, then DisplayName ASC.
+func (m *Model) lessNoQuery(ai, bi int) bool {
+	a, b := m.users[ai], m.users[bi]
+	if a.Recency != b.Recency {
+		return a.Recency > b.Recency
+	}
+	return strings.ToLower(a.DisplayName) < strings.ToLower(b.DisplayName)
+}
+```
+
+- [ ] **Step 5: Remove the placeholder filter from `model.go`**
+
+In `internal/ui/newmessagepicker/model.go`, delete the entire placeholder `filter()` function (the one with the comment "filter is a placeholder until Task 3"). The real implementation lives in `filter.go` now.
+
+- [ ] **Step 6: Run tests to confirm they pass**
+
+```
+go test ./internal/ui/newmessagepicker/ -v
+```
+
+Expected: ALL tests PASS (the 5 from Task 2 plus the 9 added in this task).
+
+- [ ] **Step 7: Commit**
+
+```
+git add internal/ui/newmessagepicker/
+git commit -m "feat(new-message): filter and rank users in the picker
+
+Prefix > substring > subsequence tiers, with recency DESC and
+display name ASC tie-breaks. Matches against both display name
+and the @handle, case-insensitively. Self is excluded from the
+filtered list even on a query match."
+```

--- a/docs/superpowers/plans/2026-05-25-new-message-feature/task-04-picker-selection.md
+++ b/docs/superpowers/plans/2026-05-25-new-message-feature/task-04-picker-selection.md
@@ -1,0 +1,370 @@
+# Task 4: Navigation + multi-select toggle + MPIM cap
+
+**Goal:** Add `HandleKey` for navigation (up/down/ctrl+p/ctrl+n), printable-rune query input, backspace, and Space/Tab to toggle the highlighted user into the pill bar. Enforce `MaxRecipients = 8` cap.
+
+**Files:**
+- Modify: `internal/ui/newmessagepicker/model.go`
+- Modify: `internal/ui/newmessagepicker/model_test.go`
+
+---
+
+- [ ] **Step 1: Add failing tests for navigation**
+
+Append to `internal/ui/newmessagepicker/model_test.go`:
+
+```go
+func TestHandleKey_DownMovesHighlight(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	// 5 users, highlight starts at 0.
+	m.HandleKey("down")
+	if m.highlight != 1 {
+		t.Errorf("expected highlight=1 after down, got %d", m.highlight)
+	}
+}
+
+func TestHandleKey_UpMovesHighlight(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	m.HandleKey("down")
+	m.HandleKey("down")
+	m.HandleKey("up")
+	if m.highlight != 1 {
+		t.Errorf("expected highlight=1 after down,down,up, got %d", m.highlight)
+	}
+}
+
+func TestHandleKey_DownClampsAtEnd(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	for i := 0; i < 20; i++ {
+		m.HandleKey("down")
+	}
+	if m.highlight != len(m.filtered)-1 {
+		t.Errorf("expected highlight clamped at %d, got %d", len(m.filtered)-1, m.highlight)
+	}
+}
+
+func TestHandleKey_UpClampsAtStart(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	m.HandleKey("up")
+	if m.highlight != 0 {
+		t.Errorf("expected highlight=0 clamped, got %d", m.highlight)
+	}
+}
+
+func TestHandleKey_CtrlNAndCtrlPAliasNavigation(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	m.HandleKey("ctrl+n")
+	if m.highlight != 1 {
+		t.Errorf("ctrl+n should be alias for down")
+	}
+	m.HandleKey("ctrl+p")
+	if m.highlight != 0 {
+		t.Errorf("ctrl+p should be alias for up")
+	}
+}
+
+func TestHandleKey_PrintableRuneAppendsToQueryAndRefilters(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	m.HandleKey("a")
+	m.HandleKey("l")
+	m.HandleKey("i")
+	if m.query != "ali" {
+		t.Errorf("expected query=ali, got %q", m.query)
+	}
+	if len(m.filtered) == 0 || m.users[m.filtered[0]].ID != "U1" {
+		t.Errorf("expected Alice (U1) first, got %v", m.filtered)
+	}
+}
+
+func TestHandleKey_BackspaceRemovesLastRune(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	m.HandleKey("a")
+	m.HandleKey("l")
+	m.HandleKey("backspace")
+	if m.query != "a" {
+		t.Errorf("expected query=a after backspace, got %q", m.query)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```
+go test ./internal/ui/newmessagepicker/ -run TestHandleKey -v
+```
+
+Expected: all `TestHandleKey_*` tests FAIL with "HandleKey undefined".
+
+- [ ] **Step 3: Add `HandleKey` for navigation only**
+
+In `internal/ui/newmessagepicker/model.go`, append:
+
+```go
+// HandleKey processes a single key event. The string form mirrors the
+// other picker packages (channelfinder, mentionpicker): "up", "down",
+// "ctrl+n", "ctrl+p", "backspace", "esc", "enter", "tab", " ", or
+// any single printable ASCII character.
+//
+// Returns a non-nil Result when the user submits the picker; the
+// caller (the mode handler) closes the picker and dispatches the
+// conversations.open call.
+//
+// This task wires the navigation arms only. Selection (Space/Tab)
+// lands in this task too; submit semantics (Enter) land in Task 5.
+func (m *Model) HandleKey(keyStr string) *Result {
+	switch keyStr {
+	case "down", "ctrl+n":
+		if m.highlight < len(m.filtered)-1 {
+			m.highlight++
+		}
+		return nil
+	case "up", "ctrl+p":
+		if m.highlight > 0 {
+			m.highlight--
+		}
+		return nil
+	case "backspace":
+		if len(m.query) > 0 {
+			m.query = m.query[:len(m.query)-1]
+			m.highlight = 0
+			m.filter()
+		}
+		return nil
+	}
+
+	// Single printable ASCII rune -> append to query.
+	if len(keyStr) == 1 && keyStr[0] >= 32 && keyStr[0] <= 126 && keyStr[0] != ' ' {
+		m.query += keyStr
+		m.highlight = 0
+		m.filter()
+	}
+	return nil
+}
+```
+
+Note we exclude the space character from the "append to query" path — Space is reserved for the selection toggle.
+
+- [ ] **Step 4: Run navigation tests**
+
+```
+go test ./internal/ui/newmessagepicker/ -run TestHandleKey -v
+```
+
+Expected: 7 PASS.
+
+- [ ] **Step 5: Add failing tests for selection toggle and the MPIM cap**
+
+Append to `model_test.go`:
+
+```go
+func TestHandleKey_SpaceTogglesHighlightedUserIntoSelection(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	// highlight starts at 0 -> Alice (U1)
+
+	m.HandleKey(" ")
+	if _, ok := m.selected["U1"]; !ok {
+		t.Error("expected U1 in selection after space")
+	}
+	if len(m.selected) != 1 {
+		t.Errorf("expected 1 selection, got %d", len(m.selected))
+	}
+}
+
+func TestHandleKey_TabAliasesSpace(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	m.HandleKey("tab")
+	if _, ok := m.selected["U1"]; !ok {
+		t.Error("expected U1 in selection after tab")
+	}
+}
+
+func TestHandleKey_SpaceOnSelectedRemovesIt(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	m.HandleKey(" ")
+	m.HandleKey(" ")
+	if _, ok := m.selected["U1"]; ok {
+		t.Error("expected U1 to be removed after second space")
+	}
+}
+
+func TestHandleKey_SpaceCapsAtMaxRecipients(t *testing.T) {
+	users := make([]User, 10)
+	for i := range users {
+		users[i] = User{
+			ID:          fmt.Sprintf("U%d", i),
+			DisplayName: fmt.Sprintf("User %d", i),
+			Username:    fmt.Sprintf("u%d", i),
+		}
+	}
+	m := New()
+	m.SetUsers(users)
+	m.Open()
+	// Select 8 users by hitting space then down 8 times.
+	for i := 0; i < 8; i++ {
+		m.HandleKey(" ")
+		m.HandleKey("down")
+	}
+	if len(m.selected) != 8 {
+		t.Fatalf("expected 8 selections, got %d", len(m.selected))
+	}
+	// 9th selection attempt must be a no-op.
+	m.HandleKey(" ")
+	if len(m.selected) != 8 {
+		t.Errorf("expected selection to be capped at 8, got %d", len(m.selected))
+	}
+}
+
+func TestHandleKey_BackspaceAtEmptyQueryRemovesLastPill(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	m.HandleKey(" ")          // select U1
+	m.HandleKey("down")       // highlight U2
+	m.HandleKey(" ")          // select U2
+	// Two pills. Query is empty. Backspace should remove the LAST pill (U2).
+	m.HandleKey("backspace")
+	if _, ok := m.selected["U2"]; ok {
+		t.Error("expected U2 removed by backspace at empty query")
+	}
+	if _, ok := m.selected["U1"]; !ok {
+		t.Error("expected U1 still selected")
+	}
+}
+```
+
+You'll need `"fmt"` in the test imports if not already present.
+
+- [ ] **Step 6: Run tests to confirm they fail**
+
+```
+go test ./internal/ui/newmessagepicker/ -v
+```
+
+Expected: 5 new tests FAIL; navigation tests still PASS.
+
+- [ ] **Step 7: Add the selection-toggle arm and a helper**
+
+In `internal/ui/newmessagepicker/model.go`, find the `HandleKey` switch and add cases for `" "` and `"tab"`. Replace the existing function with this version:
+
+```go
+func (m *Model) HandleKey(keyStr string) *Result {
+	switch keyStr {
+	case "down", "ctrl+n":
+		if m.highlight < len(m.filtered)-1 {
+			m.highlight++
+		}
+		return nil
+	case "up", "ctrl+p":
+		if m.highlight > 0 {
+			m.highlight--
+		}
+		return nil
+	case " ", "tab":
+		m.toggleHighlightedSelection()
+		return nil
+	case "backspace":
+		m.handleBackspace()
+		return nil
+	}
+
+	// Single printable ASCII rune -> append to query.
+	if len(keyStr) == 1 && keyStr[0] >= 33 && keyStr[0] <= 126 {
+		m.query += keyStr
+		m.highlight = 0
+		m.filter()
+	}
+	return nil
+}
+
+// toggleHighlightedSelection adds or removes the currently-highlighted
+// user from the pill bar. No-op when nothing is highlighted, when the
+// pill bar is at MaxRecipients capacity, or when the highlighted user
+// is already selected (in which case it removes them).
+func (m *Model) toggleHighlightedSelection() {
+	if m.highlight < 0 || m.highlight >= len(m.filtered) {
+		return
+	}
+	userID := m.users[m.filtered[m.highlight]].ID
+	if _, already := m.selected[userID]; already {
+		delete(m.selected, userID)
+		return
+	}
+	if len(m.selected) >= MaxRecipients {
+		return
+	}
+	m.selected[userID] = struct{}{}
+}
+
+// handleBackspace deletes the last rune of the query. If the query is
+// already empty AND the pill bar is non-empty, it removes the LAST
+// pill instead — letting the user erase a wrong recipient without
+// reaching for the mouse.
+func (m *Model) handleBackspace() {
+	if len(m.query) > 0 {
+		m.query = m.query[:len(m.query)-1]
+		m.highlight = 0
+		m.filter()
+		return
+	}
+	if len(m.selected) == 0 {
+		return
+	}
+	// No pill order is recorded; we use the last user ID inserted
+	// into the selected set. Since Go map iteration is randomized, we
+	// instead pop the one that appears last in m.users order — this
+	// gives the user a stable, predictable "remove most recently
+	// added" behavior tied to the user list order rather than a
+	// hidden insertion order. (Alternative would be a slice of IDs;
+	// YAGNI — a single backspace mid-flow is rare.)
+	for i := len(m.users) - 1; i >= 0; i-- {
+		id := m.users[i].ID
+		if _, ok := m.selected[id]; ok {
+			delete(m.selected, id)
+			return
+		}
+	}
+}
+```
+
+> **SOLID note:** `toggleHighlightedSelection` and `handleBackspace` are extracted as methods with single responsibilities. `HandleKey` becomes a dispatcher — fewer lines, one level of indentation per arm.
+
+> **Order-of-pills correction:** The test `TestHandleKey_BackspaceAtEmptyQueryRemovesLastPill` selects U1 then U2 and expects U2 to be removed. In `testUsers()`, U1 appears at index 0 and U2 at index 1; iterating `m.users` backwards finds U2 first. The test will pass.
+
+- [ ] **Step 8: Run all picker tests**
+
+```
+go test ./internal/ui/newmessagepicker/ -v
+```
+
+Expected: ALL tests PASS.
+
+- [ ] **Step 9: Commit**
+
+```
+git add internal/ui/newmessagepicker/
+git commit -m "feat(new-message): navigation, multi-select toggle, MPIM cap
+
+HandleKey now supports up/down/ctrl+p/ctrl+n navigation, Space/Tab
+to toggle a user into the pill bar (capped at MaxRecipients=8),
+printable runes to filter, and backspace to either delete the last
+query rune or remove the last pill when the query is empty."
+```

--- a/docs/superpowers/plans/2026-05-25-new-message-feature/task-05-picker-submit.md
+++ b/docs/superpowers/plans/2026-05-25-new-message-feature/task-05-picker-submit.md
@@ -1,0 +1,162 @@
+# Task 5: Submit & cancel semantics
+
+**Goal:** Enter and Esc complete the picker's behavioral surface. Enter returns a `*Result` containing the pill IDs (or, if pills are empty, the highlighted user's ID); Esc closes the picker and returns nil.
+
+**Files:**
+- Modify: `internal/ui/newmessagepicker/model.go`
+- Modify: `internal/ui/newmessagepicker/model_test.go`
+
+---
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `internal/ui/newmessagepicker/model_test.go`:
+
+```go
+func TestHandleKey_EnterWithPillsReturnsPillIDs(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	m.HandleKey(" ")    // select Alice (U1)
+	m.HandleKey("down") // highlight Bob
+	m.HandleKey(" ")    // select Bob (U2)
+
+	res := m.HandleKey("enter")
+	if res == nil {
+		t.Fatal("expected non-nil result from Enter with pills")
+	}
+	if len(res.UserIDs) != 2 {
+		t.Fatalf("expected 2 user IDs, got %d", len(res.UserIDs))
+	}
+	// Order within UserIDs is not guaranteed by the spec; check set membership.
+	got := map[string]bool{}
+	for _, id := range res.UserIDs {
+		got[id] = true
+	}
+	if !got["U1"] || !got["U2"] {
+		t.Errorf("expected {U1, U2}, got %v", res.UserIDs)
+	}
+}
+
+func TestHandleKey_EnterWithoutPillsUsesHighlight(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	m.HandleKey("down") // highlight Bob (U2)
+
+	res := m.HandleKey("enter")
+	if res == nil {
+		t.Fatal("expected non-nil result from Enter with highlight")
+	}
+	if len(res.UserIDs) != 1 || res.UserIDs[0] != "U2" {
+		t.Errorf("expected [U2], got %v", res.UserIDs)
+	}
+}
+
+func TestHandleKey_EnterWithNoHighlightAndNoPillsReturnsNil(t *testing.T) {
+	m := New()
+	m.SetUsers(nil) // no users -> filtered is empty
+	m.Open()
+
+	res := m.HandleKey("enter")
+	if res != nil {
+		t.Errorf("expected nil result when nothing to submit, got %+v", res)
+	}
+}
+
+func TestHandleKey_EnterWithEmptyFilteredButPillsStillSubmits(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	m.HandleKey(" ")        // select Alice
+	m.setQuery("xyzqq")    // filter to nothing
+	res := m.HandleKey("enter")
+	if res == nil || len(res.UserIDs) != 1 || res.UserIDs[0] != "U1" {
+		t.Errorf("expected pills to submit even with empty filter, got %+v", res)
+	}
+}
+
+func TestHandleKey_EscClosesPickerAndReturnsNil(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	if !m.IsVisible() {
+		t.Fatal("precondition: picker should be visible")
+	}
+	res := m.HandleKey("esc")
+	if res != nil {
+		t.Errorf("expected nil result from Esc, got %+v", res)
+	}
+	if m.IsVisible() {
+		t.Error("expected picker to be hidden after Esc")
+	}
+}
+```
+
+- [ ] **Step 2: Run to confirm tests fail**
+
+```
+go test ./internal/ui/newmessagepicker/ -run TestHandleKey_Enter -v
+go test ./internal/ui/newmessagepicker/ -run TestHandleKey_Esc -v
+```
+
+Expected: 5 failures.
+
+- [ ] **Step 3: Add Enter and Esc arms to `HandleKey`**
+
+In `internal/ui/newmessagepicker/model.go`, find the `HandleKey` switch and add two cases above the existing `"down"` case (order doesn't matter, but enter/esc first reads well):
+
+```go
+	case "enter":
+		return m.submit()
+	case "esc":
+		m.Close()
+		return nil
+```
+
+Then add the `submit` helper after `handleBackspace`:
+
+```go
+// submit returns a non-nil *Result when the picker has something to
+// submit:
+//   - If pills are present, the result carries the pill IDs.
+//   - Otherwise, if a user is highlighted, the result carries that one ID.
+//   - If neither is true (empty filter AND no pills), returns nil — Enter is a no-op.
+//
+// Pill order in the returned slice matches the user-list order so the
+// caller sees a stable, predictable order across calls.
+func (m *Model) submit() *Result {
+	if len(m.selected) > 0 {
+		ids := make([]string, 0, len(m.selected))
+		for _, u := range m.users {
+			if _, ok := m.selected[u.ID]; ok {
+				ids = append(ids, u.ID)
+			}
+		}
+		return &Result{UserIDs: ids}
+	}
+	if m.highlight < 0 || m.highlight >= len(m.filtered) {
+		return nil
+	}
+	return &Result{UserIDs: []string{m.users[m.filtered[m.highlight]].ID}}
+}
+```
+
+- [ ] **Step 4: Run all picker tests**
+
+```
+go test ./internal/ui/newmessagepicker/ -v
+```
+
+Expected: ALL tests PASS (5 from Task 2 + 9 from Task 3 + 12 from Task 4 + 5 from this task = 31).
+
+- [ ] **Step 5: Commit**
+
+```
+git add internal/ui/newmessagepicker/
+git commit -m "feat(new-message): Enter submits, Esc cancels
+
+Enter with pills returns the pill IDs in user-list order. Enter
+without pills returns the highlighted user's ID. Enter with neither
+is a no-op. Esc hides the picker and returns nil."
+```

--- a/docs/superpowers/plans/2026-05-25-new-message-feature/task-06-picker-view.md
+++ b/docs/superpowers/plans/2026-05-25-new-message-feature/task-06-picker-view.md
@@ -1,0 +1,307 @@
+# Task 6: Picker view rendering
+
+**Goal:** Add `View` and `ViewOverlay` so the picker can render. Title bar, pill bar + query input, scrollable result list with `[ext]` tag for externals, footer with key hints and `N / 8` counter. Composited via `overlay.DimmedOverlay` like `channelfinder`.
+
+**Files:**
+- Create: `internal/ui/newmessagepicker/view.go`
+
+---
+
+> **Why no automated tests?** Rendering output is ANSI-styled and width-dependent. The codebase has no golden-file infra; visual correctness is verified manually (Task 14). The structural correctness of the view (which rows appear, in what order) is already covered by Tasks 3–5 via `m.filtered`.
+
+- [ ] **Step 1: Create the view file**
+
+Write `internal/ui/newmessagepicker/view.go`:
+
+```go
+package newmessagepicker
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	"github.com/gammons/slk/internal/ui/messages"
+	"github.com/gammons/slk/internal/ui/overlay"
+	"github.com/gammons/slk/internal/ui/styles"
+	"github.com/muesli/reflow/truncate"
+)
+
+// View renders just the modal box. Use ViewOverlay for the
+// dimmed-backdrop composite that the App actually paints.
+func (m Model) View(termWidth int) string {
+	return m.renderBox(termWidth)
+}
+
+// ViewOverlay renders the modal centered on a dimmed copy of the
+// current screen. background is the already-rendered base screen.
+func (m Model) ViewOverlay(termWidth, termHeight int, background string) string {
+	if !m.visible {
+		return background
+	}
+	box := m.renderBox(termWidth)
+	if box == "" {
+		return background
+	}
+	return overlay.DimmedOverlay(termWidth, termHeight, background, box, 0.5)
+}
+
+func (m Model) renderBox(termWidth int) string {
+	if !m.visible {
+		return ""
+	}
+
+	overlayWidth := termWidth / 2
+	if overlayWidth < 40 {
+		overlayWidth = 40
+	}
+	if overlayWidth > 80 {
+		overlayWidth = 80
+	}
+	innerWidth := overlayWidth - 4
+	bg := styles.Background
+
+	title := lipgloss.NewStyle().
+		Bold(true).
+		Background(bg).
+		Foreground(styles.Primary).
+		Render("New message")
+
+	input := m.renderInputRow(innerWidth, bg)
+	rows := m.renderResultRows(innerWidth, bg)
+	footer := m.renderFooter(innerWidth, bg)
+
+	content := title + "\n" + input + "\n\n" + strings.Join(rows, "\n") + "\n\n" + footer
+
+	// Re-paint modal bg+fg after every ANSI reset emitted by inner
+	// styled spans, otherwise trailing spaces inherit the dimmed-
+	// app background. Same fix channelfinder uses.
+	content = messages.ReapplyBgAfterResets(content, messages.BgANSI()+messages.FgANSI())
+
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(styles.Primary).
+		BorderBackground(bg).
+		Background(bg).
+		Padding(1, 1).
+		Width(overlayWidth).
+		Render(content)
+}
+
+// renderInputRow renders the "To: [pill] [pill] |query█" row.
+func (m Model) renderInputRow(innerWidth int, bg lipgloss.Color) string {
+	prefix := lipgloss.NewStyle().Background(bg).Foreground(styles.TextMuted).Render("To: ")
+
+	var b strings.Builder
+	b.WriteString(prefix)
+
+	pillStyle := lipgloss.NewStyle().
+		Background(styles.Primary).
+		Foreground(styles.Background).
+		Padding(0, 1)
+
+	for _, u := range m.users {
+		if _, ok := m.selected[u.ID]; !ok {
+			continue
+		}
+		b.WriteString(pillStyle.Render(u.DisplayName))
+		b.WriteString(" ")
+	}
+
+	queryStyle := lipgloss.NewStyle().Background(bg).Foreground(styles.TextPrimary)
+	if m.query == "" && len(m.selected) == 0 {
+		placeholder := lipgloss.NewStyle().Background(bg).Foreground(styles.TextMuted).Render("type a name…")
+		b.WriteString(placeholder)
+	} else {
+		b.WriteString(queryStyle.Render(m.query))
+		b.WriteString(queryStyle.Render("█"))
+	}
+
+	row := b.String()
+	if lipgloss.Width(row) > innerWidth {
+		row = truncate.StringWithTail(row, uint(innerWidth), "…")
+	}
+	return row
+}
+
+// renderResultRows produces up to 10 visible result rows with a
+// scrollbar when the list overflows. Highlighted row gets a left bar
+// and the Primary foreground.
+func (m Model) renderResultRows(innerWidth int, bg lipgloss.Color) []string {
+	const maxVisible = 10
+	total := len(m.filtered)
+
+	if total == 0 {
+		var msg string
+		if m.query != "" {
+			msg = fmt.Sprintf("No users match %q", m.query)
+		} else {
+			msg = "No users available"
+		}
+		return []string{
+			lipgloss.NewStyle().
+				Background(bg).
+				Foreground(styles.TextMuted).
+				Italic(true).
+				Render(msg),
+		}
+	}
+
+	visible := maxVisible
+	if visible > total {
+		visible = total
+	}
+
+	startIdx := 0
+	if m.highlight >= visible {
+		startIdx = m.highlight - visible + 1
+	}
+	endIdx := startIdx + visible
+	if endIdx > total {
+		endIdx = total
+		startIdx = endIdx - visible
+		if startIdx < 0 {
+			startIdx = 0
+		}
+	}
+
+	showScrollbar := total > visible
+	contentWidth := innerWidth - 1 // 1 col for the highlight indicator
+	if showScrollbar {
+		contentWidth--
+	}
+
+	var thumbStart, thumbEnd int
+	if showScrollbar {
+		thumbHeight := visible * visible / total
+		if thumbHeight < 1 {
+			thumbHeight = 1
+		}
+		denom := total - visible
+		if denom < 1 {
+			denom = 1
+		}
+		thumbStart = startIdx * (visible - thumbHeight) / denom
+		if thumbStart < 0 {
+			thumbStart = 0
+		}
+		if thumbStart > visible-thumbHeight {
+			thumbStart = visible - thumbHeight
+		}
+		thumbEnd = thumbStart + thumbHeight
+	}
+	thumbStyle := lipgloss.NewStyle().Background(bg).Foreground(styles.Primary)
+	trackStyle := lipgloss.NewStyle().Background(bg).Foreground(styles.Border)
+
+	var rows []string
+	for i := startIdx; i < endIdx; i++ {
+		u := m.users[m.filtered[i]]
+		isHighlight := i == m.highlight
+
+		row := m.renderRow(u, contentWidth, isHighlight, bg)
+		if showScrollbar {
+			rel := i - startIdx
+			if rel >= thumbStart && rel < thumbEnd {
+				row += thumbStyle.Render("\u2588")
+			} else {
+				row += trackStyle.Render("\u2502")
+			}
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+// renderRow renders a single user row: display name, @handle, [ext]
+// tag if external, and a trailing "✓" if the user is in the pill bar.
+func (m Model) renderRow(u User, width int, highlight bool, bg lipgloss.Color) string {
+	name := u.DisplayName
+	if u.IsExternal {
+		name += " [ext]"
+	}
+
+	handle := lipgloss.NewStyle().
+		Background(bg).
+		Foreground(styles.TextMuted).
+		Render(" @" + u.Username)
+
+	var nameStyle lipgloss.Style
+	if highlight {
+		nameStyle = lipgloss.NewStyle().Background(bg).Foreground(styles.Primary).Bold(true)
+	} else {
+		nameStyle = lipgloss.NewStyle().Background(bg).Foreground(styles.TextPrimary)
+	}
+	nameRendered := nameStyle.Render(name)
+
+	check := ""
+	if _, sel := m.selected[u.ID]; sel {
+		check = lipgloss.NewStyle().Background(bg).Foreground(styles.Accent).Render(" ✓")
+	}
+
+	line := nameRendered + handle + check
+	if lipgloss.Width(line) > width {
+		line = truncate.StringWithTail(line, uint(width), "…")
+	}
+	if pad := width - lipgloss.Width(line); pad > 0 {
+		line += strings.Repeat(" ", pad)
+	}
+
+	if highlight {
+		indicator := lipgloss.NewStyle().Background(bg).Foreground(styles.Accent).Render("▌")
+		return indicator + line
+	}
+	return " " + line
+}
+
+// renderFooter is the key-hints + N/8 counter row.
+func (m Model) renderFooter(innerWidth int, bg lipgloss.Color) string {
+	left := lipgloss.NewStyle().
+		Background(bg).
+		Foreground(styles.TextMuted).
+		Render("space toggle  enter open  esc cancel")
+
+	counterText := fmt.Sprintf("%d / %d", len(m.selected), MaxRecipients)
+	var counterStyle lipgloss.Style
+	if len(m.selected) >= MaxRecipients {
+		counterStyle = lipgloss.NewStyle().Background(bg).Foreground(styles.TextMuted).Italic(true)
+		counterText += "  MPIM limit reached"
+	} else {
+		counterStyle = lipgloss.NewStyle().Background(bg).Foreground(styles.TextMuted)
+	}
+	right := counterStyle.Render(counterText)
+
+	gap := innerWidth - lipgloss.Width(left) - lipgloss.Width(right)
+	if gap < 1 {
+		gap = 1
+	}
+	return left + strings.Repeat(" ", gap) + right
+}
+```
+
+- [ ] **Step 2: Run the package tests to confirm the view code compiles and existing tests still pass**
+
+```
+go test ./internal/ui/newmessagepicker/ -v
+```
+
+Expected: all 31 tests PASS. (Compilation alone catches typos in the imports.)
+
+- [ ] **Step 3: Run a smoke render via `go vet`**
+
+```
+go vet ./internal/ui/newmessagepicker/
+```
+
+Expected: no output (no issues).
+
+- [ ] **Step 4: Commit**
+
+```
+git add internal/ui/newmessagepicker/view.go
+git commit -m "feat(new-message): render the picker modal
+
+Title, pill bar + query input, scrollable list with [ext] tag for
+externals and a ✓ for selected users, scrollbar when overflowing,
+footer with key hints and N/8 counter. Uses overlay.DimmedOverlay
+for the centered modal composition like channelfinder."
+```

--- a/docs/superpowers/plans/2026-05-25-new-message-feature/task-07-mode-and-msgs.md
+++ b/docs/superpowers/plans/2026-05-25-new-message-feature/task-07-mode-and-msgs.md
@@ -1,0 +1,122 @@
+# Task 7: Mode constant + message types + Ctrl+N keybind
+
+**Goal:** Wire the type-level surfaces that the App needs: the new `ModeNewMessage` constant, the `NewMessage` keybind in the default keymap, and the three message types in `msgs.go`. No App state or reducer yet — those land in Tasks 9 and 11.
+
+**Files:**
+- Modify: `internal/ui/mode.go`
+- Modify: `internal/ui/keys.go`
+- Modify: `internal/ui/msgs.go`
+
+---
+
+- [ ] **Step 1: Add `ModeNewMessage` to the Mode enum**
+
+In `internal/ui/mode.go`, add the new constant to the iota block (after `ModeHelp`):
+
+```go
+const (
+	ModeNormal Mode = iota
+	ModeInsert
+	ModeCommand
+	ModeSearch
+	ModeChannelFinder
+	ModeReactionPicker
+	ModeWorkspaceFinder
+	ModeThemeSwitcher
+	ModePresenceMenu
+	ModePresenceCustomSnooze
+	ModeConfirm
+	ModeHelp
+	ModeNewMessage
+)
+```
+
+Then add the `String()` case (before the `default`):
+
+```go
+	case ModeNewMessage:
+		return "NEW MSG"
+```
+
+- [ ] **Step 2: Add the `NewMessage` keybind to the KeyMap**
+
+In `internal/ui/keys.go`, add a `NewMessage` field to the `KeyMap` struct (anywhere in the struct, but next to `WorkspaceFinder` reads well):
+
+```go
+	NewMessage          key.Binding
+```
+
+In `DefaultKeyMap()`, add the corresponding initializer (place it next to `WorkspaceFinder`):
+
+```go
+		NewMessage:          key.NewBinding(key.WithKeys("ctrl+n"), key.WithHelp("ctrl+n", "new message")),
+```
+
+- [ ] **Step 3: Add the three message types to `msgs.go`**
+
+In `internal/ui/msgs.go`, scroll to the bottom of the file (after `editEmptyToastMsg`) and append:
+
+```go
+// EnterNewMessageMsg is dispatched when the user presses Ctrl+N in
+// ModeNormal. The reducer (reduceNewMessage) handles it by snapshotting
+// the workspace user list, opening the newmessagepicker, and switching
+// to ModeNewMessage.
+type EnterNewMessageMsg struct{}
+
+// NewMessageOpenedMsg carries the result of a successful
+// ChannelService.OpenConversation call. RequestID identifies which
+// submit this is the response to so the reducer can drop late
+// arrivals from cancelled submits. AlreadyOpen=true means Slack
+// returned an existing DM/MPIM; the reducer skips the
+// minimal-channel-record insert in that case (Task 12).
+//
+// Distinct from the existing ConversationOpenedMsg in this file,
+// which is dispatched by the WS event handler for Slack's
+// mpim_open / im_created events (channel side-effect of someone
+// being added to a conversation). The new-message flow has its own
+// type because it carries the in-flight RequestID and we need
+// per-message routing in reduceNewMessage.
+type NewMessageOpenedMsg struct {
+	ChannelID   string
+	AlreadyOpen bool
+	UserIDs     []string // copied through so the reducer can hydrate the cache record
+	RequestID   uint64
+}
+
+// NewMessageFailedMsg carries an error from a failed
+// ChannelService.OpenConversation call. The reducer surfaces Err in
+// the modal's footer banner; the modal stays open with the user's
+// selection intact so they can retry.
+type NewMessageFailedMsg struct {
+	RequestID uint64
+	Err       error
+}
+```
+
+- [ ] **Step 4: Verify compilation**
+
+```
+go build ./...
+```
+
+Expected: no output (build succeeds). The new constants and types are used in later tasks.
+
+- [ ] **Step 5: Run the full test suite to confirm nothing regressed**
+
+```
+go test ./...
+```
+
+Expected: all existing tests still PASS. (No new tests in this task — these are pure type additions.)
+
+- [ ] **Step 6: Commit**
+
+```
+git add internal/ui/mode.go internal/ui/keys.go internal/ui/msgs.go
+git commit -m "feat(new-message): add ModeNewMessage, Ctrl+N keybind, msg types
+
+ModeNewMessage joins the Mode enum with display string \"NEW MSG\".
+Ctrl+N is bound to the new NewMessage KeyMap field. Three messages
+sit in msgs.go: EnterNewMessageMsg (Ctrl+N dispatch),
+NewMessageOpenedMsg (success), NewMessageFailedMsg (error)."
+```

--- a/docs/superpowers/plans/2026-05-25-new-message-feature/task-08-channel-service.md
+++ b/docs/superpowers/plans/2026-05-25-new-message-feature/task-08-channel-service.md
@@ -1,0 +1,71 @@
+# Task 8: `ChannelService.OpenConversation` interface + adapter
+
+**Goal:** Extend `ChannelService` with an `OpenConversation` method so the reducer can dispatch the open-conversation call without knowing about the Slack client directly. Follows the established adapter pattern (`channelAdapter` + `ChannelServiceFuncs`).
+
+**Files:**
+- Modify: `internal/ui/services.go`
+
+---
+
+> **SOLID note — ISP:** The `ChannelService` interface is already large (the spec calls this out at services.go:339-344). Adding a method here is the right move because conversation-opening is squarely a channel-domain concern (the result IS a channel), and pulling out a one-method interface for it would just create a second collaborator with no other callers. Rule of Three not yet reached.
+
+- [ ] **Step 1: Add `OpenConversation` to the `ChannelService` interface**
+
+In `internal/ui/services.go`, find the `ChannelService` interface (starts at line 346) and add this method after `MembershipFetch` (the last method, ending around line 393):
+
+```go
+	// OpenConversation dispatches conversations.open for userIDs (1
+	// recipient = IM, 2-8 recipients = MPIM). Returns a tea.Cmd whose
+	// resolved tea.Msg is NewMessageOpenedMsg on success or
+	// NewMessageFailedMsg on error; both carry requestID so the
+	// reducer can drop late results from cancelled submits.
+	OpenConversation(userIDs []string, requestID uint64) tea.Cmd
+```
+
+- [ ] **Step 2: Add the closure field to `ChannelServiceFuncs`**
+
+In the same file, find `ChannelServiceFuncs` (around line 399) and add a field after `MembershipFetch`:
+
+```go
+	OpenConversation func(userIDs []string, requestID uint64) tea.Cmd
+```
+
+- [ ] **Step 3: Add the adapter method**
+
+After the existing `MembershipFetch` adapter method (the last one in the file, around line 481-486), append:
+
+```go
+func (c channelAdapter) OpenConversation(userIDs []string, requestID uint64) tea.Cmd {
+	if c.fns.OpenConversation == nil {
+		return nil
+	}
+	return c.fns.OpenConversation(userIDs, requestID)
+}
+```
+
+- [ ] **Step 4: Verify compilation**
+
+```
+go build ./...
+```
+
+Expected: no output. The build succeeds because `noopChannelService` (the default zero-fns adapter) returns nil from the new method via the nil-check.
+
+- [ ] **Step 5: Confirm existing channel-service tests still pass**
+
+```
+go test ./internal/ui/ -run TestChannel -v
+```
+
+Expected: existing tests PASS. (No new test is needed at this layer — `channelAdapter` is a pass-through; behavior is tested through the reducer in Task 11.)
+
+- [ ] **Step 6: Commit**
+
+```
+git add internal/ui/services.go
+git commit -m "feat(new-message): add ChannelService.OpenConversation
+
+Adapter follows the existing ChannelServiceFuncs/channelAdapter
+pattern: nil-safe (returns nil tea.Cmd when no closure is wired)
+and accepts a monotonic requestID for cancellation tracking."
+```

--- a/docs/superpowers/plans/2026-05-25-new-message-feature/task-09-app-wiring.md
+++ b/docs/superpowers/plans/2026-05-25-new-message-feature/task-09-app-wiring.md
@@ -1,0 +1,203 @@
+# Task 9: App wiring — picker field, mode handler, overlay composite
+
+**Goal:** Put a `newmessagepicker.Model` on `App`, route key events to it from a new `mode_new_message.go`, dispatch `EnterNewMessageMsg` on `Ctrl+N` from `ModeNormal`, and composite the modal in `view_overlays.go`.
+
+**Files:**
+- Modify: `internal/ui/app.go`
+- Modify: `internal/ui/mode_normal.go`
+- Modify: `internal/ui/mode_handlers.go`
+- Modify: `internal/ui/view_overlays.go`
+- Create: `internal/ui/mode_new_message.go`
+
+---
+
+> **Note:** Submit-routing through `ChannelService.OpenConversation` lands in Task 11 via the reducer. This task gets the modal opening/closing wired so a manual smoke test from Ctrl+N already shows the picker.
+
+- [ ] **Step 1: Add picker + in-flight tracking fields to App**
+
+In `internal/ui/app.go`, find the sub-models block (around line 86 where `channelFinder` is declared) and add right after `channelFinder`:
+
+```go
+	newMessagePicker newmessagepicker.Model
+```
+
+Add the import (alphabetical order in the existing import block):
+
+```go
+	"github.com/gammons/slk/internal/ui/newmessagepicker"
+```
+
+Then find the in-flight/cancellation fields section. There isn't a perfect home — add near the workspace switching fields (around line 200). Add a comment block and two fields:
+
+```go
+	// newMessageInFlightID is the monotonic counter for in-flight
+	// OpenConversation requests dispatched from the new-message
+	// picker. 0 means no submit is in flight. The reducer drops late
+	// results whose RequestID doesn't match.
+	newMessageInFlightID uint64
+	// newMessageCancelled is set to true when the user Escs the
+	// modal while a submit is in flight. A subsequent
+	// NewMessageOpenedMsg with the matching RequestID is dropped
+	// rather than switching channels behind the user's back.
+	newMessageCancelled bool
+```
+
+- [ ] **Step 2: Initialize the picker in `NewApp`**
+
+In `NewApp` (around line 289), add to the struct literal next to `channelFinder`:
+
+```go
+		newMessagePicker:     newmessagepicker.New(),
+```
+
+- [ ] **Step 3: Add the Ctrl+N entry from ModeNormal**
+
+In `internal/ui/mode_normal.go`, find the FuzzyFinder case (around line 169) and add a new case below it:
+
+```go
+	case key.Matches(msg, a.keys.NewMessage):
+		return func() tea.Msg { return EnterNewMessageMsg{} }
+```
+
+(`tea` is already imported in this file as `tea "charm.land/bubbletea/v2"`.)
+
+- [ ] **Step 4: Create the new-message mode handler**
+
+Write `internal/ui/mode_new_message.go`:
+
+```go
+// internal/ui/mode_new_message.go
+//
+// New-message mode key handler. Forwards normalised keys to the
+// newmessagepicker overlay. When the picker returns a Result, the
+// handler dispatches a new submit via ChannelService.OpenConversation
+// (with a monotonic RequestID) and tracks the in-flight state on App.
+// On Esc, marks the in-flight as cancelled so a late result is
+// dropped (see reducer_new_message.go for the dropping logic).
+package ui
+
+import (
+	tea "charm.land/bubbletea/v2"
+)
+
+func handleNewMessageMode(a *App, msg tea.KeyMsg) tea.Cmd {
+	keyStr := msg.String()
+	switch msg.Key().Code {
+	case tea.KeyEnter:
+		keyStr = "enter"
+	case tea.KeyEscape:
+		keyStr = "esc"
+	case tea.KeyUp:
+		keyStr = "up"
+	case tea.KeyDown:
+		keyStr = "down"
+	case tea.KeyBackspace:
+		keyStr = "backspace"
+	case tea.KeyTab:
+		keyStr = "tab"
+	case tea.KeySpace:
+		keyStr = " "
+	}
+
+	result := a.newMessagePicker.HandleKey(keyStr)
+	if result != nil {
+		// Submit. Bump the in-flight ID and clear cancellation
+		// before dispatch so a fresh result is honored.
+		a.newMessageInFlightID++
+		a.newMessageCancelled = false
+		reqID := a.newMessageInFlightID
+		userIDs := result.UserIDs
+		return a.channels.OpenConversation(userIDs, reqID)
+	}
+
+	// Picker closed itself (Esc). Mark any in-flight submit as
+	// cancelled so its eventual result is dropped. Switch back to
+	// ModeNormal.
+	if !a.newMessagePicker.IsVisible() {
+		if a.newMessageInFlightID != 0 {
+			a.newMessageCancelled = true
+		}
+		a.SetMode(ModeNormal)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 5: Register the mode handler**
+
+Open `internal/ui/mode_handlers.go` and search for the existing handler dispatch table. Add an entry for `ModeNewMessage` that calls `handleNewMessageMode`.
+
+```
+grep -n "handleChannelFinderMode" internal/ui/mode_handlers.go
+```
+
+The file has a dispatch map or switch. Locate the line that wires `ModeChannelFinder -> handleChannelFinderMode` and add a sibling entry directly below it:
+
+```go
+	case ModeNewMessage:
+		return handleNewMessageMode(a, msg)
+```
+
+(Match the existing file's syntax — if it's a map literal, add `ModeNewMessage: handleNewMessageMode,`.)
+
+- [ ] **Step 6: Composite the picker overlay**
+
+In `internal/ui/view_overlays.go`, edit `applyOverlays` to add a check after `channelFinder` (around line 41):
+
+```go
+	if a.newMessagePicker.IsVisible() {
+		screen = a.newMessagePicker.ViewOverlay(a.width, a.height, screen)
+	}
+```
+
+Then add the same `IsVisible()` check to `overlayActive()` (around line 75):
+
+```go
+	return a.channelFinder.IsVisible() ||
+		a.newMessagePicker.IsVisible() ||
+		a.reactionPicker.IsVisible() ||
+```
+
+- [ ] **Step 7: Skip — no residual-switch wiring needed**
+
+`internal/ui/app.go`'s `Update` residual switch (at line 440) only handles `tea.WindowSizeMsg` and `tea.KeyMsg` — all app-level messages route through reducers. The `EnterNewMessageMsg` arm lives in the new reducer in Task 11. This task does NOT touch `Update`.
+
+That means `Ctrl+N` will be a no-op until Task 11 lands — that's fine; behavioral tests live in Task 11.
+
+- [ ] **Step 8: Verify the wiring compiles**
+
+The behavioral test for "Ctrl+N enters ModeNewMessage" lives in Task 11 (where the reducer wires the actual transition). Task 9's verification is compilation only:
+
+```
+go build ./...
+```
+
+Expected: succeeds. The picker field, mode handler, overlay composite, and message constants are all in place; the reducer behavior lands next.
+
+- [ ] **Step 9: Run all existing tests to confirm no regressions**
+
+```
+go test ./...
+```
+
+Expected: all existing tests PASS. No new tests in this task.
+
+- [ ] **Step 10: Manual smoke render (optional but recommended)**
+
+```
+go build -o /tmp/slk-smoke ./cmd/slk
+```
+
+Expected: build succeeds. (Don't run the binary — it requires real Slack credentials. The visual smoke test lives in Task 14.)
+
+- [ ] **Step 11: Commit**
+
+```
+git add internal/ui/app.go internal/ui/mode_normal.go internal/ui/mode_handlers.go internal/ui/view_overlays.go internal/ui/mode_new_message.go
+git commit -m "feat(new-message): wire picker into App, mode, and overlay stack
+
+Adds App.newMessagePicker + in-flight tracking fields, the Ctrl+N
+dispatch from ModeNormal, the ModeNewMessage key handler, and the
+overlay composite. Submit-side wiring (calling OpenConversation,
+handling its result) is deferred to the reducer in Task 11."
+```

--- a/docs/superpowers/plans/2026-05-25-new-message-feature/task-10-user-list-recency.md
+++ b/docs/superpowers/plans/2026-05-25-new-message-feature/task-10-user-list-recency.md
@@ -1,0 +1,150 @@
+# Task 10: User list snapshot on modal open
+
+**Goal:** Build the `[]newmessagepicker.User` slice from the App's existing state (`a.userNames`, `a.externalUsers`, `a.currentUserID`). Push it into the picker at modal-open time so the picker always sees a fresh snapshot.
+
+**Files:**
+- Modify: `internal/ui/app.go`
+- Modify: `internal/ui/newmessagepicker/model.go` (add `Users()` accessor for tests)
+
+---
+
+> **Scoping cut — recency deferred to a follow-up:** The spec calls for recency-DESC ordering with a 30-day "recent DMs first" signal. Sourcing that data cleanly requires plumbing `WorkspaceContext.LastVisitedByChannel` (which lives in main.go) into the App alongside `SetUserNames`. That's a horizontal slice change touching `cmd/slk/main.go`, `msgs.go` (`WorkspaceReadyMsg`/`WorkspaceSwitchedMsg`), and `reducer_workspace.go`. To keep this plan shippable, v1 sorts purely by display name (alphabetical) and leaves the `User.Recency` field as 0. A follow-up plan adds the recency wiring once this lands. The picker's filter code already handles `Recency == 0` correctly — it falls through to the alpha tie-break, which IS the v1 behavior.
+
+- [ ] **Step 1: Add a failing test for the snapshot**
+
+Append to `internal/ui/app_test.go`:
+
+```go
+func TestSeedNewMessagePicker_PopulatesUsersAndExcludesSelf(t *testing.T) {
+	app := NewApp()
+	app.currentUserID = "USELF"
+	app.SetUserNames(map[string]string{
+		"USELF": "Me",
+		"U1":    "Alice",
+		"U2":    "Bob",
+	})
+	app.SetExternalUsers(map[string]bool{"U2": true})
+
+	app.seedNewMessagePicker()
+
+	users := app.newMessagePicker.Users()
+	// Picker holds all non-self users. The picker excludes self via
+	// SetCurrentUserID at filter time, not at the SetUsers slice level.
+	// So the slice should contain Alice + Bob + Me, but after Open()
+	// the filtered list excludes Me.
+	ids := map[string]bool{}
+	for _, u := range users {
+		ids[u.ID] = true
+	}
+	if !ids["U1"] {
+		t.Error("expected Alice (U1) in picker users")
+	}
+	if !ids["U2"] {
+		t.Error("expected Bob (U2) in picker users")
+	}
+	if ids["USELF"] {
+		t.Error("expected USELF excluded from seeded slice")
+	}
+
+	// External flag should propagate.
+	for _, u := range users {
+		if u.ID == "U2" && !u.IsExternal {
+			t.Error("expected Bob (U2) to be marked external")
+		}
+	}
+}
+```
+
+> The seed helper excludes self at slice-build time (skipping the iteration over `a.currentUserID`), so the slice does NOT contain Me. The `SetCurrentUserID` call is belt-and-suspenders for the picker's filter to also reject self if it somehow slips in.
+
+This test refers to `app.newMessagePicker.Users()` which doesn't exist yet — add it.
+
+- [ ] **Step 2: Add `Users()` accessor on the picker**
+
+In `internal/ui/newmessagepicker/model.go`, add (after `SetUsers`):
+
+```go
+// Users returns the user list most recently set via SetUsers. Used
+// by tests; not part of the picker's input API.
+func (m *Model) Users() []User {
+	return m.users
+}
+```
+
+- [ ] **Step 3: Run the test to confirm it fails**
+
+```
+go test ./internal/ui/ -run TestSeedNewMessagePicker_PopulatesUsersAndExcludesSelf -v
+```
+
+Expected: FAIL — `app.seedNewMessagePicker` doesn't exist yet.
+
+- [ ] **Step 4: Add `seedNewMessagePicker` helper on App**
+
+In `internal/ui/app.go`, add this method near the existing `SetUserNames` (around line 1612).
+
+```go
+// seedNewMessagePicker snapshots the current workspace's user list
+// into the new-message picker and configures the self-exclusion.
+// Called when ModeNewMessage is entered so the modal always sees a
+// fresh view of the workspace.
+//
+// User-list shape:
+//   - DisplayName from a.userNames (the workspace display name map).
+//   - Username falls back to DisplayName — there is no separate
+//     userID->handle map on App today. The picker uses Username
+//     only for filter matching, so this fallback degrades
+//     gracefully: queries against the display name still hit.
+//   - IsExternal from a.externalUsers.
+//   - Recency is left at 0 (see scoping note at the top of this task).
+//   - Self (a.currentUserID) is excluded via SetCurrentUserID.
+func (a *App) seedNewMessagePicker() {
+	users := make([]newmessagepicker.User, 0, len(a.userNames))
+	for id, name := range a.userNames {
+		if id == a.currentUserID {
+			continue
+		}
+		users = append(users, newmessagepicker.User{
+			ID:          id,
+			DisplayName: name,
+			Username:    name, // see scoping note; replaceable when a handle map lands
+			IsExternal:  a.externalUsers[id],
+		})
+	}
+
+	a.newMessagePicker.SetCurrentUserID(a.currentUserID)
+	a.newMessagePicker.SetUsers(users)
+}
+```
+
+- [ ] **Step 5: Skip — wiring happens in Task 11**
+
+The reducer in Task 11 calls `a.seedNewMessagePicker()` from its `EnterNewMessageMsg` arm. Nothing to wire here.
+
+- [ ] **Step 6: Run the test**
+
+```
+go test ./internal/ui/ -run TestSeedNewMessagePicker_PopulatesUsersAndExcludesSelf -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run the full suite**
+
+```
+go test ./...
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 8: Commit**
+
+```
+git add internal/ui/app.go internal/ui/newmessagepicker/model.go internal/ui/app_test.go
+git commit -m "feat(new-message): snapshot workspace users on modal open
+
+Builds a []newmessagepicker.User slice from a.userNames and
+a.externalUsers. Self is excluded via SetCurrentUserID. Recency
+is left at 0 (alphabetical order); plumbing it through from
+WorkspaceContext.LastVisitedByChannel is a follow-up."
+```

--- a/docs/superpowers/plans/2026-05-25-new-message-feature/task-11-reducer.md
+++ b/docs/superpowers/plans/2026-05-25-new-message-feature/task-11-reducer.md
@@ -1,0 +1,326 @@
+# Task 11: Reducer — message dispatch and in-flight tracking
+
+**Goal:** Add a dedicated reducer that handles `EnterNewMessageMsg`, `NewMessageOpenedMsg`, and `NewMessageFailedMsg`. The reducer enforces the `RequestID`-based cancellation discipline.
+
+**Files:**
+- Create: `internal/ui/reducer_new_message.go`
+- Create: `internal/ui/reducer_new_message_test.go`
+- Modify: `internal/ui/app.go` (register the reducer in `dispatchReducers`)
+
+---
+
+- [ ] **Step 1: Add a failing reducer test**
+
+Write `internal/ui/reducer_new_message_test.go`:
+
+```go
+package ui
+
+import (
+	"errors"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func newApp_WithOpenConvCapture(t *testing.T) (*App, *capturedOpenConv) {
+	t.Helper()
+	app := NewApp()
+	app.currentUserID = "USELF"
+	app.SetUserNames(map[string]string{"USELF": "Me", "U1": "Alice", "U2": "Bob"})
+
+	cap := &capturedOpenConv{}
+	app.SetChannelService(NewChannelService(ChannelServiceFuncs{
+		OpenConversation: func(userIDs []string, requestID uint64) tea.Cmd {
+			cap.calls = append(cap.calls, openConvCall{UserIDs: userIDs, RequestID: requestID})
+			return nil // tests synthesize the result message directly
+		},
+	}))
+	return app, cap
+}
+
+type openConvCall struct {
+	UserIDs   []string
+	RequestID uint64
+}
+
+type capturedOpenConv struct {
+	calls []openConvCall
+}
+
+func TestReducer_EnterNewMessageMsg_OpensPickerAndEntersMode(t *testing.T) {
+	app, _ := newApp_WithOpenConvCapture(t)
+
+	_, _ = app.Update(EnterNewMessageMsg{})
+
+	if app.mode != ModeNewMessage {
+		t.Errorf("expected ModeNewMessage, got %v", app.mode)
+	}
+	if !app.newMessagePicker.IsVisible() {
+		t.Error("expected picker visible")
+	}
+}
+
+func TestReducer_NewMessageOpenedMsg_SwitchesChannelAndEntersInsertMode(t *testing.T) {
+	app, _ := newApp_WithOpenConvCapture(t)
+	_, _ = app.Update(EnterNewMessageMsg{})
+	app.newMessageInFlightID = 7 // simulate an in-flight submit
+
+	cmd, _ := app.Update(NewMessageOpenedMsg{
+		ChannelID:   "D123",
+		AlreadyOpen: true,
+		UserIDs:     []string{"U1"},
+		RequestID:   7,
+	})
+
+	if app.mode != ModeInsert {
+		t.Errorf("expected ModeInsert after opened msg, got %v", app.mode)
+	}
+	if app.newMessagePicker.IsVisible() {
+		t.Error("expected picker closed")
+	}
+	// The reducer should emit a ChannelSelectedMsg.
+	if cmd == nil {
+		t.Fatal("expected a tea.Cmd that fires ChannelSelectedMsg")
+	}
+	msg := cmd()
+	sel, ok := msg.(ChannelSelectedMsg)
+	if !ok {
+		t.Fatalf("expected ChannelSelectedMsg, got %T", msg)
+	}
+	if sel.ID != "D123" {
+		t.Errorf("expected ChannelID=D123, got %s", sel.ID)
+	}
+}
+
+func TestReducer_NewMessageOpenedMsg_DroppedWhenCancelled(t *testing.T) {
+	app, _ := newApp_WithOpenConvCapture(t)
+	_, _ = app.Update(EnterNewMessageMsg{})
+	app.newMessageInFlightID = 7
+	app.newMessageCancelled = true
+	priorMode := app.mode
+
+	cmd, _ := app.Update(NewMessageOpenedMsg{
+		ChannelID: "D123",
+		RequestID: 7,
+	})
+
+	if app.mode != priorMode {
+		t.Errorf("mode should not change for cancelled result, got %v", app.mode)
+	}
+	if cmd != nil {
+		t.Errorf("expected nil cmd for cancelled result, got %T", cmd())
+	}
+}
+
+func TestReducer_NewMessageOpenedMsg_DroppedWhenRequestIDMismatches(t *testing.T) {
+	app, _ := newApp_WithOpenConvCapture(t)
+	_, _ = app.Update(EnterNewMessageMsg{})
+	app.newMessageInFlightID = 9 // current in-flight is 9
+	priorMode := app.mode
+
+	// Late arrival for an older request 7.
+	cmd, _ := app.Update(NewMessageOpenedMsg{
+		ChannelID: "D123",
+		RequestID: 7,
+	})
+
+	if app.mode != priorMode {
+		t.Errorf("mode should not change for stale RequestID, got %v", app.mode)
+	}
+	if cmd != nil {
+		t.Errorf("expected nil cmd for stale result")
+	}
+}
+
+func TestReducer_NewMessageFailedMsg_KeepsModalOpenAndEmitsToast(t *testing.T) {
+	app, _ := newApp_WithOpenConvCapture(t)
+	_, _ = app.Update(EnterNewMessageMsg{})
+	app.newMessageInFlightID = 7
+
+	cmd, _ := app.Update(NewMessageFailedMsg{
+		RequestID: 7,
+		Err:       errors.New("rate_limited"),
+	})
+
+	if app.mode != ModeNewMessage {
+		t.Errorf("expected to stay in ModeNewMessage on failure, got %v", app.mode)
+	}
+	if !app.newMessagePicker.IsVisible() {
+		t.Error("expected picker still visible on failure")
+	}
+	if cmd == nil {
+		t.Fatal("expected a tea.Cmd emitting ToastMsg")
+	}
+	msg := cmd()
+	toast, ok := msg.(ToastMsg)
+	if !ok {
+		t.Fatalf("expected ToastMsg, got %T", msg)
+	}
+	if toast.Text == "" {
+		t.Error("expected non-empty toast text")
+	}
+}
+```
+
+If `SetChannelService` isn't in scope, search for it:
+
+```
+grep -n "func (a \*App) SetChannelService" internal/ui/app.go
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```
+go test ./internal/ui/ -run TestReducer_ -v
+```
+
+Expected: 5 failures (or build errors, depending on how Task 9 left the residual switch).
+
+- [ ] **Step 3: Create the reducer file**
+
+Write `internal/ui/reducer_new_message.go`:
+
+```go
+// internal/ui/reducer_new_message.go
+//
+// Reducer for the new-message picker lifecycle:
+//
+//   EnterNewMessageMsg     - user pressed Ctrl+N: seed the picker
+//                            with current workspace users, open it,
+//                            enter ModeNewMessage.
+//   NewMessageOpenedMsg    - conversations.open succeeded: validate
+//                            RequestID against the in-flight counter
+//                            and the cancelled flag, then close the
+//                            modal, switch to the opened channel,
+//                            and enter ModeInsert (so the cursor
+//                            lands in compose ready to type).
+//   NewMessageFailedMsg    - conversations.open failed: log and
+//                            keep the modal open so the user can
+//                            retry or cancel.
+//
+// Cache hydration for AlreadyOpen=false is implemented in Task 12;
+// this task emits ChannelSelectedMsg directly without inserting a
+// channel record. Task 12 adds that insert.
+package ui
+
+import (
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/gammons/slk/internal/debuglog"
+)
+
+var reduceNewMessage reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
+	switch m := msg.(type) {
+	case EnterNewMessageMsg:
+		a.seedNewMessagePicker()
+		a.newMessagePicker.Open()
+		a.SetMode(ModeNewMessage)
+		return nil, true
+
+	case NewMessageOpenedMsg:
+		if !newMessageResultIsCurrent(a, m.RequestID) {
+			debuglog.Printf("new-message: dropping stale/cancelled NewMessageOpenedMsg req=%d inflight=%d cancelled=%v", m.RequestID, a.newMessageInFlightID, a.newMessageCancelled)
+			return nil, true
+		}
+		a.newMessagePicker.Close()
+		a.newMessageInFlightID = 0
+		a.newMessageCancelled = false
+		a.SetMode(ModeInsert)
+
+		// Task 12 inserts a minimal cache record here when
+		// m.AlreadyOpen == false. For now, emit ChannelSelectedMsg
+		// directly; existing flows (cache miss, RTM hydration) fill
+		// in the rest.
+		channelID := m.ChannelID
+		channelType := "dm"
+		if len(m.UserIDs) > 1 {
+			channelType = "group_dm"
+		}
+		return func() tea.Msg {
+			return ChannelSelectedMsg{ID: channelID, Type: channelType}
+		}, true
+
+	case NewMessageFailedMsg:
+		if !newMessageResultIsCurrent(a, m.RequestID) {
+			return nil, true
+		}
+		debuglog.Printf("new-message: OpenConversation failed: %v", m.Err)
+		// Stay in ModeNewMessage; modal stays visible; clear the
+		// in-flight so a follow-up submit gets a fresh ID. Surface
+		// the error via a toast (the existing app-wide notification
+		// channel) so the user knows the submit didn't go through.
+		a.newMessageInFlightID = 0
+		errText := m.Err.Error()
+		return func() tea.Msg { return ToastMsg{Text: "Open DM failed: " + errText} }, true
+	}
+	return nil, false
+}
+
+// newMessageResultIsCurrent reports whether a NewMessage* message
+// with requestID is the response to the current in-flight submit
+// AND wasn't cancelled by an Esc. Late or cancelled results are
+// dropped silently.
+func newMessageResultIsCurrent(a *App, requestID uint64) bool {
+	if requestID == 0 {
+		return false
+	}
+	if requestID != a.newMessageInFlightID {
+		return false
+	}
+	if a.newMessageCancelled {
+		return false
+	}
+	return true
+}
+```
+
+- [ ] **Step 4: Register the reducer in `App.Update`**
+
+In `internal/ui/app.go`, find the `dispatchReducers` call (around line 385) and add `reduceNewMessage` to the chain. Insert after `reduceWorkspace`:
+
+```go
+	if cmd, handled := dispatchReducers(a, msg,
+		a.presence,
+		a.preview,
+		a.drag,
+		a.typing,
+		a.bootstrap,
+		reduceReactions,
+		reduceThreads,
+		reduceSend,
+		reduceChannels,
+		reduceWorkspace,
+		reduceNewMessage,
+		reduceIO,
+		reduceMouse,
+	); handled {
+```
+
+- [ ] **Step 5: Run all reducer tests**
+
+```
+go test ./internal/ui/ -run TestReducer_ -v
+```
+
+Expected: 5 PASS.
+
+- [ ] **Step 6: Run the full suite**
+
+```
+go test ./...
+```
+
+Expected: all tests PASS across the module.
+
+- [ ] **Step 7: Commit**
+
+```
+git add internal/ui/reducer_new_message.go internal/ui/reducer_new_message_test.go internal/ui/app.go
+git commit -m "feat(new-message): reducer with in-flight cancellation tracking
+
+Reducer claims EnterNewMessageMsg, NewMessageOpenedMsg, and
+NewMessageFailedMsg. RequestID matching and the cancelled flag
+together drop late results from cancelled or superseded submits.
+Success path emits ChannelSelectedMsg + transitions to ModeInsert."
+```

--- a/docs/superpowers/plans/2026-05-25-new-message-feature/task-12-cache-hydration.md
+++ b/docs/superpowers/plans/2026-05-25-new-message-feature/task-12-cache-hydration.md
@@ -1,0 +1,212 @@
+# Task 12: Cache hydration on `AlreadyOpen=false`
+
+**Goal:** When `conversations.open` returns a freshly-created channel (`AlreadyOpen=false`), insert a minimal record into the sidebar / channel cache before emitting `ChannelSelectedMsg`. Otherwise the channel-switch path can blow up on a missing record.
+
+**Files:**
+- Modify: `internal/ui/reducer_new_message.go`
+- Modify: `internal/ui/reducer_new_message_test.go`
+
+---
+
+> **What "minimal record" means:** insert a `sidebar.ChannelItem` with `ID`, `Type` (`dm` if 1 user, `group_dm` otherwise), `Section` = the empty string (so the sidebar's default DM-section logic in `sectionForLegacy` buckets it), and `Name` derived from the workspace's `UserNames` map (joined display names for MPIM; the single peer's display name for DM). Members live in the membership manager, not on `ChannelItem`, so we don't add them here — the existing `membership.Manager` will hydrate on first need.
+
+- [ ] **Step 1: Use the existing sidebar API**
+
+The sidebar model already has the methods we need:
+
+- `UpsertItem(item ChannelItem)` at `internal/ui/sidebar/model.go:625` — appends a new channel or updates an existing one by ID.
+- `AllItems() []ChannelItem` at `internal/ui/sidebar/model.go:650` — returns the full channel slice (used in tests below).
+
+No sidebar changes are needed in this task.
+
+- [ ] **Step 2: Add failing tests for the hydration arm**
+
+Append to `internal/ui/reducer_new_message_test.go`:
+
+```go
+func TestReducer_NewMessageOpenedMsg_AlreadyOpenSkipsCacheInsert(t *testing.T) {
+	app, _ := newApp_WithOpenConvCapture(t)
+	_, _ = app.Update(EnterNewMessageMsg{})
+	app.newMessageInFlightID = 1
+	priorCount := len(app.sidebar.AllItems())
+
+	_, _ = app.Update(NewMessageOpenedMsg{
+		ChannelID:   "D456",
+		AlreadyOpen: true,
+		UserIDs:     []string{"U1"},
+		RequestID:   1,
+	})
+
+	if got := len(app.sidebar.AllItems()); got != priorCount {
+		t.Errorf("expected no sidebar mutation for AlreadyOpen=true, count went from %d to %d", priorCount, got)
+	}
+}
+
+func TestReducer_NewMessageOpenedMsg_NewChannelInsertedAsDM(t *testing.T) {
+	app, _ := newApp_WithOpenConvCapture(t)
+	_, _ = app.Update(EnterNewMessageMsg{})
+	app.newMessageInFlightID = 1
+
+	_, _ = app.Update(NewMessageOpenedMsg{
+		ChannelID:   "D789",
+		AlreadyOpen: false,
+		UserIDs:     []string{"U1"},
+		RequestID:   1,
+	})
+
+	found := false
+	for _, ch := range app.sidebar.AllItems() {
+		if ch.ID == "D789" {
+			found = true
+			if ch.Type != "dm" {
+				t.Errorf("expected Type=dm, got %s", ch.Type)
+			}
+			if ch.DMUserID != "U1" {
+				t.Errorf("expected DMUserID=U1, got %s", ch.DMUserID)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected D789 inserted into sidebar")
+	}
+}
+
+func TestReducer_NewMessageOpenedMsg_NewChannelInsertedAsGroupDM(t *testing.T) {
+	app, _ := newApp_WithOpenConvCapture(t)
+	_, _ = app.Update(EnterNewMessageMsg{})
+	app.newMessageInFlightID = 1
+
+	_, _ = app.Update(NewMessageOpenedMsg{
+		ChannelID:   "G999",
+		AlreadyOpen: false,
+		UserIDs:     []string{"U1", "U2"},
+		RequestID:   1,
+	})
+
+	found := false
+	for _, ch := range app.sidebar.AllItems() {
+		if ch.ID == "G999" {
+			found = true
+			if ch.Type != "group_dm" {
+				t.Errorf("expected Type=group_dm, got %s", ch.Type)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected G999 inserted into sidebar")
+	}
+}
+```
+
+- [ ] **Step 3: Run to confirm tests fail**
+
+```
+go test ./internal/ui/ -run TestReducer_NewMessageOpenedMsg_ -v
+```
+
+Expected: the two `_NewChannelInserted*` tests FAIL.
+
+- [ ] **Step 4: Add hydration to the reducer**
+
+In `internal/ui/reducer_new_message.go`, replace the `NewMessageOpenedMsg` case body with:
+
+```go
+	case NewMessageOpenedMsg:
+		if !newMessageResultIsCurrent(a, m.RequestID) {
+			debuglog.Printf("new-message: dropping stale/cancelled NewMessageOpenedMsg req=%d inflight=%d cancelled=%v", m.RequestID, a.newMessageInFlightID, a.newMessageCancelled)
+			return nil, true
+		}
+		a.newMessagePicker.Close()
+		a.newMessageInFlightID = 0
+		a.newMessageCancelled = false
+		a.SetMode(ModeInsert)
+
+		channelType := "dm"
+		if len(m.UserIDs) > 1 {
+			channelType = "group_dm"
+		}
+		if !m.AlreadyOpen {
+			a.hydrateNewConversation(m.ChannelID, channelType, m.UserIDs)
+		}
+
+		channelID := m.ChannelID
+		return func() tea.Msg {
+			return ChannelSelectedMsg{ID: channelID, Type: channelType}
+		}, true
+```
+
+Then add the helper at the bottom of the file:
+
+```go
+// hydrateNewConversation inserts a minimal sidebar.ChannelItem for a
+// freshly-opened DM or MPIM so the channel-switch path has a record
+// to render against. The full channel metadata is filled in by the
+// existing RTM event handlers (mpim_open / im_created) and the
+// membership.Manager.
+func (a *App) hydrateNewConversation(channelID, channelType string, userIDs []string) {
+	item := sidebar.ChannelItem{
+		ID:   channelID,
+		Type: channelType,
+		Name: a.deriveConversationName(channelType, userIDs),
+	}
+	if channelType == "dm" && len(userIDs) == 1 {
+		item.DMUserID = userIDs[0]
+	}
+	a.sidebar.UpsertItem(item)
+}
+
+// deriveConversationName builds a display name for a freshly-opened
+// DM/MPIM. For DMs we use the peer's display name. For MPIMs we
+// join up to 3 names with ", " and append "+N" for the rest.
+func (a *App) deriveConversationName(channelType string, userIDs []string) string {
+	const previewLimit = 3
+	names := make([]string, 0, len(userIDs))
+	for _, id := range userIDs {
+		if name, ok := a.userNames[id]; ok && name != "" {
+			names = append(names, name)
+		} else {
+			names = append(names, id)
+		}
+	}
+	if channelType == "dm" {
+		return names[0]
+	}
+	if len(names) <= previewLimit {
+		return strings.Join(names, ", ")
+	}
+	preview := strings.Join(names[:previewLimit], ", ")
+	return fmt.Sprintf("%s +%d", preview, len(names)-previewLimit)
+}
+```
+
+Add imports to the file: `"fmt"`, `"strings"`, and `"github.com/gammons/slk/internal/ui/sidebar"`. Update the import block at the top.
+
+- [ ] **Step 5: Run all reducer tests**
+
+```
+go test ./internal/ui/ -run TestReducer_ -v
+```
+
+Expected: all reducer tests PASS, including the new 3.
+
+- [ ] **Step 6: Run full suite**
+
+```
+go test ./...
+```
+
+Expected: all PASS.
+
+- [ ] **Step 7: Commit**
+
+```
+git add internal/ui/reducer_new_message.go internal/ui/reducer_new_message_test.go internal/ui/sidebar/model.go
+git commit -m "feat(new-message): hydrate cache record for freshly-opened DMs/MPIMs
+
+When conversations.open returns AlreadyOpen=false, insert a minimal
+sidebar.ChannelItem (ID, Type, DMUserID for 1:1, derived Name) so
+the channel-switch path has a record to render against. Existing
+RTM event handlers and membership.Manager fill in the rest."
+```
+
+(Drop `sidebar/model.go` from `git add` if it didn't need changes.)

--- a/docs/superpowers/plans/2026-05-25-new-message-feature/task-13-main-wiring.md
+++ b/docs/superpowers/plans/2026-05-25-new-message-feature/task-13-main-wiring.md
@@ -1,0 +1,86 @@
+# Task 13: `cmd/slk/main.go` — production `OpenConversation` closure
+
+**Goal:** Wire the real `ChannelService.OpenConversation` closure that calls `wctx.Client.OpenConversation` in a goroutine and emits `NewMessageOpenedMsg` or `NewMessageFailedMsg` back into the bubbletea program.
+
+**Files:**
+- Modify: `cmd/slk/main.go`
+
+---
+
+- [ ] **Step 1: Locate the existing `ChannelServiceFuncs` literal**
+
+```
+grep -n "NewChannelService(ui.ChannelServiceFuncs" cmd/slk/main.go
+```
+
+You'll land on the literal (around line 858). Other closures (Fetch, Lookup, MembershipFetch, etc.) sit inside this literal — model the new closure after them.
+
+- [ ] **Step 2: Add the `OpenConversation` closure to the literal**
+
+Inside the `ui.ChannelServiceFuncs{...}` block, add this field. Place it near `MembershipFetch` (the existing API-call-style closure) for readability:
+
+```go
+			OpenConversation: func(userIDs []string, requestID uint64) tea.Cmd {
+				wctx := router.Active()
+				if wctx == nil {
+					return func() tea.Msg {
+						return ui.NewMessageFailedMsg{
+							RequestID: requestID,
+							Err:       fmt.Errorf("no active workspace"),
+						}
+					}
+				}
+				client := wctx.Client
+				return func() tea.Msg {
+					channelID, alreadyOpen, err := client.OpenConversation(ctx, userIDs)
+					if err != nil {
+						return ui.NewMessageFailedMsg{
+							RequestID: requestID,
+							Err:       err,
+						}
+					}
+					return ui.NewMessageOpenedMsg{
+						ChannelID:   channelID,
+						AlreadyOpen: alreadyOpen,
+						UserIDs:     userIDs,
+						RequestID:   requestID,
+					}
+				}
+			},
+```
+
+Variables `ctx`, `router`, and `fmt` are all in scope at this point in main.go — confirm with:
+
+```
+grep -n "^	ctx\|router :=\|\"fmt\"" cmd/slk/main.go | head -10
+```
+
+If `fmt` isn't already imported in main.go (it likely is — most main.go files import it), add it to the import block.
+
+- [ ] **Step 3: Build**
+
+```
+go build ./cmd/slk
+```
+
+Expected: succeeds. The binary now wires the real closure.
+
+- [ ] **Step 4: Run the full test suite to confirm no regression**
+
+```
+go test ./...
+```
+
+Expected: all PASS. (No test touches main.go directly; this build is the verification.)
+
+- [ ] **Step 5: Commit**
+
+```
+git add cmd/slk/main.go
+git commit -m "feat(new-message): wire production OpenConversation closure
+
+ChannelServiceFuncs.OpenConversation now dispatches a goroutine that
+calls wctx.Client.OpenConversation and emits NewMessageOpenedMsg or
+NewMessageFailedMsg back into the bubbletea program with the
+submit's RequestID for cancellation routing."
+```

--- a/docs/superpowers/plans/2026-05-25-new-message-feature/task-14-e2e.md
+++ b/docs/superpowers/plans/2026-05-25-new-message-feature/task-14-e2e.md
@@ -1,0 +1,150 @@
+# Task 14: End-to-end test + manual verification + final commit
+
+**Goal:** Confirm the feature works end to end. Add one final integration test that simulates the full Ctrl+N → pill → Enter → channel-switch flow, then perform the manual smoke test against a real Slack workspace.
+
+**Files:**
+- Modify: `internal/ui/reducer_new_message_test.go`
+
+---
+
+- [ ] **Step 1: Add an end-to-end integration test**
+
+Append to `internal/ui/reducer_new_message_test.go`:
+
+```go
+func TestEndToEnd_CtrlN_SelectUser_Enter_OpensDM(t *testing.T) {
+	app, cap := newApp_WithOpenConvCapture(t)
+
+	// 1. User presses Ctrl+N.
+	_, _ = app.Update(EnterNewMessageMsg{})
+
+	if app.mode != ModeNewMessage {
+		t.Fatalf("step 1: expected ModeNewMessage, got %v", app.mode)
+	}
+
+	// 2. User types "ali" to filter down to Alice.
+	app.newMessagePicker.HandleKey("a")
+	app.newMessagePicker.HandleKey("l")
+	app.newMessagePicker.HandleKey("i")
+
+	// 3. User presses Enter on the highlighted (Alice) row.
+	result := app.newMessagePicker.HandleKey("enter")
+	if result == nil {
+		t.Fatal("step 3: expected non-nil Result from Enter")
+	}
+	if len(result.UserIDs) != 1 || result.UserIDs[0] != "U1" {
+		t.Errorf("step 3: expected [U1], got %v", result.UserIDs)
+	}
+
+	// 4. The mode handler would call OpenConversation here. Simulate.
+	app.newMessageInFlightID++
+	reqID := app.newMessageInFlightID
+	_ = app.channels.OpenConversation(result.UserIDs, reqID)
+
+	if len(cap.calls) != 1 {
+		t.Fatalf("step 4: expected exactly 1 OpenConversation call, got %d", len(cap.calls))
+	}
+	if cap.calls[0].UserIDs[0] != "U1" {
+		t.Errorf("step 4: expected userID U1, got %s", cap.calls[0].UserIDs[0])
+	}
+
+	// 5. Slack returns success; reducer transitions to ModeInsert.
+	cmd, _ := app.Update(NewMessageOpenedMsg{
+		ChannelID:   "D123",
+		AlreadyOpen: true,
+		UserIDs:     []string{"U1"},
+		RequestID:   reqID,
+	})
+
+	if app.mode != ModeInsert {
+		t.Errorf("step 5: expected ModeInsert, got %v", app.mode)
+	}
+	if app.newMessagePicker.IsVisible() {
+		t.Error("step 5: expected picker hidden")
+	}
+
+	// 6. The cmd should emit ChannelSelectedMsg{ID: D123, Type: dm}.
+	msg := cmd()
+	sel, ok := msg.(ChannelSelectedMsg)
+	if !ok {
+		t.Fatalf("step 6: expected ChannelSelectedMsg, got %T", msg)
+	}
+	if sel.ID != "D123" || sel.Type != "dm" {
+		t.Errorf("step 6: want {D123, dm}, got {%s, %s}", sel.ID, sel.Type)
+	}
+}
+```
+
+- [ ] **Step 2: Run the integration test**
+
+```
+go test ./internal/ui/ -run TestEndToEnd_CtrlN_SelectUser_Enter_OpensDM -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run the full test suite**
+
+```
+go test ./...
+```
+
+Expected: ALL tests PASS across the entire module.
+
+- [ ] **Step 4: Run linters**
+
+```
+go vet ./...
+```
+
+Expected: no output.
+
+If golangci-lint is available locally (the CI runs it):
+
+```
+golangci-lint run
+```
+
+Expected: no diagnostics. If diagnostics fire only in the new files, fix them inline before the final commit.
+
+- [ ] **Step 5: Build a release-mode binary**
+
+```
+go build -o /tmp/slk-new-message ./cmd/slk
+```
+
+Expected: succeeds; binary is around 19-22 MB.
+
+- [ ] **Step 6: Manual smoke test**
+
+Run the binary against a real Slack workspace. Verify each:
+
+1. From the channels view (ModeNormal), press `Ctrl+N`. The modal appears centered with title "New message", an empty pill bar, and a list of users sorted by recency.
+2. Type a few characters of a coworker's name. The list filters; the top match is highlighted.
+3. Press Enter. The modal closes, the app switches to the DM, and the compose box has focus.
+4. Press `Ctrl+N` again. Type one name, press Space. A pill appears. Backspace. The pill is removed.
+5. Press `Ctrl+N`. Build a 3-person group by toggling 3 users with Space. The counter shows `3 / 8`. Press Enter. The MPIM opens and the compose box has focus.
+6. Press `Ctrl+N`. Select 8 users. Try to select a 9th. The 9th selection is ignored; counter shows `8 / 8 MPIM limit reached`.
+7. Press `Ctrl+N`. Press Esc immediately. Modal closes, mode returns to Normal.
+8. Press `Ctrl+N`. Type a query, hit Enter to trigger a real submit. Before the response arrives (use a flaky network or a slow workspace), press Esc. Modal closes; when the response eventually lands, the app does NOT switch channels.
+
+If any check fails, file an issue and return to the relevant earlier task to fix.
+
+- [ ] **Step 7: Final commit (if any small fixes from manual testing)**
+
+If steps 1–8 all passed cleanly with no code changes, skip this step. Otherwise commit any fixes:
+
+```
+git add -p
+git commit -m "fix(new-message): <specific issue found in manual testing>"
+```
+
+- [ ] **Step 8: Verify the git log**
+
+```
+git log --oneline | head -16
+```
+
+Expected: 14 commits with `feat(new-message):` prefixes (one per task) plus the two spec commits from before the plan was executed (`30eeafb` and `e1ec0b2`).
+
+The feature is shippable.

--- a/docs/superpowers/specs/2026-05-25-ansi-palette-themes-design.md
+++ b/docs/superpowers/specs/2026-05-25-ansi-palette-themes-design.md
@@ -1,0 +1,211 @@
+# ANSI-palette themes design
+
+**Issue:** [#35 — Add a theme that uses ANSI colors only](https://github.com/gammons/slk/issues/35)
+
+**Date:** 2026-05-25
+
+## Goal
+
+Add two built-in themes — `ansi-dark` and `ansi-light` — that inherit
+the user's terminal color palette instead of using hard-coded RGB
+values. When the user re-themes their terminal (light/dark mode,
+solarized, accessibility palette, etc.), slk's UI colors should follow.
+
+## Background
+
+slk's theme system stores every color as a `string` in `ThemeColors`
+(`internal/ui/styles/themes.go:21`). At render time the string is
+passed to `lipgloss.Color(...)`, which already accepts three forms:
+
+- `"#RRGGBB"` → 24-bit truecolor (`color.RGBA`)
+- `"0"`–`"15"` → ANSI 16 (`ansi.BasicColor`)
+- `"16"`–`"255"` → ANSI 256 (`ansi.IndexedColor`)
+
+All 34 existing built-in themes use hex. No code today uses
+`ansi.BasicColor` directly, and no test exercises the non-hex code
+path.
+
+A theme that uses ANSI 16 colors is the only mechanism that yields
+palette inheritance — truecolor escapes always bypass the user's
+terminal palette and ANSI 256 indices ≥ 16 are fixed by the terminal,
+not user-configurable.
+
+## Why two themes (not one auto-adapting)
+
+An alternative design considered a single `terminal` theme that uses
+the terminal's default foreground/background (via `lipgloss.NoColor`
+or empty strings) so it auto-adapts to light or dark terminals. That
+approach was rejected for the initial implementation because slk's
+rendering pipeline assumes every color resolves to concrete RGB
+values:
+
+- `internal/ui/styles/tint.go:51-67` linearly mixes RGB channels to
+  derive selection-tint and compose-insert backgrounds. With "no
+  background," there's no RGB to mix.
+- `internal/ui/messages/render.go` always emits `\x1b[48;2;R;G;Bm`
+  style escapes; `.RGBA()` on `NoColor{}` returns `(0,0,0,0)` which
+  would render as literal black, not "terminal default."
+- `RepaintBgToSelectionTint` assumes the bg has a parameter substring
+  to substitute against.
+
+Each of these would need a NoColor branch and a fallback strategy.
+Two pinned themes ship the user-visible feature with materially less
+code change and risk. An auto-adapting variant remains a possible
+follow-up.
+
+## Required code changes
+
+### 1. New theme entries (`internal/ui/styles/themes.go`)
+
+Two entries in `builtinThemes`. All 10 required `ThemeColors` fields
+populated with ANSI 16 number strings (`"0"`–`"15"`). Optional fields
+(`SidebarBackground`, selection backgrounds, etc.) left unset so
+derived defaults compute from base colors via existing fallback
+behavior.
+
+Initial palette (subject to taste during implementation):
+
+| Field         | `ansi-dark` | `ansi-light` |
+|---------------|-------------|--------------|
+| `primary`     | `"4"` blue  | `"4"` blue   |
+| `accent`      | `"6"` cyan  | `"6"` cyan   |
+| `warning`     | `"3"` yellow| `"3"` yellow |
+| `error`       | `"1"` red   | `"1"` red    |
+| `background`  | `"0"` black | `"15"` white |
+| `surface`     | `"8"` br.bk | `"7"` white  |
+| `surface_dark`| `"0"` black | `"7"` white  |
+| `text`        | `"15"` white| `"0"` black  |
+| `text_muted`  | `"8"` br.bk | `"8"` br.bk  |
+| `border`      | `"8"` br.bk | `"8"` br.bk  |
+
+The final palette values may be tuned during implementation based on
+visual review against real terminal palettes.
+
+### 2. ANSI-aware escape emission (`internal/ui/messages/render.go`)
+
+`bgANSIFor` and `fgANSIFor` currently always emit truecolor. They
+need to type-switch on the input `color.Color`:
+
+- `ansi.BasicColor` 0–7  → `\x1b[4{n}m`  (bg) / `\x1b[3{n}m`  (fg)
+- `ansi.BasicColor` 8–15 → `\x1b[10{n-8}m` (bg) / `\x1b[9{n-8}m` (fg)
+- `ansi.IndexedColor`    → `\x1b[48;5;Nm` (bg) / `\x1b[38;5;Nm` (fg)
+- Otherwise              → existing `\x1b[48;2;R;G;Bm` / `\x1b[38;2;R;G;Bm`
+
+This makes palette inheritance work through slk's hand-rolled escape
+path (used by `BgANSI`, `FgANSI`, `SidebarBgANSI`, etc.), not just
+through bubbletea's screen-level color-profile downgrade.
+
+### 3. Boundary-aware selection-tint substitution
+
+`RepaintBgToSelectionTint` (`render.go:327`) does
+`strings.ReplaceAll(s, fromParams, toParams)` where `fromParams` is
+the bg's SGR parameter substring (e.g. `"48;2;26;26;46"`). With
+ANSI 16 colors the substring becomes a 1–3 character number like
+`"40"`, which would collide with arbitrary text in rendered output
+(timestamps, message body content, usernames).
+
+The substitution must match the source param only when it is a
+complete SGR token — i.e. preceded by `\x1b[` or `;` and followed by
+`;` or `m`. A compiled regex per-source-param is the most direct fix
+and preserves the "match across bundled SGR sequences" property the
+current code is built around (lipgloss bundles bold + fg + bg into a
+single `\x1b[1;38;2;…;48;2;…m` escape).
+
+This change applies regardless of whether the theme is ANSI or
+truecolor — it makes the substitution always safe.
+
+## Tests
+
+### `internal/ui/styles/themes_test.go` (extend)
+
+- `ansi-dark` and `ansi-light` registered in `builtinThemes` and
+  surfaced by `ThemeNames()`.
+- Required color fields populated and parse via `lipgloss.Color(...)`
+  to `ansi.BasicColor` (type assertion, not RGB comparison).
+
+### `internal/ui/messages/render_test.go` (new file)
+
+- `bgANSIFor(ansi.BasicColor(1))` → `"\x1b[41m"`
+- `bgANSIFor(ansi.BasicColor(9))` → `"\x1b[101m"`
+- `bgANSIFor(ansi.IndexedColor(42))` → `"\x1b[48;5;42m"`
+- `bgANSIFor(color.RGBA{R:26,G:26,B:46,A:255})` → `"\x1b[48;2;26;26;46m"`
+  (regression guard for existing themes)
+- Symmetric `fgANSIFor` cases.
+- `RepaintBgToSelectionTint` correctness:
+  - ANSI source bg (`"40"`): substitutes only complete SGR tokens.
+    `"hello 40 world\x1b[40mtinted\x1b[m"` → only the second `40` is
+    replaced.
+  - Bundled SGR: `"\x1b[1;31;40mboldred\x1b[m"` → the `40` token is
+    correctly substituted within the bundle.
+  - Truecolor source bg: existing behavior unchanged.
+
+## Edge cases & known behaviors
+
+- **Selection tint stays truecolor on ANSI themes.** `mixColors`
+  always returns RGB; the tinted region of a selected row uses a
+  truecolor approximation rather than a palette color. Acceptable:
+  the tint is a small accent and the rest of the row inherits palette
+  via the substituted ANSI codes.
+- **Compose-insert background** is similarly derived via `mixColors`,
+  so it's truecolor RGB on an ANSI theme. Same trade-off.
+- **Color caches** (`cachedBgColor` etc., `render.go:262-280`) key on
+  `==`; `ansi.BasicColor` is a `uint8` alias and compares fine. No
+  cache invalidation work required.
+- **Bubbletea's color-profile downgrade** still applies — on a
+  16-color terminal, even the truecolor selection-tint escapes are
+  quantized to ANSI 16, so the visual gap between "palette-inherited
+  base" and "truecolor tint" disappears on the most palette-sensitive
+  terminals.
+
+## Documentation
+
+- `wiki/Configuration.md` — short subsection in the themes area
+  explaining `ansi-dark` and `ansi-light` inherit the user's terminal
+  palette, with the selection-tint caveat noted.
+- `README.md:17` — bump the theme count from "35+" to reflect the
+  actual count (currently 34 built-ins; will be 36 after this change).
+- No changes to `wiki/Terminal-Compatibility.md` — the new themes
+  work on both truecolor and 16-color terminals.
+
+## Out of scope
+
+- Auto-adapting single `terminal` theme using default fg/bg
+  (`lipgloss.NoColor`). Possible follow-up.
+- ANSI-aware `mixColors` so selection tints also honor the user's
+  palette.
+- Documenting non-hex color strings in the user custom-theme TOML
+  schema. Works incidentally today; explicit support deferred.
+
+## Success criteria
+
+1. `ansi-dark` and `ansi-light` appear in the `Ctrl+y` theme
+   switcher.
+2. `go build ./...` succeeds.
+3. `go test ./...` passes, including new tests in `themes_test.go`
+   and `render_test.go`.
+4. **Manual verification:** while slk is open on `ansi-dark`,
+   changing the terminal's palette (e.g. switching iTerm/Alacritty
+   colorscheme) changes slk's primary/accent/warning/error/border
+   colors on the next render.
+5. **Regression:** switching to any existing hex-based theme renders
+   identically to current behavior; existing render tests pass
+   unchanged.
+
+## Risk assessment
+
+- **Highest risk:** the boundary-aware regex in
+  `RepaintBgToSelectionTint`. A wrong regex could break selection
+  rendering for all themes, not just ANSI ones. Mitigated by
+  explicit unit tests covering truecolor (existing), ANSI bare,
+  bundled SGR, and the "literal number in content" collision case.
+- **Lower risk:** ugly palette choices. Mitigated by visual review
+  during implementation.
+
+## Files touched
+
+- `internal/ui/styles/themes.go`
+- `internal/ui/styles/themes_test.go`
+- `internal/ui/messages/render.go`
+- `internal/ui/messages/render_test.go` (new)
+- `wiki/Configuration.md`
+- `README.md` (theme count)

--- a/docs/superpowers/specs/2026-05-25-new-message-feature-design.md
+++ b/docs/superpowers/specs/2026-05-25-new-message-feature-design.md
@@ -21,6 +21,7 @@ Add a "new message" picker that lets the user start a DM (1 user) or group DM / 
 - Renaming or converting an MPIM to a private channel. Out of scope.
 - User-list refresh while the modal is open. Snapshot at open time.
 - Golden-file rendering tests. The repo doesn't have that infra and we won't add it for this feature.
+- Recency-based ordering. Deferred to a follow-up plan — sourcing the data cleanly requires plumbing `WorkspaceContext.LastVisitedByChannel` from `main.go` through to the App, and that touches several files that can change independently of this feature. v1 sorts purely alphabetically; users still find people via fuzzy filter.
 
 ## User Flow
 
@@ -214,7 +215,7 @@ ModeNewMessage --(Esc / Ctrl+G)--> ModeNormal
 ModeNewMessage --(Enter w/ valid selection)--> ModeNewMessage[in-flight]
 ModeNewMessage[in-flight] --(Esc)--> ModeNormal (cancelled; late result dropped)
 ModeNewMessage[in-flight] --(NewMessageOpenedMsg, not cancelled)--> ModeInsert (in opened channel)
-ModeNewMessage[in-flight] --(NewMessageFailedMsg, not cancelled)--> ModeNewMessage (modal stays open, error banner shown)
+ModeNewMessage[in-flight] --(NewMessageFailedMsg, not cancelled)--> ModeNewMessage (modal stays open, toast surfaces the error)
 ```
 
 ### Cancellation
@@ -230,7 +231,7 @@ This avoids the surprising "channel switches after the user backed out" behavior
 
 | Failure | Surface | Recovery |
 |---|---|---|
-| Slack API error (network, auth, rate-limit) | Error banner in modal footer; modal stays open; selections preserved | User retries via Enter or Esc to cancel |
+| Slack API error (network, auth, rate-limit) | Toast via existing `ToastMsg` channel ("Open DM failed: <reason>"); modal stays open; selections preserved | User retries via Enter or Esc to cancel |
 | User picks 8 then tries to add a 9th | Space is no-op; footer dims `8 / 8` and shows `MPIM limit reached` | Remove a pill (backspace) first |
 | User cache empty at modal open | `Loading users...` placeholder; refreshes when cache populates | Type to filter once loaded |
 | Query has no matches | List shows `No users match "<query>"`; Enter is no-op | Refine query |
@@ -280,7 +281,7 @@ Add `openConversationContextFn` to `mockSlackAPI`:
 - Submit dispatches `ChannelService.OpenConversation` with correct user IDs.
 - `NewMessageOpenedMsg` (not cancelled) → emits `ChannelSelectedMsg` and transitions to `ModeInsert`; modal closes.
 - Esc during in-flight sets cancelled; late `NewMessageOpenedMsg` is dropped (no mode change, no channel switch).
-- `NewMessageFailedMsg` during in-flight keeps modal open with error banner; selections intact.
+- `NewMessageFailedMsg` during in-flight keeps modal open and emits a `ToastMsg`; selections intact.
 - Channel-not-in-cache path: minimal record inserted before `ChannelSelectedMsg`.
 
 ### Manual verification (not automated)

--- a/docs/superpowers/specs/2026-05-25-new-message-feature-design.md
+++ b/docs/superpowers/specs/2026-05-25-new-message-feature-design.md
@@ -70,8 +70,9 @@ Add a "new message" picker that lets the user start a DM (1 user) or group DM / 
                     |
                     v
 +--------------------------------------+
-| ConversationOpenedMsg{ChannelID,     |
-|                       AlreadyOpen}   |
+| NewMessageOpenedMsg{ChannelID,       |
+|                     AlreadyOpen,     |
+|                     RequestID}       |
 +-------------------+------------------+
                     |
                     v
@@ -108,12 +109,12 @@ Add a "new message" picker that lets the user start a DM (1 user) or group DM / 
 
 6. **`internal/ui/msgs.go` (edit)**
    - `EnterNewMessageMsg struct{}` (dispatched by Ctrl+N).
-   - `ConversationOpenedMsg{ChannelID string; AlreadyOpen bool; RequestID uint64}` (returned by the service cmd).
-   - Errors reuse the existing error message type used by `SendMessage`.
+   - `NewMessageOpenedMsg{ChannelID string; AlreadyOpen bool; RequestID uint64}` (returned by the service cmd). Name avoids collision with the existing `ConversationOpenedMsg` (line 198) which is dispatched for WS `mpim_open` / `im_created` events.
+   - `NewMessageFailedMsg{RequestID uint64; Err error}` for the error path. A new type (not reuse) so the cancellation-by-RequestID logic doesn't have to dig into `SendMessage`-shaped errors.
 
-7. **Reducer (`reducer_new_message.go` or extend an existing reducer)**
-   - Handles `EnterNewMessageMsg`, `ConversationOpenedMsg`, error path, and the cancel/in-flight tracking.
-   - On `ConversationOpenedMsg` with a matching un-cancelled `RequestID`: insert minimal channel record into cache (ID, Type, Members), emit `ChannelSelectedMsg`, emit `EnterInsertModeMsg`, close modal.
+7. **Reducer (`reducer_new_message.go`)**
+   - Handles `EnterNewMessageMsg`, `NewMessageOpenedMsg`, `NewMessageFailedMsg`, and the cancel/in-flight tracking.
+   - On `NewMessageOpenedMsg` with a matching un-cancelled `RequestID`: insert minimal channel record into cache (ID, Type, Members), emit `ChannelSelectedMsg`, transition to `ModeInsert`, close modal.
 
 ## UI Layout
 
@@ -212,15 +213,15 @@ ModeNormal --(Ctrl+N)--> ModeNewMessage
 ModeNewMessage --(Esc / Ctrl+G)--> ModeNormal
 ModeNewMessage --(Enter w/ valid selection)--> ModeNewMessage[in-flight]
 ModeNewMessage[in-flight] --(Esc)--> ModeNormal (cancelled; late result dropped)
-ModeNewMessage[in-flight] --(ConversationOpenedMsg, not cancelled)--> ModeInsert (in opened channel)
-ModeNewMessage[in-flight] --(error)--> ModeNewMessage (modal stays open, error banner shown)
+ModeNewMessage[in-flight] --(NewMessageOpenedMsg, not cancelled)--> ModeInsert (in opened channel)
+ModeNewMessage[in-flight] --(NewMessageFailedMsg, not cancelled)--> ModeNewMessage (modal stays open, error banner shown)
 ```
 
 ### Cancellation
 
-Each submit gets a monotonic `RequestID uint64`. The reducer tracks the in-flight ID and a `cancelled bool`. On Esc during in-flight, modal closes and `cancelled=true`. When the service result arrives:
+Each submit gets a monotonic `RequestID uint64`. The reducer tracks the current in-flight ID (`a.newMessageInFlightID`) and a `cancelled bool` (`a.newMessageCancelled`). On Esc during in-flight, modal closes and `cancelled=true`. When the service result arrives:
 
-- If its `RequestID` matches AND not cancelled → proceed.
+- If its `RequestID` matches `a.newMessageInFlightID` AND not cancelled → proceed.
 - Otherwise → drop silently.
 
 This avoids the surprising "channel switches after the user backed out" behavior.
@@ -277,9 +278,9 @@ Add `openConversationContextFn` to `mockSlackAPI`:
 
 - `Ctrl+N` in `ModeNormal` enters `ModeNewMessage` and constructs picker.
 - Submit dispatches `ChannelService.OpenConversation` with correct user IDs.
-- `ConversationOpenedMsg` (not cancelled) → emits `ChannelSelectedMsg` + `EnterInsertModeMsg`; modal closes.
-- Esc during in-flight sets cancelled; late `ConversationOpenedMsg` is dropped (no mode change, no channel switch).
-- Error during in-flight keeps modal open with error banner; selections intact.
+- `NewMessageOpenedMsg` (not cancelled) → emits `ChannelSelectedMsg` and transitions to `ModeInsert`; modal closes.
+- Esc during in-flight sets cancelled; late `NewMessageOpenedMsg` is dropped (no mode change, no channel switch).
+- `NewMessageFailedMsg` during in-flight keeps modal open with error banner; selections intact.
 - Channel-not-in-cache path: minimal record inserted before `ChannelSelectedMsg`.
 
 ### Manual verification (not automated)

--- a/docs/superpowers/specs/2026-05-25-new-message-feature-design.md
+++ b/docs/superpowers/specs/2026-05-25-new-message-feature-design.md
@@ -1,0 +1,299 @@
+# New Message Feature — Design Spec
+
+**Date:** 2026-05-25
+**Status:** Approved (pending spec review)
+
+## Summary
+
+Add a "new message" picker that lets the user start a DM (1 user) or group DM / MPIM (2–8 users) without first finding an existing conversation. Triggered by `Ctrl+N` from `ModeNormal`. Opens a centered modal with fuzzy user search, multi-select via Space, and submits via Enter. On submit, calls Slack's `conversations.open`, then switches to the resulting channel and focuses the compose box.
+
+## Goals
+
+- One keystroke from anywhere to start messaging anyone (or any group).
+- Multi-select up to 8 recipients in a single pass.
+- Match Slack desktop's behavior for edge cases (self excluded, existing conversation reused, MPIM cap = 8).
+- Respect the in-progress SOLID refactor: new state in a dedicated sub-model, mode handler is thin.
+
+## Non-Goals
+
+- Self-DM ("Notes to self"). Excluded.
+- Bots, deactivated users in the picker. Excluded.
+- Renaming or converting an MPIM to a private channel. Out of scope.
+- User-list refresh while the modal is open. Snapshot at open time.
+- Golden-file rendering tests. The repo doesn't have that infra and we won't add it for this feature.
+
+## User Flow
+
+1. User in `ModeNormal` presses `Ctrl+N`.
+2. Modal opens, centered, dimmed backdrop. Pill bar empty, query input focused. Result list shows top users by recency, then alpha.
+3. User types — list filters by prefix > substring > subsequence rank, then recency, then alpha.
+4. User presses `Space` (or `Tab`) on a highlighted user to add to pills. Repeat for additional users up to 8.
+5. User presses `Enter`:
+   - With pills empty → opens DM with currently-highlighted user.
+   - With pills populated → opens DM (1 pill) or MPIM (2–8 pills).
+6. Modal shows `Opening conversation...`; input becomes read-only.
+7. On success, modal closes; app switches to the opened channel and enters `ModeInsert` with cursor in compose box.
+8. On Esc during in-flight: modal closes immediately; if the API call completes later, the result is dropped.
+9. On Esc before submit: modal closes, no-op.
+
+## Architecture
+
+```
++--------------------------------------+
+| User presses Ctrl+N                  |
++-------------------+------------------+
+                    |
+                    v
++--------------------------------------+
+| reducer: enter ModeNewMessage,       |
+|   build user list snapshot,          |
+|   construct newmessagepicker.Model   |
++-------------------+------------------+
+                    |
+                    v
++--------------------------------------+      +-----------------------+
+| mode_new_message.go                  |      | newmessagepicker.Model|
+|   routes key events to Model         |----->|   - query input       |
+|   on Submit -> OpenConversationCmd   |      |   - filtered list     |
++-------------------+------------------+      |   - selected userIDs  |
+                    |                         |   - HandleKey, View   |
+                    v                         +-----------------------+
++--------------------------------------+
+| ChannelService.OpenConversation(IDs) |
++-------------------+------------------+
+                    |
+                    v
++--------------------------------------+
+| Client.OpenConversation              |
+|   -> slack-go OpenConversationContext|
++-------------------+------------------+
+                    |
+                    v
++--------------------------------------+
+| ConversationOpenedMsg{ChannelID,     |
+|                       AlreadyOpen}   |
++-------------------+------------------+
+                    |
+                    v
++--------------------------------------+
+| reducer: if not cancelled,           |
+|   ensure cache record,               |
+|   emit ChannelSelectedMsg +          |
+|   EnterInsertModeMsg                 |
++--------------------------------------+
+```
+
+### Surfaces (new + changed)
+
+1. **`internal/ui/newmessagepicker/` (new package)**
+   - `model.go` — `Model` struct (query, filtered list, `selected map[string]struct{}`, viewport, cap=8).
+   - `filter.go` — pure functions for filtering and ranking. Table-driven testable.
+   - `model_test.go` — tests for filter, navigation, selection, submit semantics.
+   - `View` returns the modal contents; `ViewOverlay(width, height)` returns the dimmed-overlay-placed version (mirrors `channelfinder.ViewOverlay`).
+   - `Resize(width, height)` adjusts viewport.
+
+2. **`internal/ui/mode_new_message.go` (new)** — handler routing key events to the picker; on submit, dispatches `ChannelService.OpenConversation`; on cancel, returns to `ModeNormal`. Mirrors `mode_channel_finder.go`.
+
+3. **`internal/ui/mode.go` + `keys.go` (edit)**
+   - Add `ModeNewMessage` constant and its `String()` case.
+   - Bind `Ctrl+N` in `ModeNormal` to dispatch `EnterNewMessageMsg`.
+
+4. **`internal/slack/client.go` (edit)**
+   - Add `OpenConversationContext(ctx, *slack.OpenConversationParameters) (*slack.Channel, bool, bool, error)` to the `SlackAPI` interface.
+   - Add `Client.OpenConversation(ctx, userIDs []string) (channelID string, alreadyOpen bool, err error)`.
+
+5. **`internal/ui/services.go` + `cmd/slk/main.go` (edit)**
+   - Add `OpenConversation(userIDs []string) tea.Cmd` to `ChannelService`.
+   - Implementation in `main.go` where `ChannelService` is constructed, mirroring existing service methods.
+
+6. **`internal/ui/msgs.go` (edit)**
+   - `EnterNewMessageMsg struct{}` (dispatched by Ctrl+N).
+   - `ConversationOpenedMsg{ChannelID string; AlreadyOpen bool; RequestID uint64}` (returned by the service cmd).
+   - Errors reuse the existing error message type used by `SendMessage`.
+
+7. **Reducer (`reducer_new_message.go` or extend an existing reducer)**
+   - Handles `EnterNewMessageMsg`, `ConversationOpenedMsg`, error path, and the cancel/in-flight tracking.
+   - On `ConversationOpenedMsg` with a matching un-cancelled `RequestID`: insert minimal channel record into cache (ID, Type, Members), emit `ChannelSelectedMsg`, emit `EnterInsertModeMsg`, close modal.
+
+## UI Layout
+
+```
++--------------------------------------------------------+
+|  New message                                           |
++--------------------------------------------------------+
+|  To: [Alice Chen] [Bob Singh] |                        |
++--------------------------------------------------------+
+|  > Carla Diaz          @carla        recent            |
+|    Dan Evans           @dan          recent            |
+|    Eva Frank [ext]     @eva                            |
+|    Frank Gomez         @frankg                         |
+|    ...                                                 |
++--------------------------------------------------------+
+|  space toggle  enter open  esc cancel    2 / 8         |
++--------------------------------------------------------+
+```
+
+- **Title row:** `New message`.
+- **Pill bar + input:** Selected users render as inline lipgloss-styled pills (same token family as reaction pills in `internal/ui/messages/render.go`). Cursor sits after the pills; typed query renders to the right. Backspace at column 0 with pills present removes the last pill.
+- **Result list:** Scrollable, highlight marker `>`. Each row: display name, `@handle`, right-aligned `recent` hint if the user appears in a DM/MPIM with a message in the last 30 days. External users tagged `[ext]` inline.
+- **Footer:** Key hints on the left, `N / 8` selection counter on the right. Counter dims at `8 / 8` with `MPIM limit reached`.
+
+### Key bindings (modal)
+
+| Key | Action |
+|---|---|
+| any printable | append to query |
+| `Backspace` | delete char; at col 0 with pills present, remove last pill |
+| `Up` / `Down` / `Ctrl+P` / `Ctrl+N` | move highlight |
+| `Space` | toggle highlighted user into selection (no-op at cap) |
+| `Tab` | alias for Space |
+| `Enter` | submit: empty pills → use highlighted user; otherwise use pills |
+| `Esc` / `Ctrl+G` | cancel modal |
+
+Note: `Ctrl+N` is the open keybind in `ModeNormal`; inside the modal it is repurposed for "next" (consistent with `channelfinder` repurposing `Ctrl+T`).
+
+## Filtering & Ranking
+
+Pure functions in `newmessagepicker/filter.go`:
+
+1. **Source set:** cached workspace users where `Deleted == false && IsBot == false && ID != currentUserID`. The current user ID is read from `WorkspaceContext` at modal-open time and held on the `Model`. Externals included with `[ext]` tag.
+2. **Match (when query non-empty):** case-insensitive on `display_name` and `@handle`. Tiers: prefix > substring > subsequence. Non-matchers dropped.
+3. **Recency map:** built once at modal open by scanning cached `dm` and `group_dm` channels for last-message timestamps. A user's recency = max timestamp across DM/MPIM channels they are a member of. No API calls.
+4. **Sort:** (a) match tier, (b) recency desc, (c) display name asc.
+5. **Empty query:** Show top ~50 users by recency, then alpha. So `Ctrl+N` then Enter immediately opens the most recent DM target.
+
+## Slack API Integration
+
+`conversations.open` is dual-purpose:
+- 1 user → IM (same as legacy `im.open`).
+- 2–8 users → MPIM (same as legacy `mpim.open`).
+- Idempotent: returns existing channel with `already_open=true` when present.
+
+slack-go signature: `OpenConversationContext(ctx, &OpenConversationParameters{Users: []string, ReturnIM: true})` → `(*Channel, noOp bool, alreadyOpen bool, error)`.
+
+### `Client.OpenConversation`
+
+```go
+// OpenConversation opens or returns an existing IM (1 user) or MPIM (2-8 users).
+func (c *Client) OpenConversation(ctx context.Context, userIDs []string) (channelID string, alreadyOpen bool, err error) {
+    if len(userIDs) == 0 {
+        return "", false, fmt.Errorf("OpenConversation: at least one user ID required")
+    }
+    if len(userIDs) > 8 {
+        return "", false, fmt.Errorf("OpenConversation: at most 8 user IDs allowed (got %d)", len(userIDs))
+    }
+    ch, _, alreadyOpen, err := c.api.OpenConversationContext(ctx, &slack.OpenConversationParameters{
+        Users:    userIDs,
+        ReturnIM: true,
+    })
+    if err != nil {
+        return "", false, fmt.Errorf("OpenConversation: %w", err)
+    }
+    return ch.ID, alreadyOpen, nil
+}
+```
+
+Belt-and-suspenders: also strip out the current user's ID before calling (the picker filters it out at source, but defending the API call adds zero cost).
+
+### Cache hydration
+
+When `alreadyOpen == false`, the new channel is not yet in the SQLite channel cache. Reducer inserts a minimal record before emitting `ChannelSelectedMsg`:
+
+- `ID` = channel ID returned by `conversations.open`.
+- `Type` = `dm` if `len(userIDs) == 1`, else `group_dm`.
+- `Members` = the submitted user IDs plus the current user's ID.
+
+Subsequent RTM events and the next user-list refresh fill in remaining fields. This avoids a slow round-trip refresh on the hot path.
+
+## State Machine
+
+```
+ModeNormal --(Ctrl+N)--> ModeNewMessage
+ModeNewMessage --(Esc / Ctrl+G)--> ModeNormal
+ModeNewMessage --(Enter w/ valid selection)--> ModeNewMessage[in-flight]
+ModeNewMessage[in-flight] --(Esc)--> ModeNormal (cancelled; late result dropped)
+ModeNewMessage[in-flight] --(ConversationOpenedMsg, not cancelled)--> ModeInsert (in opened channel)
+ModeNewMessage[in-flight] --(error)--> ModeNewMessage (modal stays open, error banner shown)
+```
+
+### Cancellation
+
+Each submit gets a monotonic `RequestID uint64`. The reducer tracks the in-flight ID and a `cancelled bool`. On Esc during in-flight, modal closes and `cancelled=true`. When the service result arrives:
+
+- If its `RequestID` matches AND not cancelled → proceed.
+- Otherwise → drop silently.
+
+This avoids the surprising "channel switches after the user backed out" behavior.
+
+## Error Handling
+
+| Failure | Surface | Recovery |
+|---|---|---|
+| Slack API error (network, auth, rate-limit) | Error banner in modal footer; modal stays open; selections preserved | User retries via Enter or Esc to cancel |
+| User picks 8 then tries to add a 9th | Space is no-op; footer dims `8 / 8` and shows `MPIM limit reached` | Remove a pill (backspace) first |
+| User cache empty at modal open | `Loading users...` placeholder; refreshes when cache populates | Type to filter once loaded |
+| Query has no matches | List shows `No users match "<query>"`; Enter is no-op | Refine query |
+| Self ID somehow selected | Filtered at source AND in `Client.OpenConversation`; API call would also reject | Defensive — should not occur |
+
+## Edge Cases
+
+- **Existing DM/MPIM:** `conversations.open` returns existing channel with `already_open=true`. We switch to it. No duplicate.
+- **Channel not in cache:** Minimal record inserted by reducer before switch.
+- **User list updates mid-modal:** Snapshot at open time; new users not visible until next open.
+- **Theme:** Reuses existing lipgloss style tokens; no new theme entries needed.
+- **Resize:** `Model.Resize(width, height)` recomputes viewport; centered overlay re-places via `lipgloss.Place`.
+
+## Testing Strategy
+
+Standard `go test`. No new frameworks.
+
+### Layer 1 — Picker model (`internal/ui/newmessagepicker/model_test.go`)
+
+Pure-function tests with no Slack API:
+
+- Filter & rank: prefix > substring > subsequence tiers; recency tie-breaking; alpha tie-breaking; externals tagged; current user excluded; deactivated/bots excluded.
+- Empty query → top-N by recency then alpha.
+- No matches → empty list and placeholder.
+- Navigation: Up/Down/Ctrl+P/Ctrl+N move highlight; clamp at boundaries (match `channelfinder`).
+- Selection: Space toggles; Space on selected user removes; Tab aliases Space.
+- MPIM cap: Space no-op at 8; counter state correct.
+- Backspace at column 0 removes last pill when query is empty.
+- Submit: empty pills + highlighted → `{userIDs: [highlighted.ID]}`; pills populated → `{userIDs: pills}`; no pills + no highlight → no-op.
+- Esc returns cancel signal.
+- Resize correctly recomputes viewport.
+
+### Layer 2 — Slack client (`internal/slack/client_test.go`)
+
+Add `openConversationContextFn` to `mockSlackAPI`:
+
+- 1 user → calls API with that user; returns channel ID.
+- 3 users → MPIM-shaped result.
+- 0 users → returns error; no API call.
+- 9 users → returns error; no API call.
+- API error propagates with wrapping.
+- `alreadyOpen=true` plumbed through.
+
+### Layer 3 — Mode + reducer
+
+- `Ctrl+N` in `ModeNormal` enters `ModeNewMessage` and constructs picker.
+- Submit dispatches `ChannelService.OpenConversation` with correct user IDs.
+- `ConversationOpenedMsg` (not cancelled) → emits `ChannelSelectedMsg` + `EnterInsertModeMsg`; modal closes.
+- Esc during in-flight sets cancelled; late `ConversationOpenedMsg` is dropped (no mode change, no channel switch).
+- Error during in-flight keeps modal open with error banner; selections intact.
+- Channel-not-in-cache path: minimal record inserted before `ChannelSelectedMsg`.
+
+### Manual verification (not automated)
+
+- Pill rendering, overlay centering, theme application.
+- End-to-end RTM event arrival for a newly opened MPIM.
+
+## Open Questions
+
+None at design time. Captured decisions:
+
+- Keybind: `Ctrl+N`.
+- Selection model: explicit toggle (Space/Tab), Enter submits.
+- User list: active humans + externals, recent DMs first.
+- Post-open: switch + focus compose (`ModeInsert`).
+- Edge cases: standard Slack behavior (self excluded, MPIM cap = 8, existing reused).
+- Esc during in-flight: abandon result.

--- a/internal/slack/client.go
+++ b/internal/slack/client.go
@@ -44,6 +44,7 @@ type SlackAPI interface {
 	EndDNDContext(ctx context.Context) error
 	GetDNDInfoContext(ctx context.Context, user *string, options ...slack.ParamOption) (*slack.DNDStatus, error)
 	UploadFileContext(ctx context.Context, params slack.UploadFileParameters) (*slack.FileSummary, error)
+	OpenConversationContext(ctx context.Context, params *slack.OpenConversationParameters) (*slack.Channel, bool, bool, error)
 }
 
 // defaultAPIBaseURL is the canonical Slack Web API root used as a fallback
@@ -637,6 +638,30 @@ func (c *Client) SendMessage(ctx context.Context, channelID, text string) (strin
 		return "", "", fmt.Errorf("sending message: %w", err)
 	}
 	return ts, mr, nil
+}
+
+// OpenConversation opens (or returns) a direct message channel (1 user)
+// or a multi-person direct message / MPIM (2-8 users). Idempotent:
+// when the conversation already exists, Slack returns it with
+// alreadyOpen=true.
+//
+// Defends inputs: rejects 0 users or more than 8. Slack's hard cap on
+// MPIM size is 9 participants total, so up to 8 OTHER user IDs.
+func (c *Client) OpenConversation(ctx context.Context, userIDs []string) (channelID string, alreadyOpen bool, err error) {
+	if len(userIDs) == 0 {
+		return "", false, fmt.Errorf("OpenConversation: at least one user ID required")
+	}
+	if len(userIDs) > 8 {
+		return "", false, fmt.Errorf("OpenConversation: at most 8 user IDs allowed (got %d)", len(userIDs))
+	}
+	ch, _, alreadyOpen, err := c.api.OpenConversationContext(ctx, &slack.OpenConversationParameters{
+		Users:    userIDs,
+		ReturnIM: true,
+	})
+	if err != nil {
+		return "", false, fmt.Errorf("OpenConversation: %w", err)
+	}
+	return ch.ID, alreadyOpen, nil
 }
 
 // UploadFile uploads a single file to a channel (and optional thread)

--- a/internal/slack/client.go
+++ b/internal/slack/client.go
@@ -647,19 +647,19 @@ func (c *Client) SendMessage(ctx context.Context, channelID, text string) (strin
 //
 // Defends inputs: rejects 0 users or more than 8. Slack's hard cap on
 // MPIM size is 9 participants total, so up to 8 OTHER user IDs.
-func (c *Client) OpenConversation(ctx context.Context, userIDs []string) (channelID string, alreadyOpen bool, err error) {
+func (c *Client) OpenConversation(ctx context.Context, userIDs []string) (string, bool, error) {
 	if len(userIDs) == 0 {
-		return "", false, fmt.Errorf("OpenConversation: at least one user ID required")
+		return "", false, fmt.Errorf("opening conversation: at least one user ID required")
 	}
 	if len(userIDs) > 8 {
-		return "", false, fmt.Errorf("OpenConversation: at most 8 user IDs allowed (got %d)", len(userIDs))
+		return "", false, fmt.Errorf("opening conversation: at most 8 user IDs allowed (got %d)", len(userIDs))
 	}
 	ch, _, alreadyOpen, err := c.api.OpenConversationContext(ctx, &slack.OpenConversationParameters{
 		Users:    userIDs,
 		ReturnIM: true,
 	})
 	if err != nil {
-		return "", false, fmt.Errorf("OpenConversation: %w", err)
+		return "", false, fmt.Errorf("opening conversation: %w", err)
 	}
 	return ch.ID, alreadyOpen, nil
 }

--- a/internal/slack/client_test.go
+++ b/internal/slack/client_test.go
@@ -146,6 +146,7 @@ type mockSlackAPI struct {
 	getDNDInfoContextFn             func(ctx context.Context, user *string, options ...slack.ParamOption) (*slack.DNDStatus, error)
 	uploadFileContextFn             func(ctx context.Context, params slack.UploadFileParameters) (*slack.FileSummary, error)
 	getUsersInConversationContextFn func(ctx context.Context, params *slack.GetUsersInConversationParameters) ([]string, string, error)
+	openConversationContextFn       func(ctx context.Context, params *slack.OpenConversationParameters) (*slack.Channel, bool, bool, error)
 }
 
 func (m *mockSlackAPI) GetConversations(params *slack.GetConversationsParameters) ([]slack.Channel, string, error) {
@@ -1898,5 +1899,146 @@ func TestGetUsersInConversationRetriesOnRateLimit(t *testing.T) {
 	// On rate-limit, cursor must NOT advance — the retry hits the same page.
 	if seenCursors[0] != "" || seenCursors[1] != "" {
 		t.Errorf("expected both calls with empty cursor (same page retry), got %v", seenCursors)
+	}
+}
+
+func (m *mockSlackAPI) OpenConversationContext(ctx context.Context, params *slack.OpenConversationParameters) (*slack.Channel, bool, bool, error) {
+	if m.openConversationContextFn != nil {
+		return m.openConversationContextFn(ctx, params)
+	}
+	return nil, false, false, nil
+}
+
+func TestOpenConversation_SingleUserReturnsIMChannelID(t *testing.T) {
+	mock := &mockSlackAPI{
+		openConversationContextFn: func(ctx context.Context, params *slack.OpenConversationParameters) (*slack.Channel, bool, bool, error) {
+			if len(params.Users) != 1 || params.Users[0] != "U123" {
+				t.Errorf("expected Users=[U123], got %v", params.Users)
+			}
+			if !params.ReturnIM {
+				t.Error("expected ReturnIM=true")
+			}
+			return &slack.Channel{
+				GroupConversation: slack.GroupConversation{
+					Conversation: slack.Conversation{ID: "D456"},
+				},
+			}, false, false, nil
+		},
+	}
+	c := &Client{api: mock}
+
+	channelID, alreadyOpen, err := c.OpenConversation(context.Background(), []string{"U123"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if channelID != "D456" {
+		t.Errorf("expected channelID=D456, got %q", channelID)
+	}
+	if alreadyOpen {
+		t.Error("expected alreadyOpen=false")
+	}
+}
+
+func TestOpenConversation_MultipleUsersReturnsMPIMChannelID(t *testing.T) {
+	mock := &mockSlackAPI{
+		openConversationContextFn: func(ctx context.Context, params *slack.OpenConversationParameters) (*slack.Channel, bool, bool, error) {
+			if len(params.Users) != 3 {
+				t.Errorf("expected 3 users, got %d", len(params.Users))
+			}
+			return &slack.Channel{
+				GroupConversation: slack.GroupConversation{
+					Conversation: slack.Conversation{ID: "G789"},
+				},
+			}, false, false, nil
+		},
+	}
+	c := &Client{api: mock}
+
+	channelID, _, err := c.OpenConversation(context.Background(), []string{"U1", "U2", "U3"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if channelID != "G789" {
+		t.Errorf("expected channelID=G789, got %q", channelID)
+	}
+}
+
+func TestOpenConversation_EmptyUserIDsReturnsErrorWithoutAPICall(t *testing.T) {
+	called := false
+	mock := &mockSlackAPI{
+		openConversationContextFn: func(ctx context.Context, params *slack.OpenConversationParameters) (*slack.Channel, bool, bool, error) {
+			called = true
+			return nil, false, false, nil
+		},
+	}
+	c := &Client{api: mock}
+
+	_, _, err := c.OpenConversation(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for empty userIDs")
+	}
+	if called {
+		t.Error("API should not have been called")
+	}
+}
+
+func TestOpenConversation_TooManyUserIDsReturnsErrorWithoutAPICall(t *testing.T) {
+	called := false
+	mock := &mockSlackAPI{
+		openConversationContextFn: func(ctx context.Context, params *slack.OpenConversationParameters) (*slack.Channel, bool, bool, error) {
+			called = true
+			return nil, false, false, nil
+		},
+	}
+	c := &Client{api: mock}
+
+	nine := []string{"U1", "U2", "U3", "U4", "U5", "U6", "U7", "U8", "U9"}
+	_, _, err := c.OpenConversation(context.Background(), nine)
+	if err == nil {
+		t.Fatal("expected error for 9 userIDs")
+	}
+	if called {
+		t.Error("API should not have been called")
+	}
+}
+
+func TestOpenConversation_APIErrorIsWrapped(t *testing.T) {
+	mock := &mockSlackAPI{
+		openConversationContextFn: func(ctx context.Context, params *slack.OpenConversationParameters) (*slack.Channel, bool, bool, error) {
+			return nil, false, false, fmt.Errorf("rate_limited")
+		},
+	}
+	c := &Client{api: mock}
+
+	_, _, err := c.OpenConversation(context.Background(), []string{"U1"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "OpenConversation") {
+		t.Errorf("expected error to be wrapped with OpenConversation prefix, got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "rate_limited") {
+		t.Errorf("expected error to contain underlying message, got %q", err.Error())
+	}
+}
+
+func TestOpenConversation_AlreadyOpenFlagPropagates(t *testing.T) {
+	mock := &mockSlackAPI{
+		openConversationContextFn: func(ctx context.Context, params *slack.OpenConversationParameters) (*slack.Channel, bool, bool, error) {
+			return &slack.Channel{
+				GroupConversation: slack.GroupConversation{
+					Conversation: slack.Conversation{ID: "D1"},
+				},
+			}, false, true, nil
+		},
+	}
+	c := &Client{api: mock}
+
+	_, alreadyOpen, err := c.OpenConversation(context.Background(), []string{"U1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !alreadyOpen {
+		t.Error("expected alreadyOpen=true")
 	}
 }

--- a/internal/slack/client_test.go
+++ b/internal/slack/client_test.go
@@ -2014,8 +2014,8 @@ func TestOpenConversation_APIErrorIsWrapped(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if !strings.Contains(err.Error(), "OpenConversation") {
-		t.Errorf("expected error to be wrapped with OpenConversation prefix, got %q", err.Error())
+	if !strings.Contains(err.Error(), "opening conversation") {
+		t.Errorf("expected error to be wrapped with opening conversation prefix, got %q", err.Error())
 	}
 	if !strings.Contains(err.Error(), "rate_limited") {
 		t.Errorf("expected error to contain underlying message, got %q", err.Error())

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -407,6 +407,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		reduceSend,
 		reduceChannels,
 		reduceWorkspace,
+		reduceNewMessagePicker,
 		reduceIO,
 		reduceMouse,
 	); handled {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1644,6 +1644,41 @@ func (a *App) SetUserNames(names map[string]string) {
 	a.threadCompose.SetUsers(users)
 }
 
+// seedNewMessagePicker snapshots the current workspace's user list
+// into the new-message picker and configures the self-exclusion.
+// Called when ModeNewMessage is entered so the modal always sees a
+// fresh view of the workspace.
+//
+// User-list shape:
+//   - DisplayName from a.userNames (the workspace display name map).
+//   - Username falls back to DisplayName — there is no separate
+//     userID->handle map on App today. The picker uses Username
+//     only for filter matching, so this fallback degrades
+//     gracefully: queries against the display name still hit.
+//   - IsExternal from a.externalUsers.
+//   - Recency is left at 0 (alphabetical order; recency wiring is a
+//     follow-up that needs WorkspaceContext.LastVisitedByChannel
+//     plumbed in).
+//   - Self (a.currentUserID) is excluded both at slice-build time
+//     and via SetCurrentUserID (belt-and-suspenders).
+func (a *App) seedNewMessagePicker() {
+	users := make([]newmessagepicker.User, 0, len(a.userNames))
+	for id, name := range a.userNames {
+		if id == a.currentUserID {
+			continue
+		}
+		users = append(users, newmessagepicker.User{
+			ID:          id,
+			DisplayName: name,
+			Username:    name, // see scoping note; replaceable when a handle map lands
+			IsExternal:  a.externalUsers[id],
+		})
+	}
+
+	a.newMessagePicker.SetCurrentUserID(a.currentUserID)
+	a.newMessagePicker.SetUsers(users)
+}
+
 // SetExternalUsers replaces the set of user IDs known to be Slack
 // Connect / shared-channel guests. Sticky: subsequent SetUserNames
 // calls consult this map when building mention-picker entries.

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gammons/slk/internal/ui/imgrender"
 	"github.com/gammons/slk/internal/ui/mentionpicker"
 	"github.com/gammons/slk/internal/ui/messages"
+	"github.com/gammons/slk/internal/ui/newmessagepicker"
 	"github.com/gammons/slk/internal/ui/presencemenu"
 	"github.com/gammons/slk/internal/ui/reactionpicker"
 	"github.com/gammons/slk/internal/ui/sidebar"
@@ -78,19 +79,20 @@ const openThreadDebounceDelay = 200 * time.Millisecond
 
 type App struct {
 	// Sub-models
-	workspaceRail   workspace.Model
-	sidebar         sidebar.Model
-	messagepane     messages.Model
-	compose         compose.Model
-	statusbar       statusbar.Model
-	channelFinder   channelfinder.Model
-	workspaceFinder workspacefinder.Model
-	themeSwitcher   themeswitcher.Model
-	presenceMenu    presencemenu.Model
-	help            help.Model
-	threadPanel     *thread.Model
-	threadCompose   compose.Model
-	threadsView     threadsview.Model
+	workspaceRail    workspace.Model
+	sidebar          sidebar.Model
+	messagepane      messages.Model
+	compose          compose.Model
+	statusbar        statusbar.Model
+	channelFinder    channelfinder.Model
+	newMessagePicker newmessagepicker.Model
+	workspaceFinder  workspacefinder.Model
+	themeSwitcher    themeswitcher.Model
+	presenceMenu     presencemenu.Model
+	help             help.Model
+	threadPanel      *thread.Model
+	threadCompose    compose.Model
+	threadsView      threadsview.Model
 
 	// State
 	mode           Mode
@@ -196,6 +198,17 @@ type App struct {
 	// internal/ui/edit.go.
 	editing *editController
 
+	// newMessageInFlightID is the monotonic counter for in-flight
+	// OpenConversation requests dispatched from the new-message
+	// picker. 0 means no submit is in flight. The reducer drops late
+	// results whose RequestID doesn't match.
+	newMessageInFlightID uint64
+	// newMessageCancelled is set to true when the user Escs the
+	// modal while a submit is in flight. A subsequent
+	// NewMessageOpenedMsg with the matching RequestID is dropped
+	// rather than switching channels behind the user's back.
+	newMessageCancelled bool
+
 	// Workspace switching
 	workspaceSwitcher SwitchWorkspaceFunc
 	workspaceItems    []workspace.WorkspaceItem // cached for lookup
@@ -294,6 +307,7 @@ func NewApp() *App {
 		compose:              compose.New(""),
 		statusbar:            statusbar.New(),
 		channelFinder:        channelfinder.New(),
+		newMessagePicker:     newmessagepicker.New(),
 		workspaceFinder:      workspacefinder.New(),
 		themeSwitcher:        themeswitcher.New(),
 		presenceMenu:         presencemenu.New(),

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -4274,3 +4274,42 @@ func TestChannelSelectedReturnsPromptlyEvenIfFetcherBlocks(t *testing.T) {
 		t.Fatal("Update did not return within 100ms; fetcher is being called synchronously on the Update goroutine — risks bubbletea Send-from-Update deadlock")
 	}
 }
+
+func TestSeedNewMessagePicker_PopulatesUsersAndExcludesSelf(t *testing.T) {
+	app := NewApp()
+	app.currentUserID = "USELF"
+	app.SetUserNames(map[string]string{
+		"USELF": "Me",
+		"U1":    "Alice",
+		"U2":    "Bob",
+	})
+	app.SetExternalUsers(map[string]bool{"U2": true})
+
+	app.seedNewMessagePicker()
+
+	users := app.newMessagePicker.Users()
+	// Picker holds all non-self users. The picker excludes self via
+	// SetCurrentUserID at filter time, not at the SetUsers slice level.
+	// So the slice should contain Alice + Bob + Me, but after Open()
+	// the filtered list excludes Me.
+	ids := map[string]bool{}
+	for _, u := range users {
+		ids[u.ID] = true
+	}
+	if !ids["U1"] {
+		t.Error("expected Alice (U1) in picker users")
+	}
+	if !ids["U2"] {
+		t.Error("expected Bob (U2) in picker users")
+	}
+	if ids["USELF"] {
+		t.Error("expected USELF excluded from seeded slice")
+	}
+
+	// External flag should propagate.
+	for _, u := range users {
+		if u.ID == "U2" && !u.IsExternal {
+			t.Error("expected Bob (U2) to be marked external")
+		}
+	}
+}

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -36,6 +36,7 @@ type KeyMap struct {
 	OpenPreview         key.Binding
 	MarkUnread          key.Binding
 	WorkspaceFinder     key.Binding
+	NewMessage          key.Binding
 	ThemeSwitcher       key.Binding
 	ThemeSwitcherGlobal key.Binding
 	PresenceMenu        key.Binding
@@ -79,6 +80,7 @@ func DefaultKeyMap() KeyMap {
 		OpenPreview:         key.NewBinding(key.WithKeys("O", "v"), key.WithHelp("O/v", "open image preview")),
 		MarkUnread:          key.NewBinding(key.WithKeys("U"), key.WithHelp("U", "mark unread")),
 		WorkspaceFinder:     key.NewBinding(key.WithKeys("ctrl+w"), key.WithHelp("ctrl+w", "switch workspace")),
+		NewMessage:          key.NewBinding(key.WithKeys("ctrl+n"), key.WithHelp("ctrl+n", "new message")),
 		ThemeSwitcher:       key.NewBinding(key.WithKeys("ctrl+y"), key.WithHelp("ctrl+y", "switch theme (per workspace)")),
 		ThemeSwitcherGlobal: key.NewBinding(key.WithKeys("ctrl+shift+y"), key.WithHelp("ctrl+shift+y", "set default theme")),
 		PresenceMenu:        key.NewBinding(key.WithKeys("ctrl+s"), key.WithHelp("ctrl+s", "set status")),

--- a/internal/ui/mode.go
+++ b/internal/ui/mode.go
@@ -16,6 +16,7 @@ const (
 	ModePresenceCustomSnooze
 	ModeConfirm
 	ModeHelp
+	ModeNewMessage
 )
 
 func (m Mode) String() string {
@@ -44,6 +45,8 @@ func (m Mode) String() string {
 		return "CONFIRM"
 	case ModeHelp:
 		return "HELP"
+	case ModeNewMessage:
+		return "NEW MSG"
 	default:
 		return "UNKNOWN"
 	}

--- a/internal/ui/mode_handlers.go
+++ b/internal/ui/mode_handlers.go
@@ -52,6 +52,7 @@ var modeHandlers = map[Mode]modeHandler{
 	ModeInsert:               handleInsertMode,
 	ModeCommand:              handleCommandMode,
 	ModeChannelFinder:        handleChannelFinderMode,
+	ModeNewMessage:           handleNewMessageMode,
 	ModeReactionPicker:       handleReactionPickerMode,
 	ModeConfirm:              handleConfirmMode,
 	ModeWorkspaceFinder:      handleWorkspaceFinderMode,

--- a/internal/ui/mode_new_message.go
+++ b/internal/ui/mode_new_message.go
@@ -1,0 +1,55 @@
+// internal/ui/mode_new_message.go
+//
+// New-message mode key handler. Forwards normalised keys to the
+// newmessagepicker overlay. When the picker returns a Result, the
+// handler dispatches a new submit via ChannelService.OpenConversation
+// (with a monotonic RequestID) and tracks the in-flight state on App.
+// On Esc, marks the in-flight as cancelled so a late result is
+// dropped (see reducer_new_message.go for the dropping logic).
+package ui
+
+import (
+	tea "charm.land/bubbletea/v2"
+)
+
+func handleNewMessageMode(a *App, msg tea.KeyMsg) tea.Cmd {
+	keyStr := msg.String()
+	switch msg.Key().Code {
+	case tea.KeyEnter:
+		keyStr = "enter"
+	case tea.KeyEscape:
+		keyStr = "esc"
+	case tea.KeyUp:
+		keyStr = "up"
+	case tea.KeyDown:
+		keyStr = "down"
+	case tea.KeyBackspace:
+		keyStr = "backspace"
+	case tea.KeyTab:
+		keyStr = "tab"
+	case tea.KeySpace:
+		keyStr = " "
+	}
+
+	result := a.newMessagePicker.HandleKey(keyStr)
+	if result != nil {
+		// Submit. Bump the in-flight ID and clear cancellation
+		// before dispatch so a fresh result is honored.
+		a.newMessageInFlightID++
+		a.newMessageCancelled = false
+		reqID := a.newMessageInFlightID
+		userIDs := result.UserIDs
+		return a.channels.OpenConversation(userIDs, reqID)
+	}
+
+	// Picker closed itself (Esc). Mark any in-flight submit as
+	// cancelled so its eventual result is dropped. Switch back to
+	// ModeNormal.
+	if !a.newMessagePicker.IsVisible() {
+		if a.newMessageInFlightID != 0 {
+			a.newMessageCancelled = true
+		}
+		a.SetMode(ModeNormal)
+	}
+	return nil
+}

--- a/internal/ui/mode_normal.go
+++ b/internal/ui/mode_normal.go
@@ -170,6 +170,9 @@ func handleNormalMode(a *App, msg tea.KeyMsg) tea.Cmd {
 		a.channelFinder.Open()
 		a.SetMode(ModeChannelFinder)
 
+	case key.Matches(msg, a.keys.NewMessage):
+		return func() tea.Msg { return EnterNewMessageMsg{} }
+
 	case key.Matches(msg, a.keys.Reaction):
 		if a.focusedPanel == PanelMessages {
 			return a.openPickerFromMessage()

--- a/internal/ui/msgs.go
+++ b/internal/ui/msgs.go
@@ -485,7 +485,7 @@ type previewSpinnerTickMsg struct{}
 type editEmptyToastMsg struct{}
 
 // EnterNewMessageMsg is dispatched when the user presses Ctrl+N in
-// ModeNormal. The reducer (reduceNewMessage) handles it by snapshotting
+// ModeNormal. The reducer (reduceNewMessagePicker) handles it by snapshotting
 // the workspace user list, opening the newmessagepicker, and switching
 // to ModeNewMessage.
 type EnterNewMessageMsg struct{}
@@ -502,7 +502,7 @@ type EnterNewMessageMsg struct{}
 // mpim_open / im_created events (channel side-effect of someone
 // being added to a conversation). The new-message flow has its own
 // type because it carries the in-flight RequestID and we need
-// per-message routing in reduceNewMessage.
+// per-message routing in reduceNewMessagePicker.
 type NewMessageOpenedMsg struct {
 	ChannelID   string
 	AlreadyOpen bool

--- a/internal/ui/msgs.go
+++ b/internal/ui/msgs.go
@@ -483,3 +483,38 @@ type previewSpinnerTickMsg struct{}
 // editEmptyToastMsg is delivered when the user tries to submit an
 // edit with empty text.
 type editEmptyToastMsg struct{}
+
+// EnterNewMessageMsg is dispatched when the user presses Ctrl+N in
+// ModeNormal. The reducer (reduceNewMessage) handles it by snapshotting
+// the workspace user list, opening the newmessagepicker, and switching
+// to ModeNewMessage.
+type EnterNewMessageMsg struct{}
+
+// NewMessageOpenedMsg carries the result of a successful
+// ChannelService.OpenConversation call. RequestID identifies which
+// submit this is the response to so the reducer can drop late
+// arrivals from cancelled submits. AlreadyOpen=true means Slack
+// returned an existing DM/MPIM; the reducer skips the
+// minimal-channel-record insert in that case (Task 12).
+//
+// Distinct from the existing ConversationOpenedMsg in this file,
+// which is dispatched by the WS event handler for Slack's
+// mpim_open / im_created events (channel side-effect of someone
+// being added to a conversation). The new-message flow has its own
+// type because it carries the in-flight RequestID and we need
+// per-message routing in reduceNewMessage.
+type NewMessageOpenedMsg struct {
+	ChannelID   string
+	AlreadyOpen bool
+	UserIDs     []string // copied through so the reducer can hydrate the cache record
+	RequestID   uint64
+}
+
+// NewMessageFailedMsg carries an error from a failed
+// ChannelService.OpenConversation call. The reducer surfaces Err in
+// the modal's footer banner; the modal stays open with the user's
+// selection intact so they can retry.
+type NewMessageFailedMsg struct {
+	RequestID uint64
+	Err       error
+}

--- a/internal/ui/newmessagepicker/filter.go
+++ b/internal/ui/newmessagepicker/filter.go
@@ -1,0 +1,116 @@
+package newmessagepicker
+
+import (
+	"sort"
+	"strings"
+)
+
+// filter rebuilds m.filtered from m.users honoring the current query,
+// the current-user exclusion, and the ranking rules:
+//
+//  1. Match tier (only when query non-empty):
+//     0 = prefix on display name OR username
+//     1 = substring on display name OR username
+//     2 = subsequence on display name OR username
+//     Non-matchers are dropped.
+//  2. Recency DESC.
+//  3. DisplayName ASC (case-insensitive).
+//
+// Empty query: include all users (minus self) sorted by Recency DESC
+// then DisplayName ASC.
+func (m *Model) filter() {
+	m.filtered = m.filtered[:0]
+	q := strings.ToLower(m.query)
+
+	if q == "" {
+		for i, u := range m.users {
+			if u.ID == m.currentUserID {
+				continue
+			}
+			m.filtered = append(m.filtered, i)
+		}
+		sort.SliceStable(m.filtered, func(i, j int) bool {
+			return m.lessNoQuery(m.filtered[i], m.filtered[j])
+		})
+		return
+	}
+
+	type match struct {
+		idx  int
+		tier int
+	}
+	var matches []match
+	for i, u := range m.users {
+		if u.ID == m.currentUserID {
+			continue
+		}
+		tier, ok := matchTier(u, q)
+		if !ok {
+			continue
+		}
+		matches = append(matches, match{idx: i, tier: tier})
+	}
+
+	sort.SliceStable(matches, func(i, j int) bool {
+		a, b := matches[i], matches[j]
+		if a.tier != b.tier {
+			return a.tier < b.tier
+		}
+		ua, ub := m.users[a.idx], m.users[b.idx]
+		if ua.Recency != ub.Recency {
+			return ua.Recency > ub.Recency
+		}
+		return strings.ToLower(ua.DisplayName) < strings.ToLower(ub.DisplayName)
+	})
+
+	for _, mm := range matches {
+		m.filtered = append(m.filtered, mm.idx)
+	}
+}
+
+// matchTier returns (tier, true) if u matches q on either its
+// DisplayName or its Username. tier 0 = prefix, 1 = substring,
+// 2 = subsequence. q is expected to already be lower-cased.
+func matchTier(u User, q string) (int, bool) {
+	name := strings.ToLower(u.DisplayName)
+	handle := strings.ToLower(u.Username)
+	if strings.HasPrefix(name, q) || strings.HasPrefix(handle, q) {
+		return 0, true
+	}
+	if strings.Contains(name, q) || strings.Contains(handle, q) {
+		return 1, true
+	}
+	if isSubsequence(name, q) || isSubsequence(handle, q) {
+		return 2, true
+	}
+	return 0, false
+}
+
+// isSubsequence reports whether every rune of q appears in s in
+// order. Both inputs are expected to already be lower-cased.
+func isSubsequence(s, q string) bool {
+	qi := 0
+	qrunes := []rune(q)
+	if len(qrunes) == 0 {
+		return true
+	}
+	for _, r := range s {
+		if qi >= len(qrunes) {
+			break
+		}
+		if r == qrunes[qi] {
+			qi++
+		}
+	}
+	return qi == len(qrunes)
+}
+
+// lessNoQuery is the comparator used when the query is empty:
+// Recency DESC, then DisplayName ASC.
+func (m *Model) lessNoQuery(ai, bi int) bool {
+	a, b := m.users[ai], m.users[bi]
+	if a.Recency != b.Recency {
+		return a.Recency > b.Recency
+	}
+	return strings.ToLower(a.DisplayName) < strings.ToLower(b.DisplayName)
+}

--- a/internal/ui/newmessagepicker/model.go
+++ b/internal/ui/newmessagepicker/model.go
@@ -108,6 +108,11 @@ func (m *Model) setQuery(q string) {
 // lands in this task too; submit semantics (Enter) land in Task 5.
 func (m *Model) HandleKey(keyStr string) *Result {
 	switch keyStr {
+	case "enter":
+		return m.submit()
+	case "esc":
+		m.Close()
+		return nil
 	case "down", "ctrl+n":
 		if m.highlight < len(m.filtered)-1 {
 			m.highlight++
@@ -182,4 +187,28 @@ func (m *Model) handleBackspace() {
 			return
 		}
 	}
+}
+
+// submit returns a non-nil *Result when the picker has something to
+// submit:
+//   - If pills are present, the result carries the pill IDs.
+//   - Otherwise, if a user is highlighted, the result carries that one ID.
+//   - If neither is true (empty filter AND no pills), returns nil — Enter is a no-op.
+//
+// Pill order in the returned slice matches the user-list order so the
+// caller sees a stable, predictable order across calls.
+func (m *Model) submit() *Result {
+	if len(m.selected) > 0 {
+		ids := make([]string, 0, len(m.selected))
+		for _, u := range m.users {
+			if _, ok := m.selected[u.ID]; ok {
+				ids = append(ids, u.ID)
+			}
+		}
+		return &Result{UserIDs: ids}
+	}
+	if m.highlight < 0 || m.highlight >= len(m.filtered) {
+		return nil
+	}
+	return &Result{UserIDs: []string{m.users[m.filtered[m.highlight]].ID}}
 }

--- a/internal/ui/newmessagepicker/model.go
+++ b/internal/ui/newmessagepicker/model.go
@@ -87,14 +87,10 @@ func (m Model) IsVisible() bool {
 	return m.visible
 }
 
-// filter is a placeholder until Task 3. For now it just includes
-// every user except self. Order is the natural users-slice order.
-func (m *Model) filter() {
-	m.filtered = m.filtered[:0]
-	for i, u := range m.users {
-		if u.ID == m.currentUserID {
-			continue
-		}
-		m.filtered = append(m.filtered, i)
-	}
+// setQuery is a test helper: replaces the query and refilters. The
+// real keystroke API in Task 4 will go through HandleKey.
+func (m *Model) setQuery(q string) {
+	m.query = q
+	m.highlight = 0
+	m.filter()
 }

--- a/internal/ui/newmessagepicker/model.go
+++ b/internal/ui/newmessagepicker/model.go
@@ -60,6 +60,12 @@ func (m *Model) SetUsers(users []User) {
 	m.users = users
 }
 
+// Users returns the user list most recently set via SetUsers. Used
+// by tests; not part of the picker's input API.
+func (m *Model) Users() []User {
+	return m.users
+}
+
 // SetCurrentUserID configures which user ID represents "self" so the
 // picker can hide it from the list (a user cannot start a DM with
 // themselves via this flow). May be called once at app start.

--- a/internal/ui/newmessagepicker/model.go
+++ b/internal/ui/newmessagepicker/model.go
@@ -94,3 +94,92 @@ func (m *Model) setQuery(q string) {
 	m.highlight = 0
 	m.filter()
 }
+
+// HandleKey processes a single key event. The string form mirrors the
+// other picker packages (channelfinder, mentionpicker): "up", "down",
+// "ctrl+n", "ctrl+p", "backspace", "esc", "enter", "tab", " ", or
+// any single printable ASCII character.
+//
+// Returns a non-nil Result when the user submits the picker; the
+// caller (the mode handler) closes the picker and dispatches the
+// conversations.open call.
+//
+// This task wires the navigation arms only. Selection (Space/Tab)
+// lands in this task too; submit semantics (Enter) land in Task 5.
+func (m *Model) HandleKey(keyStr string) *Result {
+	switch keyStr {
+	case "down", "ctrl+n":
+		if m.highlight < len(m.filtered)-1 {
+			m.highlight++
+		}
+		return nil
+	case "up", "ctrl+p":
+		if m.highlight > 0 {
+			m.highlight--
+		}
+		return nil
+	case " ", "tab":
+		m.toggleHighlightedSelection()
+		return nil
+	case "backspace":
+		m.handleBackspace()
+		return nil
+	}
+
+	// Single printable ASCII rune -> append to query.
+	if len(keyStr) == 1 && keyStr[0] >= 33 && keyStr[0] <= 126 {
+		m.query += keyStr
+		m.highlight = 0
+		m.filter()
+	}
+	return nil
+}
+
+// toggleHighlightedSelection adds or removes the currently-highlighted
+// user from the pill bar. No-op when nothing is highlighted, when the
+// pill bar is at MaxRecipients capacity, or when the highlighted user
+// is already selected (in which case it removes them).
+func (m *Model) toggleHighlightedSelection() {
+	if m.highlight < 0 || m.highlight >= len(m.filtered) {
+		return
+	}
+	userID := m.users[m.filtered[m.highlight]].ID
+	if _, already := m.selected[userID]; already {
+		delete(m.selected, userID)
+		return
+	}
+	if len(m.selected) >= MaxRecipients {
+		return
+	}
+	m.selected[userID] = struct{}{}
+}
+
+// handleBackspace deletes the last rune of the query. If the query is
+// already empty AND the pill bar is non-empty, it removes the LAST
+// pill instead — letting the user erase a wrong recipient without
+// reaching for the mouse.
+func (m *Model) handleBackspace() {
+	if len(m.query) > 0 {
+		m.query = m.query[:len(m.query)-1]
+		m.highlight = 0
+		m.filter()
+		return
+	}
+	if len(m.selected) == 0 {
+		return
+	}
+	// No pill order is recorded; we use the last user ID inserted
+	// into the selected set. Since Go map iteration is randomized, we
+	// instead pop the one that appears last in m.users order — this
+	// gives the user a stable, predictable "remove most recently
+	// added" behavior tied to the user list order rather than a
+	// hidden insertion order. (Alternative would be a slice of IDs;
+	// YAGNI — a single backspace mid-flow is rare.)
+	for i := len(m.users) - 1; i >= 0; i-- {
+		id := m.users[i].ID
+		if _, ok := m.selected[id]; ok {
+			delete(m.selected, id)
+			return
+		}
+	}
+}

--- a/internal/ui/newmessagepicker/model.go
+++ b/internal/ui/newmessagepicker/model.go
@@ -1,0 +1,100 @@
+// Package newmessagepicker is the Ctrl+N modal that lets the user
+// start a DM (one recipient) or group DM / MPIM (2-8 recipients).
+//
+// The model is a self-contained Bubble Tea sub-model mirroring the
+// channelfinder package: a fuzzy filter over a user list with a
+// pill-bar multi-select layered on top. Submission returns a Result
+// carrying the chosen user IDs; the caller (the App's mode handler)
+// is responsible for dispatching the conversations.open call.
+package newmessagepicker
+
+// MaxRecipients is Slack's hard cap on the number of OTHER users in
+// a multi-person direct message (MPIM). Slack itself caps total
+// MPIM participants at 9, so up to 8 other users plus self.
+const MaxRecipients = 8
+
+// User is one row in the picker's list. DisplayName is the
+// human-friendly name shown to the user; Username is the Slack handle
+// (without the leading @). Recency is the unix-second timestamp of
+// the most recent activity tied to this user; higher values sort
+// earlier under empty-query and break ties under a query. IsExternal
+// drives the [ext] tag in the rendered row.
+type User struct {
+	ID          string
+	DisplayName string
+	Username    string
+	IsExternal  bool
+	Recency     int64
+}
+
+// Result is returned by HandleKey when the user submits the picker.
+// UserIDs is the list of recipients to pass to conversations.open;
+// it always contains at least one ID when non-nil.
+type Result struct {
+	UserIDs []string
+}
+
+// Model is the picker's state. Constructed with New() and held on the
+// App while ModeNewMessage is active.
+type Model struct {
+	users         []User
+	filtered      []int // indices into users matching query + not-self
+	query         string
+	selected      map[string]struct{} // user IDs in the pill bar
+	highlight     int                 // index into filtered
+	visible       bool
+	currentUserID string
+}
+
+// New constructs an empty picker. SetUsers and (optionally)
+// SetCurrentUserID should be called before Open.
+func New() Model {
+	return Model{
+		selected: map[string]struct{}{},
+	}
+}
+
+// SetUsers replaces the user list the picker filters over.
+// Does not trigger a re-filter; that happens on Open.
+func (m *Model) SetUsers(users []User) {
+	m.users = users
+}
+
+// SetCurrentUserID configures which user ID represents "self" so the
+// picker can hide it from the list (a user cannot start a DM with
+// themselves via this flow). May be called once at app start.
+func (m *Model) SetCurrentUserID(userID string) {
+	m.currentUserID = userID
+}
+
+// Open shows the picker and resets per-session state: query, pill
+// selection, highlight, and recomputes the filtered list.
+func (m *Model) Open() {
+	m.visible = true
+	m.query = ""
+	m.selected = map[string]struct{}{}
+	m.highlight = 0
+	m.filter()
+}
+
+// Close hides the picker. Does not clear users; Open will re-filter.
+func (m *Model) Close() {
+	m.visible = false
+}
+
+// IsVisible reports whether the picker is currently open.
+func (m Model) IsVisible() bool {
+	return m.visible
+}
+
+// filter is a placeholder until Task 3. For now it just includes
+// every user except self. Order is the natural users-slice order.
+func (m *Model) filter() {
+	m.filtered = m.filtered[:0]
+	for i, u := range m.users {
+		if u.ID == m.currentUserID {
+			continue
+		}
+		m.filtered = append(m.filtered, i)
+	}
+}

--- a/internal/ui/newmessagepicker/model.go
+++ b/internal/ui/newmessagepicker/model.go
@@ -163,6 +163,14 @@ func (m *Model) toggleHighlightedSelection() {
 		return
 	}
 	m.selected[userID] = struct{}{}
+	// Clear the query on ADD so the user can immediately type the next
+	// recipient. On REMOVE (handled above), keep the query — that path
+	// is a course-correction, not a move to the next person.
+	if m.query != "" {
+		m.query = ""
+		m.highlight = 0
+		m.filter()
+	}
 }
 
 // handleBackspace deletes the last rune of the query. If the query is

--- a/internal/ui/newmessagepicker/model_test.go
+++ b/internal/ui/newmessagepicker/model_test.go
@@ -74,3 +74,141 @@ func TestSetCurrentUserID_ExcludesSelfFromList(t *testing.T) {
 		}
 	}
 }
+
+func TestFilter_EmptyQuerySortsByRecencyDesc(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers()) // Alice=500, Bob=400, Carla=300, Dan=200, Eva=100
+	m.Open()
+
+	if len(m.filtered) != 5 {
+		t.Fatalf("expected 5 users, got %d", len(m.filtered))
+	}
+	wantOrder := []string{"U1", "U2", "U3", "U4", "U5"}
+	for i, want := range wantOrder {
+		got := m.users[m.filtered[i]].ID
+		if got != want {
+			t.Errorf("position %d: want %s, got %s", i, want, got)
+		}
+	}
+}
+
+func TestFilter_EmptyQueryTieBreaksAlphabetically(t *testing.T) {
+	users := []User{
+		{ID: "U1", DisplayName: "Charlie", Username: "c", Recency: 100},
+		{ID: "U2", DisplayName: "Alice", Username: "a", Recency: 100},
+		{ID: "U3", DisplayName: "Bob", Username: "b", Recency: 100},
+	}
+	m := New()
+	m.SetUsers(users)
+	m.Open()
+
+	wantOrder := []string{"U2", "U3", "U1"} // Alice, Bob, Charlie
+	for i, want := range wantOrder {
+		got := m.users[m.filtered[i]].ID
+		if got != want {
+			t.Errorf("position %d: want %s, got %s", i, want, got)
+		}
+	}
+}
+
+func TestFilter_PrefixBeatsSubstring(t *testing.T) {
+	users := []User{
+		{ID: "U1", DisplayName: "Marcus", Username: "marcus", Recency: 100},
+		{ID: "U2", DisplayName: "Alice Marketing", Username: "amark", Recency: 999},
+	}
+	m := New()
+	m.SetUsers(users)
+	m.Open()
+	m.setQuery("mar")
+
+	if len(m.filtered) != 2 {
+		t.Fatalf("expected 2 matches, got %d", len(m.filtered))
+	}
+	if m.users[m.filtered[0]].ID != "U1" {
+		t.Errorf("prefix match should come first, got %s", m.users[m.filtered[0]].ID)
+	}
+}
+
+func TestFilter_SubstringBeatsSubsequence(t *testing.T) {
+	users := []User{
+		{ID: "U1", DisplayName: "Stephanie", Username: "steph", Recency: 100},   // contains "eph"
+		{ID: "U2", DisplayName: "Edward Phillips", Username: "ep", Recency: 999}, // subseq e-p-h
+	}
+	m := New()
+	m.SetUsers(users)
+	m.Open()
+	m.setQuery("eph")
+
+	if m.filtered[0] != 0 {
+		t.Errorf("substring match should rank first, got user at index %d", m.filtered[0])
+	}
+}
+
+func TestFilter_CaseInsensitive(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	m.setQuery("ALICE")
+
+	if len(m.filtered) == 0 {
+		t.Fatal("expected at least 1 match for ALICE")
+	}
+	if m.users[m.filtered[0]].ID != "U1" {
+		t.Errorf("expected Alice (U1) as first match, got %s", m.users[m.filtered[0]].ID)
+	}
+}
+
+func TestFilter_MatchesUsernameHandle(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	m.setQuery("dan") // Dan Evans has Username="dan"
+
+	if len(m.filtered) == 0 {
+		t.Fatal("expected match for handle 'dan'")
+	}
+	if m.users[m.filtered[0]].ID != "U4" {
+		t.Errorf("expected Dan (U4) as first match, got %s", m.users[m.filtered[0]].ID)
+	}
+}
+
+func TestFilter_NoMatchesReturnsEmpty(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	m.setQuery("xyzqq")
+
+	if len(m.filtered) != 0 {
+		t.Errorf("expected 0 matches for unmatchable query, got %d", len(m.filtered))
+	}
+}
+
+func TestFilter_ExcludesSelfEvenOnMatch(t *testing.T) {
+	users := testUsers()
+	m := New()
+	m.SetCurrentUserID("U1") // Alice is self
+	m.SetUsers(users)
+	m.Open()
+	m.setQuery("alice")
+
+	for _, idx := range m.filtered {
+		if m.users[idx].ID == "U1" {
+			t.Error("self user should be excluded even when query matches")
+		}
+	}
+}
+
+func TestFilter_RecencyTieBreaksWithinSameTier(t *testing.T) {
+	users := []User{
+		{ID: "U1", DisplayName: "alice older", Username: "a1", Recency: 100},
+		{ID: "U2", DisplayName: "alice newer", Username: "a2", Recency: 999},
+	}
+	m := New()
+	m.SetUsers(users)
+	m.Open()
+	m.setQuery("alice") // both prefix-match
+
+	if m.users[m.filtered[0]].ID != "U2" {
+		t.Errorf("higher-recency match should come first, got %s", m.users[m.filtered[0]].ID)
+	}
+}

--- a/internal/ui/newmessagepicker/model_test.go
+++ b/internal/ui/newmessagepicker/model_test.go
@@ -381,3 +381,82 @@ func TestHandleKey_BackspaceAtEmptyQueryRemovesLastPill(t *testing.T) {
 		t.Error("expected U1 still selected")
 	}
 }
+
+func TestHandleKey_EnterWithPillsReturnsPillIDs(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	m.HandleKey(" ")    // select Alice (U1)
+	m.HandleKey("down") // highlight Bob
+	m.HandleKey(" ")    // select Bob (U2)
+
+	res := m.HandleKey("enter")
+	if res == nil {
+		t.Fatal("expected non-nil result from Enter with pills")
+	}
+	if len(res.UserIDs) != 2 {
+		t.Fatalf("expected 2 user IDs, got %d", len(res.UserIDs))
+	}
+	// Order within UserIDs is not guaranteed by the spec; check set membership.
+	got := map[string]bool{}
+	for _, id := range res.UserIDs {
+		got[id] = true
+	}
+	if !got["U1"] || !got["U2"] {
+		t.Errorf("expected {U1, U2}, got %v", res.UserIDs)
+	}
+}
+
+func TestHandleKey_EnterWithoutPillsUsesHighlight(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	m.HandleKey("down") // highlight Bob (U2)
+
+	res := m.HandleKey("enter")
+	if res == nil {
+		t.Fatal("expected non-nil result from Enter with highlight")
+	}
+	if len(res.UserIDs) != 1 || res.UserIDs[0] != "U2" {
+		t.Errorf("expected [U2], got %v", res.UserIDs)
+	}
+}
+
+func TestHandleKey_EnterWithNoHighlightAndNoPillsReturnsNil(t *testing.T) {
+	m := New()
+	m.SetUsers(nil) // no users -> filtered is empty
+	m.Open()
+
+	res := m.HandleKey("enter")
+	if res != nil {
+		t.Errorf("expected nil result when nothing to submit, got %+v", res)
+	}
+}
+
+func TestHandleKey_EnterWithEmptyFilteredButPillsStillSubmits(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	m.HandleKey(" ")     // select Alice
+	m.setQuery("xyzqq") // filter to nothing
+	res := m.HandleKey("enter")
+	if res == nil || len(res.UserIDs) != 1 || res.UserIDs[0] != "U1" {
+		t.Errorf("expected pills to submit even with empty filter, got %+v", res)
+	}
+}
+
+func TestHandleKey_EscClosesPickerAndReturnsNil(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	if !m.IsVisible() {
+		t.Fatal("precondition: picker should be visible")
+	}
+	res := m.HandleKey("esc")
+	if res != nil {
+		t.Errorf("expected nil result from Esc, got %+v", res)
+	}
+	if m.IsVisible() {
+		t.Error("expected picker to be hidden after Esc")
+	}
+}

--- a/internal/ui/newmessagepicker/model_test.go
+++ b/internal/ui/newmessagepicker/model_test.go
@@ -1,0 +1,76 @@
+package newmessagepicker
+
+import "testing"
+
+func testUsers() []User {
+	return []User{
+		{ID: "U1", DisplayName: "Alice Chen", Username: "alice", Recency: 500},
+		{ID: "U2", DisplayName: "Bob Singh", Username: "bob", Recency: 400},
+		{ID: "U3", DisplayName: "Carla Diaz", Username: "carla", Recency: 300},
+		{ID: "U4", DisplayName: "Dan Evans", Username: "dan", Recency: 200},
+		{ID: "U5", DisplayName: "Eva Frank", Username: "eva", IsExternal: true, Recency: 100},
+	}
+}
+
+func TestNew_NotVisibleByDefault(t *testing.T) {
+	m := New()
+	if m.IsVisible() {
+		t.Error("expected new model to not be visible")
+	}
+}
+
+func TestOpen_MakesVisible(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	if !m.IsVisible() {
+		t.Error("expected Open() to make model visible")
+	}
+}
+
+func TestClose_HidesModel(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	m.Close()
+	if m.IsVisible() {
+		t.Error("expected Close() to hide model")
+	}
+}
+
+func TestOpen_ResetsState(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	// Simulate dirty state from a previous session.
+	m.query = "old query"
+	m.selected["U1"] = struct{}{}
+	m.highlight = 3
+
+	m.Close()
+	m.Open()
+
+	if m.query != "" {
+		t.Errorf("expected empty query after Open, got %q", m.query)
+	}
+	if len(m.selected) != 0 {
+		t.Errorf("expected empty selection after Open, got %d entries", len(m.selected))
+	}
+	if m.highlight != 0 {
+		t.Errorf("expected highlight=0 after Open, got %d", m.highlight)
+	}
+}
+
+func TestSetCurrentUserID_ExcludesSelfFromList(t *testing.T) {
+	users := testUsers()
+	m := New()
+	m.SetCurrentUserID("U2") // Bob is "self"
+	m.SetUsers(users)
+	m.Open()
+
+	for _, idx := range m.filtered {
+		if m.users[idx].ID == "U2" {
+			t.Error("self user U2 should not appear in filtered list")
+		}
+	}
+}

--- a/internal/ui/newmessagepicker/model_test.go
+++ b/internal/ui/newmessagepicker/model_test.go
@@ -1,6 +1,9 @@
 package newmessagepicker
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func testUsers() []User {
 	return []User{
@@ -210,5 +213,171 @@ func TestFilter_RecencyTieBreaksWithinSameTier(t *testing.T) {
 
 	if m.users[m.filtered[0]].ID != "U2" {
 		t.Errorf("higher-recency match should come first, got %s", m.users[m.filtered[0]].ID)
+	}
+}
+
+func TestHandleKey_DownMovesHighlight(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	// 5 users, highlight starts at 0.
+	m.HandleKey("down")
+	if m.highlight != 1 {
+		t.Errorf("expected highlight=1 after down, got %d", m.highlight)
+	}
+}
+
+func TestHandleKey_UpMovesHighlight(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	m.HandleKey("down")
+	m.HandleKey("down")
+	m.HandleKey("up")
+	if m.highlight != 1 {
+		t.Errorf("expected highlight=1 after down,down,up, got %d", m.highlight)
+	}
+}
+
+func TestHandleKey_DownClampsAtEnd(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	for i := 0; i < 20; i++ {
+		m.HandleKey("down")
+	}
+	if m.highlight != len(m.filtered)-1 {
+		t.Errorf("expected highlight clamped at %d, got %d", len(m.filtered)-1, m.highlight)
+	}
+}
+
+func TestHandleKey_UpClampsAtStart(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	m.HandleKey("up")
+	if m.highlight != 0 {
+		t.Errorf("expected highlight=0 clamped, got %d", m.highlight)
+	}
+}
+
+func TestHandleKey_CtrlNAndCtrlPAliasNavigation(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	m.HandleKey("ctrl+n")
+	if m.highlight != 1 {
+		t.Errorf("ctrl+n should be alias for down")
+	}
+	m.HandleKey("ctrl+p")
+	if m.highlight != 0 {
+		t.Errorf("ctrl+p should be alias for up")
+	}
+}
+
+func TestHandleKey_PrintableRuneAppendsToQueryAndRefilters(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	m.HandleKey("a")
+	m.HandleKey("l")
+	m.HandleKey("i")
+	if m.query != "ali" {
+		t.Errorf("expected query=ali, got %q", m.query)
+	}
+	if len(m.filtered) == 0 || m.users[m.filtered[0]].ID != "U1" {
+		t.Errorf("expected Alice (U1) first, got %v", m.filtered)
+	}
+}
+
+func TestHandleKey_BackspaceRemovesLastRune(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	m.HandleKey("a")
+	m.HandleKey("l")
+	m.HandleKey("backspace")
+	if m.query != "a" {
+		t.Errorf("expected query=a after backspace, got %q", m.query)
+	}
+}
+
+func TestHandleKey_SpaceTogglesHighlightedUserIntoSelection(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	// highlight starts at 0 -> Alice (U1)
+
+	m.HandleKey(" ")
+	if _, ok := m.selected["U1"]; !ok {
+		t.Error("expected U1 in selection after space")
+	}
+	if len(m.selected) != 1 {
+		t.Errorf("expected 1 selection, got %d", len(m.selected))
+	}
+}
+
+func TestHandleKey_TabAliasesSpace(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	m.HandleKey("tab")
+	if _, ok := m.selected["U1"]; !ok {
+		t.Error("expected U1 in selection after tab")
+	}
+}
+
+func TestHandleKey_SpaceOnSelectedRemovesIt(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	m.HandleKey(" ")
+	m.HandleKey(" ")
+	if _, ok := m.selected["U1"]; ok {
+		t.Error("expected U1 to be removed after second space")
+	}
+}
+
+func TestHandleKey_SpaceCapsAtMaxRecipients(t *testing.T) {
+	users := make([]User, 10)
+	for i := range users {
+		users[i] = User{
+			ID:          fmt.Sprintf("U%d", i),
+			DisplayName: fmt.Sprintf("User %d", i),
+			Username:    fmt.Sprintf("u%d", i),
+		}
+	}
+	m := New()
+	m.SetUsers(users)
+	m.Open()
+	// Select 8 users by hitting space then down 8 times.
+	for i := 0; i < 8; i++ {
+		m.HandleKey(" ")
+		m.HandleKey("down")
+	}
+	if len(m.selected) != 8 {
+		t.Fatalf("expected 8 selections, got %d", len(m.selected))
+	}
+	// 9th selection attempt must be a no-op.
+	m.HandleKey(" ")
+	if len(m.selected) != 8 {
+		t.Errorf("expected selection to be capped at 8, got %d", len(m.selected))
+	}
+}
+
+func TestHandleKey_BackspaceAtEmptyQueryRemovesLastPill(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+	m.HandleKey(" ")    // select U1
+	m.HandleKey("down") // highlight U2
+	m.HandleKey(" ")    // select U2
+	// Two pills. Query is empty. Backspace should remove the LAST pill (U2).
+	m.HandleKey("backspace")
+	if _, ok := m.selected["U2"]; ok {
+		t.Error("expected U2 removed by backspace at empty query")
+	}
+	if _, ok := m.selected["U1"]; !ok {
+		t.Error("expected U1 still selected")
 	}
 }

--- a/internal/ui/newmessagepicker/model_test.go
+++ b/internal/ui/newmessagepicker/model_test.go
@@ -460,3 +460,61 @@ func TestHandleKey_EscClosesPickerAndReturnsNil(t *testing.T) {
 		t.Error("expected picker to be hidden after Esc")
 	}
 }
+
+func TestHandleKey_SpaceClearsQueryAfterAdd(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+
+	// Type "ali" to filter down to Alice.
+	m.HandleKey("a")
+	m.HandleKey("l")
+	m.HandleKey("i")
+	if m.query != "ali" {
+		t.Fatalf("precondition: expected query=ali, got %q", m.query)
+	}
+
+	// Space selects Alice. Query should clear so the user can type the
+	// next name without backspacing.
+	m.HandleKey(" ")
+	if m.query != "" {
+		t.Errorf("expected query cleared after add, got %q", m.query)
+	}
+	if _, ok := m.selected["U1"]; !ok {
+		t.Error("expected U1 selected")
+	}
+	// Filter should now show all non-self users (5 minus none = 5).
+	if len(m.filtered) != 5 {
+		t.Errorf("expected filtered to be reset to all users, got %d", len(m.filtered))
+	}
+}
+
+func TestHandleKey_SpaceDoesNotClearQueryOnRemove(t *testing.T) {
+	m := New()
+	m.SetUsers(testUsers())
+	m.Open()
+
+	// Select Alice first (with no query so we have a clean starting state).
+	m.HandleKey(" ")
+	if _, ok := m.selected["U1"]; !ok {
+		t.Fatal("precondition: expected U1 selected after space")
+	}
+
+	// Now type a query that matches Alice.
+	m.HandleKey("a")
+	m.HandleKey("l")
+	m.HandleKey("i")
+	if m.query != "ali" {
+		t.Fatalf("precondition: expected query=ali, got %q", m.query)
+	}
+
+	// Space on the highlighted (already-selected) Alice should REMOVE her,
+	// and the query should be preserved (user is course-correcting).
+	m.HandleKey(" ")
+	if _, ok := m.selected["U1"]; ok {
+		t.Error("expected U1 removed")
+	}
+	if m.query != "ali" {
+		t.Errorf("expected query preserved after remove, got %q", m.query)
+	}
+}

--- a/internal/ui/newmessagepicker/view.go
+++ b/internal/ui/newmessagepicker/view.go
@@ -205,10 +205,13 @@ func (m Model) renderRow(u User, width int, highlight bool, bg color.Color) stri
 		name += " [ext]"
 	}
 
-	handle := lipgloss.NewStyle().
-		Background(bg).
-		Foreground(styles.TextMuted).
-		Render(" @" + u.Username)
+	handle := ""
+	if u.Username != "" && u.Username != u.DisplayName {
+		handle = lipgloss.NewStyle().
+			Background(bg).
+			Foreground(styles.TextMuted).
+			Render(" @" + u.Username)
+	}
 
 	var nameStyle lipgloss.Style
 	if highlight {

--- a/internal/ui/newmessagepicker/view.go
+++ b/internal/ui/newmessagepicker/view.go
@@ -1,0 +1,263 @@
+package newmessagepicker
+
+import (
+	"fmt"
+	"image/color"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	"github.com/gammons/slk/internal/ui/messages"
+	"github.com/gammons/slk/internal/ui/overlay"
+	"github.com/gammons/slk/internal/ui/styles"
+	"github.com/muesli/reflow/truncate"
+)
+
+// View renders just the modal box. Use ViewOverlay for the
+// dimmed-backdrop composite that the App actually paints.
+func (m Model) View(termWidth int) string {
+	return m.renderBox(termWidth)
+}
+
+// ViewOverlay renders the modal centered on a dimmed copy of the
+// current screen. background is the already-rendered base screen.
+func (m Model) ViewOverlay(termWidth, termHeight int, background string) string {
+	if !m.visible {
+		return background
+	}
+	box := m.renderBox(termWidth)
+	if box == "" {
+		return background
+	}
+	return overlay.DimmedOverlay(termWidth, termHeight, background, box, 0.5)
+}
+
+func (m Model) renderBox(termWidth int) string {
+	if !m.visible {
+		return ""
+	}
+
+	overlayWidth := termWidth / 2
+	if overlayWidth < 40 {
+		overlayWidth = 40
+	}
+	if overlayWidth > 80 {
+		overlayWidth = 80
+	}
+	innerWidth := overlayWidth - 4
+	bg := styles.Background
+
+	title := lipgloss.NewStyle().
+		Bold(true).
+		Background(bg).
+		Foreground(styles.Primary).
+		Render("New message")
+
+	input := m.renderInputRow(innerWidth, bg)
+	rows := m.renderResultRows(innerWidth, bg)
+	footer := m.renderFooter(innerWidth, bg)
+
+	content := title + "\n" + input + "\n\n" + strings.Join(rows, "\n") + "\n\n" + footer
+
+	// Re-paint modal bg+fg after every ANSI reset emitted by inner
+	// styled spans, otherwise trailing spaces inherit the dimmed-
+	// app background. Same fix channelfinder uses.
+	content = messages.ReapplyBgAfterResets(content, messages.BgANSI()+messages.FgANSI())
+
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(styles.Primary).
+		BorderBackground(bg).
+		Background(bg).
+		Padding(1, 1).
+		Width(overlayWidth).
+		Render(content)
+}
+
+// renderInputRow renders the "To: [pill] [pill] |query█" row.
+func (m Model) renderInputRow(innerWidth int, bg color.Color) string {
+	prefix := lipgloss.NewStyle().Background(bg).Foreground(styles.TextMuted).Render("To: ")
+
+	var b strings.Builder
+	b.WriteString(prefix)
+
+	pillStyle := lipgloss.NewStyle().
+		Background(styles.Primary).
+		Foreground(styles.Background).
+		Padding(0, 1)
+
+	for _, u := range m.users {
+		if _, ok := m.selected[u.ID]; !ok {
+			continue
+		}
+		b.WriteString(pillStyle.Render(u.DisplayName))
+		b.WriteString(" ")
+	}
+
+	queryStyle := lipgloss.NewStyle().Background(bg).Foreground(styles.TextPrimary)
+	if m.query == "" && len(m.selected) == 0 {
+		placeholder := lipgloss.NewStyle().Background(bg).Foreground(styles.TextMuted).Render("type a name…")
+		b.WriteString(placeholder)
+	} else {
+		b.WriteString(queryStyle.Render(m.query))
+		b.WriteString(queryStyle.Render("█"))
+	}
+
+	row := b.String()
+	if lipgloss.Width(row) > innerWidth {
+		row = truncate.StringWithTail(row, uint(innerWidth), "…")
+	}
+	return row
+}
+
+// renderResultRows produces up to 10 visible result rows with a
+// scrollbar when the list overflows. Highlighted row gets a left bar
+// and the Primary foreground.
+func (m Model) renderResultRows(innerWidth int, bg color.Color) []string {
+	const maxVisible = 10
+	total := len(m.filtered)
+
+	if total == 0 {
+		var msg string
+		if m.query != "" {
+			msg = fmt.Sprintf("No users match %q", m.query)
+		} else {
+			msg = "No users available"
+		}
+		return []string{
+			lipgloss.NewStyle().
+				Background(bg).
+				Foreground(styles.TextMuted).
+				Italic(true).
+				Render(msg),
+		}
+	}
+
+	visible := maxVisible
+	if visible > total {
+		visible = total
+	}
+
+	startIdx := 0
+	if m.highlight >= visible {
+		startIdx = m.highlight - visible + 1
+	}
+	endIdx := startIdx + visible
+	if endIdx > total {
+		endIdx = total
+		startIdx = endIdx - visible
+		if startIdx < 0 {
+			startIdx = 0
+		}
+	}
+
+	showScrollbar := total > visible
+	contentWidth := innerWidth - 1 // 1 col for the highlight indicator
+	if showScrollbar {
+		contentWidth--
+	}
+
+	var thumbStart, thumbEnd int
+	if showScrollbar {
+		thumbHeight := visible * visible / total
+		if thumbHeight < 1 {
+			thumbHeight = 1
+		}
+		denom := total - visible
+		if denom < 1 {
+			denom = 1
+		}
+		thumbStart = startIdx * (visible - thumbHeight) / denom
+		if thumbStart < 0 {
+			thumbStart = 0
+		}
+		if thumbStart > visible-thumbHeight {
+			thumbStart = visible - thumbHeight
+		}
+		thumbEnd = thumbStart + thumbHeight
+	}
+	thumbStyle := lipgloss.NewStyle().Background(bg).Foreground(styles.Primary)
+	trackStyle := lipgloss.NewStyle().Background(bg).Foreground(styles.Border)
+
+	var rows []string
+	for i := startIdx; i < endIdx; i++ {
+		u := m.users[m.filtered[i]]
+		isHighlight := i == m.highlight
+
+		row := m.renderRow(u, contentWidth, isHighlight, bg)
+		if showScrollbar {
+			rel := i - startIdx
+			if rel >= thumbStart && rel < thumbEnd {
+				row += thumbStyle.Render("\u2588")
+			} else {
+				row += trackStyle.Render("\u2502")
+			}
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+// renderRow renders a single user row: display name, @handle, [ext]
+// tag if external, and a trailing "✓" if the user is in the pill bar.
+func (m Model) renderRow(u User, width int, highlight bool, bg color.Color) string {
+	name := u.DisplayName
+	if u.IsExternal {
+		name += " [ext]"
+	}
+
+	handle := lipgloss.NewStyle().
+		Background(bg).
+		Foreground(styles.TextMuted).
+		Render(" @" + u.Username)
+
+	var nameStyle lipgloss.Style
+	if highlight {
+		nameStyle = lipgloss.NewStyle().Background(bg).Foreground(styles.Primary).Bold(true)
+	} else {
+		nameStyle = lipgloss.NewStyle().Background(bg).Foreground(styles.TextPrimary)
+	}
+	nameRendered := nameStyle.Render(name)
+
+	check := ""
+	if _, sel := m.selected[u.ID]; sel {
+		check = lipgloss.NewStyle().Background(bg).Foreground(styles.Accent).Render(" ✓")
+	}
+
+	line := nameRendered + handle + check
+	if lipgloss.Width(line) > width {
+		line = truncate.StringWithTail(line, uint(width), "…")
+	}
+	if pad := width - lipgloss.Width(line); pad > 0 {
+		line += strings.Repeat(" ", pad)
+	}
+
+	if highlight {
+		indicator := lipgloss.NewStyle().Background(bg).Foreground(styles.Accent).Render("▌")
+		return indicator + line
+	}
+	return " " + line
+}
+
+// renderFooter is the key-hints + N/8 counter row.
+func (m Model) renderFooter(innerWidth int, bg color.Color) string {
+	left := lipgloss.NewStyle().
+		Background(bg).
+		Foreground(styles.TextMuted).
+		Render("space toggle  enter open  esc cancel")
+
+	counterText := fmt.Sprintf("%d / %d", len(m.selected), MaxRecipients)
+	var counterStyle lipgloss.Style
+	if len(m.selected) >= MaxRecipients {
+		counterStyle = lipgloss.NewStyle().Background(bg).Foreground(styles.TextMuted).Italic(true)
+		counterText += "  MPIM limit reached"
+	} else {
+		counterStyle = lipgloss.NewStyle().Background(bg).Foreground(styles.TextMuted)
+	}
+	right := counterStyle.Render(counterText)
+
+	gap := innerWidth - lipgloss.Width(left) - lipgloss.Width(right)
+	if gap < 1 {
+		gap = 1
+	}
+	return left + strings.Repeat(" ", gap) + right
+}

--- a/internal/ui/reducer_new_message.go
+++ b/internal/ui/reducer_new_message.go
@@ -25,9 +25,13 @@
 package ui
 
 import (
+	"fmt"
+	"strings"
+
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/gammons/slk/internal/debuglog"
+	"github.com/gammons/slk/internal/ui/sidebar"
 )
 
 var reduceNewMessagePicker reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
@@ -48,15 +52,15 @@ var reduceNewMessagePicker reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, boo
 		a.newMessageCancelled = false
 		a.SetMode(ModeInsert)
 
-		// Task 12 inserts a minimal cache record here when
-		// m.AlreadyOpen == false. For now, emit ChannelSelectedMsg
-		// directly; existing flows (cache miss, RTM hydration) fill
-		// in the rest.
-		channelID := m.ChannelID
 		channelType := "dm"
 		if len(m.UserIDs) > 1 {
 			channelType = "group_dm"
 		}
+		if !m.AlreadyOpen {
+			a.hydrateNewConversation(m.ChannelID, channelType, m.UserIDs)
+		}
+
+		channelID := m.ChannelID
 		return func() tea.Msg {
 			return ChannelSelectedMsg{ID: channelID, Type: channelType}
 		}, true
@@ -75,6 +79,46 @@ var reduceNewMessagePicker reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, boo
 		return func() tea.Msg { return ToastMsg{Text: "Open DM failed: " + errText} }, true
 	}
 	return nil, false
+}
+
+// hydrateNewConversation inserts a minimal sidebar.ChannelItem for a
+// freshly-opened DM or MPIM so the channel-switch path has a record
+// to render against. The full channel metadata is filled in by the
+// existing RTM event handlers (mpim_open / im_created) and the
+// membership.Manager.
+func (a *App) hydrateNewConversation(channelID, channelType string, userIDs []string) {
+	item := sidebar.ChannelItem{
+		ID:   channelID,
+		Type: channelType,
+		Name: a.deriveConversationName(channelType, userIDs),
+	}
+	if channelType == "dm" && len(userIDs) == 1 {
+		item.DMUserID = userIDs[0]
+	}
+	a.sidebar.UpsertItem(item)
+}
+
+// deriveConversationName builds a display name for a freshly-opened
+// DM/MPIM. For DMs we use the peer's display name. For MPIMs we
+// join up to 3 names with ", " and append "+N" for the rest.
+func (a *App) deriveConversationName(channelType string, userIDs []string) string {
+	const previewLimit = 3
+	names := make([]string, 0, len(userIDs))
+	for _, id := range userIDs {
+		if name, ok := a.userNames[id]; ok && name != "" {
+			names = append(names, name)
+		} else {
+			names = append(names, id)
+		}
+	}
+	if channelType == "dm" {
+		return names[0]
+	}
+	if len(names) <= previewLimit {
+		return strings.Join(names, ", ")
+	}
+	preview := strings.Join(names[:previewLimit], ", ")
+	return fmt.Sprintf("%s +%d", preview, len(names)-previewLimit)
 }
 
 // newMessageResultIsCurrent reports whether a NewMessage* message

--- a/internal/ui/reducer_new_message.go
+++ b/internal/ui/reducer_new_message.go
@@ -61,9 +61,10 @@ var reduceNewMessagePicker reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, boo
 		}
 
 		channelID := m.ChannelID
-		return func() tea.Msg {
+		emitSelected := func() tea.Msg {
 			return ChannelSelectedMsg{ID: channelID, Type: channelType}
-		}, true
+		}
+		return tea.Batch(emitSelected, a.compose.Focus()), true
 
 	case NewMessageFailedMsg:
 		if !newMessageResultIsCurrent(a, m.RequestID) {

--- a/internal/ui/reducer_new_message.go
+++ b/internal/ui/reducer_new_message.go
@@ -1,0 +1,95 @@
+// internal/ui/reducer_new_message.go
+//
+// Reducer for the new-message picker lifecycle:
+//
+//   EnterNewMessageMsg     - user pressed Ctrl+N: seed the picker
+//                            with current workspace users, open it,
+//                            enter ModeNewMessage.
+//   NewMessageOpenedMsg    - conversations.open succeeded: validate
+//                            RequestID against the in-flight counter
+//                            and the cancelled flag, then close the
+//                            modal, switch to the opened channel,
+//                            and enter ModeInsert (so the cursor
+//                            lands in compose ready to type).
+//   NewMessageFailedMsg    - conversations.open failed: log and
+//                            keep the modal open so the user can
+//                            retry or cancel.
+//
+// Cache hydration for AlreadyOpen=false is implemented in Task 12;
+// this task emits ChannelSelectedMsg directly without inserting a
+// channel record. Task 12 adds that insert.
+//
+// Named reduceNewMessagePicker to avoid colliding with
+// reduceNewMessage in reducer_send.go (which handles the WS
+// NewMessageMsg event family — unrelated to the new-DM picker).
+package ui
+
+import (
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/gammons/slk/internal/debuglog"
+)
+
+var reduceNewMessagePicker reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
+	switch m := msg.(type) {
+	case EnterNewMessageMsg:
+		a.seedNewMessagePicker()
+		a.newMessagePicker.Open()
+		a.SetMode(ModeNewMessage)
+		return nil, true
+
+	case NewMessageOpenedMsg:
+		if !newMessageResultIsCurrent(a, m.RequestID) {
+			debuglog.General("new-message: dropping stale/cancelled NewMessageOpenedMsg req=%d inflight=%d cancelled=%v", m.RequestID, a.newMessageInFlightID, a.newMessageCancelled)
+			return nil, true
+		}
+		a.newMessagePicker.Close()
+		a.newMessageInFlightID = 0
+		a.newMessageCancelled = false
+		a.SetMode(ModeInsert)
+
+		// Task 12 inserts a minimal cache record here when
+		// m.AlreadyOpen == false. For now, emit ChannelSelectedMsg
+		// directly; existing flows (cache miss, RTM hydration) fill
+		// in the rest.
+		channelID := m.ChannelID
+		channelType := "dm"
+		if len(m.UserIDs) > 1 {
+			channelType = "group_dm"
+		}
+		return func() tea.Msg {
+			return ChannelSelectedMsg{ID: channelID, Type: channelType}
+		}, true
+
+	case NewMessageFailedMsg:
+		if !newMessageResultIsCurrent(a, m.RequestID) {
+			return nil, true
+		}
+		debuglog.General("new-message: OpenConversation failed: %v", m.Err)
+		// Stay in ModeNewMessage; modal stays visible; clear the
+		// in-flight so a follow-up submit gets a fresh ID. Surface
+		// the error via a toast (the existing app-wide notification
+		// channel) so the user knows the submit didn't go through.
+		a.newMessageInFlightID = 0
+		errText := m.Err.Error()
+		return func() tea.Msg { return ToastMsg{Text: "Open DM failed: " + errText} }, true
+	}
+	return nil, false
+}
+
+// newMessageResultIsCurrent reports whether a NewMessage* message
+// with requestID is the response to the current in-flight submit
+// AND wasn't cancelled by an Esc. Late or cancelled results are
+// dropped silently.
+func newMessageResultIsCurrent(a *App, requestID uint64) bool {
+	if requestID == 0 {
+		return false
+	}
+	if requestID != a.newMessageInFlightID {
+		return false
+	}
+	if a.newMessageCancelled {
+		return false
+	}
+	return true
+}

--- a/internal/ui/reducer_new_message_test.go
+++ b/internal/ui/reducer_new_message_test.go
@@ -117,6 +117,79 @@ func TestReducer_NewMessageOpenedMsg_DroppedWhenRequestIDMismatches(t *testing.T
 	}
 }
 
+func TestReducer_NewMessageOpenedMsg_AlreadyOpenSkipsCacheInsert(t *testing.T) {
+	app, _ := newApp_WithOpenConvCapture(t)
+	_, _ = app.Update(EnterNewMessageMsg{})
+	app.newMessageInFlightID = 1
+	priorCount := len(app.sidebar.AllItems())
+
+	_, _ = app.Update(NewMessageOpenedMsg{
+		ChannelID:   "D456",
+		AlreadyOpen: true,
+		UserIDs:     []string{"U1"},
+		RequestID:   1,
+	})
+
+	if got := len(app.sidebar.AllItems()); got != priorCount {
+		t.Errorf("expected no sidebar mutation for AlreadyOpen=true, count went from %d to %d", priorCount, got)
+	}
+}
+
+func TestReducer_NewMessageOpenedMsg_NewChannelInsertedAsDM(t *testing.T) {
+	app, _ := newApp_WithOpenConvCapture(t)
+	_, _ = app.Update(EnterNewMessageMsg{})
+	app.newMessageInFlightID = 1
+
+	_, _ = app.Update(NewMessageOpenedMsg{
+		ChannelID:   "D789",
+		AlreadyOpen: false,
+		UserIDs:     []string{"U1"},
+		RequestID:   1,
+	})
+
+	found := false
+	for _, ch := range app.sidebar.AllItems() {
+		if ch.ID == "D789" {
+			found = true
+			if ch.Type != "dm" {
+				t.Errorf("expected Type=dm, got %s", ch.Type)
+			}
+			if ch.DMUserID != "U1" {
+				t.Errorf("expected DMUserID=U1, got %s", ch.DMUserID)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected D789 inserted into sidebar")
+	}
+}
+
+func TestReducer_NewMessageOpenedMsg_NewChannelInsertedAsGroupDM(t *testing.T) {
+	app, _ := newApp_WithOpenConvCapture(t)
+	_, _ = app.Update(EnterNewMessageMsg{})
+	app.newMessageInFlightID = 1
+
+	_, _ = app.Update(NewMessageOpenedMsg{
+		ChannelID:   "G999",
+		AlreadyOpen: false,
+		UserIDs:     []string{"U1", "U2"},
+		RequestID:   1,
+	})
+
+	found := false
+	for _, ch := range app.sidebar.AllItems() {
+		if ch.ID == "G999" {
+			found = true
+			if ch.Type != "group_dm" {
+				t.Errorf("expected Type=group_dm, got %s", ch.Type)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected G999 inserted into sidebar")
+	}
+}
+
 func TestReducer_NewMessageFailedMsg_KeepsModalOpenAndEmitsToast(t *testing.T) {
 	app, _ := newApp_WithOpenConvCapture(t)
 	_, _ = app.Update(EnterNewMessageMsg{})

--- a/internal/ui/reducer_new_message_test.go
+++ b/internal/ui/reducer_new_message_test.go
@@ -63,18 +63,37 @@ func TestReducer_NewMessageOpenedMsg_SwitchesChannelAndEntersInsertMode(t *testi
 	if app.newMessagePicker.IsVisible() {
 		t.Error("expected picker closed")
 	}
-	// The reducer should emit a ChannelSelectedMsg.
+	// The reducer should emit a ChannelSelectedMsg (batched with
+	// a compose-focus cmd).
 	if cmd == nil {
 		t.Fatal("expected a tea.Cmd that fires ChannelSelectedMsg")
 	}
-	msg := cmd()
-	sel, ok := msg.(ChannelSelectedMsg)
+	sel, ok := findChannelSelected(cmd())
 	if !ok {
-		t.Fatalf("expected ChannelSelectedMsg, got %T", msg)
+		t.Fatalf("expected ChannelSelectedMsg in batch, got %T", cmd())
 	}
 	if sel.ID != "D123" {
 		t.Errorf("expected ChannelID=D123, got %s", sel.ID)
 	}
+}
+
+// findChannelSelected walks a tea.Cmd result (which may be a
+// tea.BatchMsg) and returns the first ChannelSelectedMsg it finds.
+func findChannelSelected(msg tea.Msg) (ChannelSelectedMsg, bool) {
+	if sel, ok := msg.(ChannelSelectedMsg); ok {
+		return sel, true
+	}
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		for _, c := range batch {
+			if c == nil {
+				continue
+			}
+			if sel, ok := findChannelSelected(c()); ok {
+				return sel, true
+			}
+		}
+	}
+	return ChannelSelectedMsg{}, false
 }
 
 func TestReducer_NewMessageOpenedMsg_DroppedWhenCancelled(t *testing.T) {
@@ -270,11 +289,11 @@ func TestEndToEnd_CtrlN_SelectUser_Enter_OpensDM(t *testing.T) {
 		t.Error("step 5: expected picker hidden")
 	}
 
-	// 6. The cmd should emit ChannelSelectedMsg{ID: D123, Type: dm}.
-	msg := cmd()
-	sel, ok := msg.(ChannelSelectedMsg)
+	// 6. The cmd should emit ChannelSelectedMsg{ID: D123, Type: dm}
+	// (batched with a compose-focus cmd).
+	sel, ok := findChannelSelected(cmd())
 	if !ok {
-		t.Fatalf("step 6: expected ChannelSelectedMsg, got %T", msg)
+		t.Fatalf("step 6: expected ChannelSelectedMsg in batch, got %T", cmd())
 	}
 	if sel.ID != "D123" || sel.Type != "dm" {
 		t.Errorf("step 6: want {D123, dm}, got {%s, %s}", sel.ID, sel.Type)

--- a/internal/ui/reducer_new_message_test.go
+++ b/internal/ui/reducer_new_message_test.go
@@ -1,0 +1,147 @@
+package ui
+
+import (
+	"errors"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func newApp_WithOpenConvCapture(t *testing.T) (*App, *capturedOpenConv) {
+	t.Helper()
+	app := NewApp()
+	app.currentUserID = "USELF"
+	app.SetUserNames(map[string]string{"USELF": "Me", "U1": "Alice", "U2": "Bob"})
+
+	cap := &capturedOpenConv{}
+	app.SetChannelService(NewChannelService(ChannelServiceFuncs{
+		OpenConversation: func(userIDs []string, requestID uint64) tea.Cmd {
+			cap.calls = append(cap.calls, openConvCall{UserIDs: userIDs, RequestID: requestID})
+			return nil // tests synthesize the result message directly
+		},
+	}))
+	return app, cap
+}
+
+type openConvCall struct {
+	UserIDs   []string
+	RequestID uint64
+}
+
+type capturedOpenConv struct {
+	calls []openConvCall
+}
+
+func TestReducer_EnterNewMessageMsg_OpensPickerAndEntersMode(t *testing.T) {
+	app, _ := newApp_WithOpenConvCapture(t)
+
+	_, _ = app.Update(EnterNewMessageMsg{})
+
+	if app.mode != ModeNewMessage {
+		t.Errorf("expected ModeNewMessage, got %v", app.mode)
+	}
+	if !app.newMessagePicker.IsVisible() {
+		t.Error("expected picker visible")
+	}
+}
+
+func TestReducer_NewMessageOpenedMsg_SwitchesChannelAndEntersInsertMode(t *testing.T) {
+	app, _ := newApp_WithOpenConvCapture(t)
+	_, _ = app.Update(EnterNewMessageMsg{})
+	app.newMessageInFlightID = 7 // simulate an in-flight submit
+
+	_, cmd := app.Update(NewMessageOpenedMsg{
+		ChannelID:   "D123",
+		AlreadyOpen: true,
+		UserIDs:     []string{"U1"},
+		RequestID:   7,
+	})
+
+	if app.mode != ModeInsert {
+		t.Errorf("expected ModeInsert after opened msg, got %v", app.mode)
+	}
+	if app.newMessagePicker.IsVisible() {
+		t.Error("expected picker closed")
+	}
+	// The reducer should emit a ChannelSelectedMsg.
+	if cmd == nil {
+		t.Fatal("expected a tea.Cmd that fires ChannelSelectedMsg")
+	}
+	msg := cmd()
+	sel, ok := msg.(ChannelSelectedMsg)
+	if !ok {
+		t.Fatalf("expected ChannelSelectedMsg, got %T", msg)
+	}
+	if sel.ID != "D123" {
+		t.Errorf("expected ChannelID=D123, got %s", sel.ID)
+	}
+}
+
+func TestReducer_NewMessageOpenedMsg_DroppedWhenCancelled(t *testing.T) {
+	app, _ := newApp_WithOpenConvCapture(t)
+	_, _ = app.Update(EnterNewMessageMsg{})
+	app.newMessageInFlightID = 7
+	app.newMessageCancelled = true
+	priorMode := app.mode
+
+	_, cmd := app.Update(NewMessageOpenedMsg{
+		ChannelID: "D123",
+		RequestID: 7,
+	})
+
+	if app.mode != priorMode {
+		t.Errorf("mode should not change for cancelled result, got %v", app.mode)
+	}
+	if cmd != nil {
+		t.Errorf("expected nil cmd for cancelled result, got %T", cmd())
+	}
+}
+
+func TestReducer_NewMessageOpenedMsg_DroppedWhenRequestIDMismatches(t *testing.T) {
+	app, _ := newApp_WithOpenConvCapture(t)
+	_, _ = app.Update(EnterNewMessageMsg{})
+	app.newMessageInFlightID = 9 // current in-flight is 9
+	priorMode := app.mode
+
+	// Late arrival for an older request 7.
+	_, cmd := app.Update(NewMessageOpenedMsg{
+		ChannelID: "D123",
+		RequestID: 7,
+	})
+
+	if app.mode != priorMode {
+		t.Errorf("mode should not change for stale RequestID, got %v", app.mode)
+	}
+	if cmd != nil {
+		t.Errorf("expected nil cmd for stale result")
+	}
+}
+
+func TestReducer_NewMessageFailedMsg_KeepsModalOpenAndEmitsToast(t *testing.T) {
+	app, _ := newApp_WithOpenConvCapture(t)
+	_, _ = app.Update(EnterNewMessageMsg{})
+	app.newMessageInFlightID = 7
+
+	_, cmd := app.Update(NewMessageFailedMsg{
+		RequestID: 7,
+		Err:       errors.New("rate_limited"),
+	})
+
+	if app.mode != ModeNewMessage {
+		t.Errorf("expected to stay in ModeNewMessage on failure, got %v", app.mode)
+	}
+	if !app.newMessagePicker.IsVisible() {
+		t.Error("expected picker still visible on failure")
+	}
+	if cmd == nil {
+		t.Fatal("expected a tea.Cmd emitting ToastMsg")
+	}
+	msg := cmd()
+	toast, ok := msg.(ToastMsg)
+	if !ok {
+		t.Fatalf("expected ToastMsg, got %T", msg)
+	}
+	if toast.Text == "" {
+		t.Error("expected non-empty toast text")
+	}
+}

--- a/internal/ui/reducer_new_message_test.go
+++ b/internal/ui/reducer_new_message_test.go
@@ -218,3 +218,65 @@ func TestReducer_NewMessageFailedMsg_KeepsModalOpenAndEmitsToast(t *testing.T) {
 		t.Error("expected non-empty toast text")
 	}
 }
+
+func TestEndToEnd_CtrlN_SelectUser_Enter_OpensDM(t *testing.T) {
+	app, cap := newApp_WithOpenConvCapture(t)
+
+	// 1. User presses Ctrl+N.
+	_, _ = app.Update(EnterNewMessageMsg{})
+
+	if app.mode != ModeNewMessage {
+		t.Fatalf("step 1: expected ModeNewMessage, got %v", app.mode)
+	}
+
+	// 2. User types "ali" to filter down to Alice.
+	app.newMessagePicker.HandleKey("a")
+	app.newMessagePicker.HandleKey("l")
+	app.newMessagePicker.HandleKey("i")
+
+	// 3. User presses Enter on the highlighted (Alice) row.
+	result := app.newMessagePicker.HandleKey("enter")
+	if result == nil {
+		t.Fatal("step 3: expected non-nil Result from Enter")
+	}
+	if len(result.UserIDs) != 1 || result.UserIDs[0] != "U1" {
+		t.Errorf("step 3: expected [U1], got %v", result.UserIDs)
+	}
+
+	// 4. The mode handler would call OpenConversation here. Simulate.
+	app.newMessageInFlightID++
+	reqID := app.newMessageInFlightID
+	_ = app.channels.OpenConversation(result.UserIDs, reqID)
+
+	if len(cap.calls) != 1 {
+		t.Fatalf("step 4: expected exactly 1 OpenConversation call, got %d", len(cap.calls))
+	}
+	if cap.calls[0].UserIDs[0] != "U1" {
+		t.Errorf("step 4: expected userID U1, got %s", cap.calls[0].UserIDs[0])
+	}
+
+	// 5. Slack returns success; reducer transitions to ModeInsert.
+	_, cmd := app.Update(NewMessageOpenedMsg{
+		ChannelID:   "D123",
+		AlreadyOpen: true,
+		UserIDs:     []string{"U1"},
+		RequestID:   reqID,
+	})
+
+	if app.mode != ModeInsert {
+		t.Errorf("step 5: expected ModeInsert, got %v", app.mode)
+	}
+	if app.newMessagePicker.IsVisible() {
+		t.Error("step 5: expected picker hidden")
+	}
+
+	// 6. The cmd should emit ChannelSelectedMsg{ID: D123, Type: dm}.
+	msg := cmd()
+	sel, ok := msg.(ChannelSelectedMsg)
+	if !ok {
+		t.Fatalf("step 6: expected ChannelSelectedMsg, got %T", msg)
+	}
+	if sel.ID != "D123" || sel.Type != "dm" {
+		t.Errorf("step 6: want {D123, dm}, got {%s, %s}", sel.ID, sel.Type)
+	}
+}

--- a/internal/ui/services.go
+++ b/internal/ui/services.go
@@ -391,21 +391,29 @@ type ChannelService interface {
 	// member set for channelID. Fire-and-forget; results arrive
 	// asynchronously via ChannelMembershipMsg.
 	MembershipFetch(channelID ids.ChannelID)
+
+	// OpenConversation dispatches conversations.open for userIDs (1
+	// recipient = IM, 2-8 recipients = MPIM). Returns a tea.Cmd whose
+	// resolved tea.Msg is NewMessageOpenedMsg on success or
+	// NewMessageFailedMsg on error; both carry requestID so the
+	// reducer can drop late results from cancelled submits.
+	OpenConversation(userIDs []string, requestID uint64) tea.Cmd
 }
 
 // ChannelServiceFuncs is the closure bundle accepted by
 // NewChannelService. Any field may be nil; the resulting service
 // no-ops that operation.
 type ChannelServiceFuncs struct {
-	Fetch           ChannelFetchFunc
-	FetchOlder      OlderMessagesFetchFunc
-	ReadCache       ChannelCacheReadFunc
-	SyncedAt        func(channelID ids.ChannelID) int64
-	MarkRead        func(channelID ids.ChannelID, ts ids.MessageTS) tea.Msg
-	Lookup          ChannelLookupFunc
-	Join            JoinChannelFunc
-	RecordVisit     ChannelVisitRecorder
-	MembershipFetch func(channelID ids.ChannelID)
+	Fetch            ChannelFetchFunc
+	FetchOlder       OlderMessagesFetchFunc
+	ReadCache        ChannelCacheReadFunc
+	SyncedAt         func(channelID ids.ChannelID) int64
+	MarkRead         func(channelID ids.ChannelID, ts ids.MessageTS) tea.Msg
+	Lookup           ChannelLookupFunc
+	Join             JoinChannelFunc
+	RecordVisit      ChannelVisitRecorder
+	MembershipFetch  func(channelID ids.ChannelID)
+	OpenConversation func(userIDs []string, requestID uint64) tea.Cmd
 }
 
 // NewChannelService builds a ChannelService from a
@@ -483,4 +491,11 @@ func (c channelAdapter) MembershipFetch(channelID ids.ChannelID) {
 		return
 	}
 	c.fns.MembershipFetch(channelID)
+}
+
+func (c channelAdapter) OpenConversation(userIDs []string, requestID uint64) tea.Cmd {
+	if c.fns.OpenConversation == nil {
+		return nil
+	}
+	return c.fns.OpenConversation(userIDs, requestID)
 }

--- a/internal/ui/view_overlays.go
+++ b/internal/ui/view_overlays.go
@@ -40,6 +40,9 @@ func (a *App) applyOverlays(screen string) string {
 	if a.channelFinder.IsVisible() {
 		screen = a.channelFinder.ViewOverlay(a.width, a.height, screen)
 	}
+	if a.newMessagePicker.IsVisible() {
+		screen = a.newMessagePicker.ViewOverlay(a.width, a.height, screen)
+	}
 	if a.reactionPicker.IsVisible() {
 		screen = a.reactionPicker.ViewOverlay(a.width, a.height, screen)
 	}
@@ -73,6 +76,7 @@ func (a *App) applyOverlays(screen string) string {
 // re-wrap is needed.
 func (a *App) overlayActive() bool {
 	return a.channelFinder.IsVisible() ||
+		a.newMessagePicker.IsVisible() ||
 		a.reactionPicker.IsVisible() ||
 		a.confirmPrompt.IsVisible() ||
 		a.workspaceFinder.IsVisible() ||


### PR DESCRIPTION
## Summary

Adds a `Ctrl+N` modal picker for starting a direct message or group DM (MPIM) with 1–8 recipients, mirroring Slack desktop's "new message" flow.

closes #31 

- Fuzzy filter over the workspace user list (prefix > substring > subsequence)
- Multi-select via `Space` / `Tab` (with `8 / 8` cap enforcement, matching Slack's MPIM limit)
- `Enter` opens the conversation via `conversations.open`, switches to the resulting channel, and focuses the compose box
- `Esc` during the in-flight API call abandons the result via monotonic `RequestID` tracking — no surprise channel-switch after backing out
- Failures surface via the existing `ToastMsg` channel; modal stays open so the user can retry or cancel

## What's new

- **Package** `internal/ui/newmessagepicker/` — self-contained model + filter + view, 35 tests
- **Client wrapper** `Client.OpenConversation` in `internal/slack/client.go` (validates 1–8 user IDs, wraps slack-go's `OpenConversationContext`)
- **Service method** `ChannelService.OpenConversation` follows the existing `ChannelServiceFuncs` adapter pattern
- **Mode** `ModeNewMessage` with handler in `internal/ui/mode_new_message.go`
- **Reducer** `internal/ui/reducer_new_message.go` with in-flight cancellation discipline
- **Cache hydration** — freshly-created DMs/MPIMs get a minimal `sidebar.ChannelItem` inserted before the channel switch so the sidebar's render path has a record to draw against

## Test Plan

Automated (all passing — `go test ./...`):

- [x] 35 picker unit tests (filter ranking, navigation, selection, cap, submit, query-clear-on-add)
- [x] 6 Slack client tests (1/3/0/9 user paths, error wrap, alreadyOpen propagation)
- [x] 8 reducer tests (mode entry, success → mode switch, cancel drop, stale-RequestID drop, failure → toast, AlreadyOpen skip-insert, DM insert, MPIM insert)
- [x] 1 end-to-end integration test (`TestEndToEnd_CtrlN_SelectUser_Enter_OpensDM`)
- [x] `go vet ./...` clean

Manual (verified on real workspace):

- [x] Ctrl+N opens centered modal with workspace users
- [x] Type → filter → Enter opens DM and lands in insert mode
- [x] Space adds pills (counter shows N/8), 9th attempt is no-op
- [x] Tab aliases Space
- [x] Backspace at empty query removes last pill
- [x] After Space adds a pill, query clears so the next name can be typed immediately
- [x] Esc cancels modal cleanly

## Design / plan

- Spec: `docs/superpowers/specs/2026-05-25-new-message-feature-design.md`
- Plan: `docs/superpowers/plans/2026-05-25-new-message-feature.md` + per-task files under `docs/superpowers/plans/2026-05-25-new-message-feature/`

## Out of scope (filed as follow-ups)

- Recency-based ordering — v1 sorts alphabetically; plumbing `WorkspaceContext.LastVisitedByChannel` through to the App is a follow-up
- Real userID→handle map — Username currently falls back to display name; rendered `@handle` is suppressed when it would duplicate the display name
- Read-only modal during in-flight — cancellation logic already makes double-submit safe; visual loading state is a polish improvement