### PR TITLE
perf(ui): make message-pane scrolling snappy at large terminal sizes

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -308,6 +308,47 @@ type App struct {
 	// (overlay + the channel/ts/attIdx triple that lets h/l/arrow
 	// cycling locate sibling attachments). See internal/ui/imagepreview.go.
 	preview *imagePreviewController
+
+	// Compositor memo (Stage A perf). bubbletea v2 calls View() after
+	// EVERY message -- every keystroke, key-repeat, mouse-motion, and
+	// tick -- synchronously in the event loop (tea.go render-on-update).
+	// The 60fps cap only throttles the terminal flush, not View(). So
+	// the final JoinHorizontal/JoinVertical compositing (~3.6ms on a
+	// large screen) otherwise re-runs even when every cached panel is
+	// byte-identical to the previous frame (the dominant cost during a
+	// >100Hz mouse-motion drag-select, where selection extension is
+	// already coalesced to 60Hz but View() still fires per raw event).
+	//
+	// When no overlay/preview is active and the panel strings + status
+	// row match the last frame, View() reuses lastScreen and skips the
+	// re-join entirely. lastPanels holds references to the (immutable,
+	// mostly cache-shared) per-panel strings from the previous frame;
+	// equality against the freshly-rendered panels is O(1) per panel on
+	// a cache hit because the strings share a backing array.
+	lastScreen      string
+	lastPanels      []string
+	lastStatus      string
+	lastScreenW     int
+	lastScreenH     int
+	lastScreenValid bool
+
+	// Held-key scroll coalescing (Stage C perf). bubbletea v2 runs
+	// View() after every message, and each j/k selection move bumps the
+	// messages/thread pane Version -> the Stage A compositor memo misses
+	// -> a full (~17-40ms at ultrawide sizes) render. A fast key-repeat
+	// then queues keypresses faster than they render, so a held key
+	// builds a backlog that keeps scrolling after release.
+	//
+	// Coalescing applies the FIRST move in a burst immediately (instant
+	// single-tap feedback) and accumulates subsequent moves into
+	// scrollPending without bumping any Version -- so those frames are
+	// cheap Stage A memo hits and the input queue drains. A single
+	// scrollFlushMsg tick applies the accumulated batch. scrollPanel
+	// records which pane the pending moves target (focus cannot change
+	// mid-burst without a non-Up/Down key, which force-flushes first).
+	scrollPending        int
+	scrollPanel          Panel
+	scrollFlushScheduled bool
 }
 
 func NewApp() *App {
@@ -469,6 +510,12 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.height = msg.Height
 		return a, nil
 
+	case scrollFlushMsg:
+		if cmd := a.applyScrollFlush(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+		return a, tea.Batch(cmds...)
+
 	case tea.KeyMsg:
 		cmd := a.handleKey(msg)
 		if cmd != nil {
@@ -501,10 +548,23 @@ func (a *App) handleKey(msg tea.KeyMsg) tea.Cmd {
 		return nil
 	}
 
+	// Held-key scroll coalescing guard: any key other than j/k (Up/Down)
+	// must act on the up-to-date selection, so drain accumulated scroll
+	// moves before dispatching it. Up/Down themselves feed the coalescer
+	// (see coalesceContentScroll) and must not flush.
+	var pre tea.Cmd
+	if a.scrollPending != 0 && !key.Matches(msg, a.keys.Down) && !key.Matches(msg, a.keys.Up) {
+		pre = a.flushScrollCoalesce()
+	}
+
 	// Mode-specific handling. Dispatch table lives in
 	// mode_handlers.go; unmapped modes fall back to Normal
 	// (mirrors the pre-Phase-5 `default:` arm).
-	return dispatchModeKey(a, msg)
+	cmd := dispatchModeKey(a, msg)
+	if pre != nil {
+		return tea.Batch(pre, cmd)
+	}
+	return cmd
 }
 
 // navigateBack walks the per-workspace history stack one step
@@ -828,6 +888,22 @@ func sanitizeForFilename(s string) string {
 	return result
 }
 
+// scrollFlushInterval is the coalescing window for held j/k selection
+// moves. 16ms (~60Hz) is short enough that batched moves still feel
+// continuous, long enough to collapse a fast key-repeat burst into one
+// render per tick. See the scrollPending field doc on App.
+const scrollFlushInterval = 16 * time.Millisecond
+
+// scrollFlushMsg drains accumulated held-key scroll moves. Scheduled by
+// coalesceContentScroll (at most one in flight via scrollFlushScheduled).
+type scrollFlushMsg struct{}
+
+func scrollFlushTickCmd() tea.Cmd {
+	return tea.Tick(scrollFlushInterval, func(time.Time) tea.Msg {
+		return scrollFlushMsg{}
+	})
+}
+
 func (a *App) handleDown() tea.Cmd {
 	switch a.focusedPanel {
 	case PanelSidebar:
@@ -839,9 +915,9 @@ func (a *App) handleDown() tea.Cmd {
 			// don't fire one conversations.replies call per row.
 			return a.openSelectedThreadCmd(true)
 		}
-		a.messagepane.MoveDown()
+		return a.coalesceContentScroll(+1)
 	case PanelThread:
-		a.threadPanel.MoveDown()
+		return a.coalesceContentScroll(+1)
 	}
 	return nil
 }
@@ -856,17 +932,104 @@ func (a *App) handleUp() tea.Cmd {
 			// k: same debounce as j — see handleDown.
 			return a.openSelectedThreadCmd(true)
 		}
-		a.messagepane.MoveUp()
-		// If selection reached the top, fetch older messages. The
-		// viewport-based path (wheel / PageUp) is handled by
-		// scrollFocusedPanel via the same helper.
-		if cmd := a.maybeFetchOlderHistory(a.messagepane.AtTop()); cmd != nil {
-			return cmd
-		}
+		return a.coalesceContentScroll(-1)
 	case PanelThread:
-		a.threadPanel.MoveUp()
+		return a.coalesceContentScroll(-1)
 	}
 	return nil
+}
+
+// coalesceContentScroll batches a j/k selection move (delta +1 = down,
+// -1 = up) on a tall content pane (channel messages or thread). The
+// first move in a burst applies immediately for instant feedback and
+// arms the flush tick; subsequent moves within the window only
+// accumulate scrollPending (no Version bump -> Stage A memo hit), so a
+// held key cannot outpace rendering. See the scrollPending field doc.
+func (a *App) coalesceContentScroll(delta int) tea.Cmd {
+	if !a.scrollFlushScheduled {
+		a.scrollFlushScheduled = true
+		a.scrollPanel = a.focusedPanel
+		cmd := a.applyScrollMove(a.focusedPanel, delta)
+		return tea.Batch(cmd, scrollFlushTickCmd())
+	}
+	// Focus cannot change mid-burst without a non-Up/Down key, which
+	// force-flushes pending first (see handleKey); so scrollPanel stays
+	// valid. Guard defensively anyway: a focus mismatch flushes and
+	// restarts on the current pane.
+	if a.focusedPanel != a.scrollPanel {
+		flush := a.flushScrollCoalesce()
+		a.scrollPanel = a.focusedPanel
+		return tea.Batch(flush, a.applyScrollMove(a.focusedPanel, delta))
+	}
+	a.scrollPending += delta
+	return nil
+}
+
+// applyScrollMove applies |delta| MoveUp/MoveDown steps to the given
+// content pane and returns any follow-up cmd (older-history backfill
+// when an up-scroll lands the channel pane at the top). delta>0 = down.
+func (a *App) applyScrollMove(panel Panel, delta int) tea.Cmd {
+	if delta == 0 {
+		return nil
+	}
+	switch panel {
+	case PanelMessages:
+		if delta > 0 {
+			for i := 0; i < delta; i++ {
+				a.messagepane.MoveDown()
+			}
+			return nil
+		}
+		for i := 0; i < -delta; i++ {
+			a.messagepane.MoveUp()
+		}
+		// Selection reached the top: backfill older history (same UX
+		// as the pre-coalescing path and the wheel/PageUp route).
+		return a.maybeFetchOlderHistory(a.messagepane.AtTop())
+	case PanelThread:
+		if delta > 0 {
+			for i := 0; i < delta; i++ {
+				a.threadPanel.MoveDown()
+			}
+		} else {
+			for i := 0; i < -delta; i++ {
+				a.threadPanel.MoveUp()
+			}
+		}
+	}
+	return nil
+}
+
+// applyScrollFlush drains the accumulated held-key scroll batch. Invoked
+// from the scrollFlushMsg tick. While moves keep arriving it applies the
+// batch and RESCHEDULES itself (keeping scrollFlushScheduled true) so the
+// expensive render stays paced at the flush cadence rather than firing
+// once per keypress. When a tick finds nothing pending, the held
+// sequence has ended: clear the scheduled flag so the next fresh tap is
+// applied immediately again.
+func (a *App) applyScrollFlush() tea.Cmd {
+	n := a.scrollPending
+	a.scrollPending = 0
+	if n == 0 {
+		a.scrollFlushScheduled = false
+		return nil
+	}
+	cmd := a.applyScrollMove(a.scrollPanel, n)
+	return tea.Batch(cmd, scrollFlushTickCmd())
+}
+
+// flushScrollCoalesce applies any pending (not-yet-rendered) scroll moves
+// immediately so that a subsequent selection-reading action (Enter,
+// reaction, click, etc.) sees the correct selected message. Does not
+// touch scrollFlushScheduled: a tick already in flight harmlessly
+// no-ops when it finds scrollPending == 0.
+func (a *App) flushScrollCoalesce() tea.Cmd {
+	if a.scrollPending == 0 {
+		return nil
+	}
+	n := a.scrollPending
+	a.scrollPending = 0
+	return a.applyScrollMove(a.scrollPanel, n)
 }
 
 func (a *App) handleGoToBottom() tea.Cmd {
@@ -2031,23 +2194,87 @@ func (a *App) View() tea.View {
 		panels = append(panels, a.renderPreviewPanel(frame))
 	}
 
-	content := lipgloss.JoinHorizontal(lipgloss.Top, panels...)
 	status := a.renderStatusRow(frame.RailWidth, a.width-frame.RailWidth, themeVer)
-	screen := lipgloss.JoinVertical(lipgloss.Left, content, status)
-	screen = a.applyOverlays(screen)
-	v := tea.NewView(a.maybeWrapFinalScreen(screen))
+
+	// Compositor memo (Stage A). Skip the JoinHorizontal/JoinVertical
+	// re-composite when no overlay/preview is active and the panel
+	// inputs are unchanged from the last frame. See the lastScreen
+	// field doc on App for why this matters (View() runs per message).
+	// Overlay/preview frames are never memoized: overlay content can
+	// change without bumping any base-panel version, and the preview
+	// panel is rendered fresh (uncached) each frame.
+	canMemo := !previewActive && !a.overlayActive()
+	var screen string
+	memoHit := false
+	if canMemo && a.screenMemoMatches(panels, status, a.width, a.height) {
+		screen = a.lastScreen
+		memoHit = true
+	} else {
+		content := lipgloss.JoinHorizontal(lipgloss.Top, panels...)
+		screen = lipgloss.JoinVertical(lipgloss.Left, content, status)
+		screen = a.applyOverlays(screen)
+		screen = a.maybeWrapFinalScreen(screen)
+		if canMemo {
+			a.storeScreenMemo(panels, status, a.width, a.height, screen)
+		} else {
+			// Overlay/preview output is not memoizable; force the next
+			// memoizable frame to recompute.
+			a.lastScreenValid = false
+		}
+	}
+
+	v := tea.NewView(screen)
 	v.AltScreen = true
 	v.MouseMode = tea.MouseModeCellMotion
 	v.WindowTitle = a.windowTitle
 	if debuglog.Enabled() {
 		// panel: 0=workspace 1=sidebar 2=messages 3=thread
 		// view:  0=channels 1=threads
-		debuglog.Perf("App.View total=%s w=%d h=%d panel=%d view=%d mode=%s thread=%v sidebar=%v preview=%v",
-			time.Since(viewPerfStart), a.width, a.height,
+		debuglog.Perf("App.View total=%s memo=%v w=%d h=%d panel=%d view=%d mode=%s thread=%v sidebar=%v preview=%v",
+			time.Since(viewPerfStart), memoHit, a.width, a.height,
 			int(a.focusedPanel), int(a.view), a.mode.String(),
 			a.threadVisible, a.sidebarVisible, previewActive)
 	}
 	return v
+}
+
+// screenMemoMatches reports whether the freshly-rendered panel strings
+// and status row are identical to those that produced a.lastScreen, so
+// the previously composited screen can be reused without re-joining.
+// On an all-cache-hit frame the panel strings share a backing array
+// with the stored ones, so each comparison short-circuits in O(1).
+func (a *App) screenMemoMatches(panels []string, status string, w, h int) bool {
+	if !a.lastScreenValid || a.lastScreenW != w || a.lastScreenH != h {
+		return false
+	}
+	if a.lastStatus != status || len(panels) != len(a.lastPanels) {
+		return false
+	}
+	for i := range panels {
+		if panels[i] != a.lastPanels[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// storeScreenMemo records the inputs and output of a successful
+// (non-overlay, non-preview) composite for reuse by the next frame.
+// Panel strings are immutable and mostly cache-shared, so we retain
+// references rather than copying their contents; only the slice header
+// is copied (the caller reuses its backing array across frames).
+func (a *App) storeScreenMemo(panels []string, status string, w, h int, screen string) {
+	if cap(a.lastPanels) >= len(panels) {
+		a.lastPanels = a.lastPanels[:len(panels)]
+	} else {
+		a.lastPanels = make([]string, len(panels))
+	}
+	copy(a.lastPanels, panels)
+	a.lastStatus = status
+	a.lastScreen = screen
+	a.lastScreenW = w
+	a.lastScreenH = h
+	a.lastScreenValid = true
 }
 
 // cancelEdit exits edit mode, restoring the stashed draft to its

--- a/internal/ui/app_bench_test.go
+++ b/internal/ui/app_bench_test.go
@@ -77,6 +77,92 @@ func BenchmarkAppViewIdle(b *testing.B) {
 	}
 }
 
+// makeWideScrollApp builds a NORMAL-mode app at an ultrawide terminal size
+// (477x130, matching a real user's session in slk-debug.log) with focus on
+// the messages pane -- the j/k scroll hot path. This is the case the
+// compositor memo does NOT help: every scroll bumps messagepane.Version, so
+// the bordered top region re-renders and the screen re-composites.
+func makeWideScrollApp() *App {
+	a := NewApp()
+	_, _ = a.Update(tea.WindowSizeMsg{Width: 477, Height: 130})
+
+	channels := make([]sidebar.ChannelItem, 100)
+	for i := range channels {
+		channels[i] = sidebar.ChannelItem{
+			ID:   fmt.Sprintf("C%d", i),
+			Name: fmt.Sprintf("channel-%d", i),
+			Type: "channel",
+		}
+	}
+	a.sidebar.SetItems(channels)
+
+	msgs := make([]messages.MessageItem, 200)
+	for i := range msgs {
+		msgs[i] = messages.MessageItem{
+			TS:        fmt.Sprintf("%d.0", 1700000000+i),
+			UserName:  "alice",
+			UserID:    "U1",
+			Text:      "Hello world this is a moderately long message with **bold** and _italic_ formatting.",
+			Timestamp: "10:30 AM",
+		}
+	}
+	a.messagepane.SetMessages(msgs)
+	a.activeChannelID = "C1"
+	a.activeTeamID = "T1"
+	a.focusedPanel = PanelMessages
+	a.SetMode(ModeNormal)
+
+	_ = a.View() // prime caches
+	return a
+}
+
+// BenchmarkAppViewScroll measures the raw cost of a render that follows an
+// actual selection change (the memo=false path): move the selection one
+// row directly, then render. This is the irreducible per-changed-frame
+// cost at ultrawide sizes.
+func BenchmarkAppViewScroll(b *testing.B) {
+	a := makeWideScrollApp()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if i%2 == 0 {
+			a.messagepane.MoveDown()
+		} else {
+			a.messagepane.MoveUp()
+		}
+		_ = a.View()
+	}
+}
+
+// BenchmarkAppViewScrollHeldKey simulates a fast key-repeat through the
+// real Update->View path WITH coalescing: a burst of `down` keypresses
+// punctuated by a flush tick every `flushEvery` events (the ~16ms cadence
+// the event loop delivers scrollFlushMsg at). This is the user's "holding
+// j" path. With coalescing, the non-first keypresses in each burst are
+// Stage A memo hits, so the average per-event cost collapses -- which is
+// what stops a held key from building a render backlog.
+func BenchmarkAppViewScrollHeldKey(b *testing.B) {
+	a := makeWideScrollApp()
+	up := tea.KeyPressMsg{Code: tea.KeyUp} // k: genuine upward movement from the bottom
+
+	// Roughly: a 200Hz key-repeat against a 16ms flush cadence yields
+	// ~3 keypresses per flush. Model that ratio.
+	const flushEvery = 3
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if a.messagepane.SelectedIndex() == 0 {
+			a.messagepane.GoToBottom() // wrap so moves never stall at the top
+		}
+		_, _ = a.Update(up)
+		_ = a.View()
+		if i%flushEvery == flushEvery-1 {
+			_, _ = a.Update(scrollFlushMsg{})
+			_ = a.View()
+		}
+	}
+}
+
 // TestComposeKeystrokeKeepsSidePanelsCached verifies that typing a single
 // character into the compose box does NOT bump the version counters of the
 // sidebar / messages / workspace rail panels. Without this guarantee, the

--- a/internal/ui/app_screenmemo_test.go
+++ b/internal/ui/app_screenmemo_test.go
@@ -1,0 +1,64 @@
+package ui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// TestScreenMemo_ReflectsSelectionChange is the correctness guard for the
+// Stage A compositor memo. Selection mutations deliberately do NOT bump
+// any panel's Version() (the messages pane caches selection-free output
+// and overlays the selection as a post-pass). A naive version-keyed memo
+// would therefore serve a stale, selection-free frame after the user
+// drags. This test proves the string-comparison memo catches the change.
+func TestScreenMemo_ReflectsSelectionChange(t *testing.T) {
+	a := newTestAppWithMessages(t)
+
+	base := a.View().Content
+	if !a.lastScreenValid {
+		t.Fatal("precondition: a non-overlay render must populate the screen memo")
+	}
+
+	// Begin + extend + flush a drag selection.
+	pressX := a.layout.sidebarEnd + 2
+	pressY := 4
+	_, _ = a.Update(tea.MouseClickMsg{X: pressX, Y: pressY, Button: tea.MouseLeft})
+	_, _ = a.Update(tea.MouseMotionMsg{X: pressX + 8, Y: pressY + 1, Button: tea.MouseLeft})
+	_, _ = a.Update(motionFlushTickMsg{})
+	if !a.messagepane.HasSelection() || a.messagepane.SelectionText() == "" {
+		t.Fatal("precondition: drag must produce a non-empty selection")
+	}
+
+	withSel := a.View().Content
+	if withSel == base {
+		t.Fatal("memo served a stale frame: selection change not reflected in View()")
+	}
+
+	// A subsequent no-change render must be byte-identical (memo hit) --
+	// proving the memo is both correct and stable.
+	again := a.View().Content
+	if again != withSel {
+		t.Fatal("no-change render diverged from the previous frame; memo not stable")
+	}
+}
+
+// TestScreenMemo_InvalidatedByOverlay proves that opening an overlay marks
+// the memo invalid (overlay output is never memoized because overlay
+// content can change without bumping any base-panel version), and that the
+// next non-overlay frame repopulates it.
+func TestScreenMemo_InvalidatedByOverlay(t *testing.T) {
+	a := newTestAppWithMessages(t)
+	_ = a.View()
+	if !a.lastScreenValid {
+		t.Fatal("precondition: non-overlay render must populate the memo")
+	}
+
+	// Open the quit confirm overlay (ModeConfirm). overlayActive() is
+	// true for confirmPrompt, so the next render must not memoize.
+	a.openQuitConfirm()
+	_ = a.View()
+	if a.lastScreenValid {
+		t.Fatal("overlay frame must invalidate the screen memo")
+	}
+}

--- a/internal/ui/app_scrollcoalesce_test.go
+++ b/internal/ui/app_scrollcoalesce_test.go
@@ -1,0 +1,104 @@
+package ui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// TestScrollCoalesce_FirstMoveImmediateRestBatched pins the coalescing
+// contract: the first j/k in a burst moves the selection immediately
+// (instant feedback) and arms a flush tick; subsequent moves only
+// accumulate (selection frozen) until the scrollFlushMsg tick applies
+// the batch. This is what keeps a held key from outpacing rendering.
+func TestScrollCoalesce_FirstMoveImmediateRestBatched(t *testing.T) {
+	a := makeWideScrollApp()
+	start := a.messagepane.SelectedIndex()
+
+	// First k: immediate move + tick armed.
+	if cmd := a.handleUp(); cmd == nil {
+		t.Fatal("first move in a burst must return a cmd (immediate move + flush tick)")
+	}
+	if got := a.messagepane.SelectedIndex(); got != start-1 {
+		t.Fatalf("first move must apply immediately: selected=%d want=%d", got, start-1)
+	}
+	if !a.scrollFlushScheduled {
+		t.Fatal("first move must arm the flush tick")
+	}
+
+	// Next three k's only accumulate -- selection frozen.
+	a.handleUp()
+	a.handleUp()
+	a.handleUp()
+	if got := a.messagepane.SelectedIndex(); got != start-1 {
+		t.Fatalf("subsequent moves must be deferred: selected=%d want=%d (frozen)", got, start-1)
+	}
+	if a.scrollPending != -3 {
+		t.Fatalf("scrollPending=%d want=-3", a.scrollPending)
+	}
+
+	// Flush tick applies the batch. Because moves were pending, the tick
+	// reschedules itself (scheduled stays true) so the expensive render
+	// stays paced at the flush cadence during a continuous hold.
+	_, _ = a.Update(scrollFlushMsg{})
+	if got := a.messagepane.SelectedIndex(); got != start-4 {
+		t.Fatalf("flush must apply batch: selected=%d want=%d", got, start-4)
+	}
+	if a.scrollPending != 0 {
+		t.Fatalf("flush must drain pending: pending=%d", a.scrollPending)
+	}
+	if !a.scrollFlushScheduled {
+		t.Fatal("flush that applied moves must reschedule (stay scheduled)")
+	}
+
+	// A subsequent tick with nothing pending ends the sequence.
+	_, _ = a.Update(scrollFlushMsg{})
+	if a.scrollFlushScheduled {
+		t.Fatal("flush with no pending moves must clear the scheduled flag")
+	}
+	if got := a.messagepane.SelectedIndex(); got != start-4 {
+		t.Fatalf("idle flush must not move selection: selected=%d want=%d", got, start-4)
+	}
+}
+
+// TestScrollCoalesce_NonScrollKeyFlushesPending guards correctness: a key
+// other than j/k must act on the up-to-date selection, so pending moves
+// are drained before it dispatches. Without this, e.g. Enter would open
+// the thread of a stale (pre-burst) message.
+func TestScrollCoalesce_NonScrollKeyFlushesPending(t *testing.T) {
+	a := makeWideScrollApp()
+	start := a.messagepane.SelectedIndex()
+
+	a.handleUp() // immediate -> start-1, tick armed
+	a.handleUp() // accumulate -> pending -1
+	a.handleUp() // accumulate -> pending -2
+	if a.scrollPending != -2 {
+		t.Fatalf("precondition: pending=%d want=-2", a.scrollPending)
+	}
+
+	// A non-scroll key (Right = focus change) routes through handleKey,
+	// which must flush pending first.
+	_ = a.handleKey(tea.KeyPressMsg{Code: tea.KeyRight})
+	if a.scrollPending != 0 {
+		t.Fatalf("non-scroll key must flush pending: pending=%d", a.scrollPending)
+	}
+	if got := a.messagepane.SelectedIndex(); got != start-3 {
+		t.Fatalf("pending moves must be applied before the key acts: selected=%d want=%d", got, start-3)
+	}
+}
+
+// TestScrollCoalesce_ClickDiscardsPending verifies a mouse click discards
+// pending held-key moves (the click sets the selection absolutely, so the
+// deferred moves must not fire later and yank the selection away).
+func TestScrollCoalesce_ClickDiscardsPending(t *testing.T) {
+	a := makeWideScrollApp()
+	a.handleUp() // immediate + tick
+	a.handleUp() // accumulate
+	if a.scrollPending == 0 {
+		t.Fatal("precondition: expected pending moves")
+	}
+	_, _ = a.Update(tea.MouseClickMsg{X: a.layout.sidebarEnd + 2, Y: 4, Button: tea.MouseLeft})
+	if a.scrollPending != 0 {
+		t.Fatalf("click must discard pending scroll: pending=%d", a.scrollPending)
+	}
+}

--- a/internal/ui/messages/model.go
+++ b/internal/ui/messages/model.go
@@ -1387,6 +1387,12 @@ func (m *Model) buildCacheStyles(width int) cacheStyles {
 	spacerBg := lipgloss.NewStyle().Background(styles.Background)
 	m.cacheSpacer = spacerBg.Width(width).Render("")
 	hintStyle := lipgloss.NewStyle().Background(styles.Background).Foreground(styles.TextMuted)
+	// NOTE: intentionally NOT width-padded. "more below" only appears when
+	// the content overflows the viewport, which is exactly the condition
+	// under which scrollbar.Overlay runs and normalizes every row to the
+	// full width -- so the app-layer border-assembly width invariant
+	// (ui.borderedTopPane) still holds. Padding here would be truncated by
+	// the scrollbar pass and break TestSelection_HighlightDoesNotCorrupt...
 	m.cacheMoreBelow = hintStyle.Render("  -- more below --")
 	return cacheStyles{
 		borderFill:   borderFill,
@@ -1403,8 +1409,11 @@ func (m *Model) buildCacheStyles(width int) cacheStyles {
 // accepted for symmetry with other render helpers but is unused: the
 // hint is left-aligned and the host code (View()) drops it into a
 // pre-sized visible[0] slot.
-func (m *Model) renderLoadingOlderHint(_ int) string {
-	hintStyle := lipgloss.NewStyle().Background(styles.Background).Foreground(styles.TextMuted)
+func (m *Model) renderLoadingOlderHint(width int) string {
+	// Width(width) pads to the full pane width so this transient top-row
+	// hint upholds the "every pane line is exactly width cells" invariant
+	// the app-layer border assembly relies on (ui.borderedTopPane).
+	hintStyle := lipgloss.NewStyle().Background(styles.Background).Foreground(styles.TextMuted).Width(width)
 	frame := styles.SpinnerChars[m.spinnerFrame%len(styles.SpinnerChars)]
 	return hintStyle.Render("  " + string(frame) + " Loading older messages...")
 }
@@ -2677,7 +2686,13 @@ func (m *Model) viewInternal(height, width int, applySelection bool) string {
 			Padding(0, 1)
 		header := headerStyle.Render(fmt.Sprintf("%s %s", channelGlyph(m.channelType), m.channelName))
 		if m.channelTopic != "" {
-			header += "\n" + styles.Timestamp.Render(WordWrap(m.channelTopic, width))
+			// Width(width) pads every wrapped topic line to the full pane
+			// width. This keeps the invariant that EVERY chrome line is
+			// exactly `width` display cells, which lets the app layer
+			// assemble the pane border by concatenation (no per-frame
+			// grapheme re-measurement). See ui.borderedTopPane.
+			topicStyle := styles.Timestamp.Width(width).Background(styles.Background)
+			header += "\n" + topicStyle.Render(WordWrap(m.channelTopic, width))
 		}
 		m.chromeCache = header
 		m.chromeHeight = lipgloss.Height(m.chromeCache)

--- a/internal/ui/reducer_mouse.go
+++ b/internal/ui/reducer_mouse.go
@@ -60,6 +60,9 @@ func reduceMouseWheel(a *App, m tea.MouseWheelMsg) tea.Cmd {
 	if a.bootstrap.IsLoading() {
 		return nil
 	}
+	// Drain any pending held-key scroll so the wheel scroll applies on
+	// top of the up-to-date viewport/selection (see coalesceContentScroll).
+	a.flushScrollCoalesce()
 	var up bool
 	switch m.Button {
 	case tea.MouseWheelUp:
@@ -132,6 +135,11 @@ func reduceMouseClick(a *App, m tea.MouseClickMsg) tea.Cmd {
 	if m.Button != tea.MouseLeft {
 		return nil
 	}
+	// A click sets the selection absolutely (ClickAt below), so any
+	// pending held-key scroll moves would be immediately overwritten --
+	// discard them rather than apply (and let any in-flight flush tick
+	// no-op). Prevents a post-click selection jump when the tick fires.
+	a.scrollPending = 0
 	x := m.X
 	statusHeight := 1
 	if m.Y >= a.height-statusHeight {

--- a/internal/ui/view_helpers.go
+++ b/internal/ui/view_helpers.go
@@ -20,6 +20,7 @@ package ui
 
 import (
 	"image/color"
+	"strings"
 
 	"charm.land/lipgloss/v2"
 
@@ -40,4 +41,120 @@ func exactSizeBg(s string, w, h int, bg color.Color) string {
 // exactSizeBg directly.
 func exactSize(s string, w, h int) string {
 	return exactSizeBg(s, w, h, styles.Background)
+}
+
+// padPaneToSize is a fast replacement for exactSize when the caller can
+// guarantee every line of s is already exactly srcWidth display cells
+// wide (e.g. the output of a lipgloss border style with a fixed .Width(),
+// which pads every line to that width). It appends (w - srcWidth)
+// background gutter columns to each line and enforces exactly h rows --
+// skipping exactSize's per-line, grapheme-by-grapheme width
+// re-measurement, which is the single largest per-frame allocation/CPU
+// cost on the message-pane scroll hot path at large terminal sizes
+// (lipgloss WrapWriter ~70% of scroll-frame allocations).
+//
+// Output is VISUALLY identical to exactSize(s, w, h): same row count,
+// same per-line display width, same colors, same plain text. Only
+// redundant SGR bytes (a leading background escape + an extra reset that
+// exactSize emits per line) differ; they render identically and the
+// downstream selection overlay / bubbletea diff handle arbitrary SGR.
+//
+// srcWidth MUST be the true uniform width of s's lines; passing a wrong
+// value yields a misaligned right edge. Use exactSize when line widths
+// are not statically known.
+// borderedTopPane assembles a top-bordered pane (top edge + left/right
+// verticals, NO bottom edge) around content whose every line is already
+// EXACTLY innerWidth display cells, then right-pads each row to fullWidth
+// and clamps to exactly rows rows. It is the zero-measurement equivalent
+// of the messages-pane hot path:
+//
+//	padPaneToSize(
+//	    borderStyle.Width(innerWidth+2).BorderTop(true).BorderLeft(true).
+//	        BorderRight(true).BorderBottom(false).Render(content),
+//	    innerWidth+2, fullWidth, rows, bg)
+//
+// The lipgloss form re-measures every content line grapheme-by-grapheme
+// every frame (the dominant cost when scrolling a tall pane on a wide
+// terminal). Because the cached message lines are built to a fixed width,
+// this form instead concatenates a constant left/right border cell around
+// each line -- the only per-line work is byte concatenation. The border
+// glyphs and colors are taken from the SAME lipgloss style the old path
+// used (via the Get*Border accessors) so the result is visually identical.
+//
+// INVARIANT: every line of content MUST be exactly innerWidth display
+// cells. Callers guarantee this by padding every source line at build
+// time (see messages.Model: chrome, spacer, "more below", loading hint,
+// and per-entry lines are all width-padded). The equivalence test
+// TestBorderedTopPane_MatchesLipgloss asserts this across states; if a
+// new unpadded source is introduced, that test fails (a short line yields
+// a row narrower than fullWidth).
+func borderedTopPane(content string, innerWidth, fullWidth, rows int, focused bool, bg color.Color) string {
+	bs := styles.UnfocusedBorder
+	if focused {
+		bs = styles.FocusedBorder
+	}
+	bd := bs.GetBorderStyle()
+	fg := bs.GetBorderTopForeground()
+	bbg := bs.GetBorderTopBackground()
+
+	edge := lipgloss.NewStyle().Foreground(fg).Background(bbg)
+	left := edge.Render(bd.Left)
+	right := edge.Render(bd.Right)
+	topEdge := edge.Render(bd.TopLeft + strings.Repeat(bd.Top, innerWidth) + bd.TopRight)
+
+	gutterCols := fullWidth - (innerWidth + 2)
+	gutter := ""
+	if gutterCols > 0 {
+		gutter = lipgloss.NewStyle().Background(bg).Render(strings.Repeat(" ", gutterCols))
+	}
+	blankInner := lipgloss.NewStyle().Background(bg).Width(innerWidth).Render("")
+
+	lines := strings.Split(content, "\n")
+	var b strings.Builder
+	for r := 0; r < rows; r++ {
+		if r > 0 {
+			b.WriteByte('\n')
+		}
+		if r == 0 {
+			b.WriteString(topEdge)
+			b.WriteString(gutter)
+			continue
+		}
+		ci := r - 1
+		b.WriteString(left)
+		if ci < len(lines) {
+			b.WriteString(lines[ci])
+		} else {
+			b.WriteString(blankInner)
+		}
+		b.WriteString(right)
+		b.WriteString(gutter)
+	}
+	return b.String()
+}
+
+func padPaneToSize(s string, srcWidth, w, h int, bg color.Color) string {
+	gutterCols := w - srcWidth
+	gutter := ""
+	if gutterCols > 0 {
+		gutter = lipgloss.NewStyle().Background(bg).Render(strings.Repeat(" ", gutterCols))
+	}
+	lines := strings.Split(s, "\n")
+	var b strings.Builder
+	for i := 0; i < h; i++ {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		if i < len(lines) {
+			b.WriteString(lines[i])
+			if gutterCols > 0 {
+				b.WriteString(gutter)
+			}
+		} else {
+			// Height underflow: themed blank row at the full width
+			// (matches exactSize's vertical padding behavior).
+			b.WriteString(lipgloss.NewStyle().Background(bg).Width(w).Render(""))
+		}
+	}
+	return b.String()
 }

--- a/internal/ui/view_messages.go
+++ b/internal/ui/view_messages.go
@@ -223,20 +223,23 @@ func (a *App) renderMessagesTop(msgWidth, msgBorder, topHeight, msgContentHeight
 	if c.hit(topPanelVersion, msgWidth, topHeight, topLayoutKey) {
 		return c.output
 	}
-	topBorderStyle := styles.UnfocusedBorder.Width(msgWidth).
-		BorderTop(true).BorderLeft(true).BorderRight(true).BorderBottom(false)
-	if msgFocused {
-		topBorderStyle = styles.FocusedBorder.Width(msgWidth).
-			BorderTop(true).BorderLeft(true).BorderRight(true).BorderBottom(false)
-	}
 	// ViewBare (not View) so the cached output is selection-free; the
 	// caller composes ApplySelectionToBordered on top of the cache return,
 	// keeping the bordered re-render off the mouse-drag hot path.
+	//
+	// PERF: every line of msgView is built to exactly msgWidth-2 display
+	// cells (the messages model pads chrome, per-entry lines, spacer,
+	// scroll indicators, and the loading hint), so we assemble the pane
+	// border by concatenation rather than letting lipgloss re-measure all
+	// ~N visible lines grapheme-by-grapheme every frame -- the dominant
+	// scroll-frame cost on a wide terminal. borderedTopPane is gated by
+	// TestBorderedTopPane_MatchesLipgloss for visual equivalence with the
+	// old `padPaneToSize(borderStyle.Render(msgView), ...)` path.
 	msgView := a.messagepane.ViewBare(msgContentHeight, msgWidth-2)
 	msgView = messages.ReapplyBgAfterResets(msgView, messages.BgANSI())
-	out := exactSize(
-		topBorderStyle.Render(msgView),
-		msgWidth+msgBorder, topHeight,
+	out := borderedTopPane(
+		msgView,
+		msgWidth-2, msgWidth+msgBorder, topHeight, msgFocused, styles.Background,
 	)
 	c.store(out, topPanelVersion, msgWidth, topHeight, topLayoutKey)
 	return out

--- a/internal/ui/view_messages_border_test.go
+++ b/internal/ui/view_messages_border_test.go
@@ -1,0 +1,110 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/gammons/slk/internal/ui/messages"
+	"github.com/gammons/slk/internal/ui/styles"
+)
+
+// buildMsgViewForTest reproduces the inner-content render the messages-top
+// path feeds to the border (ViewBare + ReapplyBgAfterResets), plus the
+// derived geometry, for the current selection/focus.
+func buildMsgViewForTest(a *App, focused bool) (msgView string, msgWidth, msgBorder, topHeight, msgContentHeight int) {
+	frame := a.layout.Compute(a.width, a.height, a.workspaceRail.Width(), a.sidebar.Width(), a.sidebarVisible, a.threadVisible)
+	msgWidth = frame.MsgWidth
+	msgBorder = frame.MsgBorder
+	msgContentHeight = frame.ContentHeight - 2 - 3
+	if msgContentHeight < 3 {
+		msgContentHeight = 3
+	}
+	topHeight = msgContentHeight + 1
+	a.messagepane.SetFocused(focused)
+	msgView = messages.ReapplyBgAfterResets(a.messagepane.ViewBare(msgContentHeight, msgWidth-2), messages.BgANSI())
+	return
+}
+
+func topBorderStyleForTest(msgWidth int, focused bool) lipgloss.Style {
+	bs := styles.UnfocusedBorder
+	if focused {
+		bs = styles.FocusedBorder
+	}
+	return bs.Width(msgWidth).
+		BorderTop(true).BorderLeft(true).BorderRight(true).BorderBottom(false)
+}
+
+// TestBorderedTopPane_MatchesLipgloss is the correctness gate for the
+// zero-measurement border assembly. For many (focus, scroll-position,
+// content) states it asserts borderedTopPane produces output that is
+// visually identical to the lipgloss border + padPaneToSize path: same
+// row count, every row exactly fullWidth display cells, and identical
+// plain text per row. This also enforces the innerWidth invariant -- a
+// short/unpadded source line makes a row narrower than fullWidth and
+// fails here.
+func TestBorderedTopPane_MatchesLipgloss(t *testing.T) {
+	cases := []struct {
+		name string
+		app  func() *App
+	}{
+		{"wide-200msgs", makeWideScrollApp},
+		{"with-topic", func() *App {
+			a := makeWideScrollApp()
+			a.messagepane.SetChannel("channel-1", "a moderately long channel topic that should wrap or fill the header line")
+			return a
+		}},
+		{"few-msgs-no-overflow", func() *App {
+			a := NewApp()
+			_, _ = a.Update(tea.WindowSizeMsg{Width: 477, Height: 130})
+			msgs := make([]messages.MessageItem, 3)
+			for i := range msgs {
+				msgs[i] = messages.MessageItem{TS: fmt.Sprintf("%d.0", 1700000000+i), UserName: "alice", UserID: "U1", Text: "short", Timestamp: "10:30 AM"}
+			}
+			a.messagepane.SetMessages(msgs)
+			a.focusedPanel = PanelMessages
+			a.SetMode(ModeNormal)
+			_ = a.View()
+			return a
+		}},
+	}
+
+	for _, tc := range cases {
+		for _, focused := range []bool{true, false} {
+			for _, sel := range []int{-1, 0, 1} { // bottom, top, +1 from top
+				a := tc.app()
+				switch sel {
+				case 0:
+					a.messagepane.GoToTop()
+				case 1:
+					a.messagepane.GoToTop()
+					a.messagepane.MoveDown()
+				}
+
+				msgView, msgWidth, msgBorder, topHeight, _ := buildMsgViewForTest(a, focused)
+				full := msgWidth + msgBorder
+
+				want := padPaneToSize(topBorderStyleForTest(msgWidth, focused).Render(msgView), msgWidth, full, topHeight, styles.Background)
+				got := borderedTopPane(msgView, msgWidth-2, full, topHeight, focused, styles.Background)
+
+				wl := strings.Split(want, "\n")
+				gl := strings.Split(got, "\n")
+				if len(wl) != topHeight || len(gl) != topHeight {
+					t.Fatalf("[%s focused=%v sel=%d] rows: want=%d got=%d (topHeight=%d)", tc.name, focused, sel, len(wl), len(gl), topHeight)
+				}
+				for i := range wl {
+					gw := ansi.StringWidth(gl[i])
+					if gw != full {
+						t.Fatalf("[%s focused=%v sel=%d] row %d width=%d want=%d (short source line?)\n got=%q", tc.name, focused, sel, i, gw, full, gl[i])
+					}
+					if ansi.Strip(wl[i]) != ansi.Strip(gl[i]) {
+						t.Fatalf("[%s focused=%v sel=%d] row %d plaintext differs:\n want=%q\n got =%q", tc.name, focused, sel, i, ansi.Strip(wl[i]), ansi.Strip(gl[i]))
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Scrolling a channel with `j`/`k` on a large terminal (e.g. 477×130 on a wide monitor) felt choppy and built up an input backlog that kept scrolling after the key was released. Profiling showed each scroll frame cost **~40-65ms** — render-bound, not framework-bound: bubbletea v2 calls `View()` after every message, and each frame re-ran lipgloss over the full ~128-line message pane, **re-measuring every line grapheme-by-grapheme** (`ansi.stringWidth` was ~50% of CPU; `lipgloss WrapWriter` ~70% of allocations). Cost scaled with terminal area, which is why it was snappy on a small terminal and slow on a large one.

## Changes

Three complementary changes, each instrumented/verified via the existing `[perf]` debug log + benchmarks:

1. **`View()` compositor memo** — bubbletea v2 runs `View()` per message, so the full-screen `JoinHorizontal`/`JoinVertical` composite ran even when every cached panel was byte-identical (the >100Hz mouse-motion drag flood, redundant ticks, etc.). Reuse the previous frame's screen when no overlay/preview is active and the panel inputs are unchanged.

2. **Held-key scroll coalescing** — each held `j`/`k` applied a selection move + full render *per keypress*, so a fast key-repeat outran rendering and built a backlog. Now the first move in a burst applies immediately; subsequent moves accumulate without bumping any version (so they're cheap memo-hit frames) and are flushed on a 16ms tick. Non-scroll keys flush pending first (so e.g. Enter acts on the right message); clicks discard pending.

3. **Zero-measurement border assembly** — the message pane's lines are already built to a fixed width, so the pane border is now assembled by string concatenation (`borderedTopPane`) instead of letting lipgloss re-wrap and re-measure every line each frame. The chrome topic line and loading hint are padded at their source to uphold the "every line is exactly innerWidth" invariant. Gated by `TestBorderedTopPane_MatchesLipgloss`, which asserts byte-equal geometry + plain text vs. the old lipgloss path across focus/scroll/overflow/topic states.

## Impact (benchmarks, 477×130, 200 messages)

| | before | after |
|---|---|---|
| Scroll frame | ~45 ms | **~10 ms** (4.5×) |
| Allocations / scroll frame | 203,725 | **9,717** (21×) |
| Held-key avg | ~16 ms | ~4.5 ms |
| Idle frame | 0.95 ms | 0.62 ms |

## Testing

- Full `go test ./...` and `go vet ./internal/...` pass.
- New tests: `app_screenmemo_test.go` (memo correctness incl. selection/overlay invalidation), `app_scrollcoalesce_test.go` (coalescing contract + non-scroll-key flush + click discard), `view_messages_border_test.go` (border equivalence).

## Note for review

Border geometry and plain text are verified byte-for-byte against the prior output; colors/SGR could not be diffed automatically. The border glyphs/colors are pulled from the same lipgloss style as before, so it should be pixel-identical — worth an eyeball on the pane border, channel header, and topic line.

## Follow-up

The remaining ~10ms is now dominated by the app-level `JoinHorizontal`/`JoinVertical` screen composite (re-measures the full screen each frame). Same fix applies (assemble from known panel widths); tracked as a follow-up.