### PR TITLE
fix(blockkit): render Block Kit blocks nested in legacy attachments

### DIFF
--- a/docs/superpowers/specs/2026-06-08-list-message-reactions-design.md
+++ b/docs/superpowers/specs/2026-06-08-list-message-reactions-design.md
@@ -1,0 +1,107 @@
+# List reactions on a message (issue #48)
+
+## Problem
+
+Reactions can be used for planning and decision making, so users want to be
+able to see, for a given message, which users reacted and with what. Today the
+app renders reaction pills (emoji + count) but provides no way to see *who*
+reacted.
+
+GitHub issue: #48 — "Add ability to list the reactions to a message".
+
+## Goal
+
+A read-only modal that lists every reaction on the selected message, grouped by
+emoji, showing the display names of the users who reacted with each emoji.
+
+## Key finding
+
+The per-user reaction data already exists locally. `cache.ReactionRow`
+(`internal/cache/reactions.go:8-12`) carries `UserIDs`, populated from the Slack
+`conversations.history`/`replies` responses and kept up to date by the
+`OnReactionAdded` / `OnReactionRemoved` websocket handlers
+(`cmd/slk/main.go`). The UI model `messages.ReactionItem`
+(`internal/ui/messages/model.go:79-83`) currently drops `UserIDs`, keeping only
+emoji/count/`HasReacted`. So this feature is primarily plumbing + a new view; no
+new Slack API surface is required.
+
+## Non-goals
+
+- No fresh `reactions.get` API call. Data is cache-only.
+- No actions inside the modal (read-only). It does not add/remove reactions.
+- No async name resolution work for now. Unresolved user IDs fall back to the
+  raw ID via the existing `userNameFor` helper. Revisit only if it proves to be
+  a problem in practice.
+
+## Trigger & behavior
+
+- **Key:** `L` (uppercase) in normal mode. Mnemonic "List reactions".
+- **Main message pane:** acts on the currently selected message.
+- **Thread pane:** acts on the currently selected reply (whichever pane has
+  focus), consistent with how `r`/`R`/`E`/`D` already work in both panes.
+- **No reactions on the message:** pressing `L` is a no-op; the modal does not
+  open. Keeps the UX quiet rather than showing an empty box.
+- **Toggle/close:** `esc` closes; pressing `L` again while open also closes.
+
+## Data flow
+
+1. On open, read reactions for the message from the cache via
+   `cache.GetReactions(messageTS, channelID)`, returning
+   `ReactionRow{Emoji, UserIDs, Count}`.
+2. Resolve each `UserID` to a name using the existing `App.userNameFor`
+   (`internal/ui/app.go:1476`), which falls back to the raw ID when unresolved.
+3. Mark the current user's own entry as `(you)` using the client's user ID.
+4. No network calls; no additions to the `SlackAPI` interface.
+
+## UI / layout
+
+A centered dimmed overlay modeled on the existing reaction picker
+(`internal/ui/reactionpicker/model.go`), reusing `overlay.DimmedOverlay`.
+Content is grouped by emoji with a per-emoji count and is scrollable when long:
+
+```
+ Reactions
+ ──────────────────────
+ :thumbsup:  (3)
+   Alice Smith
+   Bob Jones
+   You (you)
+ :eyes:  (1)
+   Carol Lee
+ ──────────────────────
+ ↑/↓ scroll · esc close
+```
+
+- Emojis are rendered the same way the existing reaction pills render them.
+- Scroll with `↑/↓` and `j/k`; close with `esc` (or `L` toggles closed).
+- Read-only: no actions from within the modal.
+
+## Code structure
+
+New package and touched files:
+
+- **New** `internal/ui/reactionsview/` — `Model` exposing
+  `Open(...)`, `Close()`, `IsVisible()`, `HandleKey()`, `ViewOverlay()`.
+  Mirrors the shape of `reactionpicker`.
+- **`internal/ui/mode.go`** — add a mode/overlay-visible state for the view,
+  following the pattern used by other modals.
+- **`internal/ui/keys.go`** — add a `ListReactions` binding bound to `L`.
+- **`internal/ui/mode_normal.go`** — dispatch `L`: build grouped data from the
+  selected message (main pane) or selected reply (thread pane) and open the
+  modal; no-op when there are no reactions.
+- **`internal/ui/app.go`** — add a `reactionsView *reactionsview.Model` field
+  and its construction; add a helper that assembles the grouped data (resolving
+  names via `userNameFor` and marking the current user `(you)`).
+- **`internal/ui/view_overlays.go`** — register the modal in `applyOverlays`
+  and `overlayActive`.
+- **`internal/ui/help/`** — add `L` to the keybindings help list.
+
+## Testing
+
+- Unit-test the data-assembly helper: given cache rows + a name map + the
+  current user ID, it produces correctly grouped/ordered entries, marks `(you)`
+  for the current user, and falls back to raw IDs for unresolved names.
+- Unit-test the modal `Model`: open/close/visibility, scroll bounds, and
+  no-op/empty-input behavior.
+- Follow the test patterns established by `reactionpicker` and the other modal
+  packages.

--- a/internal/ui/messages/blockkit/attachments.go
+++ b/internal/ui/messages/blockkit/attachments.go
@@ -126,6 +126,31 @@ func appendLegacyAttachment(out *RenderResult, a LegacyAttachment, ctx Context, 
 			perf.textTotal += time.Since(t0)
 		}
 	}
+	// Nested Block Kit blocks. Slack's newer link-unfurl shape
+	// (Linear/Jira/GitHub issue cards) carries all content here while
+	// Title/Text/Fields are empty. Render them via the standard block
+	// renderer at the stripe-indented content width, then splice the
+	// resulting lines into body so they pick up the colored stripe
+	// prefix below. Image flushes/sixels/hits from the sub-render are
+	// merged with row/col offsets after the stripe loop.
+	var nested RenderResult
+	var nestedRowStartInBody int
+	if len(a.Blocks) > 0 {
+		var t0 time.Time
+		if perf != nil {
+			t0 = time.Now()
+		}
+		nested = Render(a.Blocks, ctx, contentW)
+		nestedRowStartInBody = len(body)
+		body = append(body, nested.Lines...)
+		if nested.Interactive {
+			out.Interactive = true
+		}
+		if perf != nil {
+			perf.otherTotal += time.Since(t0)
+		}
+	}
+
 	// Inline image (Task 13). Uses the same fetcher path as image
 	// blocks; falls back to a single OSC-8 link line when no fetcher
 	// is configured or the protocol is off.
@@ -213,6 +238,28 @@ func appendLegacyAttachment(out *RenderResult, a LegacyAttachment, ctx Context, 
 		imageHitInBody.ColStart += stripeCol
 		imageHitInBody.ColEnd += stripeCol
 		out.Hits = append(out.Hits, *imageHitInBody)
+	}
+
+	// Merge nested-block image artifacts. Sub-render coordinates are
+	// relative to nested.Lines (0-based); translate to absolute
+	// out.Lines rows by adding startRow + the block region's offset
+	// within body, and shift columns by the stripe prefix.
+	if len(a.Blocks) > 0 {
+		rowOffset := startRow + nestedRowStartInBody
+		out.Flushes = append(out.Flushes, nested.Flushes...)
+		for k, v := range nested.SixelRows {
+			if out.SixelRows == nil {
+				out.SixelRows = map[int]SixelEntry{}
+			}
+			out.SixelRows[k+rowOffset] = v
+		}
+		for _, h := range nested.Hits {
+			h.RowStart += rowOffset
+			h.RowEnd += rowOffset
+			h.ColStart += stripeCol
+			h.ColEnd += stripeCol
+			out.Hits = append(out.Hits, h)
+		}
 	}
 }
 

--- a/internal/ui/messages/blockkit/attachments_test.go
+++ b/internal/ui/messages/blockkit/attachments_test.go
@@ -173,3 +173,37 @@ func TestRenderLegacyImageURLFallbackWhenNoFetcher(t *testing.T) {
 		t.Errorf("expected '[image]' marker in fallback, got %q", plain)
 	}
 }
+
+// TestRenderLegacyRendersNestedBlocks covers link-unfurl attachments
+// (Linear/Jira/etc.) whose entire content lives in nested Block Kit
+// blocks while Title/Text/Fields are empty. Those blocks must render
+// inside the attachment's colored stripe, otherwise the card shows
+// nothing.
+func TestRenderLegacyRendersNestedBlocks(t *testing.T) {
+	ctx := Context{
+		RenderText: func(s string, _ map[string]string) string { return s },
+		WrapText:   func(s string, _ int) string { return s },
+	}
+	r := RenderLegacy([]LegacyAttachment{{
+		Color: "#2d1c9c",
+		Blocks: []Block{
+			SectionBlock{Text: "TRU-111 Customer Facing Blacklist Monitoring"},
+			ContextBlock{Elements: []ContextElement{{Text: "*State*  In Progress"}}},
+		},
+	}}, ctx, 60)
+	if r.Height == 0 {
+		t.Fatalf("Height = 0, expected nested blocks to render")
+	}
+	plain := ansi.Strip(strings.Join(r.Lines, "\n"))
+	if !strings.Contains(plain, "TRU-111 Customer Facing Blacklist Monitoring") {
+		t.Errorf("missing section text: %q", plain)
+	}
+	if !strings.Contains(plain, "In Progress") {
+		t.Errorf("missing context text: %q", plain)
+	}
+	for i, line := range r.Lines {
+		if !strings.HasPrefix(ansi.Strip(line), "█") {
+			t.Errorf("line %d missing stripe prefix: %q", i, ansi.Strip(line))
+		}
+	}
+}

--- a/internal/ui/messages/blockkit/parse.go
+++ b/internal/ui/messages/blockkit/parse.go
@@ -181,6 +181,7 @@ func parseAttachment(a slack.Attachment) LegacyAttachment {
 		ThumbURL:   a.ThumbURL,
 		Footer:     a.Footer,
 		FooterIcon: a.FooterIcon,
+		Blocks:     Parse(a.Blocks),
 	}
 	for _, f := range a.Fields {
 		la.Fields = append(la.Fields, LegacyField{

--- a/internal/ui/messages/blockkit/parse_test.go
+++ b/internal/ui/messages/blockkit/parse_test.go
@@ -293,3 +293,31 @@ func TestParseAttachmentImageAndThumb(t *testing.T) {
 		t.Errorf("ThumbURL = %q", a.ThumbURL)
 	}
 }
+
+// TestParseAttachmentNestedBlocks covers Slack's newer attachment
+// shape (used by Linear/Jira/etc. link unfurls) where the attachment
+// carries no title/text/fields and instead nests Block Kit blocks in
+// its `blocks` array. The parser must surface those so the renderer
+// can display them.
+func TestParseAttachmentNestedBlocks(t *testing.T) {
+	in := []slack.Attachment{{
+		Color: "#2d1c9c",
+		Blocks: slack.Blocks{BlockSet: []slack.Block{
+			slack.NewSectionBlock(
+				slack.NewTextBlockObject("mrkdwn", "TRU-111 Customer Facing Blacklist Monitoring", false, false),
+				nil, nil,
+			),
+		}},
+	}}
+	a := ParseAttachments(in)[0]
+	if len(a.Blocks) != 1 {
+		t.Fatalf("Blocks len = %d, want 1", len(a.Blocks))
+	}
+	sec, ok := a.Blocks[0].(SectionBlock)
+	if !ok {
+		t.Fatalf("Blocks[0] type = %T, want SectionBlock", a.Blocks[0])
+	}
+	if sec.Text != "TRU-111 Customer Facing Blacklist Monitoring" {
+		t.Errorf("section text = %q", sec.Text)
+	}
+}

--- a/internal/ui/messages/blockkit/types.go
+++ b/internal/ui/messages/blockkit/types.go
@@ -173,6 +173,12 @@ type LegacyAttachment struct {
 	Footer     string
 	FooterIcon string // tiny inline image rendered before Footer
 	TS         int64  // unix seconds; 0 means absent
+	// Blocks holds Block Kit blocks nested inside the attachment.
+	// Slack's newer link-unfurl shape (Linear/Jira/GitHub issue
+	// cards, etc.) carries all visible content here while
+	// Title/Text/Fields are empty. Rendered inside the colored
+	// stripe after the classic fields. nil when absent.
+	Blocks []Block
 }
 
 // LegacyField is one entry in a LegacyAttachment's Fields slice.

--- a/internal/ui/messages/render.go
+++ b/internal/ui/messages/render.go
@@ -48,6 +48,13 @@ var (
 	// raw <#CID> token.
 	channelMentionRe = regexp.MustCompile(`<#([A-Z0-9]+)(?:\|([^>]+))?>`)
 
+	// Slack date tokens: <!date^TIMESTAMP^FORMAT|FALLBACK> (an optional
+	// ^LINK segment may precede the |). Common in bot/unfurl content
+	// (Linear, Jira, GitHub). We render the precomputed FALLBACK text
+	// (already localized by Slack) rather than re-deriving the date from
+	// the format string. Group 1 is the fallback.
+	dateTokenRe = regexp.MustCompile(`<!date\^[^|>]*\|([^>]*)>`)
+
 	// Slack escapes &, <, > in user-typed text per
 	// https://api.slack.com/reference/surfaces/formatting#escaping.
 	// We decode AFTER all markup regexes (which consume legitimate
@@ -726,6 +733,12 @@ func renderInlineFormattingWith(text string, opts RenderSlackMarkdownOpts) strin
 		url := linkBareRe.FindStringSubmatch(match)[1]
 		visible := strings.TrimPrefix(url, "mailto:")
 		return osc8Hyperlink(url, linkStyle().Render(visible))
+	})
+
+	// Date tokens: <!date^TS^FORMAT|FALLBACK> -> FALLBACK. Done before
+	// channel/user mentions; the token never contains <#/<@ forms.
+	text = dateTokenRe.ReplaceAllStringFunc(text, func(match string) string {
+		return dateTokenRe.FindStringSubmatch(match)[1]
 	})
 
 	// Channel mentions: <#C1234|channel-name> -> #channel-name, or

--- a/internal/ui/messages/render_test.go
+++ b/internal/ui/messages/render_test.go
@@ -225,6 +225,23 @@ func TestNonHTTPBracketedSurvives(t *testing.T) {
 	}
 }
 
+// TestDateTokenRendersFallback covers Slack's <!date^TS^FORMAT|FALLBACK>
+// token (emitted by Linear/Jira/etc. unfurls). We render the precomputed
+// fallback text and never leak the raw token or its format string.
+func TestDateTokenRendersFallback(t *testing.T) {
+	in := "<https://linear.app/truelist-io/team/TRU/all|Truelist> | <!date^1779996974^{date_short_pretty}|May 28, 2026>"
+	out := ansi.Strip(RenderSlackMarkdown(in, nil, nil))
+	if !strings.Contains(out, "May 28, 2026") {
+		t.Errorf("missing fallback date: %q", out)
+	}
+	if strings.Contains(out, "<!date") {
+		t.Errorf("raw date token leaked: %q", out)
+	}
+	if strings.Contains(out, "date_short_pretty") {
+		t.Errorf("date format string leaked: %q", out)
+	}
+}
+
 // TestRenderAttachmentsImageMarker asserts that an Image attachment renders
 // with an [Image] marker, the URL (visible for copy-paste), and an OSC 8
 // hyperlink for clickability. Filenames are intentionally omitted to keep

--- a/internal/ui/thread/model.go
+++ b/internal/ui/thread/model.go
@@ -16,6 +16,7 @@ import (
 	imgpkg "github.com/gammons/slk/internal/image"
 	"github.com/gammons/slk/internal/ui/imgrender"
 	"github.com/gammons/slk/internal/ui/messages"
+	"github.com/gammons/slk/internal/ui/messages/blockkit"
 	"github.com/gammons/slk/internal/ui/scrollbar"
 	"github.com/gammons/slk/internal/ui/selection"
 	"github.com/gammons/slk/internal/ui/styles"
@@ -1696,6 +1697,45 @@ func (m *Model) HitTestReaction(row, col int) (replyIdx int, emoji string, ok bo
 // (mirroring messages.Model). v1: per-block Hit and SixelRows from
 // imgrender are discarded — click-to-preview from a thread reply and
 // inline sixel emission are out of scope.
+// blockkitContext wires the thread pane's host dependencies into a
+// blockkit.Context. Mirrors messages.Model.blockkitContext so Block
+// Kit blocks and legacy attachments render identically in the thread
+// panel and the main message pane.
+func (m *Model) blockkitContext(msg messages.MessageItem, userNames, channelNames map[string]string) blockkit.Context {
+	var imgCtx imgrender.ImageContext
+	if m.imgRenderer != nil {
+		imgCtx = m.imgRenderer.Context()
+	}
+	send := imgCtx.SendMsg
+	return blockkit.Context{
+		Protocol:    imgCtx.Protocol,
+		Fetcher:     imgCtx.Fetcher,
+		KittyRender: imgCtx.KittyRender,
+		CellPixels:  imgCtx.CellPixels,
+		MaxRows:     imgCtx.MaxRows,
+		MaxCols:     imgCtx.MaxCols,
+		UserNames:   userNames,
+		MessageTS:   msg.TS,
+		Channel:     m.channelID,
+		RenderText: func(s string, un map[string]string) string {
+			return messages.RenderSlackMarkdownWith(s, messages.RenderSlackMarkdownOpts{
+				UserNames:    un,
+				ChannelNames: channelNames,
+				PlaceCtx:     m.emojiCtx.PlaceCtx,
+				EmojiCells:   m.emojiCtx.Cells,
+				Customs:      m.emojiCtx.Customs,
+				EmojiFlushes: nil,
+			})
+		},
+		WrapText: messages.WordWrap,
+		SendMsg: func(v any) {
+			if send != nil {
+				send(v)
+			}
+		},
+	}
+}
+
 func (m *Model) renderThreadMessage(msg messages.MessageItem, width int, userNames map[string]string, channelNames map[string]string, isSelected bool) (string, []func(io.Writer) error, []reactionEntryHit) {
 	line := styles.Username.Render(msg.UserName) + lipgloss.NewStyle().Background(styles.Background).Render("  ") + styles.Timestamp.Render(msg.Timestamp)
 
@@ -1718,6 +1758,35 @@ func (m *Model) renderThreadMessage(msg messages.MessageItem, width int, userNam
 		EmojiFlushes: &flushes,
 	}
 	text := styles.MessageText.Render(messages.WordWrap(messages.RenderSlackMarkdownWith(messages.MessageTextSource(msg), bodyOpts), contentWidth))
+
+	// Block Kit blocks + legacy attachments render between the body
+	// text and file attachments, mirroring the main message pane's
+	// renderMessagePlain. Image flushes are aggregated into the shared
+	// `flushes` slice; per-image Hit/SixelRows are discarded (v1 thread
+	// rendering, consistent with the file-attachment path below).
+	bkCtx := m.blockkitContext(msg, userNames, channelNames)
+	var bkLines []string
+	bkInteractive := false
+	if len(msg.Blocks) > 0 {
+		res := blockkit.Render(msg.Blocks, bkCtx, contentWidth)
+		bkLines = append(bkLines, res.Lines...)
+		flushes = append(flushes, res.Flushes...)
+		bkInteractive = bkInteractive || res.Interactive
+	}
+	if len(msg.LegacyAttachments) > 0 {
+		res := blockkit.RenderLegacy(msg.LegacyAttachments, bkCtx, contentWidth)
+		bkLines = append(bkLines, res.Lines...)
+		flushes = append(flushes, res.Flushes...)
+		bkInteractive = bkInteractive || res.Interactive
+	}
+	if bkInteractive {
+		bkLines = append(bkLines, styles.Timestamp.Render("↗ open in Slack to interact"))
+	}
+	bkBlock := ""
+	bkLineCount := len(bkLines)
+	if bkLineCount > 0 {
+		bkBlock = "\n" + strings.Join(bkLines, "\n")
+	}
 
 	var reactionLine string
 	// pillSpecs captures one entry per real (non-"+") reaction pill in
@@ -1885,14 +1954,15 @@ func (m *Model) renderThreadMessage(msg messages.MessageItem, width int, userNam
 	// of the reply content (pre-border, pre-tint):
 	//   row 0: username + timestamp line
 	//   rows [1 .. 1+textRows): wrapped body text
-	//   rows [1+textRows .. 1+textRows+attachmentLineCount): attachments
+	//   rows [.. +bkLineCount): block kit + legacy attachment content
+	//   rows [.. +attachmentLineCount): file attachments
 	//   rows [reactionRowBase ..): reaction lines
 	// buildCache wraps the content with a thick left border in col 0
 	// (so contentColBase = 1); it adds no rows.
 	var reactionHits []reactionEntryHit
 	if len(pillSpecs) > 0 && reactionLineCount > 0 {
 		const contentColBase = 1 // thick left border occupies col 0 of linesNormal
-		reactionRowBase := 1 + lipgloss.Height(text) + attachmentLineCount
+		reactionRowBase := 1 + lipgloss.Height(text) + bkLineCount + attachmentLineCount
 		for _, ps := range pillSpecs {
 			row := reactionRowBase + ps.lineIdx
 			reactionHits = append(reactionHits, reactionEntryHit{
@@ -1905,5 +1975,5 @@ func (m *Model) renderThreadMessage(msg messages.MessageItem, width int, userNam
 		}
 	}
 
-	return line + "\n" + text + attachmentLines + reactionLine, flushes, reactionHits
+	return line + "\n" + text + bkBlock + attachmentLines + reactionLine, flushes, reactionHits
 }

--- a/internal/ui/thread/render_test.go
+++ b/internal/ui/thread/render_test.go
@@ -7,6 +7,7 @@ import (
 	"charm.land/lipgloss/v2"
 
 	"github.com/gammons/slk/internal/ui/messages"
+	"github.com/gammons/slk/internal/ui/messages/blockkit"
 )
 
 // TestRenderThreadMessageAttachmentLinesFit asserts that a message with a
@@ -47,4 +48,53 @@ func TestRenderThreadMessageAttachmentLinesFit(t *testing.T) {
 		t.Fatalf("expected rendered output to include [File] marker; got %q", got)
 	}
 	_ = lipgloss.Width // keep import; older assertion measured per-line widths
+}
+
+// TestRenderThreadMessageLegacyAttachmentBlocks asserts that a reply
+// carrying a link-unfurl legacy attachment (Linear/Jira issue card,
+// whose content lives in nested Block Kit blocks) renders its content
+// in the thread panel, matching the main message pane.
+func TestRenderThreadMessageLegacyAttachmentBlocks(t *testing.T) {
+	const width = 60
+	m := New()
+	msg := messages.MessageItem{
+		TS:        "1700000002.000000",
+		UserName:  "alice",
+		Text:      "see ticket",
+		Timestamp: "10:31 AM",
+		LegacyAttachments: []blockkit.LegacyAttachment{{
+			Color: "#2d1c9c",
+			Blocks: []blockkit.Block{
+				blockkit.SectionBlock{Text: "TRU-111 Customer Facing Blacklist Monitoring"},
+				blockkit.ContextBlock{Elements: []blockkit.ContextElement{{Text: "*State*  In Progress"}}},
+			},
+		}},
+	}
+	got, _, _ := m.renderThreadMessage(msg, width, nil, nil, false)
+	if !strings.Contains(got, "TRU-111 Customer Facing Blacklist Monitoring") {
+		t.Errorf("thread render missing legacy-attachment block content; got %q", got)
+	}
+	if !strings.Contains(got, "In Progress") {
+		t.Errorf("thread render missing context block content; got %q", got)
+	}
+}
+
+// TestRenderThreadMessageTopLevelBlocks asserts that a reply carrying
+// top-level Block Kit blocks (bot messages) renders them in the thread
+// panel.
+func TestRenderThreadMessageTopLevelBlocks(t *testing.T) {
+	const width = 60
+	m := New()
+	msg := messages.MessageItem{
+		TS:        "1700000003.000000",
+		UserName:  "deploybot",
+		Timestamp: "10:32 AM",
+		Blocks: []blockkit.Block{
+			blockkit.SectionBlock{Text: "Deploy finished: v1.2.3"},
+		},
+	}
+	got, _, _ := m.renderThreadMessage(msg, width, nil, nil, false)
+	if !strings.Contains(got, "Deploy finished: v1.2.3") {
+		t.Errorf("thread render missing top-level block content; got %q", got)
+	}
 }


### PR DESCRIPTION
## Summary

Slack link unfurls for Linear/Jira/GitHub issue cards weren't displaying in slk (the official Slack desktop shows them fine). Root cause: these unfurls arrive as a **legacy attachment whose content lives entirely in a nested `blocks` array**, with empty `Title`/`Text`/`Fields`. `parseAttachment` never read `a.Blocks`, so the card parsed to nothing and rendered nothing — not a WebSocket drop and not the top-level Block Kit renderer.

- **blockkit**: add `LegacyAttachment.Blocks`, populate it from `a.Blocks` in `parseAttachment`, and render it inside the attachment's colored stripe in `appendLegacyAttachment` (merging nested image flushes/sixels/hits with correct row/col offsets).
- **messages/render**: handle Slack `<!date^TS^FORMAT|FALLBACK>` date tokens (used inside these unfurls) by rendering the precomputed fallback text instead of leaking the raw token/format string.
- **thread**: render `msg.Blocks` and `msg.LegacyAttachments` in `renderThreadMessage` so unfurls/bot cards display in the thread panel, matching the main message pane (reaction-hit row math updated accordingly).

## Test Plan

- [x] `go build ./...`, `go vet ./internal/ui/...`, `go test ./...` — all pass
- [x] New unit tests:
  - `TestParseAttachmentNestedBlocks`, `TestRenderLegacyRendersNestedBlocks`
  - `TestDateTokenRendersFallback`
  - `TestRenderThreadMessageLegacyAttachmentBlocks`, `TestRenderThreadMessageTopLevelBlocks`
- [ ] Manual: open a channel with a Linear issue URL and confirm the card renders in both the main pane and the thread view, with a clean `Truelist | May 28, 2026` line

## Notes / follow-ups (not in this PR)

- The live-edit path (`reducer_send.go:218`) still only updates `.Text`, not blocks/attachments — relevant when Slack delivers an unfurl by editing a freshly-posted message (card may not appear live until channel reload).
- Block image hits/sixel are discarded in the thread view, consistent with the existing thread v1 file-attachment behavior.