### PR TITLE
feat(sections): order channels within a section via ":N" suffix

### DIFF
--- a/cmd/slk/channelitem.go
+++ b/cmd/slk/channelitem.go
@@ -62,10 +62,13 @@ func buildChannelItem(ch slack.Channel, wctx *WorkspaceContext, cfg config.Confi
 		}
 	}
 	var sectionOrder int
+	var channelOrder int
 	if section == "" {
-		section = cfg.MatchSection(teamID, ch.Name)
+		var matchedOrder int
+		section, matchedOrder = cfg.MatchSectionAndOrder(teamID, ch.Name)
 		if section != "" {
 			sectionOrder = cfg.SectionOrder(teamID, section)
+			channelOrder = matchedOrder
 		}
 	}
 
@@ -80,6 +83,7 @@ func buildChannelItem(ch slack.Channel, wctx *WorkspaceContext, cfg config.Confi
 		Type:         chType,
 		Section:      section,
 		SectionOrder: sectionOrder,
+		ChannelOrder: channelOrder,
 		IsMuted:      muted,
 	}
 	if ch.IsIM {

--- a/cmd/slk/channelitem_test.go
+++ b/cmd/slk/channelitem_test.go
@@ -195,6 +195,79 @@ func TestBuildChannelItem_StoreNil_UsesGlob(t *testing.T) {
 	}
 }
 
+func TestBuildChannelItem_GlobMatchPopulatesChannelOrder(t *testing.T) {
+	// Config-mode (no SectionStore): the "<pattern>:<N>" suffix on a
+	// channel entry should land on the resulting ChannelItem's
+	// ChannelOrder field, where the sidebar comparator picks it up.
+	cfg := config.Config{
+		Sections: map[string]config.SectionDef{
+			"Eng": {Channels: []string{"eng-general:1", "eng-*:5"}, Order: 1},
+		},
+	}
+	wctx := &WorkspaceContext{
+		SectionStore:      nil,
+		UserNames:         map[string]string{},
+		UserNamesByHandle: map[string]string{},
+		BotUserIDs:        map[string]bool{},
+	}
+	// "eng-general" matches the literal pattern first → order 1.
+	ch1 := slack.Channel{
+		GroupConversation: slack.GroupConversation{
+			Conversation: slack.Conversation{ID: "C1"},
+			Name:         "eng-general",
+		},
+	}
+	item1, _ := buildChannelItem(ch1, wctx, cfg, "T1")
+	if item1.Section != "Eng" {
+		t.Errorf("Section = %q, want Eng", item1.Section)
+	}
+	if item1.ChannelOrder != 1 {
+		t.Errorf("ChannelOrder = %d, want 1", item1.ChannelOrder)
+	}
+	// "eng-alerts" matches the glob → order 5.
+	ch2 := slack.Channel{
+		GroupConversation: slack.GroupConversation{
+			Conversation: slack.Conversation{ID: "C2"},
+			Name:         "eng-alerts",
+		},
+	}
+	item2, _ := buildChannelItem(ch2, wctx, cfg, "T1")
+	if item2.ChannelOrder != 5 {
+		t.Errorf("ChannelOrder = %d, want 5 (glob match)", item2.ChannelOrder)
+	}
+}
+
+func TestBuildChannelItem_SlackStoreWins_ChannelOrderZero(t *testing.T) {
+	// In Slack-native mode, ChannelOrder must remain 0 — the ":N"
+	// suffix syntax is a config-glob-only feature. Even if a config
+	// glob would have matched, the SectionStore claim short-circuits
+	// the lookup, and the resulting item carries no ChannelOrder.
+	cfg := config.Config{
+		Sections: map[string]config.SectionDef{
+			"Eng": {Channels: []string{"alerts-*:9"}, Order: 1},
+		},
+	}
+	wctx := &WorkspaceContext{
+		SectionStore:      bootstrappedStore(t, map[string][]string{"L_SLACK": {"C1"}}),
+		UserNames:         map[string]string{},
+		UserNamesByHandle: map[string]string{},
+		BotUserIDs:        map[string]bool{},
+	}
+	ch := slack.Channel{
+		GroupConversation: slack.GroupConversation{
+			Conversation: slack.Conversation{ID: "C1"},
+			Name:         "alerts-prod",
+		},
+	}
+	item, _ := buildChannelItem(ch, wctx, cfg, "T1")
+	if item.Section != "L_SLACK" {
+		t.Fatalf("precondition: Section = %q, want L_SLACK", item.Section)
+	}
+	if item.ChannelOrder != 0 {
+		t.Errorf("ChannelOrder = %d, want 0 in Slack-native mode", item.ChannelOrder)
+	}
+}
+
 func TestBuildChannelItem_StoreNotReady_UsesGlob(t *testing.T) {
 	cfg := config.Config{
 		Sections: map[string]config.SectionDef{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
+	"strings"
 
 	toml "github.com/pelletier/go-toml/v2"
 )
@@ -25,9 +27,37 @@ type Config struct {
 // SectionDef defines a sidebar section with channel name patterns.
 // Channels matching any pattern are placed in this section.
 // Patterns support simple glob matching (* for any characters).
+//
+// Each entry in Channels may optionally carry a per-channel sort
+// suffix of the form "<pattern>:<N>" where N is a non-negative
+// integer. Channels matching a pattern with an explicit N are placed
+// above un-annotated channels within the section, sorted by N
+// ascending. Example: channels = ["general:1", "alerts:2", "random"].
+// The ":N" syntax is only honored when use_slack_sections = false
+// (or as a fallback when Slack's section endpoint is unreachable);
+// in Slack-native mode, channel order is taken from Slack.
 type SectionDef struct {
 	Channels []string `toml:"channels"`
 	Order    int      `toml:"order"` // lower = higher in sidebar
+}
+
+// parseChannelPattern splits a "<pattern>:<N>" config entry into its
+// pattern and order components. If the suffix after the last ':' is
+// not a non-negative integer, the whole input is returned as the
+// pattern with order 0 (so e.g. accidentally-included colons in
+// patterns are treated as literal characters, not orders). Slack
+// channel names cannot contain ':', so well-formed configs are never
+// ambiguous.
+func parseChannelPattern(s string) (pattern string, order int) {
+	i := strings.LastIndex(s, ":")
+	if i < 0 {
+		return s, 0
+	}
+	n, err := strconv.Atoi(s[i+1:])
+	if err != nil || n < 0 {
+		return s, 0
+	}
+	return s[:i], n
 }
 
 type General struct {
@@ -225,11 +255,21 @@ func (c Config) TeamIDForDefaultWorkspace() (string, error) {
 // otherwise the global Sections apply. Returns "" if no pattern
 // matches.
 func (c Config) MatchSection(teamID, channelName string) string {
+	section, _ := c.MatchSectionAndOrder(teamID, channelName)
+	return section
+}
+
+// MatchSectionAndOrder is like MatchSection but also returns the
+// per-channel sort order encoded in the matching pattern's ":N"
+// suffix (see SectionDef). Returns ("", 0) when no pattern matches,
+// and (sectionName, 0) when the matching pattern has no explicit
+// order suffix.
+func (c Config) MatchSectionAndOrder(teamID, channelName string) (string, int) {
 	sections := c.Sections
 	if ws, ok := c.WorkspaceByTeamID(teamID); ok && len(ws.Sections) > 0 {
 		sections = ws.Sections
 	}
-	return matchSectionIn(sections, channelName)
+	return matchSectionAndOrderIn(sections, channelName)
 }
 
 // SectionOrder returns the Order field for the named section,
@@ -249,6 +289,15 @@ func (c Config) SectionOrder(teamID, sectionName string) int {
 // matchSectionIn walks sections in Order-ascending order and returns
 // the first section name whose patterns match channelName.
 func matchSectionIn(sections map[string]SectionDef, channelName string) string {
+	name, _ := matchSectionAndOrderIn(sections, channelName)
+	return name
+}
+
+// matchSectionAndOrderIn is the order-aware sibling of matchSectionIn.
+// It also returns the per-channel order encoded in the matching
+// pattern's ":N" suffix (0 if absent). Patterns are stripped of any
+// ":N" suffix before being passed to filepath.Match.
+func matchSectionAndOrderIn(sections map[string]SectionDef, channelName string) (string, int) {
 	type entry struct {
 		name     string
 		order    int
@@ -262,13 +311,14 @@ func matchSectionIn(sections map[string]SectionDef, channelName string) string {
 		return entries[i].order < entries[j].order
 	})
 	for _, e := range entries {
-		for _, pattern := range e.patterns {
+		for _, raw := range e.patterns {
+			pattern, chOrder := parseChannelPattern(raw)
 			if matched, _ := filepath.Match(pattern, channelName); matched {
-				return e.name
+				return e.name, chOrder
 			}
 		}
 	}
-	return ""
+	return "", 0
 }
 
 // EffectiveUseSlackSections returns whether Slack-native sidebar sections

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -286,17 +286,11 @@ func (c Config) SectionOrder(teamID, sectionName string) int {
 	return 0
 }
 
-// matchSectionIn walks sections in Order-ascending order and returns
-// the first section name whose patterns match channelName.
-func matchSectionIn(sections map[string]SectionDef, channelName string) string {
-	name, _ := matchSectionAndOrderIn(sections, channelName)
-	return name
-}
-
-// matchSectionAndOrderIn is the order-aware sibling of matchSectionIn.
-// It also returns the per-channel order encoded in the matching
-// pattern's ":N" suffix (0 if absent). Patterns are stripped of any
-// ":N" suffix before being passed to filepath.Match.
+// matchSectionAndOrderIn walks sections in Order-ascending order and
+// returns the first section name whose patterns match channelName,
+// along with the per-channel order encoded in the matching pattern's
+// ":N" suffix (0 if absent). Patterns are stripped of any ":N" suffix
+// before being passed to filepath.Match.
 func matchSectionAndOrderIn(sections map[string]SectionDef, channelName string) (string, int) {
 	type entry struct {
 		name     string

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -619,3 +619,106 @@ func TestEffectiveUseSlackSections_UnknownTeamUsesGlobal(t *testing.T) {
 		t.Errorf("unknown team should fall through to global=false")
 	}
 }
+
+func TestMatchSectionAndOrder_ExplicitOrder(t *testing.T) {
+	c := Config{
+		Sections: map[string]SectionDef{
+			"Eng": {Channels: []string{"eng-general:1", "eng-alerts:2"}, Order: 1},
+		},
+	}
+	if section, order := c.MatchSectionAndOrder("", "eng-general"); section != "Eng" || order != 1 {
+		t.Errorf(`MatchSectionAndOrder("eng-general") = (%q, %d), want ("Eng", 1)`, section, order)
+	}
+	if section, order := c.MatchSectionAndOrder("", "eng-alerts"); section != "Eng" || order != 2 {
+		t.Errorf(`MatchSectionAndOrder("eng-alerts") = (%q, %d), want ("Eng", 2)`, section, order)
+	}
+}
+
+func TestMatchSectionAndOrder_NoOrderDefaultsZero(t *testing.T) {
+	c := Config{
+		Sections: map[string]SectionDef{
+			"Eng": {Channels: []string{"eng-general"}, Order: 1},
+		},
+	}
+	if section, order := c.MatchSectionAndOrder("", "eng-general"); section != "Eng" || order != 0 {
+		t.Errorf(`MatchSectionAndOrder = (%q, %d), want ("Eng", 0)`, section, order)
+	}
+}
+
+func TestMatchSectionAndOrder_GlobPattern(t *testing.T) {
+	c := Config{
+		Sections: map[string]SectionDef{
+			"Team": {Channels: []string{"team-*:5"}, Order: 1},
+		},
+	}
+	if section, order := c.MatchSectionAndOrder("", "team-alpha"); section != "Team" || order != 5 {
+		t.Errorf(`MatchSectionAndOrder("team-alpha") = (%q, %d), want ("Team", 5)`, section, order)
+	}
+}
+
+func TestMatchSectionAndOrder_NonNumericSuffixTreatedAsLiteral(t *testing.T) {
+	// "weird:abc" — suffix after colon is not an integer. Whole thing
+	// is the pattern; order defaults to 0. Slack channel names can't
+	// contain colons, so this match will only succeed if a user
+	// literally configures such a pattern; we don't error on it.
+	c := Config{
+		Sections: map[string]SectionDef{
+			"Misc": {Channels: []string{"weird:abc"}, Order: 1},
+		},
+	}
+	// The literal pattern matches the literal string "weird:abc".
+	if section, order := c.MatchSectionAndOrder("", "weird:abc"); section != "Misc" || order != 0 {
+		t.Errorf(`MatchSectionAndOrder("weird:abc") = (%q, %d), want ("Misc", 0)`, section, order)
+	}
+	// And "weird" alone does NOT match (we did not split off the :abc).
+	if section, _ := c.MatchSectionAndOrder("", "weird"); section != "" {
+		t.Errorf(`MatchSectionAndOrder("weird") = %q, want "" (no split for non-numeric suffix)`, section)
+	}
+}
+
+func TestMatchSectionAndOrder_NoMatchReturnsEmpty(t *testing.T) {
+	c := Config{
+		Sections: map[string]SectionDef{
+			"Eng": {Channels: []string{"eng-*:1"}, Order: 1},
+		},
+	}
+	if section, order := c.MatchSectionAndOrder("", "random"); section != "" || order != 0 {
+		t.Errorf(`MatchSectionAndOrder("random") = (%q, %d), want ("", 0)`, section, order)
+	}
+}
+
+func TestMatchSection_BackwardCompatWithOrderSuffix(t *testing.T) {
+	// Existing MatchSection must keep working when patterns use the
+	// new ":N" suffix syntax — it just discards the order.
+	c := Config{
+		Sections: map[string]SectionDef{
+			"Eng": {Channels: []string{"eng-general:3"}, Order: 1},
+		},
+	}
+	if got := c.MatchSection("", "eng-general"); got != "Eng" {
+		t.Errorf(`MatchSection("eng-general") = %q, want "Eng"`, got)
+	}
+}
+
+func TestMatchSectionAndOrder_WorkspaceOverride(t *testing.T) {
+	c := Config{
+		Sections: map[string]SectionDef{
+			"GlobalEng": {Channels: []string{"eng-*:1"}, Order: 1},
+		},
+		Workspaces: map[string]Workspace{
+			"work": {
+				TeamID: "T01",
+				Sections: map[string]SectionDef{
+					"WorkAlerts": {Channels: []string{"alerts:7"}, Order: 1},
+				},
+			},
+		},
+	}
+	if section, order := c.MatchSectionAndOrder("T01", "alerts"); section != "WorkAlerts" || order != 7 {
+		t.Errorf(`MatchSectionAndOrder("T01","alerts") = (%q, %d), want ("WorkAlerts", 7)`, section, order)
+	}
+	// Global is shadowed for T01.
+	if section, _ := c.MatchSectionAndOrder("T01", "eng-foo"); section != "" {
+		t.Errorf(`MatchSectionAndOrder("T01","eng-foo") = %q, want "" (workspace shadows global)`, section)
+	}
+}

--- a/internal/ui/sidebar/model.go
+++ b/internal/ui/sidebar/model.go
@@ -33,6 +33,12 @@ type ChannelItem struct {
 	Type         string // channel, dm, group_dm, private, app
 	Section      string // section name for grouping (e.g. "Engineering", "Starred")
 	SectionOrder int    // sort order from config; lower = higher in sidebar (custom sections only)
+	// ChannelOrder is the per-channel sort position within a section,
+	// sourced from the SectionDef "<pattern>:<N>" suffix syntax. >0
+	// means the channel sorts ahead of un-annotated peers (which fall
+	// back to input order); among annotated channels, lower wins.
+	// Always 0 in Slack-native sections mode (config-glob feature only).
+	ChannelOrder int
 	IsStarred    bool
 	Presence     string // for DMs: active, away, dnd
 	DMUserID     string // for DMs: the user ID of the other party
@@ -865,19 +871,35 @@ func (m *Model) rebuildFilter() {
 
 	// Sort filtered indices to match the visual section display order so that
 	// j/k navigation traverses items in the same order they're rendered.
-	// Within a section, preserve the original (Slack-provided) item order.
+	// Within a section:
+	//   1. Channels with ChannelOrder > 0 come first, sorted ascending
+	//      (from SectionDef "<pattern>:<N>" suffixes; config-mode only).
+	//   2. Channels with ChannelOrder == 0 follow, in input order
+	//      (preserves Slack-provided order in Slack mode, and
+	//      bootstrap-order in config mode without ":N" suffixes).
 	sectionOrder := m.modelOrderedSections(m.filtered)
 	rank := make(map[string]int, len(sectionOrder))
 	for i, name := range sectionOrder {
 		rank[name] = i
 	}
 	sort.SliceStable(m.filtered, func(a, b int) bool {
-		ra := rank[m.sectionFor(m.items[m.filtered[a]])]
-		rb := rank[m.sectionFor(m.items[m.filtered[b]])]
+		ia, ib := m.filtered[a], m.filtered[b]
+		ra := rank[m.sectionFor(m.items[ia])]
+		rb := rank[m.sectionFor(m.items[ib])]
 		if ra != rb {
 			return ra < rb
 		}
-		return m.filtered[a] < m.filtered[b]
+		// Within a section: annotated (ChannelOrder > 0) before
+		// un-annotated; among annotated, lower wins; among
+		// un-annotated, preserve input order via stable sort.
+		oa, ob := m.items[ia].ChannelOrder, m.items[ib].ChannelOrder
+		if (oa > 0) != (ob > 0) {
+			return oa > 0
+		}
+		if oa != ob {
+			return oa < ob
+		}
+		return ia < ib
 	})
 }
 

--- a/internal/ui/sidebar/model_test.go
+++ b/internal/ui/sidebar/model_test.go
@@ -681,6 +681,68 @@ func TestView_RendersDotFromReadStateReader(t *testing.T) {
 	}
 }
 
+// TestRebuildFilter_OrdersChannelsWithinSectionByChannelOrder verifies
+// that within a section, channels with an explicit ChannelOrder > 0
+// sort ahead of un-annotated channels (input order), and that
+// annotated channels are themselves sorted by ChannelOrder ascending.
+// This is the config-mode (use_slack_sections=false) behavior driven
+// by the SectionDef "<pattern>:<N>" suffix syntax.
+func TestRebuildFilter_OrdersChannelsWithinSectionByChannelOrder(t *testing.T) {
+	// Inserted in deliberately scrambled input order. All in the
+	// same custom section "Eng" so the section-rank tie-breaker is
+	// what's being tested.
+	items := []ChannelItem{
+		{ID: "C1", Name: "alpha", Type: "channel", Section: "Eng", SectionOrder: 1, ChannelOrder: 0},
+		{ID: "C2", Name: "beta", Type: "channel", Section: "Eng", SectionOrder: 1, ChannelOrder: 2},
+		{ID: "C3", Name: "gamma", Type: "channel", Section: "Eng", SectionOrder: 1, ChannelOrder: 0},
+		{ID: "C4", Name: "delta", Type: "channel", Section: "Eng", SectionOrder: 1, ChannelOrder: 1},
+	}
+	m := New(items)
+
+	// Collect IDs in filtered (display) order.
+	var got []string
+	for _, idx := range m.filtered {
+		got = append(got, m.items[idx].ID)
+	}
+
+	// Expected: annotated first (C4 order=1, C2 order=2), then
+	// un-annotated in input order (C1, C3).
+	want := []string{"C4", "C2", "C1", "C3"}
+	if len(got) != len(want) {
+		t.Fatalf("filtered len = %d, want %d (got=%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("position %d: got %q, want %q (full=%v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+// TestRebuildFilter_NoChannelOrderPreservesInputOrder is a regression
+// guard: when every item has ChannelOrder == 0 (the default), the
+// existing input-order behavior must be preserved bit-for-bit.
+func TestRebuildFilter_NoChannelOrderPreservesInputOrder(t *testing.T) {
+	items := []ChannelItem{
+		{ID: "C1", Name: "alpha", Type: "channel", Section: "Eng", SectionOrder: 1},
+		{ID: "C2", Name: "beta", Type: "channel", Section: "Eng", SectionOrder: 1},
+		{ID: "C3", Name: "gamma", Type: "channel", Section: "Eng", SectionOrder: 1},
+	}
+	m := New(items)
+	var got []string
+	for _, idx := range m.filtered {
+		got = append(got, m.items[idx].ID)
+	}
+	want := []string{"C1", "C2", "C3"}
+	if len(got) != len(want) {
+		t.Fatalf("filtered len = %d, want %d (got=%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("position %d: got %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
 // TestView_MutedChannelNoDot confirms that a muted channel never
 // renders the unread dot even when HasUnread=true. Slack's contract:
 // muted = no notification surface.

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -40,6 +40,15 @@ max_image_cache_mb = 200
 channels = ["alerts", "ops", "*-alerts"]
 order = 1
 
+# Channels can carry an optional ":<N>" suffix to pin their order
+# within the section. Lower numbers sort higher. Entries without a
+# suffix fall after annotated ones, in the order they appear.
+# This syntax is only honored when use_slack_sections = false;
+# in Slack-native mode, channel order comes from Slack.
+[sections.Engineering]
+channels = ["eng-general:1", "eng-alerts:2", "eng-*"]
+order = 2
+
 # Per-workspace settings: keyed by a slug you choose at --add-workspace
 # time. team_id ties the slug to the underlying Slack workspace.
 [workspaces.work]
@@ -85,6 +94,30 @@ per-workspace, to opt into glob-based sections instead.
 Per-workspace `[workspaces.<slug>.sections.*]` blocks fully replace the
 global `[sections.*]` for that workspace. Workspaces that define no
 sections of their own fall back to the global table.
+
+### Ordering channels within a section
+
+Each entry in a section's `channels` list may carry an optional `:<N>`
+suffix where `N` is a non-negative integer. Channels matched by an
+annotated pattern sort ahead of channels matched by un-annotated
+patterns; among annotated channels, lower `N` wins; un-annotated
+channels keep the order Slack returned them in.
+
+```toml
+[sections.Engineering]
+channels = ["eng-general:1", "eng-alerts:2", "eng-*"]
+order = 2
+```
+
+In the example above, `#eng-general` is pinned to the top of the
+Engineering section, followed by `#eng-alerts`, followed by every
+other `eng-*` channel in Slack-API order.
+
+This syntax is only honored when `use_slack_sections = false` (or
+when Slack's section endpoint is unreachable and slk falls back to
+glob mode). In Slack-native mode, channel order within a section
+comes from Slack and the `:<N>` suffix is ignored along with the
+rest of the `[sections.*]` block.
 
 ### v1 limitations of Slack-native sections
 

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -64,7 +64,7 @@ See [[Terminal Compatibility|Terminal-Compatibility]] for which protocol your te
 - **Slack-native sidebar sections** — slk reads your sections directly from Slack and reflects them live: section names, emoji, linked-list order, and channel/DM membership are kept in sync via the same WebSocket events the official client uses. Reorder, rename, create, or delete sections in any other Slack client; slk catches up within a couple seconds. Read-only: section editing still happens in the official client. Falls back to glob-based config sections when disabled or if the API is unavailable.
 - Collapsible sections — `Enter`/`Space` on a section header toggles it. The default Channels section starts collapsed (`▸ Channels •3` shows aggregate unreads); pinned sections and DMs start expanded
 - Live unread indicators: bold + blue dot for unread channels, muted text for read ones, aggregate dot+count on collapsed section headers
-- Glob-based config sections (`[sections.*]` in `config.toml`) — used when `use_slack_sections = false` or as a fallback when Slack's API is unreachable
+- Glob-based config sections (`[sections.*]` in `config.toml`) — used when `use_slack_sections = false` or as a fallback when Slack's API is unreachable. Channel patterns can carry an optional `":<N>"` suffix (e.g. `"eng-general:1"`) to pin order within a section; see [Configuration › Ordering channels within a section](Configuration.md#ordering-channels-within-a-section).
 - Fuzzy channel finder (`Ctrl+t` / `Ctrl+p`) — auto-expands a collapsed section when you open a channel inside it; ranks 1:1 DMs above group DMs when searching by person name
 - Workspace picker (`Ctrl+w`) and direct jump (`1`–`9`)
 - All workspaces stay connected in parallel for live unread badges


### PR DESCRIPTION
Closes #45.

## What

Adds support for ordering channels within a config-glob section via an optional `":<N>"` suffix on each entry in `[sections.*].channels`:

```toml
[sections.Engineering]
channels = ["eng-general:1", "eng-alerts:2", "eng-*"]
order = 2
```

`#eng-general` pins to the top of Engineering, then `#eng-alerts`, then every other `eng-*` channel in Slack-API order.

## Rules

- Channels matched by an annotated pattern (N > 0) sort ahead of channels matched by un-annotated patterns within the same section.
- Among annotated channels, lower N wins.
- Un-annotated channels keep input order via the existing stable sort, preserving todays behavior bit-for-bit when no suffix is used.
- Non-numeric suffixes (e.g. `"weird:abc"`) are treated as literal patterns, not orders. Slack channel names cannot contain `":"`, so well-formed configs are never ambiguous.

## Scope

This is a **config-glob mode only** feature: only active when `use_slack_sections = false` (or as a fallback when Slacks section endpoint is unreachable). In Slack-native mode the `[sections.*]` block is shadowed as it is today, and `ChannelOrder` is left at 0. Documented in `wiki/Configuration.md`.

Pre-existing gap (unchanged by this PR, worth filing separately): Slack-native mode does not honor the channel order shown in the official Slack desktop client — channels within a section are rendered in `users.conversations` order. The `channel_ids` array from `users.channelSections.list` is consulted only to build a channel→section lookup map; its ordering is discarded at `internal/service/sectionstore.go:74-80`.

## Code map

- `internal/config/config.go` — added `parseChannelPattern`, `MatchSectionAndOrder`, `matchSectionAndOrderIn`. Existing `MatchSection` now delegates.
- `internal/ui/sidebar/model.go` — new `ChannelOrder int` field on `ChannelItem`; extended the in-section tiebreaker in `rebuildFilter`.
- `cmd/slk/channelitem.go` — populates `ChannelOrder` from the new config helper. Slack-store-claimed items keep `ChannelOrder = 0`.
- `wiki/Configuration.md`, `wiki/Features.md` — documented the syntax and its scope.

## Tests

TDD throughout — red-green for each layer.

- Config: 7 new tests covering explicit order, default 0, glob patterns with order, non-numeric suffix (literal), unmatched channel, workspace override, backward-compat for `MatchSection`.
- `buildChannelItem`: 2 new tests — glob-match populates `ChannelOrder`; Slack-store wins and `ChannelOrder` stays 0.
- Sidebar sort: 2 new tests — annotated-before-unannotated ordering; regression guard for no-suffix input-order preservation.

`go vet ./... && go build ./... && go test ./...` all green.

## Not shipped (deferred)

- `channel_order = "alphabetical" | "manual"` setting. The issue calls this "might be nice"; happy to add as a follow-up if anyone asks.
- Slack-native channel-order parity (separate pre-existing gap noted above).