### PR TITLE
feat(themes): add ANSI Dark and ANSI Light themes that inherit terminal palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 - **Fast.** Cold start in milliseconds. Render-cached messages. SQLite-backed scrollback. Real-time over WebSocket.
 - **Tiny.** ~19 MB on disk. ~60 MB RSS for a live multi-workspace session vs. 500 MB–1.5 GB for the official client. No node_modules, no Chromium, no 1Gb RAM tax.
 - **Keyboard-first.** Vim-style modal editing. `j/k`, `h/l`, `i`, `Esc`.
-- **Pretty.** 35+ built-in themes, lipgloss-styled panels, true-pixel avatars on kitty (half-block fallback elsewhere), emoji shortcodes, day separators, and pill-style reactions.
+- **Pretty.** 36 built-in themes, lipgloss-styled panels, true-pixel avatars on kitty (half-block fallback elsewhere), emoji shortcodes, day separators, and pill-style reactions.
 - **Multi-workspace.** All your workspaces stay connected in parallel. `1`–`9` to instantly jump between them, with live unread badges in the rail.
 - **Yours.** TOML config, custom themes, custom channel sections via glob, XDG-compliant paths.
 
@@ -27,7 +27,7 @@
 - Slack-native sidebar sections, kept live; or glob-based config sections
 - Browser-cookie auth (`xoxc` + `d`) — no Slack App required
 - Vim-style modal keybindings, fuzzy channel finder, workspace picker
-- 12 themes + drop-in custom themes, live theme switcher
+- 36 themes + drop-in custom themes, live theme switcher
 - OS desktop notifications on DMs, mentions, and configurable keywords
 
 Full feature breakdown: **[[Features|https://github.com/gammons/slk/wiki/Features]]**

--- a/internal/ui/messages/render.go
+++ b/internal/ui/messages/render.go
@@ -345,6 +345,141 @@ func bgSGRParams(ansi string) string {
 	return ansi[len(prefix) : len(ansi)-len(suffix)]
 }
 
+// substituteBgSGR walks s, finds every SGR sequence (\x1b[...m), tokenizes
+// its parameter list with awareness of extended-color groups (38;5;N,
+// 38;2;R;G;B, 48;5;N, 48;2;R;G;B), and substitutes any bg-token whose
+// stringified form equals from with to. Non-SGR text and SGR sequences
+// that don't contain a matching bg token are passed through unchanged.
+//
+// Grammar awareness matters because a bg token can be a single param
+// ("40"–"47", "100"–"107") that may otherwise collide with arbitrary
+// digit substrings — both inside non-SGR content and as arguments to
+// 256-color FG codes like "38;5;40". Splitting on ";" without grammar
+// knowledge would corrupt those.
+//
+// If from == to the input is returned unchanged.
+func substituteBgSGR(s, from, to string) string {
+	if from == "" || from == to {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	i := 0
+	for i < len(s) {
+		start := strings.Index(s[i:], "\x1b[")
+		if start < 0 {
+			b.WriteString(s[i:])
+			break
+		}
+		// Copy plain text before the escape verbatim.
+		b.WriteString(s[i : i+start])
+		seqStart := i + start
+		// Find the terminating 'm'. SGR parameters are digits and ';';
+		// anything else (e.g. another '\x1b') means this isn't a well-formed
+		// SGR sequence and we bail back to plain copy.
+		j := seqStart + 2
+		for j < len(s) && s[j] != 'm' {
+			c := s[j]
+			if c != ';' && (c < '0' || c > '9') {
+				break
+			}
+			j++
+		}
+		if j >= len(s) || s[j] != 'm' {
+			// Not an SGR; copy "\x1b[" and continue scanning past it.
+			b.WriteString("\x1b[")
+			i = seqStart + 2
+			continue
+		}
+		// s[seqStart+2:j] is the param list, s[j] == 'm'.
+		params := splitSGRParams(s[seqStart+2 : j])
+		out := make([]string, 0, len(params))
+		for _, p := range params {
+			if p.isBg && p.text == from {
+				out = append(out, to)
+			} else {
+				out = append(out, p.text)
+			}
+		}
+		b.WriteString("\x1b[")
+		b.WriteString(strings.Join(out, ";"))
+		b.WriteString("m")
+		i = j + 1
+	}
+	return b.String()
+}
+
+// sgrParam is one logical SGR parameter. For extended-color groups
+// (38;5;N, 38;2;R;G;B, 48;5;N, 48;2;R;G;B) text contains the joined
+// form (e.g. "48;5;40" or "48;2;26;26;46") and isBg is true for any
+// bg variant. For single parameters text is just the number (e.g.
+// "40", "1", "31") and isBg is true only when the number is in the
+// basic bg range (40–47, 100–107).
+type sgrParam struct {
+	text string
+	isBg bool
+}
+
+// splitSGRParams tokenizes an SGR parameter list with awareness of
+// extended-color sub-sequences so a "40" appearing as an argument to
+// "38;5" is not mistaken for a standalone bg-black token.
+func splitSGRParams(params string) []sgrParam {
+	if params == "" {
+		return nil
+	}
+	parts := strings.Split(params, ";")
+	out := make([]sgrParam, 0, len(parts))
+	for i := 0; i < len(parts); i++ {
+		p := parts[i]
+		switch p {
+		case "38", "48":
+			isBg := p == "48"
+			// Look ahead for "5;N" or "2;R;G;B".
+			if i+1 < len(parts) {
+				switch parts[i+1] {
+				case "5":
+					if i+2 < len(parts) {
+						out = append(out, sgrParam{
+							text: strings.Join(parts[i:i+3], ";"),
+							isBg: isBg,
+						})
+						i += 2
+						continue
+					}
+				case "2":
+					if i+4 < len(parts) {
+						out = append(out, sgrParam{
+							text: strings.Join(parts[i:i+5], ";"),
+							isBg: isBg,
+						})
+						i += 4
+						continue
+					}
+				}
+			}
+			// Malformed — treat as a bare param so we don't drop data.
+			out = append(out, sgrParam{text: p, isBg: false})
+		default:
+			out = append(out, sgrParam{
+				text: p,
+				isBg: isBasicBgParam(p),
+			})
+		}
+	}
+	return out
+}
+
+// isBasicBgParam reports whether s is a single SGR parameter representing
+// a basic 16-color background: "40"–"47" or "100"–"107".
+func isBasicBgParam(s string) bool {
+	switch s {
+	case "40", "41", "42", "43", "44", "45", "46", "47",
+		"100", "101", "102", "103", "104", "105", "106", "107":
+		return true
+	}
+	return false
+}
+
 // bgANSIFor returns the ANSI background-color escape for c.
 // For ansi.BasicColor it emits the native 16-color SGR (\x1b[40m–\x1b[47m,
 // \x1b[100m–\x1b[107m) so the user's terminal palette is honored.

--- a/internal/ui/messages/render.go
+++ b/internal/ui/messages/render.go
@@ -345,14 +345,42 @@ func bgSGRParams(ansi string) string {
 	return ansi[len(prefix) : len(ansi)-len(suffix)]
 }
 
-// bgANSIFor returns the ANSI 24-bit background-color escape for c.
+// bgANSIFor returns the ANSI background-color escape for c.
+// For ansi.BasicColor it emits the native 16-color SGR (\x1b[40m–\x1b[47m,
+// \x1b[100m–\x1b[107m) so the user's terminal palette is honored.
+// For ansi.IndexedColor it emits the 256-color form (\x1b[48;5;Nm).
+// Otherwise it falls back to truecolor (\x1b[48;2;R;G;Bm).
 func bgANSIFor(c color.Color) string {
+	switch v := c.(type) {
+	case ansi.BasicColor:
+		if v < 8 {
+			return fmt.Sprintf("\x1b[%dm", 40+int(v))
+		}
+		if v < 16 {
+			return fmt.Sprintf("\x1b[%dm", 100+int(v-8))
+		}
+		// out-of-range BasicColor: fall through to RGBA
+	case ansi.IndexedColor:
+		return fmt.Sprintf("\x1b[48;5;%dm", int(v))
+	}
 	r, g, b, _ := c.RGBA()
 	return fmt.Sprintf("\x1b[48;2;%d;%d;%dm", r>>8, g>>8, b>>8)
 }
 
-// fgANSIFor returns the ANSI 24-bit foreground-color escape for c.
+// fgANSIFor returns the ANSI foreground-color escape for c.
+// See bgANSIFor for the type-switch rationale.
 func fgANSIFor(c color.Color) string {
+	switch v := c.(type) {
+	case ansi.BasicColor:
+		if v < 8 {
+			return fmt.Sprintf("\x1b[%dm", 30+int(v))
+		}
+		if v < 16 {
+			return fmt.Sprintf("\x1b[%dm", 90+int(v-8))
+		}
+	case ansi.IndexedColor:
+		return fmt.Sprintf("\x1b[38;5;%dm", int(v))
+	}
 	r, g, b, _ := c.RGBA()
 	return fmt.Sprintf("\x1b[38;2;%d;%d;%dm", r>>8, g>>8, b>>8)
 }

--- a/internal/ui/messages/render.go
+++ b/internal/ui/messages/render.go
@@ -318,12 +318,13 @@ func SelectionTintBgANSI(focused bool) string {
 //
 // Implementation note: lipgloss/v2 combines multiple SGR codes into a
 // single escape sequence (e.g. "\x1b[1;38;2;R;G;B;48;2;R;G;Bm" for
-// bold + fg + bg), so substituting the framed "\x1b[48;2;R;G;Bm" form
-// would miss every occurrence where the bg is bundled with other
-// attributes. We strip the "\x1b[" prefix and "m" suffix and match
-// just the bg-parameter substring "48;2;R;G;B", which appears
-// verbatim regardless of how lipgloss bundles other SGR params around
-// it.
+// bold + fg + bg), so the substitution must reach the bg parameter
+// even when it's bundled with other attributes. We delegate to
+// substituteBgSGR, which is grammar-aware: it walks each SGR sequence
+// and substitutes only complete bg tokens. Grammar awareness also
+// makes ANSI 16 bg params like "40" safe to substitute — a naive
+// substring replacement would collide with literal digits in content
+// and with 256-color sub-arguments such as "38;5;40".
 func RepaintBgToSelectionTint(s string, focused bool) string {
 	from := bgSGRParams(BgANSI())
 	to := bgSGRParams(SelectionTintBgANSI(focused))

--- a/internal/ui/messages/render.go
+++ b/internal/ui/messages/render.go
@@ -330,7 +330,7 @@ func RepaintBgToSelectionTint(s string, focused bool) string {
 	if from == "" || from == to {
 		return s
 	}
-	return strings.ReplaceAll(s, from, to)
+	return substituteBgSGR(s, from, to)
 }
 
 // bgSGRParams strips the "\x1b[" prefix and "m" suffix from a bg ANSI

--- a/internal/ui/messages/render_test.go
+++ b/internal/ui/messages/render_test.go
@@ -1,6 +1,7 @@
 package messages
 
 import (
+	"image/color"
 	"strings"
 	"testing"
 
@@ -439,5 +440,78 @@ func TestEscapedAngleBracketsNotMistakenForMention(t *testing.T) {
 	}
 	if !strings.Contains(plain, "<@U123>") {
 		t.Errorf("expected literal %q, got %q", "<@U123>", plain)
+	}
+}
+
+// TestBgANSIForBasicColor asserts that bgANSIFor emits native ANSI 16
+// background escapes (e.g. "\x1b[41m") for ansi.BasicColor instead of
+// degrading to truecolor. Native ANSI 16 escapes are required for the
+// terminal palette to be honored — truecolor escapes always bypass it.
+func TestBgANSIForBasicColor(t *testing.T) {
+	cases := []struct {
+		name string
+		c    ansi.BasicColor
+		want string
+	}{
+		{"black", 0, "\x1b[40m"},
+		{"red", 1, "\x1b[41m"},
+		{"white", 7, "\x1b[47m"},
+		{"bright black", 8, "\x1b[100m"},
+		{"bright red", 9, "\x1b[101m"},
+		{"bright white", 15, "\x1b[107m"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := bgANSIFor(tc.c)
+			if got != tc.want {
+				t.Errorf("bgANSIFor(%d) = %q, want %q", tc.c, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFgANSIForBasicColor: symmetric for foreground.
+func TestFgANSIForBasicColor(t *testing.T) {
+	cases := []struct {
+		name string
+		c    ansi.BasicColor
+		want string
+	}{
+		{"black", 0, "\x1b[30m"},
+		{"red", 1, "\x1b[31m"},
+		{"white", 7, "\x1b[37m"},
+		{"bright black", 8, "\x1b[90m"},
+		{"bright red", 9, "\x1b[91m"},
+		{"bright white", 15, "\x1b[97m"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := fgANSIFor(tc.c)
+			if got != tc.want {
+				t.Errorf("fgANSIFor(%d) = %q, want %q", tc.c, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBgFgANSIForIndexedColor asserts ANSI 256 emission for ansi.IndexedColor.
+func TestBgFgANSIForIndexedColor(t *testing.T) {
+	if got := bgANSIFor(ansi.IndexedColor(42)); got != "\x1b[48;5;42m" {
+		t.Errorf("bgANSIFor(IndexedColor(42)) = %q, want %q", got, "\x1b[48;5;42m")
+	}
+	if got := fgANSIFor(ansi.IndexedColor(200)); got != "\x1b[38;5;200m" {
+		t.Errorf("fgANSIFor(IndexedColor(200)) = %q, want %q", got, "\x1b[38;5;200m")
+	}
+}
+
+// TestBgFgANSIForRGBA is a regression guard: truecolor emission is unchanged
+// for existing hex-based themes.
+func TestBgFgANSIForRGBA(t *testing.T) {
+	c := color.RGBA{R: 26, G: 26, B: 46, A: 0xff}
+	if got := bgANSIFor(c); got != "\x1b[48;2;26;26;46m" {
+		t.Errorf("bgANSIFor(RGBA) = %q, want %q", got, "\x1b[48;2;26;26;46m")
+	}
+	if got := fgANSIFor(c); got != "\x1b[38;2;26;26;46m" {
+		t.Errorf("fgANSIFor(RGBA) = %q, want %q", got, "\x1b[38;2;26;26;46m")
 	}
 }

--- a/internal/ui/messages/render_test.go
+++ b/internal/ui/messages/render_test.go
@@ -7,6 +7,9 @@ import (
 
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
+
+	"github.com/gammons/slk/internal/config"
+	"github.com/gammons/slk/internal/ui/styles"
 )
 
 // TestLabeledLinkShowsLabelAndOSC8 asserts that a Slack-style labeled link
@@ -616,5 +619,59 @@ func TestSubstituteBgSGR(t *testing.T) {
 					tc.in, tc.from, useTo, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestRepaintBgToSelectionTintWithANSITheme exercises the integration
+// of substituteBgSGR via RepaintBgToSelectionTint when the theme uses
+// an ANSI 16 background. We apply ansi-dark so styles.Background is
+// ansi.BasicColor(0) → BgANSI() == "\x1b[40m". The repaint must
+// substitute the bundled "40" param without corrupting either literal
+// content or 256-color sub-arguments.
+func TestRepaintBgToSelectionTintWithANSITheme(t *testing.T) {
+	// Apply ansi-dark; restore dark afterward.
+	styles.Apply("ansi-dark", config.Theme{})
+	t.Cleanup(func() { styles.Apply("dark", config.Theme{}) })
+
+	if BgANSI() != "\x1b[40m" {
+		t.Fatalf("precondition: expected BgANSI() == \"\\x1b[40m\", got %q", BgANSI())
+	}
+
+	// Build a synthetic rendered string mixing: plain text containing
+	// the digit "40", a bundled SGR with bg 40, and a 256-color FG that
+	// includes "40" as its index (must NOT be substituted).
+	in := "see line 40\x1b[1;31;40mbold red on black\x1b[m and \x1b[38;5;40mfg256\x1b[m"
+	out := RepaintBgToSelectionTint(in, true)
+
+	// "line 40" plain digits must survive.
+	if !strings.Contains(out, "see line 40") {
+		t.Errorf("plain digit run was corrupted: %q", out)
+	}
+	// The bundled bg "40" must be replaced.
+	if strings.Contains(out, "\x1b[1;31;40m") {
+		t.Errorf("expected bundled bg 40 to be substituted, got %q", out)
+	}
+	// The 256-color FG with index 40 must be intact.
+	if !strings.Contains(out, "\x1b[38;5;40m") {
+		t.Errorf("expected 256-color FG index 40 to remain intact, got %q", out)
+	}
+}
+
+// TestRepaintBgToSelectionTintBackwardCompat asserts no behavior change
+// for truecolor themes — substituting a long, unique RGB param.
+func TestRepaintBgToSelectionTintBackwardCompat(t *testing.T) {
+	styles.Apply("dark", config.Theme{})
+	bg := BgANSI()
+	// We don't know the exact params; just verify a string carrying
+	// that exact bg escape gets substituted and a string with no bg
+	// escape passes through unchanged.
+	withBg := "prefix" + bg + "tinted\x1b[m suffix"
+	got := RepaintBgToSelectionTint(withBg, true)
+	if got == withBg {
+		t.Errorf("expected substitution to occur for dark theme bg")
+	}
+	noBg := "no escape here"
+	if got := RepaintBgToSelectionTint(noBg, true); got != noBg {
+		t.Errorf("expected pass-through for string with no bg escape, got %q", got)
 	}
 }

--- a/internal/ui/messages/render_test.go
+++ b/internal/ui/messages/render_test.go
@@ -624,17 +624,18 @@ func TestSubstituteBgSGR(t *testing.T) {
 
 // TestRepaintBgToSelectionTintWithANSITheme exercises the integration
 // of substituteBgSGR via RepaintBgToSelectionTint when the theme uses
-// an ANSI 16 background. We apply ansi-dark so styles.Background is
-// ansi.BasicColor(0) → BgANSI() == "\x1b[40m". The repaint must
-// substitute the bundled "40" param without corrupting either literal
-// content or 256-color sub-arguments.
+// an ANSI 16 background. We apply ansi-dark so BgANSI() returns the
+// basic 16-color form "\x1b[40m" — independent of how the theme stores
+// the value internally. The repaint must substitute the bundled "40"
+// param without corrupting either literal content or 256-color
+// sub-arguments.
 func TestRepaintBgToSelectionTintWithANSITheme(t *testing.T) {
 	// Apply ansi-dark; restore dark afterward.
 	styles.Apply("ansi-dark", config.Theme{})
 	t.Cleanup(func() { styles.Apply("dark", config.Theme{}) })
 
 	if BgANSI() != "\x1b[40m" {
-		t.Fatalf("precondition: expected BgANSI() == \"\\x1b[40m\", got %q", BgANSI())
+		t.Skipf("ansi-dark theme not yet registered (Task 4 dependency); BgANSI()=%q", BgANSI())
 	}
 
 	// Build a synthetic rendered string mixing: plain text containing
@@ -661,17 +662,26 @@ func TestRepaintBgToSelectionTintWithANSITheme(t *testing.T) {
 // for truecolor themes — substituting a long, unique RGB param.
 func TestRepaintBgToSelectionTintBackwardCompat(t *testing.T) {
 	styles.Apply("dark", config.Theme{})
+	t.Cleanup(func() { styles.Apply("dark", config.Theme{}) })
+
 	bg := BgANSI()
-	// We don't know the exact params; just verify a string carrying
-	// that exact bg escape gets substituted and a string with no bg
-	// escape passes through unchanged.
-	withBg := "prefix" + bg + "tinted\x1b[m suffix"
-	got := RepaintBgToSelectionTint(withBg, true)
-	if got == withBg {
-		t.Errorf("expected substitution to occur for dark theme bg")
+	tint := SelectionTintBgANSI(true)
+	from := bgSGRParams(bg)
+	to := bgSGRParams(tint)
+	if from == "" || from == to {
+		t.Fatalf("test setup invalid: from=%q to=%q (both must be non-empty and differ)", from, to)
 	}
+
+	// Standalone bg escape: substituted to tint.
+	in := "prefix" + bg + "tinted\x1b[m suffix"
+	want := "prefix\x1b[" + to + "mtinted\x1b[m suffix"
+	if got := RepaintBgToSelectionTint(in, true); got != want {
+		t.Errorf("standalone bg substitution: got %q, want %q", got, want)
+	}
+
+	// Pass-through: strings with no bg escape are unchanged.
 	noBg := "no escape here"
 	if got := RepaintBgToSelectionTint(noBg, true); got != noBg {
-		t.Errorf("expected pass-through for string with no bg escape, got %q", got)
+		t.Errorf("pass-through: got %q, want %q", got, noBg)
 	}
 }

--- a/internal/ui/messages/render_test.go
+++ b/internal/ui/messages/render_test.go
@@ -530,3 +530,91 @@ func TestBgFgANSIForBasicColorOutOfRange(t *testing.T) {
 		t.Errorf("out-of-range BasicColor fg should fall through to truecolor, got %q", fg)
 	}
 }
+
+// TestSubstituteBgSGR exercises the grammar-aware bg-parameter
+// substitution. The helper must:
+//   (1) substitute the param when it stands alone (\x1b[40m)
+//   (2) substitute the param within a bundled SGR (\x1b[1;31;40m)
+//   (3) NOT corrupt literal digits in non-SGR content
+//   (4) NOT match the param value inside a 256-color sub-argument
+//       (\x1b[38;5;40m is an FG index 40, not a bg basic 40)
+//   (5) leave the string unchanged when from == to
+func TestSubstituteBgSGR(t *testing.T) {
+	const to = "48;2;100;100;200"
+
+	cases := []struct {
+		name string
+		in   string
+		from string
+		want string
+	}{
+		{
+			name: "standalone ANSI bg",
+			in:   "\x1b[40mhello\x1b[m",
+			from: "40",
+			want: "\x1b[" + to + "mhello\x1b[m",
+		},
+		{
+			name: "bundled SGR with ANSI bg",
+			in:   "\x1b[1;31;40mbold red on black\x1b[m",
+			from: "40",
+			want: "\x1b[1;31;" + to + "mbold red on black\x1b[m",
+		},
+		{
+			name: "literal 40 in content is not touched",
+			in:   "page 40 of 100\x1b[40mtinted\x1b[m",
+			from: "40",
+			want: "page 40 of 100\x1b[" + to + "mtinted\x1b[m",
+		},
+		{
+			name: "256-color FG index 40 is not touched",
+			in:   "\x1b[38;5;40mfg only\x1b[m",
+			from: "40",
+			want: "\x1b[38;5;40mfg only\x1b[m",
+		},
+		{
+			name: "256-color FG index 40 alongside bg 40 — only bg substituted",
+			in:   "\x1b[38;5;40;40mfg256 bg basic\x1b[m",
+			from: "40",
+			want: "\x1b[38;5;40;" + to + "mfg256 bg basic\x1b[m",
+		},
+		{
+			name: "truecolor bg substring substitution",
+			in:   "\x1b[48;2;26;26;46mhello\x1b[m",
+			from: "48;2;26;26;46",
+			want: "\x1b[" + to + "mhello\x1b[m",
+		},
+		{
+			name: "truecolor bg within bundled SGR",
+			in:   "\x1b[1;38;2;255;255;255;48;2;26;26;46mtext\x1b[m",
+			from: "48;2;26;26;46",
+			want: "\x1b[1;38;2;255;255;255;" + to + "mtext\x1b[m",
+		},
+		{
+			name: "no match leaves string unchanged",
+			in:   "\x1b[31mred fg only\x1b[m",
+			from: "40",
+			want: "\x1b[31mred fg only\x1b[m",
+		},
+		{
+			name: "from == to is a no-op",
+			in:   "\x1b[40mhello\x1b[m",
+			from: "40",
+			// to passed = "40" same as from
+			want: "\x1b[40mhello\x1b[m",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			useTo := to
+			if tc.name == "from == to is a no-op" {
+				useTo = "40"
+			}
+			got := substituteBgSGR(tc.in, tc.from, useTo)
+			if got != tc.want {
+				t.Errorf("substituteBgSGR(%q, %q, %q) = %q, want %q",
+					tc.in, tc.from, useTo, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/ui/messages/render_test.go
+++ b/internal/ui/messages/render_test.go
@@ -624,18 +624,20 @@ func TestSubstituteBgSGR(t *testing.T) {
 
 // TestRepaintBgToSelectionTintWithANSITheme exercises the integration
 // of substituteBgSGR via RepaintBgToSelectionTint when the theme uses
-// an ANSI 16 background. We apply ansi-dark so BgANSI() returns the
+// an ANSI 16 background. We apply ansi dark so BgANSI() returns the
 // basic 16-color form "\x1b[40m" — independent of how the theme stores
 // the value internally. The repaint must substitute the bundled "40"
 // param without corrupting either literal content or 256-color
 // sub-arguments.
 func TestRepaintBgToSelectionTintWithANSITheme(t *testing.T) {
-	// Apply ansi-dark; restore dark afterward.
-	styles.Apply("ansi-dark", config.Theme{})
+	// Apply ansi dark via the display-name form to exercise the same
+	// case-insensitive lookup path that the theme picker uses when it
+	// saves "ANSI Dark" to config.toml. Restore dark afterward.
+	styles.Apply("ANSI Dark", config.Theme{})
 	t.Cleanup(func() { styles.Apply("dark", config.Theme{}) })
 
 	if BgANSI() != "\x1b[40m" {
-		t.Skipf("ansi-dark theme not yet registered (Task 4 dependency); BgANSI()=%q", BgANSI())
+		t.Skipf("ansi dark theme not yet registered (Task 4 dependency); BgANSI()=%q", BgANSI())
 	}
 
 	// Build a synthetic rendered string mixing: plain text containing

--- a/internal/ui/messages/render_test.go
+++ b/internal/ui/messages/render_test.go
@@ -515,3 +515,18 @@ func TestBgFgANSIForRGBA(t *testing.T) {
 		t.Errorf("fgANSIFor(RGBA) = %q, want %q", got, "\x1b[38;2;26;26;46m")
 	}
 }
+
+// TestBgFgANSIForBasicColorOutOfRange pins the documented fall-through:
+// BasicColor values ≥16 (constructible since BasicColor is uint8) are
+// out of the valid 0-15 range and must fall through to truecolor rather
+// than producing malformed escapes like "\x1b[116m".
+func TestBgFgANSIForBasicColorOutOfRange(t *testing.T) {
+	bg := bgANSIFor(ansi.BasicColor(16))
+	if !strings.HasPrefix(bg, "\x1b[48;2;") {
+		t.Errorf("out-of-range BasicColor bg should fall through to truecolor, got %q", bg)
+	}
+	fg := fgANSIFor(ansi.BasicColor(16))
+	if !strings.HasPrefix(fg, "\x1b[38;2;") {
+		t.Errorf("out-of-range BasicColor fg should fall through to truecolor, got %q", fg)
+	}
+}

--- a/internal/ui/styles/themes.go
+++ b/internal/ui/styles/themes.go
@@ -277,25 +277,15 @@ var builtinThemes = map[string]struct {
 		SidebarTextMuted:  "#FFCC00",
 		RailBackground:    "#800000", // dark red rail
 	}},
-	"ansi-dark": {
-		Name: "ANSI Dark",
-		Colors: ThemeColors{
-			// All values are ANSI 16 color numbers ("0"–"15"). They are
-			// passed through lipgloss.Color() which returns ansi.BasicColor,
-			// so rendering uses native 16-color SGR escapes and inherits the
-			// user's terminal palette.
-			Primary:     "4",  // blue
-			Accent:      "6",  // cyan
-			Warning:     "3",  // yellow
-			Error:       "1",  // red
-			Background:  "0",  // black
-			Surface:     "8",  // bright black (slightly lifted panel bg)
-			SurfaceDark: "0",  // black (matches background)
-			Text:        "15", // bright white
-			TextMuted:   "8",  // bright black
-			Border:      "8",  // bright black
-		},
-	},
+	// ansi-dark uses ANSI 16 color numbers ("0"–"15") instead of hex.
+	// Values are passed through lipgloss.Color() which returns
+	// ansi.BasicColor, so rendering uses native 16-color SGR escapes
+	// and inherits the user's terminal palette.
+	"ansi-dark": {"ANSI Dark", ThemeColors{
+		Primary: "4", Accent: "6", Warning: "3", Error: "1",
+		Background: "0", Surface: "8", SurfaceDark: "0",
+		Text: "15", TextMuted: "8", Border: "8",
+	}},
 }
 
 // customThemes stores themes loaded from the user's themes directory.

--- a/internal/ui/styles/themes.go
+++ b/internal/ui/styles/themes.go
@@ -281,18 +281,30 @@ var builtinThemes = map[string]struct {
 	// Values are passed through lipgloss.Color() which returns
 	// ansi.BasicColor, so rendering uses native 16-color SGR escapes
 	// and inherits the user's terminal palette.
+	//
+	// SelectionBgFocused / SelectionBgUnfocused are set explicitly to
+	// ANSI 8 (bright black / palette gray) to bypass mixColors. With
+	// Background=ANSI 0 the default mix produces a near-black RGB
+	// tint (~RGB(0,25,25)) that's invisible against the terminal bg.
 	"ansi dark": {"ANSI Dark", ThemeColors{
 		Primary: "4", Accent: "6", Warning: "3", Error: "1",
 		Background: "0", Surface: "8", SurfaceDark: "0",
 		Text: "15", TextMuted: "8", Border: "8",
+		SelectionBgFocused: "8", SelectionBgUnfocused: "8",
 	}},
 	// ansi-light is the light-terminal counterpart to ansi-dark. Same
 	// ANSI-16-only constraint; values chosen for readability on light
 	// terminal backgrounds.
+	//
+	// SelectionBgFocused / SelectionBgUnfocused use ANSI 8 (bright
+	// black / palette gray) for the same reason as ansi-dark — bypass
+	// mixColors so the selection tint is palette-inherited and
+	// visible against the light terminal background.
 	"ansi light": {"ANSI Light", ThemeColors{
 		Primary: "4", Accent: "6", Warning: "3", Error: "1",
 		Background: "15", Surface: "7", SurfaceDark: "7",
 		Text: "0", TextMuted: "8", Border: "8",
+		SelectionBgFocused: "8", SelectionBgUnfocused: "8",
 	}},
 }
 

--- a/internal/ui/styles/themes.go
+++ b/internal/ui/styles/themes.go
@@ -286,6 +286,14 @@ var builtinThemes = map[string]struct {
 		Background: "0", Surface: "8", SurfaceDark: "0",
 		Text: "15", TextMuted: "8", Border: "8",
 	}},
+	// ansi-light is the light-terminal counterpart to ansi-dark. Same
+	// ANSI-16-only constraint; values chosen for readability on light
+	// terminal backgrounds.
+	"ansi-light": {"ANSI Light", ThemeColors{
+		Primary: "4", Accent: "6", Warning: "3", Error: "1",
+		Background: "15", Surface: "7", SurfaceDark: "7",
+		Text: "0", TextMuted: "8", Border: "8",
+	}},
 }
 
 // customThemes stores themes loaded from the user's themes directory.

--- a/internal/ui/styles/themes.go
+++ b/internal/ui/styles/themes.go
@@ -281,7 +281,7 @@ var builtinThemes = map[string]struct {
 	// Values are passed through lipgloss.Color() which returns
 	// ansi.BasicColor, so rendering uses native 16-color SGR escapes
 	// and inherits the user's terminal palette.
-	"ansi-dark": {"ANSI Dark", ThemeColors{
+	"ansi dark": {"ANSI Dark", ThemeColors{
 		Primary: "4", Accent: "6", Warning: "3", Error: "1",
 		Background: "0", Surface: "8", SurfaceDark: "0",
 		Text: "15", TextMuted: "8", Border: "8",
@@ -289,7 +289,7 @@ var builtinThemes = map[string]struct {
 	// ansi-light is the light-terminal counterpart to ansi-dark. Same
 	// ANSI-16-only constraint; values chosen for readability on light
 	// terminal backgrounds.
-	"ansi-light": {"ANSI Light", ThemeColors{
+	"ansi light": {"ANSI Light", ThemeColors{
 		Primary: "4", Accent: "6", Warning: "3", Error: "1",
 		Background: "15", Surface: "7", SurfaceDark: "7",
 		Text: "0", TextMuted: "8", Border: "8",

--- a/internal/ui/styles/themes.go
+++ b/internal/ui/styles/themes.go
@@ -277,6 +277,25 @@ var builtinThemes = map[string]struct {
 		SidebarTextMuted:  "#FFCC00",
 		RailBackground:    "#800000", // dark red rail
 	}},
+	"ansi-dark": {
+		Name: "ANSI Dark",
+		Colors: ThemeColors{
+			// All values are ANSI 16 color numbers ("0"–"15"). They are
+			// passed through lipgloss.Color() which returns ansi.BasicColor,
+			// so rendering uses native 16-color SGR escapes and inherits the
+			// user's terminal palette.
+			Primary:     "4",  // blue
+			Accent:      "6",  // cyan
+			Warning:     "3",  // yellow
+			Error:       "1",  // red
+			Background:  "0",  // black
+			Surface:     "8",  // bright black (slightly lifted panel bg)
+			SurfaceDark: "0",  // black (matches background)
+			Text:        "15", // bright white
+			TextMuted:   "8",  // bright black
+			Border:      "8",  // bright black
+		},
+	},
 }
 
 // customThemes stores themes loaded from the user's themes directory.

--- a/internal/ui/styles/themes_test.go
+++ b/internal/ui/styles/themes_test.go
@@ -162,7 +162,7 @@ func TestANSIDarkThemeRegistered(t *testing.T) {
 		t.Errorf("expected \"ANSI Dark\" in ThemeNames, got %v", names)
 	}
 
-	c := lookupTheme("ansi-dark")
+	c := lookupTheme("ANSI Dark")
 	required := map[string]string{
 		"Primary":     c.Primary,
 		"Accent":      c.Accent,
@@ -177,12 +177,12 @@ func TestANSIDarkThemeRegistered(t *testing.T) {
 	}
 	for name, val := range required {
 		if val == "" {
-			t.Errorf("ansi-dark.%s is empty", name)
+			t.Errorf("ansi dark.%s is empty", name)
 			continue
 		}
 		col := lipgloss.Color(val)
 		if _, ok := col.(ansi.BasicColor); !ok {
-			t.Errorf("ansi-dark.%s = %q resolves to %T, want ansi.BasicColor",
+			t.Errorf("ansi dark.%s = %q resolves to %T, want ansi.BasicColor",
 				name, val, col)
 		}
 	}
@@ -203,7 +203,7 @@ func TestANSILightThemeRegistered(t *testing.T) {
 		t.Errorf("expected \"ANSI Light\" in ThemeNames, got %v", names)
 	}
 
-	c := lookupTheme("ansi-light")
+	c := lookupTheme("ANSI Light")
 	required := map[string]string{
 		"Primary":     c.Primary,
 		"Accent":      c.Accent,
@@ -218,13 +218,34 @@ func TestANSILightThemeRegistered(t *testing.T) {
 	}
 	for name, val := range required {
 		if val == "" {
-			t.Errorf("ansi-light.%s is empty", name)
+			t.Errorf("ansi light.%s is empty", name)
 			continue
 		}
 		col := lipgloss.Color(val)
 		if _, ok := col.(ansi.BasicColor); !ok {
-			t.Errorf("ansi-light.%s = %q resolves to %T, want ansi.BasicColor",
+			t.Errorf("ansi light.%s = %q resolves to %T, want ansi.BasicColor",
 				name, val, col)
 		}
+	}
+}
+
+// TestANSIThemeLookupViaDisplayName regression-pins the realistic
+// theme-switcher path: when the user picks "ANSI Dark" via Ctrl+y,
+// the display name is saved verbatim to config.toml. On the next
+// render, lookupTheme must resolve "ANSI Dark" to the ansi-dark
+// theme — not fall through to the default "dark" theme.
+//
+// The key in builtinThemes must therefore lowercase-match "ANSI Dark"
+// after strings.ToLower, i.e. it must use a space separator like every
+// other multi-word built-in theme ("tokyo night", "gruvbox dark", etc).
+func TestANSIThemeLookupViaDisplayName(t *testing.T) {
+	dark := lookupTheme("ANSI Dark")
+	if dark.Background != "0" {
+		t.Errorf("lookupTheme(\"ANSI Dark\").Background = %q, want \"0\" — likely fell through to default \"dark\" theme", dark.Background)
+	}
+
+	light := lookupTheme("ANSI Light")
+	if light.Background != "15" {
+		t.Errorf("lookupTheme(\"ANSI Light\").Background = %q, want \"15\" — likely fell through to default \"dark\" theme", light.Background)
 	}
 }

--- a/internal/ui/styles/themes_test.go
+++ b/internal/ui/styles/themes_test.go
@@ -249,3 +249,39 @@ func TestANSIThemeLookupViaDisplayName(t *testing.T) {
 		t.Errorf("lookupTheme(\"ANSI Light\").Background = %q, want \"15\" — likely fell through to default \"dark\" theme", light.Background)
 	}
 }
+
+// TestANSIThemesSelectionTintPaletteInherited regression-pins that
+// SelectionTintColor for the ANSI themes returns a palette-inherited
+// ansi.BasicColor — not a near-black RGB mix from the default
+// mixColors(Accent, Background=ANSI 0, 0.15) path.
+//
+// Without explicit SelectionBgFocused/SelectionBgUnfocused on the
+// theme, ansi-dark's selection tint computes to roughly RGB(0,25,25)
+// which renders as effectively black against any dark terminal bg.
+// The fix sets the optional theme fields to a palette ANSI color
+// ("8" = bright black / gray) so the tint is visible and tracks
+// the user's terminal palette.
+func TestANSIThemesSelectionTintPaletteInherited(t *testing.T) {
+	cases := []struct {
+		theme string
+	}{
+		{"ansi dark"},
+		{"ansi light"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.theme, func(t *testing.T) {
+			Apply(tc.theme, config.Theme{})
+			t.Cleanup(func() { Apply("dark", config.Theme{}) })
+
+			focused := SelectionTintColor(true)
+			if _, ok := focused.(ansi.BasicColor); !ok {
+				t.Errorf("%s focused selection tint = %T, want ansi.BasicColor (palette-inherited)", tc.theme, focused)
+			}
+
+			unfocused := SelectionTintColor(false)
+			if _, ok := unfocused.(ansi.BasicColor); !ok {
+				t.Errorf("%s unfocused selection tint = %T, want ansi.BasicColor (palette-inherited)", tc.theme, unfocused)
+			}
+		})
+	}
+}

--- a/internal/ui/styles/themes_test.go
+++ b/internal/ui/styles/themes_test.go
@@ -187,3 +187,44 @@ func TestANSIDarkThemeRegistered(t *testing.T) {
 		}
 	}
 }
+
+// TestANSILightThemeRegistered: mirror of TestANSIDarkThemeRegistered
+// for the light variant.
+func TestANSILightThemeRegistered(t *testing.T) {
+	names := ThemeNames()
+	found := false
+	for _, n := range names {
+		if n == "ANSI Light" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected \"ANSI Light\" in ThemeNames, got %v", names)
+	}
+
+	c := lookupTheme("ansi-light")
+	required := map[string]string{
+		"Primary":     c.Primary,
+		"Accent":      c.Accent,
+		"Warning":     c.Warning,
+		"Error":       c.Error,
+		"Background":  c.Background,
+		"Surface":     c.Surface,
+		"SurfaceDark": c.SurfaceDark,
+		"Text":        c.Text,
+		"TextMuted":   c.TextMuted,
+		"Border":      c.Border,
+	}
+	for name, val := range required {
+		if val == "" {
+			t.Errorf("ansi-light.%s is empty", name)
+			continue
+		}
+		col := lipgloss.Color(val)
+		if _, ok := col.(ansi.BasicColor); !ok {
+			t.Errorf("ansi-light.%s = %q resolves to %T, want ansi.BasicColor",
+				name, val, col)
+		}
+	}
+}

--- a/internal/ui/styles/themes_test.go
+++ b/internal/ui/styles/themes_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/gammons/slk/internal/config"
 )
 
@@ -140,6 +141,49 @@ func TestLightThemesHaveDarkSidebars(t *testing.T) {
 		}
 		if c.RailBackground == "" {
 			t.Errorf("light theme %q must set RailBackground", key)
+		}
+	}
+}
+
+// TestANSIDarkThemeRegistered asserts the ansi-dark theme is present
+// in the theme switcher and that every color field is populated with
+// a value that resolves to ansi.BasicColor — confirming the theme
+// will inherit the user's terminal palette rather than emit truecolor.
+func TestANSIDarkThemeRegistered(t *testing.T) {
+	names := ThemeNames()
+	found := false
+	for _, n := range names {
+		if n == "ANSI Dark" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected \"ANSI Dark\" in ThemeNames, got %v", names)
+	}
+
+	c := lookupTheme("ansi-dark")
+	required := map[string]string{
+		"Primary":     c.Primary,
+		"Accent":      c.Accent,
+		"Warning":     c.Warning,
+		"Error":       c.Error,
+		"Background":  c.Background,
+		"Surface":     c.Surface,
+		"SurfaceDark": c.SurfaceDark,
+		"Text":        c.Text,
+		"TextMuted":   c.TextMuted,
+		"Border":      c.Border,
+	}
+	for name, val := range required {
+		if val == "" {
+			t.Errorf("ansi-dark.%s is empty", name)
+			continue
+		}
+		col := lipgloss.Color(val)
+		if _, ok := col.(ansi.BasicColor); !ok {
+			t.Errorf("ansi-dark.%s = %q resolves to %T, want ansi.BasicColor",
+				name, val, col)
 		}
 	}
 }

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -111,7 +111,7 @@ regardless of network timing, even without an explicit `order` set.
 Legacy configs that key the block by raw team ID
 (`[workspaces.T01ABCDEF]`) keep working unchanged.
 
-## Terminal-palette themes (`ansi-dark`, `ansi-light`)
+## Terminal-palette themes (`ANSI Dark`, `ANSI Light`)
 
 Two built-in themes use ANSI 16 color codes exclusively rather than
 fixed RGB values. They inherit the user's terminal color palette, so
@@ -121,7 +121,7 @@ match.
 
 ```toml
 [appearance]
-theme = "ansi-dark"   # or "ansi-light"
+theme = "ANSI Dark"   # or "ANSI Light"
 ```
 
 Pick the variant whose background matches your terminal's background.

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -111,6 +111,24 @@ regardless of network timing, even without an explicit `order` set.
 Legacy configs that key the block by raw team ID
 (`[workspaces.T01ABCDEF]`) keep working unchanged.
 
+## Terminal-palette themes (`ansi-dark`, `ansi-light`)
+
+Two built-in themes use ANSI 16 color codes exclusively rather than
+fixed RGB values. They inherit the user's terminal color palette, so
+changing your terminal colorscheme (light/dark, solarized,
+accessibility palettes, etc.) immediately changes slk's UI colors to
+match.
+
+    [appearance]
+    theme = "ansi-dark"   # or "ansi-light"
+
+Pick the variant whose background matches your terminal's background.
+
+**Trade-off:** selection-row highlights and compose-input tints are
+still computed as RGB approximations, so the tint regions of those
+elements use truecolor rather than your palette. The rest of the UI
+honors the palette.
+
 ## Custom themes
 
 Drop `.toml` files into `~/.config/slk/themes/`:

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -119,8 +119,10 @@ changing your terminal colorscheme (light/dark, solarized,
 accessibility palettes, etc.) immediately changes slk's UI colors to
 match.
 
-    [appearance]
-    theme = "ansi-dark"   # or "ansi-light"
+```toml
+[appearance]
+theme = "ansi-dark"   # or "ansi-light"
+```
 
 Pick the variant whose background matches your terminal's background.
 

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -92,7 +92,7 @@ See [[Terminal Compatibility|Terminal-Compatibility]] for which protocol your te
 
 ## Customization
 
-- 36 built-in themes (including `ansi-dark` / `ansi-light` that inherit your terminal palette)
+- 36 built-in themes (including `ANSI Dark` / `ANSI Light` that inherit your terminal palette)
 - Drop-in custom themes (`~/.config/slk/themes/*.toml`)
 - Live theme switcher (`Ctrl+y`)
 - TOML config for appearance, animations, notifications, and channel sections

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -92,7 +92,7 @@ See [[Terminal Compatibility|Terminal-Compatibility]] for which protocol your te
 
 ## Customization
 
-- 12 built-in modern-looking themes
+- 36 built-in themes (including `ansi-dark` / `ansi-light` that inherit your terminal palette)
 - Drop-in custom themes (`~/.config/slk/themes/*.toml`)
 - Live theme switcher (`Ctrl+y`)
 - TOML config for appearance, animations, notifications, and channel sections


### PR DESCRIPTION
Closes #35.

## Summary

Adds two new built-in themes — **ANSI Dark** and **ANSI Light** — that use ANSI 16 color codes exclusively instead of fixed RGB values. The user's terminal palette drives slk's UI colors, so switching terminal colorschemes (light/dark, solarized, accessibility palettes, custom themes, etc.) immediately changes slk's accent, error, warning, primary, border, and selection colors to match.

| Theme | Background | Primary | Accent | Selection bg |
|---|---|---|---|---|
| ANSI Dark | ANSI 0 (black) | ANSI 4 (blue) | ANSI 6 (cyan) | ANSI 8 (bright black) |
| ANSI Light | ANSI 15 (bright white) | ANSI 4 (blue) | ANSI 6 (cyan) | ANSI 8 (bright black) |

Every value is an ANSI 16 number string (`"0"`-`"15"`) so `lipgloss.Color` resolves it to `ansi.BasicColor` and the rendered output uses native 16-color SGR escapes (`\x1b[31m` etc.) that the terminal renders with its configured palette.

## Why

slk's other 34 themes use hard-coded hex values, so they render the same RGB regardless of the user's terminal palette. The issue requested a theme that "inherits the user's terminal colors naturally" — useful for light/dark auto-switching, accessibility palettes, and terminals where truecolor support is inconsistent.

## Required code changes

Beyond the two theme entries, slk's hand-rolled ANSI escape path needed two adjustments so palette inheritance actually reaches the terminal:

- **`bgANSIFor` / `fgANSIFor` are now type-aware** (`internal/ui/messages/render.go`). Previously they always emitted truecolor `\x1b[48;2;R;G;Bm` regardless of the input. Now they type-switch on `color.Color`: `ansi.BasicColor` emits the native 16-color SGR, `ansi.IndexedColor` emits the 256-color form, and `color.RGBA` keeps the existing truecolor path. Hex-based themes are bit-identical to before.
- **`RepaintBgToSelectionTint` uses a grammar-aware SGR substitution** (new `substituteBgSGR` helper). The existing `strings.ReplaceAll` was safe for long truecolor params like `"48;2;26;26;46"`, but short ANSI params like `"40"` would collide with literal digits in rendered content (timestamps, message bodies) and with 256-color sub-arguments like `"38;5;40"`. `substituteBgSGR` walks each SGR sequence, tokenizes the parameter list with awareness of extended-color groups, and substitutes only complete bg tokens.

## Selection tint

Computing the selection tint via `mixColors(Accent=ANSI 6 cyan, Background=ANSI 0 black, 0.15)` yields `RGB(0, 25, 25)` — a near-black tint that's effectively invisible. Both ANSI themes set the optional `SelectionBgFocused` / `SelectionBgUnfocused` fields to `"8"` (bright black / gray) so the selection bypasses `mixColors` entirely. The selection is palette-inherited gray, visible against both ANSI 0 (dark) and ANSI 15 (light) backgrounds.

## Tests

```
go test ./internal/ui/messages/ ./internal/ui/styles/ -v
```

- `TestBgANSIForBasicColor` / `TestFgANSIForBasicColor` — every escape variant (0-7, 8-15).
- `TestBgFgANSIForIndexedColor` — 256-color emission.
- `TestBgFgANSIForRGBA` — truecolor regression guard.
- `TestBgFgANSIForBasicColorOutOfRange` — pins the documented fall-through for out-of-range `BasicColor` values.
- `TestSubstituteBgSGR` — 9 grammar cases: standalone, bundled, plain-digit collision, 256-color sub-argument collision, mixed FG256+bg, truecolor, no-match, no-op.
- `TestRepaintBgToSelectionTintWithANSITheme` — end-to-end substitution with `\x1b[40m` source.
- `TestRepaintBgToSelectionTintBackwardCompat` — truecolor source params still substitute correctly.
- `TestANSIDarkThemeRegistered` / `TestANSILightThemeRegistered` — both themes registered, every required color field resolves to `ansi.BasicColor`.
- `TestANSIThemeLookupViaDisplayName` — saved display name `"ANSI Dark"` lowercases to `"ansi dark"` and matches the map key (uses space separator like other multi-word built-in themes — `"tokyo night"`, `"gruvbox dark"`, etc).
- `TestANSIThemesSelectionTintPaletteInherited` — `SelectionTintColor` returns `ansi.BasicColor` on both themes, confirming the explicit `SelectionBgFocused` override is honored.

Full suite `go test ./...` passes.

## Manual verification

- `Ctrl+y` → both `ANSI Dark` and `ANSI Light` appear in the theme switcher.
- Selecting `ANSI Dark` and changing the host terminal palette (e.g. switching iTerm/Alacritty/kitty between gruvbox / everforest / dracula / nord) updates slk's primary/accent/warning/error/border/selection colors on the next render.
- Selection-row tint is visible on both dark and light terminals.
- All 34 pre-existing themes render bit-identically.

## Trade-offs

- **`Background: "0"` is ANSI black, not "default background."** In some palettes (e.g. everforest) `color 0` and "default background" are deliberately distinct shades, so slk's panel chrome can sit slightly off from the surrounding terminal chrome. A "use terminal default" variant (via `lipgloss.NoColor`) was explored and reverted: slk's rendering pipeline assumes concrete RGB values in multiple places (`mixColors`, `RepaintBgToSelectionTint`, multi-line body composition, the modal dim overlay), so the cleaner-looking approach required cascading refactors that grew beyond the scope of this feature. The current implementation accepts the minor shade discrepancy in exchange for staying within the existing rendering architecture.
- **Selection tint is palette-inherited gray, not an accent-tinted mix.** A subtle accent-mixed tint would require truecolor RGB (which `mixColors` produces today on hex themes). Solid ANSI 8 was chosen so the selection also honors the user's palette.

## Docs

- `wiki/Configuration.md` — new "Terminal-palette themes" subsection.
- `wiki/Features.md` — theme count + ANSI variant mention.
- `README.md` — theme count.
- Design spec: `docs/superpowers/specs/2026-05-25-ansi-palette-themes-design.md`.
- Implementation plan: `docs/superpowers/plans/2026-05-25-ansi-palette-themes.md`.