### PR TITLE
Reduce binary size via compiler flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           cache: true
 
       - name: Build
-        run: go build ./...
+        run: go build -ldflags="-s -w" -trimpath ./...
 
       - name: Test
         run: go test ./... -race

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BINARY=slk
 BUILD_DIR=bin
 
 build:
-	go build -o $(BUILD_DIR)/$(BINARY) ./cmd/slk
+	go build -ldflags="-s -w" -trimpath -o $(BUILD_DIR)/$(BINARY) ./cmd/slk
 
 test:
 	go test ./... -v -race

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ sudo mv slk /usr/local/bin/
 **Go:**
 
 ```bash
-go install github.com/gammons/slk/cmd/slk@latest
+go install -ldflags="-s -w" -trimpath github.com/gammons/slk/cmd/slk@latest
 ```
 
 For `.deb` / `.rpm` / `.apk` packages, Windows, build-from-source, and checksums, see the [Installation wiki page](https://github.com/gammons/slk/wiki/Installation).


### PR DESCRIPTION
## Summary

- Add `-ldflags="-s -w"` to strip the symbol table and DWARF debug info from the binary
- Add `-trimpath` to remove local filesystem paths from the compiled binary, improving build reproducibility
- update 'go install' instructions in `README.md`
- update 'go build' in `.github/workflows/ci.yml`

## Test plan

- [X] Run `make build` and verify it completes without errors
- [X] Compare the binary size before and after (expect a meaningful reduction)
- [X] Confirm `bin/slk` runs correctly
- [X] Confirm `go install -ldflags="-s -w" -trimpath github.com/gammons/slk/cmd/slk@latest` runs correctly 
- [X] Confirm `go build -ldflags="-s -w" -trimpath ./...` runs correctly 
