### PR TITLE
perf(messages): drop uniseg sentence-break work from plain-line mapping

### DIFF
--- a/internal/ui/app_bench_test.go
+++ b/internal/ui/app_bench_test.go
@@ -163,6 +163,26 @@ func BenchmarkAppViewScrollHeldKey(b *testing.B) {
 	}
 }
 
+// BenchmarkThreadToggle measures the cost of opening/closing the thread
+// panel. Flipping threadVisible shrinks the messages pane width, which
+// forces a full message-cache rebuild at the new width -- the ~500ms
+// redraw the user reported. Each iteration does one open + one close.
+func BenchmarkThreadToggle(b *testing.B) {
+	a := makeWideScrollApp()
+	parent := a.messagepane.Messages()[0]
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Open: thread visible -> messages pane narrows -> rebuild.
+		a.threadVisible = true
+		a.threadPanel.SetThread(parent, nil, "C1", parent.TS)
+		_ = a.View()
+		// Close: messages pane widens back -> rebuild again.
+		a.threadVisible = false
+		_ = a.View()
+	}
+}
+
 // TestComposeKeystrokeKeepsSidePanelsCached verifies that typing a single
 // character into the compose box does NOT bump the version counters of the
 // sidebar / messages / workspace rail panels. Without this guarantee, the

--- a/internal/ui/messages/buildplainline_test.go
+++ b/internal/ui/messages/buildplainline_test.go
@@ -1,0 +1,66 @@
+package messages
+
+import (
+	"testing"
+
+	"github.com/rivo/uniseg"
+)
+
+// buildPlainLineUniseg is the previous uniseg.NewGraphemes-based reference
+// implementation, kept here only to prove the faster grapheme-only
+// FirstGraphemeClusterInString rewrite in buildPlainLine produces an
+// identical column->byte map.
+func buildPlainLineUniseg(line string) plainLine {
+	if line == "" {
+		return plainLine{Text: "", Bytes: []int{0}}
+	}
+	g := uniseg.NewGraphemes(line)
+	bytesMap := make([]int, 0, len(line))
+	byteOffset := 0
+	for g.Next() {
+		cluster := g.Str()
+		w := g.Width()
+		if w <= 0 {
+			byteOffset += len(cluster)
+			continue
+		}
+		for k := 0; k < w; k++ {
+			bytesMap = append(bytesMap, byteOffset)
+		}
+		byteOffset += len(cluster)
+	}
+	bytesMap = append(bytesMap, len(line))
+	return plainLine{Text: line, Bytes: bytesMap}
+}
+
+func TestBuildPlainLine_MatchesUnisegGraphemes(t *testing.T) {
+	cases := []string{
+		"",
+		"hello world",
+		"a moderately long message with **bold** and _italic_ formatting.",
+		"emoji 😀 here",
+		"flag 🇺🇸 and family 👨‍👩‍👧‍👦 done",
+		"wide 你好世界 chars",
+		"combining e\u0301 acute",
+		"zwj 👩‍💻 dev",
+		"tabs\tand   spaces",
+		"❤️ variation selector",
+		"mixed 12 ab 漢字 😀 e\u0301 end",
+		"trailing combining a\u0301",
+	}
+	for _, s := range cases {
+		want := buildPlainLineUniseg(s)
+		got := buildPlainLine(s)
+		if got.Text != want.Text {
+			t.Fatalf("Text mismatch for %q: got %q want %q", s, got.Text, want.Text)
+		}
+		if len(got.Bytes) != len(want.Bytes) {
+			t.Fatalf("Bytes len mismatch for %q: got %v want %v", s, got.Bytes, want.Bytes)
+		}
+		for i := range want.Bytes {
+			if got.Bytes[i] != want.Bytes[i] {
+				t.Fatalf("Bytes[%d] mismatch for %q: got %v want %v", i, s, got.Bytes, want.Bytes)
+			}
+		}
+	}
+}

--- a/internal/ui/messages/render.go
+++ b/internal/ui/messages/render.go
@@ -1071,12 +1071,21 @@ func buildPlainLine(line string) plainLine {
 	if line == "" {
 		return plainLine{Text: "", Bytes: []int{0}}
 	}
-	g := uniseg.NewGraphemes(line)
+	// Use the grapheme-only iterator (FirstGraphemeClusterInString)
+	// instead of uniseg.NewGraphemes/.Next(): the latter runs uniseg's
+	// full StepString state machine, which also computes word/sentence/
+	// line-break boundaries we never use. That sentence-break work was
+	// ~67% of a full buildCache (the ~500ms thread-open / channel-switch
+	// rebuild). The grapheme cluster boundaries and widths produced are
+	// identical (verified by TestBuildPlainLine_MatchesUnisegGraphemes).
 	bytesMap := make([]int, 0, len(line))
 	byteOffset := 0
-	for g.Next() {
-		cluster := g.Str()
-		w := g.Width()
+	state := -1
+	rest := line
+	for len(rest) > 0 {
+		var cluster string
+		var w int
+		cluster, rest, w, state = uniseg.FirstGraphemeClusterInString(rest, state)
 		if w <= 0 {
 			// Zero-width cluster: bytes go into Text but no column is
 			// produced. The byte offset advances; the next W>0 cluster


### PR DESCRIPTION
Stacked on #55.

## Problem

Opening/closing the thread panel takes ~500ms to redraw (reported by a user; reproduced). Flipping the thread panel narrows the message pane, which forces a full message-cache rebuild at the new width (the same happens on channel switch). Profiling that rebuild showed **~67% of the time in uniseg's sentence-break state machine** (`transitionSentenceBreakState`), reached via `uniseg.NewGraphemes().Next()` in `buildPlainLine` — the per-line column→byte map used for mouse-selection slicing.

`uniseg.NewGraphemes` runs `StepString`, which computes grapheme **and** word **and** sentence **and** line-break boundaries. We only need grapheme clusters and their widths.

## Change

Switch `buildPlainLine` to uniseg's grapheme-only `FirstGraphemeClusterInString` iterator. Output is byte-for-byte identical — verified by `TestBuildPlainLine_MatchesUnisegGraphemes` across ASCII, wide CJK, emoji / ZWJ / flag sequences, and combining marks (the old `uniseg.NewGraphemes` impl is kept in the test as the reference).

## Impact (`BenchmarkThreadToggle`, 477×130, 200 msgs)

| | before | after |
|---|---|---|
| Thread open + close | ~1.03 s | **~0.28 s** (3.6×) |

This also speeds up channel switches, which hit the same `buildCache` path.

## Note

This is a safe, localized win but doesn't fully reach "instant" on a 200-message channel — the remaining cost is `lipgloss.Style.Render` re-rendering each message's border/fill (and a pre-rendered *selected* variant for every message). Reducing that further (lazy selected-variant, or rendering only the visible window on a width change) is a larger refactor with scroll-path tradeoffs; tracked as follow-up.