### PR TITLE
Fix frozen help modal + add version/attribution footer

### DIFF
--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gammons/slk/internal/ui/styles"
 	"github.com/gammons/slk/internal/ui/themeswitcher"
 	"github.com/gammons/slk/internal/ui/workspace"
+	versionpkg "github.com/gammons/slk/internal/version"
 	"github.com/gammons/slk/internal/wake"
 	emoji "github.com/kyokomi/emoji/v2"
 	"github.com/slack-go/slack"
@@ -540,6 +541,7 @@ func run() error {
 
 	// Create app
 	app := ui.NewApp()
+	app.SetHelpFooter(versionpkg.ModalFooter(version))
 	app.SetClipboardAvailable(clipboardOK)
 	if useWaylandClipboard {
 		app.SetClipboardReader(ui.WaylandClipboardReader())

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2098,6 +2098,12 @@ func (a *App) SetTypingEnabled(enabled bool) {
 	a.typing.SetEnabled(enabled)
 }
 
+// SetHelpFooter sets the attribution line shown at the bottom of the
+// help modal (e.g. the version + author credit). Pass "" to clear it.
+func (a *App) SetHelpFooter(s string) {
+	a.help.SetFooter(s)
+}
+
 // SetMouseWheelLines configures the number of lines the viewport scrolls per
 // mouse-wheel notch. Values < 1 are coerced to 1 to guarantee scroll progress.
 func (a *App) SetMouseWheelLines(n int) {

--- a/internal/ui/help/footer_test.go
+++ b/internal/ui/help/footer_test.go
@@ -1,0 +1,29 @@
+package help
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFooterRendersWhenSet(t *testing.T) {
+	m := New()
+	m.SetEntries(sampleEntries())
+	m.SetFooter("slk dev - footer line")
+	m.Open()
+
+	out := m.ViewOverlay(100, 40, "")
+	if !strings.Contains(out, "slk dev - footer line") {
+		t.Errorf("expected footer text in rendered modal, got:\n%s", out)
+	}
+}
+
+func TestFooterAbsentWhenEmpty(t *testing.T) {
+	m := New()
+	m.SetEntries(sampleEntries())
+	m.Open()
+
+	out := m.ViewOverlay(100, 40, "")
+	if strings.Contains(out, "Made with") {
+		t.Errorf("did not expect a footer line when none set, got:\n%s", out)
+	}
+}

--- a/internal/ui/help/footer_test.go
+++ b/internal/ui/help/footer_test.go
@@ -3,7 +3,21 @@ package help
 import (
 	"strings"
 	"testing"
+
+	"github.com/charmbracelet/x/ansi"
 )
+
+// footerLine returns the ANSI-stripped line containing needle from a
+// rendered modal, or "" if not found.
+func footerLine(rendered, needle string) string {
+	for _, raw := range strings.Split(rendered, "\n") {
+		line := ansi.Strip(raw)
+		if strings.Contains(line, needle) {
+			return line
+		}
+	}
+	return ""
+}
 
 func TestFooterRendersWhenSet(t *testing.T) {
 	m := New()
@@ -25,5 +39,44 @@ func TestFooterAbsentWhenEmpty(t *testing.T) {
 	out := m.ViewOverlay(100, 40, "")
 	if strings.Contains(out, "Made with") {
 		t.Errorf("did not expect a footer line when none set, got:\n%s", out)
+	}
+}
+
+func TestFooterRendersAtBottom(t *testing.T) {
+	m := New()
+	m.SetEntries(sampleEntries())
+	m.SetFooter("slk dev - attribution")
+	m.Open()
+
+	out := ansi.Strip(m.ViewOverlay(100, 40, ""))
+	controlsAt := strings.Index(out, "esc/q close")
+	footerAt := strings.Index(out, "attribution")
+	if controlsAt < 0 || footerAt < 0 {
+		t.Fatalf("missing controls or footer in output:\n%s", out)
+	}
+	if footerAt < controlsAt {
+		t.Errorf("attribution should be below the controls line (at bottom); got controls@%d footer@%d", controlsAt, footerAt)
+	}
+}
+
+func TestFooterIsCentered(t *testing.T) {
+	m := New()
+	m.SetEntries(sampleEntries())
+	m.SetFooter("slk dev - centered")
+	m.Open()
+
+	out := m.ViewOverlay(100, 40, "")
+	// Both lines live in the same box, so they share the same screen
+	// offset + border prefix. The controls line is left-aligned, so a
+	// centered footer must start at a larger column than it.
+	ctrl := footerLine(out, "/ search")
+	attr := footerLine(out, "centered")
+	if ctrl == "" || attr == "" {
+		t.Fatalf("missing controls or footer line in:\n%s", ansi.Strip(out))
+	}
+	ctrlCol := strings.Index(ctrl, "/ search")
+	attrCol := strings.Index(attr, "slk dev")
+	if attrCol <= ctrlCol {
+		t.Errorf("expected centered footer indented more than left-aligned controls; attr@%d ctrl@%d", attrCol, ctrlCol)
 	}
 }

--- a/internal/ui/help/model.go
+++ b/internal/ui/help/model.go
@@ -31,7 +31,8 @@ type Model struct {
 	query     string
 	selected  int // index into filtered
 	visible   bool
-	searching bool // true while typing in the / search input
+	searching bool   // true while typing in the / search input
+	footer    string // optional attribution line rendered above the controls footer
 }
 
 // New creates a new help overlay.
@@ -43,6 +44,12 @@ func New() Model {
 func (m *Model) SetEntries(entries []Entry) {
 	m.entries = entries
 	m.filter()
+}
+
+// SetFooter sets an optional attribution line rendered above the
+// controls footer. Pass "" to clear it.
+func (m *Model) SetFooter(s string) {
+	m.footer = s
 }
 
 // FromKeyMap derives Entries from any struct whose fields are key.Binding.
@@ -447,10 +454,20 @@ func (m Model) renderBox(termWidth, termHeight int) string {
 			Render("No matching keybindings"))
 	}
 
-	footer := lipgloss.NewStyle().
+	controlsFooter := lipgloss.NewStyle().
 		Background(bg).
 		Foreground(styles.TextMuted).
 		Render("/ search   esc/q close")
+
+	footer := controlsFooter
+	if m.footer != "" {
+		attribution := lipgloss.NewStyle().
+			Background(bg).
+			Foreground(styles.TextMuted).
+			MaxWidth(innerWidth).
+			Render(m.footer)
+		footer = attribution + "\n" + controlsFooter
+	}
 
 	content := title + "\n" + inputLine + "\n\n" + strings.Join(rows, "\n") + "\n\n" + footer
 

--- a/internal/ui/help/model.go
+++ b/internal/ui/help/model.go
@@ -461,12 +461,15 @@ func (m Model) renderBox(termWidth, termHeight int) string {
 
 	footer := controlsFooter
 	if m.footer != "" {
+		// Attribution sits at the very bottom of the modal, centered
+		// across the inner width and below the controls line.
 		attribution := lipgloss.NewStyle().
 			Background(bg).
 			Foreground(styles.TextMuted).
-			MaxWidth(innerWidth).
+			Width(innerWidth).
+			Align(lipgloss.Center).
 			Render(m.footer)
-		footer = attribution + "\n" + controlsFooter
+		footer = controlsFooter + "\n\n" + attribution
 	}
 
 	content := title + "\n" + inputLine + "\n\n" + strings.Join(rows, "\n") + "\n\n" + footer

--- a/internal/ui/help_render_test.go
+++ b/internal/ui/help_render_test.go
@@ -1,0 +1,40 @@
+// internal/ui/help_render_test.go
+package ui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/gammons/slk/internal/ui/help"
+)
+
+// Regression: when only the help modal is open, App.View must re-render
+// as the modal selection changes. The screen-memoization cache keys off
+// the base panels/status/size only; if help is not treated as an active
+// overlay, a selection change returns a stale cached frame and the modal
+// appears frozen (keys "do nothing" on screen even though state moves).
+func TestHelpModal_ViewUpdatesOnSelectionChange(t *testing.T) {
+	a := NewApp()
+	a.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+
+	entries := make([]help.Entry, 0, 20)
+	for i := 0; i < 20; i++ {
+		entries = append(entries, help.Entry{Key: "k", Desc: "binding"})
+	}
+	a.help.SetEntries(entries)
+	a.help.Open()
+	a.SetMode(ModeHelp)
+
+	first := a.View().Content
+
+	// Move the selection the way a keypress would.
+	a.help.HandleKey("j")
+
+	second := a.View().Content
+
+	if first == second {
+		t.Fatalf("help modal View did not change after selection moved; " +
+			"stale memoized frame served (overlayActive omits help)")
+	}
+}

--- a/internal/ui/view_overlays.go
+++ b/internal/ui/view_overlays.go
@@ -82,6 +82,7 @@ func (a *App) overlayActive() bool {
 		a.workspaceFinder.IsVisible() ||
 		a.themeSwitcher.IsVisible() ||
 		a.presenceMenu.IsVisible() ||
+		a.help.IsVisible() ||
 		a.mode == ModePresenceCustomSnooze ||
 		a.bootstrap.IsLoading()
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,22 @@
+// Package version provides formatting helpers for slk's build-time
+// version metadata. The build vars themselves live in package main
+// (injected via -ldflags by GoReleaser); callers pass the version
+// string in so this package stays free of build-time coupling.
+package version
+
+// osc8 wraps url as a clickable OSC-8 hyperlink whose visible label is
+// the URL itself. Terminals without OSC-8 support render the label as
+// plain text.
+func osc8(url string) string {
+	return "\x1b]8;;" + url + "\x1b\\" + url + "\x1b]8;;\x1b\\"
+}
+
+// ModalFooter returns the single attribution line shown at the bottom
+// of the TUI help modal, e.g.:
+//
+//	slk dev - Made with ❤️ by Grant Ammons (https://grant.dev)
+//
+// The URL is OSC-8 wrapped so supporting terminals make it clickable.
+func ModalFooter(version string) string {
+	return "slk " + version + " - Made with \u2764\ufe0f by Grant Ammons (" + osc8("https://grant.dev") + ")"
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,43 @@
+package version
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestModalFooter(t *testing.T) {
+	got := ModalFooter("v1.2.3")
+
+	// Version is interpolated.
+	if !strings.Contains(got, "slk v1.2.3") {
+		t.Errorf("footer missing version: %q", got)
+	}
+	// Attribution wording.
+	if !strings.Contains(got, "Made with") {
+		t.Errorf("footer missing 'Made with': %q", got)
+	}
+	if !strings.Contains(got, "\u2764") {
+		t.Errorf("footer missing heart glyph: %q", got)
+	}
+	if !strings.Contains(got, "Grant Ammons") {
+		t.Errorf("footer missing author: %q", got)
+	}
+	// URL is present and OSC-8 wrapped (clickable), with visible label.
+	if !strings.Contains(got, "https://grant.dev") {
+		t.Errorf("footer missing url: %q", got)
+	}
+	if !strings.Contains(got, "\x1b]8;;https://grant.dev\x1b\\") {
+		t.Errorf("footer url not OSC-8 wrapped: %q", got)
+	}
+	// URL is parenthesized.
+	if !strings.Contains(got, "(") || !strings.Contains(got, ")") {
+		t.Errorf("footer url not parenthesized: %q", got)
+	}
+}
+
+func TestModalFooterUsesGivenVersion(t *testing.T) {
+	got := ModalFooter("dev")
+	if !strings.Contains(got, "slk dev") {
+		t.Errorf("expected 'slk dev' in %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Two related changes to the keybindings (help) modal.

### 1. Fix: help modal appeared frozen (`727970d`)
`j`/`k`/arrow keys and `/` search moved the selection in state but the screen never repainted, so the modal looked dead (mouse scroll too).

**Root cause:** `App.View` gates its screen-memoization cache on `overlayActive()`, which listed every modal overlay **except** the help modal. With help open, the app believed no overlay was active, memoized the frame, and re-served the stale frame on every keypress (the memo key excludes `help.Selected()`). Every other modal was already in that list, which is why only help was affected.

**Fix:** add `a.help.IsVisible()` to `overlayActive()` so help frames are never memoized — one line, matching the other modals.

Diagnosed via the app's own `SLK_DEBUG` log, which proved input was working all along (selection advanced on every key) and isolated the bug to rendering.

### 2. Feature: version/attribution footer (`71143ff`)
Adds a credit line at the bottom of the modal:

```
slk <version> - Made with ❤️ by Grant Ammons (https://grant.dev)
```

The URL is OSC-8 wrapped so supporting terminals make it clickable. `<version>` comes from `main`'s existing ldflags-injected version var.

- `internal/version`: new pure `ModalFooter(version)` helper
- `help.Model`: optional `footer` field + `SetFooter`, rendered above the controls line
- `App.SetHelpFooter` forwards to the help model; `main` wires it at startup

## Testing
- TDD throughout; both changes have regression tests
- `go test ./...` green; `make build` succeeds
- Render output verified manually

## Notes
- The separate mouse-wheel **delivery** issue (no `MouseWheelMsg` reached the app in the debug session) is **not** addressed here — likely terminal/multiplexer wheel forwarding, worth a follow-up.