### PR TITLE
perf(ui,messages): screen composite + thread-open speedup (re-target to main)

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2210,8 +2210,21 @@ func (a *App) View() tea.View {
 		screen = a.lastScreen
 		memoHit = true
 	} else {
-		content := lipgloss.JoinHorizontal(lipgloss.Top, panels...)
-		screen = lipgloss.JoinVertical(lipgloss.Left, content, status)
+		// Composite the side-by-side panels. The panels are uniform-width
+		// and all exactly frame.ContentHeight rows, so a row-wise concat
+		// is byte-identical to lipgloss's JoinHorizontal but skips its
+		// per-line grapheme width measurement (a large share of the
+		// remaining scroll-frame cost at wide sizes). Fall back to lipgloss
+		// if the fast path declines (e.g. a height-clamped pane).
+		content, ok := joinPanelsHorizontal(panels, frame.ContentHeight)
+		if !ok {
+			content = lipgloss.JoinHorizontal(lipgloss.Top, panels...)
+		}
+		// Stack content over status without re-measuring every content
+		// line (lipgloss.JoinVertical's getLines was the other large share
+		// of the composite cost). stackContentStatus reproduces lipgloss's
+		// left-align padding byte-for-byte; see its doc.
+		screen = stackContentStatus(content, status)
 		screen = a.applyOverlays(screen)
 		screen = a.maybeWrapFinalScreen(screen)
 		if canMemo {

--- a/internal/ui/app_bench_test.go
+++ b/internal/ui/app_bench_test.go
@@ -163,6 +163,26 @@ func BenchmarkAppViewScrollHeldKey(b *testing.B) {
 	}
 }
 
+// BenchmarkThreadToggle measures the cost of opening/closing the thread
+// panel. Flipping threadVisible shrinks the messages pane width, which
+// forces a full message-cache rebuild at the new width -- the ~500ms
+// redraw the user reported. Each iteration does one open + one close.
+func BenchmarkThreadToggle(b *testing.B) {
+	a := makeWideScrollApp()
+	parent := a.messagepane.Messages()[0]
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Open: thread visible -> messages pane narrows -> rebuild.
+		a.threadVisible = true
+		a.threadPanel.SetThread(parent, nil, "C1", parent.TS)
+		_ = a.View()
+		// Close: messages pane widens back -> rebuild again.
+		a.threadVisible = false
+		_ = a.View()
+	}
+}
+
 // TestComposeKeystrokeKeepsSidePanelsCached verifies that typing a single
 // character into the compose box does NOT bump the version counters of the
 // sidebar / messages / workspace rail panels. Without this guarantee, the

--- a/internal/ui/messages/buildplainline_test.go
+++ b/internal/ui/messages/buildplainline_test.go
@@ -1,0 +1,66 @@
+package messages
+
+import (
+	"testing"
+
+	"github.com/rivo/uniseg"
+)
+
+// buildPlainLineUniseg is the previous uniseg.NewGraphemes-based reference
+// implementation, kept here only to prove the faster grapheme-only
+// FirstGraphemeClusterInString rewrite in buildPlainLine produces an
+// identical column->byte map.
+func buildPlainLineUniseg(line string) plainLine {
+	if line == "" {
+		return plainLine{Text: "", Bytes: []int{0}}
+	}
+	g := uniseg.NewGraphemes(line)
+	bytesMap := make([]int, 0, len(line))
+	byteOffset := 0
+	for g.Next() {
+		cluster := g.Str()
+		w := g.Width()
+		if w <= 0 {
+			byteOffset += len(cluster)
+			continue
+		}
+		for k := 0; k < w; k++ {
+			bytesMap = append(bytesMap, byteOffset)
+		}
+		byteOffset += len(cluster)
+	}
+	bytesMap = append(bytesMap, len(line))
+	return plainLine{Text: line, Bytes: bytesMap}
+}
+
+func TestBuildPlainLine_MatchesUnisegGraphemes(t *testing.T) {
+	cases := []string{
+		"",
+		"hello world",
+		"a moderately long message with **bold** and _italic_ formatting.",
+		"emoji 😀 here",
+		"flag 🇺🇸 and family 👨‍👩‍👧‍👦 done",
+		"wide 你好世界 chars",
+		"combining e\u0301 acute",
+		"zwj 👩‍💻 dev",
+		"tabs\tand   spaces",
+		"❤️ variation selector",
+		"mixed 12 ab 漢字 😀 e\u0301 end",
+		"trailing combining a\u0301",
+	}
+	for _, s := range cases {
+		want := buildPlainLineUniseg(s)
+		got := buildPlainLine(s)
+		if got.Text != want.Text {
+			t.Fatalf("Text mismatch for %q: got %q want %q", s, got.Text, want.Text)
+		}
+		if len(got.Bytes) != len(want.Bytes) {
+			t.Fatalf("Bytes len mismatch for %q: got %v want %v", s, got.Bytes, want.Bytes)
+		}
+		for i := range want.Bytes {
+			if got.Bytes[i] != want.Bytes[i] {
+				t.Fatalf("Bytes[%d] mismatch for %q: got %v want %v", i, s, got.Bytes, want.Bytes)
+			}
+		}
+	}
+}

--- a/internal/ui/messages/render.go
+++ b/internal/ui/messages/render.go
@@ -1071,12 +1071,21 @@ func buildPlainLine(line string) plainLine {
 	if line == "" {
 		return plainLine{Text: "", Bytes: []int{0}}
 	}
-	g := uniseg.NewGraphemes(line)
+	// Use the grapheme-only iterator (FirstGraphemeClusterInString)
+	// instead of uniseg.NewGraphemes/.Next(): the latter runs uniseg's
+	// full StepString state machine, which also computes word/sentence/
+	// line-break boundaries we never use. That sentence-break work was
+	// ~67% of a full buildCache (the ~500ms thread-open / channel-switch
+	// rebuild). The grapheme cluster boundaries and widths produced are
+	// identical (verified by TestBuildPlainLine_MatchesUnisegGraphemes).
 	bytesMap := make([]int, 0, len(line))
 	byteOffset := 0
-	for g.Next() {
-		cluster := g.Str()
-		w := g.Width()
+	state := -1
+	rest := line
+	for len(rest) > 0 {
+		var cluster string
+		var w int
+		cluster, rest, w, state = uniseg.FirstGraphemeClusterInString(rest, state)
 		if w <= 0 {
 			// Zero-width cluster: bytes go into Text but no column is
 			// produced. The byte offset advances; the next W>0 cluster

--- a/internal/ui/view_composite_test.go
+++ b/internal/ui/view_composite_test.go
@@ -1,0 +1,107 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/gammons/slk/internal/ui/messages"
+)
+
+// TestJoinPanelsHorizontal_MatchesLipgloss verifies the zero-measurement
+// row-concat join is byte-identical to lipgloss.JoinHorizontal for
+// uniform-width, equal-height panels (the View invariant), and that it
+// declines (ok=false) when heights differ so the caller can fall back.
+func TestJoinPanelsHorizontal_MatchesLipgloss(t *testing.T) {
+	mk := func(w, h int, fill rune) string {
+		row := strings.Repeat(string(fill), w)
+		rows := make([]string, h)
+		for i := range rows {
+			rows[i] = row
+		}
+		return strings.Join(rows, "\n")
+	}
+
+	// Equal heights, mixed widths -> must match lipgloss byte-for-byte.
+	panels := []string{mk(3, 5, 'a'), mk(10, 5, 'b'), mk(2, 5, 'c')}
+	got, ok := joinPanelsHorizontal(panels, 5)
+	if !ok {
+		t.Fatal("expected ok for equal-height panels")
+	}
+	want := lipgloss.JoinHorizontal(lipgloss.Top, panels...)
+	if got != want {
+		t.Fatalf("join mismatch:\n got=%q\nwant=%q", got, want)
+	}
+
+	// Mismatched height -> decline.
+	if _, ok := joinPanelsHorizontal([]string{mk(3, 5, 'a'), mk(3, 4, 'b')}, 5); ok {
+		t.Fatal("expected ok=false when a panel has the wrong row count")
+	}
+}
+
+// buildViewPanels mirrors App.View's panel assembly so the composite
+// helpers can be checked against lipgloss on real rendered panels.
+func buildViewPanels(a *App) (panels []string, status string, contentHeight, width int) {
+	themeVer := int64(0)
+	frame := a.layout.Compute(a.width, a.height, a.workspaceRail.Width(), a.sidebar.Width(), a.sidebarVisible, a.threadVisible)
+	panels = append(panels, a.renderRail(frame.RailWidth, frame.ContentHeight, themeVer))
+	if a.sidebarVisible {
+		panels = append(panels, a.renderSidebar(frame.SidebarWidth, frame.SidebarBorder, frame.ContentHeight, themeVer))
+	}
+	if s := a.renderMessagesRegion(frame, themeVer, false); s != "" {
+		panels = append(panels, s)
+	}
+	if a.threadVisible && frame.ThreadWidth > 0 {
+		panels = append(panels, a.renderThreadRegion(frame, themeVer))
+	}
+	status = a.renderStatusRow(frame.RailWidth, a.width-frame.RailWidth, themeVer)
+	return panels, status, frame.ContentHeight, a.width
+}
+
+// TestViewComposite_MatchesLipgloss checks the full screen composite
+// (horizontal panel join + vertical status stack) is byte-identical to
+// the lipgloss path across layout configurations (sidebar/thread on/off).
+func TestViewComposite_MatchesLipgloss(t *testing.T) {
+	newApp := func(sidebar, thread bool) *App {
+		a := NewApp()
+		_, _ = a.Update(tea.WindowSizeMsg{Width: 477, Height: 130})
+		msgs := make([]messages.MessageItem, 40)
+		for i := range msgs {
+			msgs[i] = messages.MessageItem{TS: fmt.Sprintf("%d.0", 1700000000+i), UserName: "alice", UserID: "U1", Text: "hello world", Timestamp: "10:30 AM"}
+		}
+		a.messagepane.SetMessages(msgs)
+		a.sidebarVisible = sidebar
+		if thread {
+			a.threadVisible = true
+			a.threadPanel.SetThread(msgs[0], nil, "C1", msgs[0].TS)
+		}
+		a.focusedPanel = PanelMessages
+		a.SetMode(ModeNormal)
+		_ = a.View()
+		return a
+	}
+
+	for _, sidebar := range []bool{true, false} {
+		for _, thread := range []bool{false, true} {
+			a := newApp(sidebar, thread)
+			panels, status, ch, _ := buildViewPanels(a)
+
+			gotH, ok := joinPanelsHorizontal(panels, ch)
+			if !ok {
+				t.Fatalf("[sidebar=%v thread=%v] fast join declined unexpectedly", sidebar, thread)
+			}
+			wantH := lipgloss.JoinHorizontal(lipgloss.Top, panels...)
+			if gotH != wantH {
+				t.Fatalf("[sidebar=%v thread=%v] horizontal join differs from lipgloss", sidebar, thread)
+			}
+
+			gotV := stackContentStatus(gotH, status)
+			wantV := lipgloss.JoinVertical(lipgloss.Left, wantH, status)
+			if gotV != wantV {
+				t.Fatalf("[sidebar=%v thread=%v] vertical stack differs from lipgloss", sidebar, thread)
+			}
+		}
+	}
+}

--- a/internal/ui/view_helpers.go
+++ b/internal/ui/view_helpers.go
@@ -23,9 +23,95 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/gammons/slk/internal/ui/styles"
 )
+
+// joinPanelsHorizontal is a zero-measurement replacement for
+// lipgloss.JoinHorizontal(lipgloss.Top, panels...) for the App.View
+// composite. The view's panels (rail, sidebar, messages, thread) are each
+// built to exactly `height` rows of a uniform per-panel width (via
+// exactSize / borderedTopPane), so lipgloss's per-line width measurement
+// and height padding are pure overhead -- the join is just a row-wise
+// concatenation.
+//
+// It returns ok=false (and the caller falls back to lipgloss) if ANY
+// panel does not have exactly `height` rows, which is the only condition
+// under which lipgloss's height-padding would actually differ from a
+// naive concat (e.g. a clamped pane on a very short terminal, or the
+// preview panel). Uniform per-panel line width is guaranteed by the
+// renderers and asserted by TestJoinPanelsHorizontal_MatchesLipgloss.
+func joinPanelsHorizontal(panels []string, height int) (string, bool) {
+	if len(panels) == 0 || height <= 0 {
+		return "", false
+	}
+	cols := make([][]string, len(panels))
+	for i, p := range panels {
+		lines := strings.Split(p, "\n")
+		if len(lines) != height {
+			return "", false
+		}
+		cols[i] = lines
+	}
+	var b strings.Builder
+	for r := 0; r < height; r++ {
+		if r > 0 {
+			b.WriteByte('\n')
+		}
+		for i := range cols {
+			b.WriteString(cols[i][r])
+		}
+	}
+	return b.String(), true
+}
+
+// stackContentStatus is a near-zero-measurement replacement for
+// lipgloss.JoinVertical(lipgloss.Left, content, status) for the two
+// final blocks of App.View. content is the horizontally-joined panel
+// block (uniform line width); status is the single status row. lipgloss
+// left-aligns by padding every line of the narrower block to the wider
+// block's width with plain spaces -- so we measure just one content line
+// (content is uniform) and the status row, then pad with constant runs.
+//
+// This reproduces lipgloss's output byte-for-byte (verified by
+// TestViewComposite_MatchesLipgloss), INCLUDING the case where the status
+// row is wider than the content (a pre-existing statusbar width quirk):
+// lipgloss right-pads the content lines to the status width, and so do we.
+func stackContentStatus(content, status string) string {
+	contentW := 0
+	if nl := strings.IndexByte(content, '\n'); nl >= 0 {
+		contentW = ansi.StringWidth(content[:nl])
+	} else {
+		contentW = ansi.StringWidth(content)
+	}
+	statusW := ansi.StringWidth(status)
+	maxW := contentW
+	if statusW > maxW {
+		maxW = statusW
+	}
+
+	var b strings.Builder
+	if maxW > contentW {
+		pad := strings.Repeat(" ", maxW-contentW)
+		lines := strings.Split(content, "\n")
+		for i, line := range lines {
+			if i > 0 {
+				b.WriteByte('\n')
+			}
+			b.WriteString(line)
+			b.WriteString(pad)
+		}
+	} else {
+		b.WriteString(content)
+	}
+	b.WriteByte('\n')
+	b.WriteString(status)
+	if maxW > statusW {
+		b.WriteString(strings.Repeat(" ", maxW-statusW))
+	}
+	return b.String()
+}
 
 // exactSizeBg forces s to exactly (w, h) cells with bg as the
 // background color. Uses an explicit width parameter instead of


### PR DESCRIPTION
#54 merged to `main`, but the stacked PRs #55 and #56 merged into their (stale) base branches instead of `main` — so these two changes never reached `main`. This re-targets both onto `main` in one PR so they can ship in the next release.

Brings:
- **#55** — `perf(ui): assemble the View screen composite without re-measuring` (row-concat `JoinHorizontal` + `stackContentStatus`, byte-identical, gated by equivalence tests).
- **#56** — `perf(messages): drop uniseg sentence-break work from plain-line mapping` (grapheme-only iterator in `buildPlainLine`; ~3.6× faster thread-open / channel-switch rebuild).

Diff is exactly those two commits (6 files). Full `go test ./...` and `go vet` pass.