### PR TITLE
perf(selection): keep mouse-drag selection off the bordered render cache hot path

### DIFF
--- a/internal/ui/app_selection_test.go
+++ b/internal/ui/app_selection_test.go
@@ -343,3 +343,159 @@ func TestApp_ToggleSidebarClearsSelection(t *testing.T) {
 		t.Fatal("ToggleSidebar must clear selection")
 	}
 }
+
+// drainBatchCmds is like drainBatch but returns the leaf tea.Cmds
+// instead of invoking them. Lets tests inspect a batch for the
+// presence of a specific Cmd-shape (e.g. a tea.Tick) without
+// triggering its side effects. Built by walking the outermost
+// BatchMsg only -- nested batches are flattened the same way.
+func drainBatchCmds(cmd tea.Cmd) []tea.Cmd {
+	if cmd == nil {
+		return nil
+	}
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		return []tea.Cmd(batch)
+	}
+	// Single-msg cmd: re-wrap so callers can still invoke it.
+	return []tea.Cmd{func() tea.Msg { return msg }}
+}
+
+// TestDrag_MotionCoalescing_DefersExtendSelectionAt is the perf
+// invariant for the motion-coalescing flush tick: a MouseMotionMsg
+// must NOT immediately call ExtendSelectionAt on the panel. It
+// latches the cursor position and schedules a single flush tick
+// (motionFlushTickMsg) that, when fired, applies the latest latched
+// position. Bubbletea's main loop delivers MouseMotionMsg at the
+// terminal's mouse-reporting rate (often >100 Hz) — coalescing
+// caps the work done per cell at ~60 Hz.
+func TestDrag_MotionCoalescing_DefersExtendSelectionAt(t *testing.T) {
+	a := newTestAppWithMessages(t)
+	pressX := a.layout.sidebarEnd + 2
+	pressY := 4
+	_, _ = a.Update(tea.MouseClickMsg{X: pressX, Y: pressY, Button: tea.MouseLeft})
+
+	// Precondition: Click started a selection (Begin sets selRange
+	// to {Start, Start}) but SelectionText is empty since End == Start.
+	if !a.messagepane.HasSelection() {
+		t.Fatal("precondition: Click must Begin a selection")
+	}
+	if got := a.messagepane.SelectionText(); got != "" {
+		t.Fatalf("precondition: Begin must leave selection empty; got %q", got)
+	}
+
+	// Motion -- with coalescing this MUST NOT extend the selection
+	// immediately. The pane's SelectionText stays empty.
+	_, cmd := a.Update(tea.MouseMotionMsg{X: pressX + 10, Y: pressY + 1, Button: tea.MouseLeft})
+	if got := a.messagepane.SelectionText(); got != "" {
+		t.Errorf("MouseMotionMsg must defer ExtendSelectionAt (coalesced); got SelectionText=%q", got)
+	}
+
+	// And it MUST have returned a Cmd that, when invoked, produces a
+	// motionFlushTickMsg (the deferred extend trigger).
+	var sawFlushTickProducer bool
+	for _, c := range drainBatchCmds(cmd) {
+		if _, ok := c().(motionFlushTickMsg); ok {
+			sawFlushTickProducer = true
+		}
+	}
+	if !sawFlushTickProducer {
+		t.Fatalf("expected a motionFlushTickMsg producer in the returned cmd")
+	}
+
+	// Sending motionFlushTickMsg explicitly applies the latched
+	// position; selection should now be non-empty.
+	_, _ = a.Update(motionFlushTickMsg{})
+	if got := a.messagepane.SelectionText(); got == "" {
+		t.Errorf("motionFlushTickMsg must apply latched position; SelectionText still empty")
+	}
+}
+
+// TestDrag_MotionCoalescing_ReleaseFlushesPending pins the contract
+// that MouseReleaseMsg force-flushes any pending motion before
+// finalizing, so the clipboard captures the most recent cursor
+// position even if the flush tick hasn't fired yet.
+func TestDrag_MotionCoalescing_ReleaseFlushesPending(t *testing.T) {
+	a := newTestAppWithMessages(t)
+	pressX := a.layout.sidebarEnd + 2
+	pressY := 4
+	_, _ = a.Update(tea.MouseClickMsg{X: pressX, Y: pressY, Button: tea.MouseLeft})
+	_, _ = a.Update(tea.MouseMotionMsg{X: pressX + 10, Y: pressY + 1, Button: tea.MouseLeft})
+	// NO motionFlushTickMsg sent -- mirrors the "user releases inside
+	// the 16 ms window" case.
+	_, cmd := a.Update(tea.MouseReleaseMsg{X: pressX + 10, Y: pressY + 1, Button: tea.MouseLeft})
+
+	var sawClipboard bool
+	for _, m := range drainBatch(cmd) {
+		if payload, ok := looksLikeSetClipboardMsg(m); ok && payload != "" {
+			sawClipboard = true
+		}
+	}
+	if !sawClipboard {
+		t.Errorf("Release must drain pending motion and emit clipboard cmd; got drained=%v", drainBatch(cmd))
+	}
+}
+
+// TestDrag_MotionCoalescing_OneTickPerBurst pins the coalescing
+// invariant: multiple MouseMotionMsg events in a row schedule AT
+// MOST one motionFlushTickMsg (the first one). Subsequent motions
+// only update the latched pending position.
+func TestDrag_MotionCoalescing_OneTickPerBurst(t *testing.T) {
+	a := newTestAppWithMessages(t)
+	pressX := a.layout.sidebarEnd + 2
+	pressY := 4
+	_, _ = a.Update(tea.MouseClickMsg{X: pressX, Y: pressY, Button: tea.MouseLeft})
+
+	countFlush := func(cmd tea.Cmd) int {
+		n := 0
+		for _, c := range drainBatchCmds(cmd) {
+			if _, ok := c().(motionFlushTickMsg); ok {
+				n++
+			}
+		}
+		return n
+	}
+
+	_, cmd1 := a.Update(tea.MouseMotionMsg{X: pressX + 1, Y: pressY + 1, Button: tea.MouseLeft})
+	_, cmd2 := a.Update(tea.MouseMotionMsg{X: pressX + 2, Y: pressY + 1, Button: tea.MouseLeft})
+	_, cmd3 := a.Update(tea.MouseMotionMsg{X: pressX + 3, Y: pressY + 1, Button: tea.MouseLeft})
+
+	if got := countFlush(cmd1); got != 1 {
+		t.Errorf("first motion in burst: want 1 motionFlushTickMsg producer; got %d", got)
+	}
+	if got := countFlush(cmd2); got != 0 {
+		t.Errorf("second motion in burst: want 0 flush producers (already scheduled); got %d", got)
+	}
+	if got := countFlush(cmd3); got != 0 {
+		t.Errorf("third motion in burst: want 0 flush producers; got %d", got)
+	}
+}
+
+// TestDrag_MotionCoalescing_TickAllowsReschedule pins the
+// flushScheduled latch reset on tick: after a motionFlushTickMsg
+// fires, the next MouseMotionMsg must be allowed to schedule a
+// fresh tick. Without this, mouse motion would freeze after the
+// first burst.
+func TestDrag_MotionCoalescing_TickAllowsReschedule(t *testing.T) {
+	a := newTestAppWithMessages(t)
+	pressX := a.layout.sidebarEnd + 2
+	pressY := 4
+	_, _ = a.Update(tea.MouseClickMsg{X: pressX, Y: pressY, Button: tea.MouseLeft})
+
+	// First motion schedules a tick.
+	_, _ = a.Update(tea.MouseMotionMsg{X: pressX + 1, Y: pressY + 1, Button: tea.MouseLeft})
+	// Fire the tick -- should reset the flushScheduled latch.
+	_, _ = a.Update(motionFlushTickMsg{})
+
+	// Next motion must schedule a new tick.
+	_, cmd := a.Update(tea.MouseMotionMsg{X: pressX + 2, Y: pressY + 1, Button: tea.MouseLeft})
+	var sawFlush bool
+	for _, c := range drainBatchCmds(cmd) {
+		if _, ok := c().(motionFlushTickMsg); ok {
+			sawFlush = true
+		}
+	}
+	if !sawFlush {
+		t.Errorf("post-tick motion must schedule a new motionFlushTickMsg; cmd produced no flush tick")
+	}
+}

--- a/internal/ui/drag.go
+++ b/internal/ui/drag.go
@@ -47,6 +47,16 @@ import (
 // autoScrollActive is the once-claim guard for the edge-autoscroll
 // tea.Tick chain; ClaimAutoScroll returns true exactly once until
 // ClearAutoScroll resets it.
+//
+// pendingX/Y/hasPending + flushScheduled implement motion coalescing.
+// MouseMotionMsg latches the latest cursor position into pending* and
+// schedules a single motionFlushTickMsg at most once per
+// motionFlushInterval. The tick applies the latched position via
+// panel.ExtendSelectionAt -- collapsing a burst of cell-motion events
+// (terminals routinely fire >100 Hz; some 1000 Hz) into one selection
+// update per tick. MouseReleaseMsg force-flushes pending so the final
+// selection captures the most recent cursor cell even if the tick has
+// not fired yet.
 type dragState struct {
 	panel            Panel
 	pressX, pressY   int
@@ -54,6 +64,10 @@ type dragState struct {
 	moved            bool
 	autoScrollActive bool
 	clickedMessage   bool
+
+	pendingX, pendingY int
+	hasPending         bool
+	flushScheduled     bool
 }
 
 func newDragState() *dragState { return &dragState{} }
@@ -140,6 +154,26 @@ func autoScrollTickCmd() tea.Cmd {
 	})
 }
 
+// motionFlushInterval is the cadence for the mouse-motion coalescing
+// flush tick. 16ms = ~60 Hz: fast enough that selection still feels
+// instantaneous, slow enough to collapse the >100 Hz cell-motion
+// stream most terminals emit while a button is held into a single
+// ExtendSelectionAt + render per tick.
+const motionFlushInterval = 16 * time.Millisecond
+
+// motionFlushTickMsg is the tick that drains dragState.hasPending
+// into the panel's selection. Scheduled by the MouseMotionMsg arm
+// (at most once per motionFlushInterval via flushScheduled).
+type motionFlushTickMsg struct{}
+
+// motionFlushTickCmd schedules the next motionFlushTickMsg. See
+// Handle's MouseMotionMsg / motionFlushTickMsg arms.
+func motionFlushTickCmd() tea.Cmd {
+	return tea.Tick(motionFlushInterval, func(time.Time) tea.Msg {
+		return motionFlushTickMsg{}
+	})
+}
+
 // Handle is the drag-FSM reducer for App.Update (Phase 4c). Owns
 // the three Update arms that read/mutate drag state:
 //
@@ -172,19 +206,29 @@ func (d *dragState) Handle(a *App, msg tea.Msg) (tea.Cmd, bool) {
 			return nil, true
 		}
 		panel, px, py, _ := a.panelAt(m.X, m.Y)
-		// Clamp to the originating pane: if the cursor leaves the
-		// pane, pin extension at the last known coordinates inside it.
+		// Drag bookkeeping (lastX/lastY/moved) MUST run every motion
+		// event even when the panel-level ExtendSelectionAt is deferred
+		// to the flush tick: MouseReleaseMsg branches on d.moved to
+		// distinguish drag-finalize from plain-click, and the
+		// autoScrollTickMsg chain reads d.LastPos() to extend selection
+		// while held against an edge.
+		//
+		// Extend ALSO clamps the (px, py) to the originating pane when
+		// the cursor leaves it, pinning the latched pending position at
+		// the last in-pane coordinates -- the same behavior we had pre-
+		// coalescing.
 		px, py = d.Extend(panel, px, py)
-		switch d.Panel() {
-		case PanelMessages:
-			a.messagepane.ExtendSelectionAt(py, px)
-		case PanelThread:
-			a.threadPanel.ExtendSelectionAt(py, px)
-		}
-		// If the cursor is at the top/bottom edge of the originating
-		// pane, schedule an auto-scroll tick. ClaimAutoScroll returns
-		// true once until ClearAutoScroll resets it, guarding against
-		// parallel tick chains accumulating.
+		// Latch the latest position for the coalescing flush tick.
+		// Subsequent motion events in the same window overwrite this
+		// without scheduling additional ticks.
+		d.pendingX, d.pendingY = px, py
+		d.hasPending = true
+
+		// Edge auto-scroll detection stays inline (NOT coalesced):
+		// the autoscroll chain is already throttled to one in-flight
+		// tick via ClaimAutoScroll + has its own 50ms cadence, and
+		// keeping it inline preserves edge-drag responsiveness even
+		// when the user is moving slowly (one motion event per cell).
 		var hint int
 		switch d.Panel() {
 		case PanelMessages:
@@ -192,8 +236,43 @@ func (d *dragState) Handle(a *App, msg tea.Msg) (tea.Cmd, bool) {
 		case PanelThread:
 			hint = a.threadPanel.ScrollHintForDrag(py)
 		}
+		var cmds []tea.Cmd
 		if hint != 0 && d.ClaimAutoScroll() {
-			return autoScrollTickCmd(), true
+			cmds = append(cmds, autoScrollTickCmd())
+		}
+		if !d.flushScheduled {
+			d.flushScheduled = true
+			cmds = append(cmds, motionFlushTickCmd())
+		}
+		switch len(cmds) {
+		case 0:
+			return nil, true
+		case 1:
+			return cmds[0], true
+		default:
+			return tea.Batch(cmds...), true
+		}
+
+	case motionFlushTickMsg:
+		_ = m
+		// Tick consumed -- allow a future MouseMotionMsg to schedule
+		// the next one. Drop pending if the drag ended (e.g. the
+		// MouseReleaseMsg arm already drained it and reset state).
+		d.flushScheduled = false
+		if !d.IsActive() {
+			d.hasPending = false
+			return nil, true
+		}
+		if !d.hasPending {
+			return nil, true
+		}
+		d.hasPending = false
+		px, py := d.pendingX, d.pendingY
+		switch d.Panel() {
+		case PanelMessages:
+			a.messagepane.ExtendSelectionAt(py, px)
+		case PanelThread:
+			a.threadPanel.ExtendSelectionAt(py, px)
 		}
 		return nil, true
 
@@ -242,6 +321,20 @@ func (d *dragState) Handle(a *App, msg tea.Msg) (tea.Cmd, bool) {
 		_ = m
 		if !d.IsActive() {
 			return nil, true
+		}
+		// Drain any pending coalesced motion BEFORE finalizing so
+		// the panel's selRange.End (and therefore the clipboard
+		// text we're about to emit) reflects the most recent
+		// cursor position even if motionFlushTickMsg has not fired
+		// since the last MouseMotionMsg.
+		if d.hasPending {
+			switch d.Panel() {
+			case PanelMessages:
+				a.messagepane.ExtendSelectionAt(d.pendingY, d.pendingX)
+			case PanelThread:
+				a.threadPanel.ExtendSelectionAt(d.pendingY, d.pendingX)
+			}
+			d.hasPending = false
 		}
 		moved, panel, clickedMessage := d.Finish()
 		if !moved {

--- a/internal/ui/messages/model.go
+++ b/internal/ui/messages/model.go
@@ -2373,7 +2373,14 @@ func (m *Model) BeginSelectionAt(viewportY, x int) {
 	}
 	m.selRange = selection.Range{Start: a, End: a, Active: true}
 	m.hasSelection = true
-	m.dirty()
+	// No m.dirty() here: the App-layer bordered render cache stores
+	// the SELECTION-FREE output (see ViewBare + ApplySelectionToBordered),
+	// so selection mutations must not bump Version() -- otherwise we
+	// invalidate the cache on every cell of mouse-drag motion and pay
+	// the multi-pass O(height x width) ansi re-border cost per cell.
+	// Bubbletea's main loop re-runs App.View() after every Update, so
+	// the new overlay is visible on the very next frame without needing
+	// a Version bump.
 }
 
 // ExtendSelectionAt updates the End anchor of the active selection.
@@ -2392,8 +2399,13 @@ func (m *Model) ExtendSelectionAt(viewportY, x int) {
 	if !ok {
 		return
 	}
+	if a == m.selRange.End {
+		return
+	}
 	m.selRange.End = a
-	m.dirty()
+	// No m.dirty() here either -- see BeginSelectionAt for the rationale.
+	// The selection lives in ApplySelectionToBordered's post-cache pass,
+	// which reads selRange directly each frame.
 }
 
 // EndSelection finalizes the drag, returning the plain-text contents of
@@ -2408,11 +2420,9 @@ func (m *Model) EndSelection() (string, bool) {
 	if m.selRange.IsEmpty() {
 		m.hasSelection = false
 		m.selRange = selection.Range{}
-		m.dirty()
 		return "", false
 	}
 	text := m.SelectionText()
-	m.dirty()
 	if text == "" {
 		return "", false
 	}
@@ -2426,7 +2436,6 @@ func (m *Model) ClearSelection() {
 	}
 	m.hasSelection = false
 	m.selRange = selection.Range{}
-	m.dirty()
 }
 
 // HasSelection reports whether a selection is currently active or
@@ -2512,7 +2521,13 @@ func (m *Model) SelectionText() string {
 	return strings.TrimRight(b.String(), "\n")
 }
 
-func (m *Model) View(height, width int) string {
+// viewInternal is the body shared by View and ViewBare. When
+// applySelection is true, the selection-highlight overlay is applied
+// to the inner content before the scrollbar overlay (preserving the
+// pre-refactor render order). When false, the overlay is skipped so
+// the App-layer cache can store a selection-free bordered output and
+// run ApplySelectionToBordered as a cheap post-pass.
+func (m *Model) viewInternal(height, width int, applySelection bool) string {
 	// Chrome (header + separator) is cached; only rebuilt on width / channel
 	// name / topic change. This avoids per-keypress strings.Repeat + lipgloss
 	// renders that don't depend on the selection.
@@ -2875,27 +2890,32 @@ func (m *Model) View(height, width int) string {
 	}
 
 	// Scroll indicators replace the first / last line when applicable.
-	// Track which rows were overridden so the selection overlay knows to
-	// leave them alone -- otherwise the overlay would re-compose the
-	// indicator line using the underlying message's plain text and
-	// corrupt the indicator.
-	overrodeFirst := false
-	overrodeLast := false
+	// applySelectionToRows recomputes the same conditions (m.loading and
+	// m.yOffset+msgAreaHeight < m.totalLines) so it can skip the override
+	// rows without us threading skip flags through -- this is what lets
+	// the bordered post-pass (ApplySelectionToBordered, which operates
+	// on cached output and so doesn't see this scope) protect indicators
+	// using the same logic.
 	if m.loading && len(visible) > 0 {
 		// Render the hint fresh per frame -- it MUST reflect the
 		// current m.spinnerFrame, which advances independently of
 		// the cache rebuild signals (width / message count). See
 		// buildCacheStyles' comment for the rationale.
 		visible[0] = m.renderLoadingOlderHint(width)
-		overrodeFirst = true
 	}
 	if m.yOffset+msgAreaHeight < m.totalLines && len(visible) > 0 {
 		visible[len(visible)-1] = m.cacheMoreBelow
-		overrodeLast = true
 	}
 
-	if m.hasSelection {
-		visible = m.applySelectionOverlay(visible, overrodeFirst, overrodeLast)
+	// Selection overlay is intentionally NOT applied here when applySelection
+	// is false. The App layer caches the bordered form of this output (keyed
+	// on Version) and overlays the selection via ApplySelectionToBordered as
+	// a cheap post-pass, so selection-only mutations no longer bust the
+	// bordered render cache. The top-level View() public method below sets
+	// applySelection=true so direct callers (tests, anything not going
+	// through the bordered cache) still see the highlighted output.
+	if applySelection && m.hasSelection {
+		m.applySelectionToRows(visible, 0, 0, msgAreaHeight)
 	}
 
 	// Overlay a 1-col scrollbar on the right of the message area when content
@@ -2907,38 +2927,73 @@ func (m *Model) View(height, width int) string {
 	return chrome + "\n" + strings.Join(visible, "\n")
 }
 
-// applySelectionOverlay re-composes lines that intersect the active
-// selection range. linesNormal supplies the original styled prefix and
-// suffix; the selected interior is rendered through styles.SelectionStyle
-// over the plain-text segment so the highlight is uniform.
+// View renders the messages pane with the selection-highlight overlay
+// applied to the inner content (unbordered). Direct callers (tests,
+// callers not going through the App-layer bordered cache) should call
+// View; the App layer calls ViewBare instead so the cached bordered
+// output stays selection-free and the cheap ApplySelectionToBordered
+// post-pass paints the selection at draw time.
+func (m *Model) View(height, width int) string {
+	return m.viewInternal(height, width, true)
+}
+
+// ViewBare renders the messages pane WITHOUT the selection-highlight
+// overlay. Used by the App-layer bordered render cache: caching the
+// selection-free output and applying the overlay via
+// ApplySelectionToBordered as a post-pass means a mouse-drag selection
+// no longer invalidates the bordered render every cell of motion.
+func (m *Model) ViewBare(height, width int) string {
+	return m.viewInternal(height, width, false)
+}
+
+// applySelectionToRows is the shared selection-overlay loop. It
+// paints the rows in `lines` covered by the active selection,
+// shifting display columns by leftColOffset to absorb any outer
+// left border.
 //
-// visible is mutated in place when possible. The selection's plain
-// columns are translated to display columns by adding the entry's
-// contentColOffset.
+// startRow is the index in `lines` where the message-area band
+// begins:
+//   - 0 when operating on the msg-area-only slice produced inside
+//     View() (called by the View wrapper at chromeHeight=0 since
+//     the slice itself contains only msg-area rows -- chrome and
+//     border live in separate strings at that point).
+//   - topBorderRows + chromeHeight when operating on the bordered
+//     output produced by the App layer (see ApplySelectionToBordered).
 //
-// skipFirst / skipLast tell the overlay to leave row 0 / row N-1 alone
-// when those rows have been replaced with scroll indicators (loading
-// hint, "more below"). Without this guard the overlay would re-compose
-// the indicator line from the underlying entry's plain text, corrupting
-// the indicator.
-func (m *Model) applySelectionOverlay(visible []string, skipFirst, skipLast bool) []string {
+// msgAreaHeight is the number of message-area rows. Scroll-indicator
+// rows (loading hint at vRow=0 when m.loading, "more below" at
+// vRow=msgAreaHeight-1 when content exceeds the viewport) are
+// skipped so the overlay does not corrupt them.
+//
+// Mutates lines in place. No-op when !m.hasSelection or the
+// selection resolves to empty.
+func (m *Model) applySelectionToRows(lines []string, startRow, leftColOffset, msgAreaHeight int) {
+	if !m.hasSelection {
+		return
+	}
 	loA, hiA := m.selRange.Normalize()
 	loLine, loCol, ok1 := m.resolveAnchor(loA)
 	hiLine, hiCol, ok2 := m.resolveAnchor(hiA)
 	if !ok1 || !ok2 {
-		return visible
+		return
 	}
 	if loLine > hiLine || (loLine == hiLine && loCol >= hiCol) {
-		return visible
+		return
 	}
+	overrodeFirst := m.loading
+	overrodeLast := m.yOffset+msgAreaHeight < m.totalLines
 
 	selStyle := styles.SelectionStyle()
 
-	for row := 0; row < len(visible); row++ {
-		if (row == 0 && skipFirst) || (row == len(visible)-1 && skipLast) {
+	for vRow := 0; vRow < msgAreaHeight; vRow++ {
+		row := startRow + vRow
+		if row < 0 || row >= len(lines) {
 			continue
 		}
-		absLine := m.yOffset + row
+		if (vRow == 0 && overrodeFirst) || (vRow == msgAreaHeight-1 && overrodeLast) {
+			continue
+		}
+		absLine := m.yOffset + vRow
 		if absLine < loLine || absLine > hiLine {
 			continue
 		}
@@ -2960,10 +3015,10 @@ func (m *Model) applySelectionOverlay(visible []string, skipFirst, skipLast bool
 			continue
 		}
 		plain := e.linesPlain[j]
-		styled := visible[row]
+		styled := lines[row]
 
 		// from / to are PLAIN columns. They become display columns by
-		// adding contentColOffset.
+		// adding contentColOffset + leftColOffset.
 		from := 0
 		to := displayWidthOfPlain(plain)
 		if absLine == loLine {
@@ -2981,9 +3036,8 @@ func (m *Model) applySelectionOverlay(visible []string, skipFirst, skipLast bool
 		if from >= to {
 			continue
 		}
-		// Translate to display columns.
-		dispFrom := from + e.contentColOffset
-		dispTo := to + e.contentColOffset
+		dispFrom := from + e.contentColOffset + leftColOffset
+		dispTo := to + e.contentColOffset + leftColOffset
 
 		styledWidth := ansi.StringWidth(styled)
 		if dispFrom >= styledWidth {
@@ -2995,9 +3049,36 @@ func (m *Model) applySelectionOverlay(visible []string, skipFirst, skipLast bool
 		prefix := ansi.Cut(styled, 0, dispFrom)
 		suffix := ansi.Cut(styled, dispTo, styledWidth)
 		seg := sliceColumns(plain, from, to)
-		visible[row] = prefix + selStyle.Render(seg) + suffix
+		lines[row] = prefix + selStyle.Render(seg) + suffix
 	}
-	return visible
+}
+
+// ApplySelectionToBordered overlays the active selection on top of
+// a pre-bordered, pre-cached pane output produced by the App layer.
+// Splitting the overlay out of View() lets the App layer cache the
+// (selection-free) bordered output keyed on messagepane.Version()
+// and survive selection-only mutations: the cache key no longer
+// churns on every cell of mouse-drag motion, which used to invalidate
+// the bordered render (a multi-pass O(height x width) ansi-aware
+// re-render) on every cell.
+//
+// topBorderRows is the number of border rows above the chrome
+// (1 for the standard top-bordered panel). leftBorderCols is the
+// number of border columns at the start of each row (1 for the
+// standard side-bordered panel).
+//
+// No-op when there is no active selection or the model has not
+// rendered yet (lastViewHeight == 0).
+func (m *Model) ApplySelectionToBordered(bordered string, topBorderRows, leftBorderCols int) string {
+	if !m.hasSelection {
+		return bordered
+	}
+	if m.lastViewHeight <= 0 {
+		return bordered
+	}
+	lines := strings.Split(bordered, "\n")
+	m.applySelectionToRows(lines, topBorderRows+m.chromeHeight, leftBorderCols, m.lastViewHeight)
+	return strings.Join(lines, "\n")
 }
 
 // DateFromTS returns the local-day date string ("2006-01-02") for a

--- a/internal/ui/messages/selection_test.go
+++ b/internal/ui/messages/selection_test.go
@@ -361,3 +361,100 @@ func TestSelection_FirstContentRowAnchorsAtFirstMessage(t *testing.T) {
 		t.Fatalf("expected first-message content; got %q", text)
 	}
 }
+
+// TestSelection_ExtendUnchangedDoesNotDirty guards the mouse-drag
+// perf hot path: with MouseModeCellMotion the terminal emits a
+// MouseMotionMsg for every cell the cursor traverses while the
+// button is held, and many of those cells resolve to the same
+// snapped end-anchor. Bumping m.version on each one invalidates
+// the bordered-messages render cache for no reason. ExtendSelectionAt
+// must early-out (no version bump) when the resolved end anchor
+// matches the current m.selRange.End.
+func TestSelection_ExtendUnchangedDoesNotDirty(t *testing.T) {
+	m := newTestModel(60)
+	m.BeginSelectionAt(firstContentY(m), 0)
+	// First extend establishes a real end anchor and dirties.
+	m.ExtendSelectionAt(firstContentY(m)+1, 10)
+	end := m.selRange.End
+	beforeVersion := m.version
+
+	// Re-call with the exact same coordinates: the resolved end
+	// anchor must be identical and no version bump should occur.
+	m.ExtendSelectionAt(firstContentY(m)+1, 10)
+
+	if m.selRange.End != end {
+		t.Fatalf("selRange.End drifted across identical Extend: before=%+v after=%+v", end, m.selRange.End)
+	}
+	if m.version != beforeVersion {
+		t.Errorf("ExtendSelectionAt with unchanged end anchor must not bump version (before=%d after=%d)", beforeVersion, m.version)
+	}
+}
+
+// TestSelection_MutationsDoNotBumpVersion is the perf invariant for
+// the selection-as-post-cache-overlay refactor: the App-level
+// bordered-messages cache (keyed on messagepane.Version) must
+// survive ANY selection mutation, including character-granularity
+// extends where the resolved end anchor genuinely changes every
+// cell. The selection is now applied as a post-pass over the
+// cached bordered output (see Model.ApplySelectionToBordered),
+// so Begin / Extend / End / Clear must NOT bump version.
+func TestSelection_MutationsDoNotBumpVersion(t *testing.T) {
+	m := newTestModel(60)
+	_ = m.View(40, 60) // prime cache
+	v0 := m.version
+
+	m.BeginSelectionAt(firstContentY(m), 0)
+	if m.version != v0 {
+		t.Errorf("BeginSelectionAt bumped version: before=%d after=%d", v0, m.version)
+	}
+	// Drag character-by-character — each Extend resolves to a
+	// distinct end anchor (Col advances by 1 every call).
+	for col := 1; col <= 8; col++ {
+		m.ExtendSelectionAt(firstContentY(m)+1, col)
+		if m.version != v0 {
+			t.Errorf("ExtendSelectionAt(col=%d) bumped version: before=%d after=%d", col, v0, m.version)
+		}
+	}
+	_, _ = m.EndSelection()
+	if m.version != v0 {
+		t.Errorf("EndSelection bumped version: before=%d after=%d", v0, m.version)
+	}
+	m.ClearSelection()
+	if m.version != v0 {
+		t.Errorf("ClearSelection bumped version: before=%d after=%d", v0, m.version)
+	}
+}
+
+// TestApplySelectionToBordered_OverlaysOnContentRows is a unit
+// test for the new post-cache overlay path. The function operates
+// on a bordered-output string (top border row + chrome rows +
+// message-area rows, sided by left/right border columns), and must:
+//   - leave rows above the message area (border + chrome) untouched
+//   - apply the selection style inside the message-area band,
+//     shifted by leftBorderCols so the border column at col 0 is
+//     preserved verbatim.
+//
+// Returns the bordered string with the SelectionStyle ANSI sequence
+// injected on the row(s) intersected by the selection.
+func TestApplySelectionToBordered_OverlaysOnContentRows(t *testing.T) {
+	m := newTestModel(60)
+	bare := m.ViewBare(40, 60)
+	// No selection set — function must be an identity.
+	if got := m.ApplySelectionToBordered(bare, 0, 0); got != bare {
+		t.Fatal("ApplySelectionToBordered with no selection must return input unchanged")
+	}
+
+	// Now set a selection that covers a known content row (firstContentY+1
+	// is one row past the date separator -- inside msg1).
+	y := firstContentY(m) + 1
+	m.BeginSelectionAt(y, 5)
+	m.ExtendSelectionAt(y, 15)
+	// View() applies the overlay internally; that's our reference output
+	// for the unbordered case (topBorderRows=0, leftBorderCols=0).
+	withOverlayViaView := m.View(40, 60)
+	withOverlayViaApply := m.ApplySelectionToBordered(bare, 0, 0)
+	if withOverlayViaApply != withOverlayViaView {
+		t.Fatalf("ApplySelectionToBordered(0,0) must match View() overlay output\nwant:\n%q\ngot:\n%q",
+			withOverlayViaView, withOverlayViaApply)
+	}
+}

--- a/internal/ui/thread/model.go
+++ b/internal/ui/thread/model.go
@@ -858,6 +858,15 @@ func (m *Model) ExtendSelectionAt(viewportY, x int) {
 	if !ok {
 		return
 	}
+	// Perf: MouseModeCellMotion fires a MouseMotionMsg for every
+	// cell traversed while the button is held, and many of those
+	// cells resolve (via anchorAt) to the same end anchor. Bumping
+	// m.version unconditionally would bust the thread-pane render
+	// cache on every motion event. Skip the dirty when nothing
+	// actually changed.
+	if a == m.selRange.End {
+		return
+	}
 	m.selRange.End = a
 	m.dirty()
 }

--- a/internal/ui/thread/selection_test.go
+++ b/internal/ui/thread/selection_test.go
@@ -165,3 +165,30 @@ func TestThreadSelection_FirstContentRowAnchorsAtFirstReply(t *testing.T) {
 		t.Fatalf("expected first-reply content; got %q", text)
 	}
 }
+
+// TestThreadSelection_ExtendUnchangedDoesNotDirty mirrors the messages-
+// pane perf guard: with MouseModeCellMotion the terminal emits a
+// MouseMotionMsg for every cell traversed while the button is held,
+// and many of those resolve to the same end anchor. Bumping
+// m.version on each one needlessly invalidates the thread-pane
+// render cache. ExtendSelectionAt must early-out when the resolved
+// end anchor matches the current m.selRange.End.
+func TestThreadSelection_ExtendUnchangedDoesNotDirty(t *testing.T) {
+	m := newTestThread()
+	m.BeginSelectionAt(firstContentY(m), 0)
+	// First extend establishes a real end anchor and dirties.
+	m.ExtendSelectionAt(firstContentY(m)+1, 10)
+	end := m.selRange.End
+	beforeVersion := m.version
+
+	// Re-call with the exact same coordinates: the resolved end
+	// anchor must be identical and no version bump should occur.
+	m.ExtendSelectionAt(firstContentY(m)+1, 10)
+
+	if m.selRange.End != end {
+		t.Fatalf("selRange.End drifted across identical Extend: before=%+v after=%+v", end, m.selRange.End)
+	}
+	if m.version != beforeVersion {
+		t.Errorf("ExtendSelectionAt with unchanged end anchor must not bump version (before=%d after=%d)", beforeVersion, m.version)
+	}
+}

--- a/internal/ui/view_messages.go
+++ b/internal/ui/view_messages.go
@@ -183,11 +183,17 @@ func (a *App) renderChannelMessagesPanel(msgWidth, msgBorder, contentHeight int,
 		msgContentHeight = 3
 	}
 
-	// Cached top region: messages + top edge + side edges.
+	// Cached top region: messages + top edge + side edges. The cache
+	// stores the SELECTION-FREE bordered output (see ViewBare +
+	// ApplySelectionToBordered below): selection mutations no longer
+	// bump messagepane.Version, so a mouse-drag's per-cell extends do
+	// not invalidate this cache. The selection is overlaid as a cheap
+	// post-pass against the cached output.
 	topPanelVersion := a.messagepane.Version()
 	topLayoutKey := msgLayoutKey | int64(composeHeight)<<16
 	topHeight := msgContentHeight + 1 // +1 for top border edge
 	topBordered := a.renderMessagesTop(msgWidth, msgBorder, topHeight, msgContentHeight, topPanelVersion, topLayoutKey, msgFocused)
+	topBordered = a.messagepane.ApplySelectionToBordered(topBordered, 1, 1)
 
 	// Fresh bottom region: typing line + compose, with bottom
 	// edge. Same lipgloss/v2 quirk applies.
@@ -223,7 +229,10 @@ func (a *App) renderMessagesTop(msgWidth, msgBorder, topHeight, msgContentHeight
 		topBorderStyle = styles.FocusedBorder.Width(msgWidth).
 			BorderTop(true).BorderLeft(true).BorderRight(true).BorderBottom(false)
 	}
-	msgView := a.messagepane.View(msgContentHeight, msgWidth-2)
+	// ViewBare (not View) so the cached output is selection-free; the
+	// caller composes ApplySelectionToBordered on top of the cache return,
+	// keeping the bordered re-render off the mouse-drag hot path.
+	msgView := a.messagepane.ViewBare(msgContentHeight, msgWidth-2)
 	msgView = messages.ReapplyBgAfterResets(msgView, messages.BgANSI())
 	out := exactSize(
 		topBorderStyle.Render(msgView),


### PR DESCRIPTION
Mouse-drag text selection in the messages pane was slow because every cell of motion bumped `messagepane.Version`, which invalidated the bordered-panel render cache and forced a full multi-pass ansi-aware re-render per cell. This PR layers three independent fixes.

## What's in the box

### 1. `ExtendSelectionAt` early-out (messages + thread)
Skip `m.dirty()` in both `messages.Model` and `thread.Model` when the snapped end-anchor matches `selRange.End`. Many cell-motion events resolve to the same anchor (the message-row snap is coarse), so this alone collapses a sub-word drag from one cache miss per cell to one per anchor crossing.

### 2. Selection-as-post-cache overlay (messages pane)
Refactored `messages.Model`:
- `View(height, width)` is now a thin wrapper over a new `viewInternal(height, width, applySelection bool)` that gates the in-View selection overlay step.
- New `ViewBare(height, width)` returns the selection-free inner content.
- New `ApplySelectionToBordered(bordered, topBorderRows, leftBorderCols)` overlays selection on the post-border output via a generalized `applySelectionToRows` helper.
- `view_messages.renderMessagesTop` now caches the selection-free bordered output (keyed on `Version`) and runs the cheap overlay as a post-pass each frame.
- `Begin/Extend/End/ClearSelection` no longer call `m.dirty()`. Result: selection mutations no longer bump `Version` at all in the messages pane, so the bordered cache survives an entire character-granularity drag.

### 3. Motion event coalescing
- `dragState` gains `pendingX/Y` + `hasPending` + `flushScheduled`.
- `MouseMotionMsg` latches the latest cursor position and schedules a single `motionFlushTickMsg` per 16ms window (~60Hz cap) instead of calling `ExtendSelectionAt` synchronously. `drag.Extend` (which sets `moved` and updates `lastX/Y`) still runs every event because Release and the autoscroll chain depend on those.
- `motionFlushTickMsg` drains pending into `panel.ExtendSelectionAt`.
- `MouseReleaseMsg` force-flushes pending before finalizing so the clipboard text captures the final cursor cell even when release happens inside the 16ms window.
- Edge auto-scroll detection stays inline; its chain already throttles via `ClaimAutoScroll`.

## Scope

Messages pane gets the full treatment (1 + 2 + 3). Thread pane gets only (1) because its `viewport.SetContent` flow needs a different refactor for (2); leaving that for a follow-up.

## Tests added

- `TestSelection_ExtendUnchangedDoesNotDirty` (messages + thread) — pins the early-out for the coarse-snap case.
- `TestSelection_MutationsDoNotBumpVersion` — pins the perf invariant that `Begin/Extend/End/Clear` never bump `messagepane.Version`, including per-cell character-granularity extends.
- `TestApplySelectionToBordered_OverlaysOnContentRows` — round-trips the new post-cache overlay against `View()`'s in-view overlay (with `topBorderRows=0, leftBorderCols=0`).
- `TestDrag_MotionCoalescing_DefersExtendSelectionAt` — Motion does NOT extend selection until tick fires.
- `TestDrag_MotionCoalescing_ReleaseFlushesPending` — Release force-flushes pending so the clipboard is correct even mid-window.
- `TestDrag_MotionCoalescing_OneTickPerBurst` — multiple motions schedule at most one flush tick.
- `TestDrag_MotionCoalescing_TickAllowsReschedule` — after a tick fires, the next motion can schedule a new one.

Full suite passes (`go test ./...`), `go vet ./...` and `go build ./...` clean.

## Known limit

Even with these fixes, native terminal selection (Shift-drag on most terminals; Option-drag on macOS Terminal.app) is still faster than the in-app path — the in-app round trip (terminal → PTY → Update → View → PTY → terminal) has an irreducible latency floor that native selection (entirely inside the terminal emulator) doesn't pay. The in-app selection's value-add is message-aware copy (chrome stripped, ordered by row, etc.) for users who specifically want that.

A potential follow-up is exposing a config flag (e.g. `appearance.mouse = "off"`) that sets `tea.MouseModeNone` and disables click reducers, giving users who prefer truly native selection an opt-out — at the cost of click-to-open-thread, click-to-react, click-on-rail, etc. Not included here.

## Note on commit granularity

This is one commit because the three fixes share `internal/ui/messages/model.go` and `internal/ui/messages/selection_test.go` heavily; splitting them cleanly would require disentangling the diff in ways that hurt readability. Happy to split into 3 commits along the (1)/(2)/(3) seams if you'd prefer.