### PR TITLE
Show own reactions from other devices live; fix mis-styling of others' reactions

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2180,6 +2180,8 @@ func (a *App) SetReactionService(r ReactionService) {
 func (a *App) SetCurrentUserID(userID string) {
 	a.currentUserID = userID
 	a.threadsView.SetSelfUserID(userID)
+	a.messagepane.SetCurrentUser(userID)
+	a.threadPanel.SetCurrentUser(userID)
 }
 
 // SetNowTimestampFormatter wires the formatter used to render the

--- a/internal/ui/messages/model.go
+++ b/internal/ui/messages/model.go
@@ -278,6 +278,11 @@ type Model struct {
 	reactionNavActive bool
 	reactionNavIndex  int
 
+	// currentUserID is the authenticated user; UpdateReaction uses it to
+	// set ReactionItem.HasReacted only for the current user's own
+	// reactions (not other users'). Empty until SetCurrentUser is called.
+	currentUserID string
+
 	lastReadTS string
 
 	// version increments on every state change that could alter rendered
@@ -1150,12 +1155,20 @@ func (m *Model) UpdateReaction(messageTS, emojiName, userID string, remove bool)
 			if remove {
 				for j, r := range msg.Reactions {
 					if r.Emoji == emojiName {
+						// Idempotent: only decrement if userID was actually
+						// present (a duplicate WS echo must not under-count).
+						newIDs := RemoveUserID(r.UserIDs, userID)
+						if len(newIDs) == len(r.UserIDs) {
+							break // userID wasn't reacting; nothing to do
+						}
+						r.UserIDs = newIDs
 						r.Count--
-						r.UserIDs = RemoveUserID(r.UserIDs, userID)
+						if userID == m.currentUserID {
+							r.HasReacted = false
+						}
 						if r.Count <= 0 {
 							m.messages[i].Reactions = append(msg.Reactions[:j], msg.Reactions[j+1:]...)
 						} else {
-							r.HasReacted = false
 							m.messages[i].Reactions[j] = r
 						}
 						break
@@ -1165,9 +1178,17 @@ func (m *Model) UpdateReaction(messageTS, emojiName, userID string, remove bool)
 				found := false
 				for j, r := range msg.Reactions {
 					if r.Emoji == emojiName {
-						r.Count++
-						r.HasReacted = true
-						r.UserIDs = AppendUserID(r.UserIDs, userID)
+						// Idempotent: only increment if userID is newly
+						// added, so our own optimistic update + the WS echo
+						// of the same reaction don't double-count.
+						newIDs := AppendUserID(r.UserIDs, userID)
+						if len(newIDs) != len(r.UserIDs) {
+							r.UserIDs = newIDs
+							r.Count++
+						}
+						if userID == m.currentUserID {
+							r.HasReacted = true
+						}
 						m.messages[i].Reactions[j] = r
 						found = true
 						break
@@ -1177,7 +1198,7 @@ func (m *Model) UpdateReaction(messageTS, emojiName, userID string, remove bool)
 					m.messages[i].Reactions = append(m.messages[i].Reactions, ReactionItem{
 						Emoji:      emojiName,
 						Count:      1,
-						HasReacted: true,
+						HasReacted: userID == m.currentUserID,
 						UserIDs:    AppendUserID(nil, userID),
 					})
 				}
@@ -1250,6 +1271,12 @@ func (m *Model) SetUserNames(names map[string]string) {
 	m.userNames = names
 	m.cache = nil // invalidate cache so mentions re-render
 	m.dirty()
+}
+
+// SetCurrentUser records the authenticated user ID so UpdateReaction can
+// flag the current user's own reactions (HasReacted) correctly.
+func (m *Model) SetCurrentUser(userID string) {
+	m.currentUserID = userID
 }
 
 // PatchUserName updates the in-memory userNames map (used for @mention

--- a/internal/ui/messages/model.go
+++ b/internal/ui/messages/model.go
@@ -1158,8 +1158,14 @@ func (m *Model) UpdateReaction(messageTS, emojiName, userID string, remove bool)
 						// Idempotent: only decrement if userID was actually
 						// present (a duplicate WS echo must not under-count).
 						newIDs := RemoveUserID(r.UserIDs, userID)
-						if len(newIDs) == len(r.UserIDs) {
-							break // userID wasn't reacting; nothing to do
+						if len(newIDs) == len(r.UserIDs) && r.Count <= len(r.UserIDs) {
+							// userID isn't among the listed reactors and the
+							// list isn't truncated, so this is a duplicate echo
+							// of a removal we already applied — skip to avoid
+							// under-counting. When Count > len(UserIDs), Slack
+							// truncated the reactor list for a popular reaction;
+							// the removal is real, so fall through and decrement.
+							break
 						}
 						r.UserIDs = newIDs
 						r.Count--

--- a/internal/ui/messages/model_test.go
+++ b/internal/ui/messages/model_test.go
@@ -72,7 +72,7 @@ func TestMessagePaneAppend(t *testing.T) {
 // follows the glyph verbatim.
 func TestHeaderGlyph_ByChannelType(t *testing.T) {
 	cases := []struct {
-		chType   string
+		chType    string
 		wantGlyph string
 	}{
 		{"channel", "#"},
@@ -1156,10 +1156,10 @@ func TestPatchUserName_InvalidatesCacheEvenWithNoMatchingMessages(t *testing.T) 
 func TestHitTestReaction_OnPill(t *testing.T) {
 	msgs := []MessageItem{
 		{
-			TS:       "1700000001.000000",
-			UserID:   "U1",
-			UserName: "alice",
-			Text:     "hello",
+			TS:        "1700000001.000000",
+			UserID:    "U1",
+			UserName:  "alice",
+			Text:      "hello",
 			Timestamp: "10:30 AM",
 			Reactions: []ReactionItem{
 				{Emoji: "thumbsup", Count: 1, HasReacted: false},
@@ -1402,6 +1402,56 @@ func TestUpdateReactionMaintainsUserIDs(t *testing.T) {
 	msg, _ = m.SelectedMessage()
 	if len(msg.Reactions) != 0 {
 		t.Fatalf("want 0 reactions after all removed, got %d", len(msg.Reactions))
+	}
+}
+
+// TestUpdateReactionIdempotentAndHasReacted covers the live-reaction fix:
+// an optimistic self-update plus its WS echo must collapse to one count,
+// reactions made by the current user from another device still apply, and
+// HasReacted reflects only the current user.
+func TestUpdateReactionIdempotentAndHasReacted(t *testing.T) {
+	m := New([]MessageItem{{TS: "100.0", Text: "hi"}}, "general")
+	m.SetCurrentUser("ME")
+
+	// Self reaction (optimistic) then the WS echo of the same reaction:
+	// must NOT double-count.
+	m.UpdateReaction("100.0", "tada", "ME", false)
+	m.UpdateReaction("100.0", "tada", "ME", false)
+	msg, _ := m.SelectedMessage()
+	if len(msg.Reactions) != 1 || msg.Reactions[0].Count != 1 {
+		t.Fatalf("self add + echo: want one reaction count 1, got %+v", msg.Reactions)
+	}
+	if !msg.Reactions[0].HasReacted {
+		t.Errorf("want HasReacted=true for current user's reaction")
+	}
+
+	// Another user adds the same emoji: count 2, HasReacted stays true.
+	m.UpdateReaction("100.0", "tada", "OTHER", false)
+	msg, _ = m.SelectedMessage()
+	if msg.Reactions[0].Count != 2 {
+		t.Errorf("want count 2 after other user adds, got %d", msg.Reactions[0].Count)
+	}
+	if !msg.Reactions[0].HasReacted {
+		t.Errorf("HasReacted should remain true (current user still reacted)")
+	}
+
+	// Reaction by another user only: must not be flagged HasReacted.
+	m.UpdateReaction("100.0", "eyes", "OTHER", false)
+	msg, _ = m.SelectedMessage()
+	for _, r := range msg.Reactions {
+		if r.Emoji == "eyes" {
+			if r.HasReacted {
+				t.Errorf("other-user-only reaction must have HasReacted=false")
+			}
+			// Absent-user remove must not under-count.
+			m.UpdateReaction("100.0", "eyes", "ME", true)
+			msg2, _ := m.SelectedMessage()
+			for _, r2 := range msg2.Reactions {
+				if r2.Emoji == "eyes" && r2.Count != 1 {
+					t.Errorf("absent-user remove changed count to %d, want 1", r2.Count)
+				}
+			}
+		}
 	}
 }
 

--- a/internal/ui/messages/model_test.go
+++ b/internal/ui/messages/model_test.go
@@ -1405,6 +1405,33 @@ func TestUpdateReactionMaintainsUserIDs(t *testing.T) {
 	}
 }
 
+// TestUpdateReactionTruncatedRemoval covers the PR #68 review follow-up:
+// Slack truncates reactions[].users for popular reactions, so a removal of a
+// user absent from the (truncated) list must still decrement when Count >
+// len(UserIDs) — while a duplicate echo on a non-truncated list must not.
+func TestUpdateReactionTruncatedRemoval(t *testing.T) {
+	// Truncated reactor list: Count(5) > len(UserIDs)(2).
+	m := New([]MessageItem{{TS: "100.0", Reactions: []ReactionItem{
+		{Emoji: "tada", Count: 5, UserIDs: []string{"A", "B"}},
+	}}}, "general")
+	m.UpdateReaction("100.0", "tada", "Z", true) // Z not listed, but list is truncated
+	msg, _ := m.SelectedMessage()
+	if got := msg.Reactions[0].Count; got != 4 {
+		t.Errorf("truncated removal must decrement: Count=%d, want 4", got)
+	}
+
+	// Non-truncated list: Count(2) == len(UserIDs)(2). A removal of an
+	// un-listed user is a duplicate echo — must NOT under-count.
+	m2 := New([]MessageItem{{TS: "200.0", Reactions: []ReactionItem{
+		{Emoji: "tada", Count: 2, UserIDs: []string{"A", "B"}},
+	}}}, "general")
+	m2.UpdateReaction("200.0", "tada", "Z", true)
+	msg2, _ := m2.SelectedMessage()
+	if got := msg2.Reactions[0].Count; got != 2 {
+		t.Errorf("duplicate-echo removal must not under-count: Count=%d, want 2", got)
+	}
+}
+
 // TestUpdateReactionIdempotentAndHasReacted covers the live-reaction fix:
 // an optimistic self-update plus its WS echo must collapse to one count,
 // reactions made by the current user from another device still apply, and

--- a/internal/ui/reducer_reactions.go
+++ b/internal/ui/reducer_reactions.go
@@ -5,16 +5,16 @@
 // Owns the three Update arms for reaction WS echoes / API results:
 //
 //	ReactionAddedMsg    - server confirmed a reaction was added.
-//	                      WS echoes of our own optimistic updates
-//	                      are filtered by currentUserID; remote
-//	                      users' reactions are merged into the
-//	                      message's reaction list.
+//	                      Applied unconditionally; updateReactionOnMessage
+//	                      is idempotent per (emoji, userID), so the echo
+//	                      of our own optimistic update collapses to one
+//	                      count while reactions from other users (or our
+//	                      own from another device) still merge in live.
 //	ReactionRemovedMsg  - server confirmed a reaction was removed
-//	                      (same WS-echo dedup as Added).
-//	ReactionSentMsg     - our reaction API call completed. On failure
-//	                      the optimistic update is rolled back (inverse
-//	                      op) and logged, so a rejected reaction doesn't
-//	                      linger on screen.
+//	                      (same idempotent application as Added).
+//	ReactionSentMsg     - our reaction API call completed. On failure the
+//	                      optimistic update is rolled back (inverse op) and
+//	                      logged, so a rejected reaction doesn't linger.
 //
 // Free reducer (no dedicated controller) because reactions are a
 // per-message annotation with no cross-message invariant and no
@@ -32,18 +32,17 @@ import (
 var reduceReactions reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
 	switch m := msg.(type) {
 	case ReactionAddedMsg:
-		// Skip WebSocket echo of our own optimistic updates: when
-		// we add a reaction the UI updates immediately; the echo
-		// arrives later with our own userID and is dropped.
-		if m.UserID != a.currentUserID {
-			a.updateReactionOnMessage(m.ChannelID, m.MessageTS, m.Emoji, m.UserID, false)
-		}
+		// Apply every reaction event, including echoes of our own.
+		// updateReactionOnMessage is idempotent per (emoji, userID), so
+		// our optimistic update and the WS echo that follows it collapse
+		// to a single count — while reactions we make from another device
+		// (web/mobile), which have no optimistic update here, still show
+		// up live instead of being dropped.
+		a.updateReactionOnMessage(m.ChannelID, m.MessageTS, m.Emoji, m.UserID, false)
 		return nil, true
 
 	case ReactionRemovedMsg:
-		if m.UserID != a.currentUserID {
-			a.updateReactionOnMessage(m.ChannelID, m.MessageTS, m.Emoji, m.UserID, true)
-		}
+		a.updateReactionOnMessage(m.ChannelID, m.MessageTS, m.Emoji, m.UserID, true)
 		return nil, true
 
 	case ReactionSentMsg:

--- a/internal/ui/reducer_reactions_live_test.go
+++ b/internal/ui/reducer_reactions_live_test.go
@@ -1,0 +1,45 @@
+package ui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/gammons/slk/internal/ui/messages"
+)
+
+// TestReactionAddedAppliesOwnUserLive is the headline of the live-reactions
+// fix: a ReactionAddedMsg by OUR OWN user that has no local optimistic
+// update (e.g. made from web/mobile) must be applied by the reducer. The
+// previous code dropped any echo whose userID == currentUserID.
+func TestReactionAddedAppliesOwnUserLive(t *testing.T) {
+	a := NewApp()
+	_, _ = a.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+	a.SetCurrentUserID("ME")
+	a.messagepane.SetMessages([]messages.MessageItem{{TS: "100.0", Text: "hi"}})
+
+	// No optimistic update here — this is purely the WS echo of a reaction
+	// we made elsewhere. It must show live.
+	a.Update(ReactionAddedMsg{ChannelID: "C1", MessageTS: "100.0", UserID: "ME", Emoji: "tada"})
+	msg, _ := a.messagepane.SelectedMessage()
+	if len(msg.Reactions) != 1 || msg.Reactions[0].Count != 1 {
+		t.Fatalf("own-device reaction must show live, got %+v", msg.Reactions)
+	}
+
+	// Optimistic add + its own WS echo must collapse to one count —
+	// idempotency is what makes dropping the self-filter safe.
+	a.updateReactionOnMessage("C1", "100.0", "rocket", "ME", false) // optimistic
+	a.Update(ReactionAddedMsg{ChannelID: "C1", MessageTS: "100.0", UserID: "ME", Emoji: "rocket"})
+	msg, _ = a.messagepane.SelectedMessage()
+	var rocketCount int
+	found := false
+	for _, r := range msg.Reactions {
+		if r.Emoji == "rocket" {
+			rocketCount = r.Count
+			found = true
+		}
+	}
+	if !found || rocketCount != 1 {
+		t.Errorf("optimistic + echo must collapse to count 1, got %+v", msg.Reactions)
+	}
+}

--- a/internal/ui/reducer_reactions_live_test.go
+++ b/internal/ui/reducer_reactions_live_test.go
@@ -6,7 +6,36 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/gammons/slk/internal/ui/messages"
+	"github.com/gammons/slk/internal/ui/sidebar"
 )
+
+// TestLiveOwnReactionStyledViaWorkspaceReady drives the PRODUCTION path:
+// WorkspaceReadyMsg sets the current user (and must wire the panes), so a
+// live own-device reaction renders as ours (HasReacted=true). Regression
+// guard for the review on PR #68 — the prior code assigned a.currentUserID
+// directly in the reducer, leaving the pane's currentUserID empty in real
+// sessions even though SetCurrentUserID-based tests passed.
+func TestLiveOwnReactionStyledViaWorkspaceReady(t *testing.T) {
+	a := NewApp()
+	_, _ = a.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+
+	a.Update(WorkspaceReadyMsg{
+		TeamID:        "T1",
+		InitialActive: true,
+		UserID:        "ME",
+		Channels:      []sidebar.ChannelItem{{ID: "C1", Name: "general", Type: "channel"}},
+	})
+	a.messagepane.SetMessages([]messages.MessageItem{{TS: "100.0", Text: "hi"}})
+
+	a.Update(ReactionAddedMsg{ChannelID: "C1", MessageTS: "100.0", UserID: "ME", Emoji: "tada"})
+	msg, _ := a.messagepane.SelectedMessage()
+	if len(msg.Reactions) != 1 {
+		t.Fatalf("expected 1 reaction, got %+v", msg.Reactions)
+	}
+	if !msg.Reactions[0].HasReacted {
+		t.Error("live own-device reaction must render as ours (HasReacted=true) via the WorkspaceReadyMsg path")
+	}
+}
 
 // TestReactionAddedAppliesOwnUserLive is the headline of the live-reactions
 // fix: a ReactionAddedMsg by OUR OWN user that has no local optimistic

--- a/internal/ui/reducer_workspace.go
+++ b/internal/ui/reducer_workspace.go
@@ -6,37 +6,37 @@
 // per-workspace data resolution echoes, and the sidebar / read-state
 // refresh paths:
 //
-//   WorkspaceReadyMsg       - one of the configured workspaces
-//                             finished its initial connect. If
-//                             InitialActive (claimed exactly once),
-//                             activate it: apply theme, push
-//                             channels/users/emoji, open the first
-//                             channel. Always fires an initial
-//                             threads-list fetch.
-//   WorkspaceSwitchedMsg    - user picked a different workspace.
-//                             Tear down per-workspace transient
-//                             state (threads view, edit, selection,
-//                             compose draft), push new channels/users/
-//                             emoji, apply theme, restore the last
-//                             channel viewed for this workspace.
-//   ConversationOpenedMsg   - WS event: a DM/MPIM just opened.
-//                             Upsert into the active sidebar.
-//   SectionsRefreshedMsg    - cache notice: sidebar sections were
-//                             reorganized. Re-push channel items
-//                             for the active workspace.
-//   DMNameResolvedMsg       - DM display-name resolved (im.open
-//                             roundtrip): patch the sidebar entry
-//                             and re-render.
-//   UserResolvedMsg         - per-user display-name resolved:
-//                             patch any in-history references in
-//                             both messages pane and thread panel.
-//   UserExternalMsg         - per-user external/internal flag
-//                             resolved: update the cache + re-push
-//                             SetUserNames so styling refreshes.
-//   ReadStateChangedMsg     - persistent read-state changed in the
-//                             cache: refresh sidebar + workspace rail.
-//   CustomEmojisLoadedMsg   - per-workspace emoji list arrived.
-//                             Apply only to the active workspace.
+//	WorkspaceReadyMsg       - one of the configured workspaces
+//	                          finished its initial connect. If
+//	                          InitialActive (claimed exactly once),
+//	                          activate it: apply theme, push
+//	                          channels/users/emoji, open the first
+//	                          channel. Always fires an initial
+//	                          threads-list fetch.
+//	WorkspaceSwitchedMsg    - user picked a different workspace.
+//	                          Tear down per-workspace transient
+//	                          state (threads view, edit, selection,
+//	                          compose draft), push new channels/users/
+//	                          emoji, apply theme, restore the last
+//	                          channel viewed for this workspace.
+//	ConversationOpenedMsg   - WS event: a DM/MPIM just opened.
+//	                          Upsert into the active sidebar.
+//	SectionsRefreshedMsg    - cache notice: sidebar sections were
+//	                          reorganized. Re-push channel items
+//	                          for the active workspace.
+//	DMNameResolvedMsg       - DM display-name resolved (im.open
+//	                          roundtrip): patch the sidebar entry
+//	                          and re-render.
+//	UserResolvedMsg         - per-user display-name resolved:
+//	                          patch any in-history references in
+//	                          both messages pane and thread panel.
+//	UserExternalMsg         - per-user external/internal flag
+//	                          resolved: update the cache + re-push
+//	                          SetUserNames so styling refreshes.
+//	ReadStateChangedMsg     - persistent read-state changed in the
+//	                          cache: refresh sidebar + workspace rail.
+//	CustomEmojisLoadedMsg   - per-workspace emoji list arrived.
+//	                          Apply only to the active workspace.
 //
 // Free reducer (not controller-absorbed): these arms cooperate on
 // the sidebar, messagepane, threadPanel, statusbar, channelFinder,
@@ -193,7 +193,10 @@ func reduceWorkspaceReady(a *App, m WorkspaceReadyMsg) tea.Cmd {
 		a.SetExternalUsers(m.ExternalUsers)
 		a.SetUserNames(m.UserNames)
 		a.SetCustomEmoji(m.CustomEmoji)
-		a.currentUserID = m.UserID
+		// Route through the setter so messagepane/threadPanel also learn
+		// the current user — production never calls SetCurrentUserID
+		// otherwise, which would leave live self-reactions unstyled.
+		a.SetCurrentUserID(m.UserID)
 		a.activeTeamID = m.TeamID
 		pres, dndEnabled, dndEnd, _ := a.presence.Status(a.activeTeamID)
 		a.statusbar.SetStatus(pres, dndEnabled, dndEnd)
@@ -267,7 +270,9 @@ func reduceWorkspaceSwitched(a *App, m WorkspaceSwitchedMsg) tea.Cmd {
 	a.SetExternalUsers(m.ExternalUsers)
 	a.SetUserNames(m.UserNames)
 	a.SetCustomEmoji(m.CustomEmoji)
-	a.currentUserID = m.UserID
+	// Route through the setter so messagepane/threadPanel also learn the
+	// current user (see WorkspaceReadyMsg above).
+	a.SetCurrentUserID(m.UserID)
 	a.activeTeamID = m.TeamID
 	pres, dndEnabled, dndEnd, _ := a.presence.Status(a.activeTeamID)
 	a.statusbar.SetStatus(pres, dndEnabled, dndEnd)

--- a/internal/ui/thread/model.go
+++ b/internal/ui/thread/model.go
@@ -101,6 +101,9 @@ type Model struct {
 	vp                viewport.Model
 	reactionNavActive bool
 	reactionNavIndex  int
+	// currentUserID is the authenticated user; UpdateReaction uses it to
+	// set HasReacted only for the current user's own reactions.
+	currentUserID string
 
 	// Render cache -- pre-rendered reply entries (unbordered content
 	// captured per reply; borders are applied later when assembling
@@ -579,6 +582,12 @@ func (m *Model) SetUserNames(names map[string]string) {
 	m.InvalidateCache()
 }
 
+// SetCurrentUser records the authenticated user ID so UpdateReaction can
+// flag the current user's own reactions (HasReacted) correctly.
+func (m *Model) SetCurrentUser(userID string) {
+	m.currentUserID = userID
+}
+
 // PatchUserName updates the in-memory userNames map (used for @mention
 // rendering) and overwrites the UserName field on the parent message
 // and every cached reply authored by userID. Always invalidates the
@@ -802,12 +811,19 @@ func (m *Model) UpdateReaction(messageTS, emojiName, userID string, remove bool)
 			if remove {
 				for j, r := range reply.Reactions {
 					if r.Emoji == emojiName {
+						// Idempotent: only decrement if userID was present.
+						newIDs := messages.RemoveUserID(r.UserIDs, userID)
+						if len(newIDs) == len(r.UserIDs) {
+							break // userID wasn't reacting; nothing to do
+						}
+						r.UserIDs = newIDs
 						r.Count--
-						r.UserIDs = messages.RemoveUserID(r.UserIDs, userID)
+						if userID == m.currentUserID {
+							r.HasReacted = false
+						}
 						if r.Count <= 0 {
 							m.replies[i].Reactions = append(reply.Reactions[:j], reply.Reactions[j+1:]...)
 						} else {
-							r.HasReacted = false
 							m.replies[i].Reactions[j] = r
 						}
 						break
@@ -817,9 +833,16 @@ func (m *Model) UpdateReaction(messageTS, emojiName, userID string, remove bool)
 				found := false
 				for j, r := range reply.Reactions {
 					if r.Emoji == emojiName {
-						r.Count++
-						r.HasReacted = true
-						r.UserIDs = messages.AppendUserID(r.UserIDs, userID)
+						// Idempotent: only increment if userID is newly added,
+						// so an optimistic update + its WS echo don't double-count.
+						newIDs := messages.AppendUserID(r.UserIDs, userID)
+						if len(newIDs) != len(r.UserIDs) {
+							r.UserIDs = newIDs
+							r.Count++
+						}
+						if userID == m.currentUserID {
+							r.HasReacted = true
+						}
 						m.replies[i].Reactions[j] = r
 						found = true
 						break
@@ -829,7 +852,7 @@ func (m *Model) UpdateReaction(messageTS, emojiName, userID string, remove bool)
 					m.replies[i].Reactions = append(m.replies[i].Reactions, messages.ReactionItem{
 						Emoji:      emojiName,
 						Count:      1,
-						HasReacted: true,
+						HasReacted: userID == m.currentUserID,
 						UserIDs:    messages.AppendUserID(nil, userID),
 					})
 				}

--- a/internal/ui/thread/model.go
+++ b/internal/ui/thread/model.go
@@ -813,8 +813,12 @@ func (m *Model) UpdateReaction(messageTS, emojiName, userID string, remove bool)
 					if r.Emoji == emojiName {
 						// Idempotent: only decrement if userID was present.
 						newIDs := messages.RemoveUserID(r.UserIDs, userID)
-						if len(newIDs) == len(r.UserIDs) {
-							break // userID wasn't reacting; nothing to do
+						if len(newIDs) == len(r.UserIDs) && r.Count <= len(r.UserIDs) {
+							// Duplicate echo of an already-applied removal
+							// (un-listed reactor, non-truncated list) — skip.
+							// When Count > len(UserIDs) the list is truncated,
+							// so the removal is real; fall through to decrement.
+							break
 						}
 						r.UserIDs = newIDs
 						r.Count--


### PR DESCRIPTION
Closes #67.

## Problem

A reaction you add from another device (Slack web/mobile) didn't appear live in slk on the channel you were viewing — it only showed after switching channels and back. The WS `reaction_added` event arrived fine (verified via `SLK_DEBUG`); the live UI update was being dropped.

## Root cause

`reduceReactions` filtered out every reaction by your own account (`if m.UserID != a.currentUserID`) to avoid double-counting the WS echo of your own optimistic update. But that also discarded reactions you made elsewhere, which had no optimistic update in slk — so they never rendered until a cache reload. The underlying reason a filter was needed at all: `UpdateReaction` incremented `Count` even when the userID was already present.

A related secondary bug: `UpdateReaction` set `HasReacted = true` for any reactor, so another user's reaction (which already showed live) was mis-styled as your own.

## Fix

- Drop the blanket self-filter; apply every `reaction_added` / `reaction_removed` event.
- Make `UpdateReaction` idempotent per `(emoji, userID)` — `Count` changes only on real membership change — so an optimistic update and its WS echo collapse to one count. This is what makes dropping the self-filter safe.
- Set `HasReacted` only for the current user via a new `SetCurrentUser` on the message and thread panes, fixing the mis-styling of other users' reactions.

## Testing

- `go test ./...` passes; added `TestUpdateReactionIdempotentAndHasReacted` covering double-apply (optimistic + echo → count 1), other-user merge, and `HasReacted` correctness.
- Verified end-to-end in a kitty terminal: reactions made from web/mobile now appear live on the active channel without a channel switch.
