### PR TITLE
perf(ui): assemble the View screen composite without re-measuring

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2210,8 +2210,21 @@ func (a *App) View() tea.View {
 		screen = a.lastScreen
 		memoHit = true
 	} else {
-		content := lipgloss.JoinHorizontal(lipgloss.Top, panels...)
-		screen = lipgloss.JoinVertical(lipgloss.Left, content, status)
+		// Composite the side-by-side panels. The panels are uniform-width
+		// and all exactly frame.ContentHeight rows, so a row-wise concat
+		// is byte-identical to lipgloss's JoinHorizontal but skips its
+		// per-line grapheme width measurement (a large share of the
+		// remaining scroll-frame cost at wide sizes). Fall back to lipgloss
+		// if the fast path declines (e.g. a height-clamped pane).
+		content, ok := joinPanelsHorizontal(panels, frame.ContentHeight)
+		if !ok {
+			content = lipgloss.JoinHorizontal(lipgloss.Top, panels...)
+		}
+		// Stack content over status without re-measuring every content
+		// line (lipgloss.JoinVertical's getLines was the other large share
+		// of the composite cost). stackContentStatus reproduces lipgloss's
+		// left-align padding byte-for-byte; see its doc.
+		screen = stackContentStatus(content, status)
 		screen = a.applyOverlays(screen)
 		screen = a.maybeWrapFinalScreen(screen)
 		if canMemo {

--- a/internal/ui/view_composite_test.go
+++ b/internal/ui/view_composite_test.go
@@ -1,0 +1,107 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/gammons/slk/internal/ui/messages"
+)
+
+// TestJoinPanelsHorizontal_MatchesLipgloss verifies the zero-measurement
+// row-concat join is byte-identical to lipgloss.JoinHorizontal for
+// uniform-width, equal-height panels (the View invariant), and that it
+// declines (ok=false) when heights differ so the caller can fall back.
+func TestJoinPanelsHorizontal_MatchesLipgloss(t *testing.T) {
+	mk := func(w, h int, fill rune) string {
+		row := strings.Repeat(string(fill), w)
+		rows := make([]string, h)
+		for i := range rows {
+			rows[i] = row
+		}
+		return strings.Join(rows, "\n")
+	}
+
+	// Equal heights, mixed widths -> must match lipgloss byte-for-byte.
+	panels := []string{mk(3, 5, 'a'), mk(10, 5, 'b'), mk(2, 5, 'c')}
+	got, ok := joinPanelsHorizontal(panels, 5)
+	if !ok {
+		t.Fatal("expected ok for equal-height panels")
+	}
+	want := lipgloss.JoinHorizontal(lipgloss.Top, panels...)
+	if got != want {
+		t.Fatalf("join mismatch:\n got=%q\nwant=%q", got, want)
+	}
+
+	// Mismatched height -> decline.
+	if _, ok := joinPanelsHorizontal([]string{mk(3, 5, 'a'), mk(3, 4, 'b')}, 5); ok {
+		t.Fatal("expected ok=false when a panel has the wrong row count")
+	}
+}
+
+// buildViewPanels mirrors App.View's panel assembly so the composite
+// helpers can be checked against lipgloss on real rendered panels.
+func buildViewPanels(a *App) (panels []string, status string, contentHeight, width int) {
+	themeVer := int64(0)
+	frame := a.layout.Compute(a.width, a.height, a.workspaceRail.Width(), a.sidebar.Width(), a.sidebarVisible, a.threadVisible)
+	panels = append(panels, a.renderRail(frame.RailWidth, frame.ContentHeight, themeVer))
+	if a.sidebarVisible {
+		panels = append(panels, a.renderSidebar(frame.SidebarWidth, frame.SidebarBorder, frame.ContentHeight, themeVer))
+	}
+	if s := a.renderMessagesRegion(frame, themeVer, false); s != "" {
+		panels = append(panels, s)
+	}
+	if a.threadVisible && frame.ThreadWidth > 0 {
+		panels = append(panels, a.renderThreadRegion(frame, themeVer))
+	}
+	status = a.renderStatusRow(frame.RailWidth, a.width-frame.RailWidth, themeVer)
+	return panels, status, frame.ContentHeight, a.width
+}
+
+// TestViewComposite_MatchesLipgloss checks the full screen composite
+// (horizontal panel join + vertical status stack) is byte-identical to
+// the lipgloss path across layout configurations (sidebar/thread on/off).
+func TestViewComposite_MatchesLipgloss(t *testing.T) {
+	newApp := func(sidebar, thread bool) *App {
+		a := NewApp()
+		_, _ = a.Update(tea.WindowSizeMsg{Width: 477, Height: 130})
+		msgs := make([]messages.MessageItem, 40)
+		for i := range msgs {
+			msgs[i] = messages.MessageItem{TS: fmt.Sprintf("%d.0", 1700000000+i), UserName: "alice", UserID: "U1", Text: "hello world", Timestamp: "10:30 AM"}
+		}
+		a.messagepane.SetMessages(msgs)
+		a.sidebarVisible = sidebar
+		if thread {
+			a.threadVisible = true
+			a.threadPanel.SetThread(msgs[0], nil, "C1", msgs[0].TS)
+		}
+		a.focusedPanel = PanelMessages
+		a.SetMode(ModeNormal)
+		_ = a.View()
+		return a
+	}
+
+	for _, sidebar := range []bool{true, false} {
+		for _, thread := range []bool{false, true} {
+			a := newApp(sidebar, thread)
+			panels, status, ch, _ := buildViewPanels(a)
+
+			gotH, ok := joinPanelsHorizontal(panels, ch)
+			if !ok {
+				t.Fatalf("[sidebar=%v thread=%v] fast join declined unexpectedly", sidebar, thread)
+			}
+			wantH := lipgloss.JoinHorizontal(lipgloss.Top, panels...)
+			if gotH != wantH {
+				t.Fatalf("[sidebar=%v thread=%v] horizontal join differs from lipgloss", sidebar, thread)
+			}
+
+			gotV := stackContentStatus(gotH, status)
+			wantV := lipgloss.JoinVertical(lipgloss.Left, wantH, status)
+			if gotV != wantV {
+				t.Fatalf("[sidebar=%v thread=%v] vertical stack differs from lipgloss", sidebar, thread)
+			}
+		}
+	}
+}

--- a/internal/ui/view_helpers.go
+++ b/internal/ui/view_helpers.go
@@ -23,9 +23,95 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/gammons/slk/internal/ui/styles"
 )
+
+// joinPanelsHorizontal is a zero-measurement replacement for
+// lipgloss.JoinHorizontal(lipgloss.Top, panels...) for the App.View
+// composite. The view's panels (rail, sidebar, messages, thread) are each
+// built to exactly `height` rows of a uniform per-panel width (via
+// exactSize / borderedTopPane), so lipgloss's per-line width measurement
+// and height padding are pure overhead -- the join is just a row-wise
+// concatenation.
+//
+// It returns ok=false (and the caller falls back to lipgloss) if ANY
+// panel does not have exactly `height` rows, which is the only condition
+// under which lipgloss's height-padding would actually differ from a
+// naive concat (e.g. a clamped pane on a very short terminal, or the
+// preview panel). Uniform per-panel line width is guaranteed by the
+// renderers and asserted by TestJoinPanelsHorizontal_MatchesLipgloss.
+func joinPanelsHorizontal(panels []string, height int) (string, bool) {
+	if len(panels) == 0 || height <= 0 {
+		return "", false
+	}
+	cols := make([][]string, len(panels))
+	for i, p := range panels {
+		lines := strings.Split(p, "\n")
+		if len(lines) != height {
+			return "", false
+		}
+		cols[i] = lines
+	}
+	var b strings.Builder
+	for r := 0; r < height; r++ {
+		if r > 0 {
+			b.WriteByte('\n')
+		}
+		for i := range cols {
+			b.WriteString(cols[i][r])
+		}
+	}
+	return b.String(), true
+}
+
+// stackContentStatus is a near-zero-measurement replacement for
+// lipgloss.JoinVertical(lipgloss.Left, content, status) for the two
+// final blocks of App.View. content is the horizontally-joined panel
+// block (uniform line width); status is the single status row. lipgloss
+// left-aligns by padding every line of the narrower block to the wider
+// block's width with plain spaces -- so we measure just one content line
+// (content is uniform) and the status row, then pad with constant runs.
+//
+// This reproduces lipgloss's output byte-for-byte (verified by
+// TestViewComposite_MatchesLipgloss), INCLUDING the case where the status
+// row is wider than the content (a pre-existing statusbar width quirk):
+// lipgloss right-pads the content lines to the status width, and so do we.
+func stackContentStatus(content, status string) string {
+	contentW := 0
+	if nl := strings.IndexByte(content, '\n'); nl >= 0 {
+		contentW = ansi.StringWidth(content[:nl])
+	} else {
+		contentW = ansi.StringWidth(content)
+	}
+	statusW := ansi.StringWidth(status)
+	maxW := contentW
+	if statusW > maxW {
+		maxW = statusW
+	}
+
+	var b strings.Builder
+	if maxW > contentW {
+		pad := strings.Repeat(" ", maxW-contentW)
+		lines := strings.Split(content, "\n")
+		for i, line := range lines {
+			if i > 0 {
+				b.WriteByte('\n')
+			}
+			b.WriteString(line)
+			b.WriteString(pad)
+		}
+	} else {
+		b.WriteString(content)
+	}
+	b.WriteByte('\n')
+	b.WriteString(status)
+	if maxW > statusW {
+		b.WriteString(strings.Repeat(" ", maxW-statusW))
+	}
+	return b.String()
+}
 
 // exactSizeBg forces s to exactly (w, h) cells with bg as the
 // background color. Uses an explicit width parameter instead of


### PR DESCRIPTION
Stacked on #54 (base branch `perf/message-pane-scroll`).

## Problem

After #54 de-lipglossed the per-frame message-pane border, profiling showed the remaining scroll-frame cost was dominated by the `App.View` screen composite: `lipgloss.JoinHorizontal` + `JoinVertical` re-split and re-measure every line of every panel (and then the whole screen) grapheme-by-grapheme on every frame (`getLines` + `JoinVertical` + `JoinHorizontal` were ~70% of `ansi.stringWidth`).

## Change

The view's panels (rail, sidebar, messages, thread) are each built to exactly `frame.ContentHeight` rows of a uniform per-panel width, so the join is just concatenation:

- **`joinPanelsHorizontal`** row-concatenates the panels, falling back to lipgloss if any panel's row count differs `frame.ContentHeight` (e.g. a height-clamped pane on a tiny terminal — the only case where lipgloss's height padding would actually differ).
- **`stackContentStatus`** stacks the content block over the status row, padding to the wider block exactly as `lipgloss.JoinVertical(Left)` does (including the pre-existing case where the status row is a few cells wider than the content) — but with two width measurements instead of one per line.

Both reproduce lipgloss output **byte-for-byte**, gated by `TestJoinPanelsHorizontal_MatchesLipgloss` and `TestViewComposite_MatchesLipgloss` across sidebar/thread layout configurations.

## Impact (benchmark, 477×130, 200 msgs)

| | before #54 | after #54 | after this |
|---|---|---|---|
| Scroll frame | ~45 ms | ~9.9 ms | **~7.1 ms** (6×) |

## Testing

Full `go test ./...` and `go vet ./internal/...` pass. Same review caveat as #54: geometry + plain text verified byte-for-byte; colors/SGR could not be diffed automatically (but the output is byte-identical to the prior lipgloss composite in the tested configs).

## Remaining

The leftover `stringWidth` is now mostly `scrollbar.Overlay` re-measuring visible lines; it's entangled with the unpadded scroll-indicator rows, so it's left as-is for now (diminishing returns at ~7ms / ~140fps).