### PR TITLE
Show online/away presence for DM peers in the sidebar

### DIFF
--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -95,10 +95,10 @@ func (a sectionsProviderAdapter) OrderedSlackSections() []sidebar.SectionMeta {
 
 // WorkspaceContext holds all state for a single connected workspace.
 type WorkspaceContext struct {
-	Client      *slackclient.Client
-	ConnMgr     *slackclient.ConnectionManager
-	RTMHandler  *rtmEventHandler
-	UserNames   map[string]string
+	Client     *slackclient.Client
+	ConnMgr    *slackclient.ConnectionManager
+	RTMHandler *rtmEventHandler
+	UserNames  map[string]string
 	// AvatarURLs maps userID -> avatar image URL. Populated from the
 	// local users cache at connect time (synchronous, before any
 	// goroutines spin up) and refreshed from the background
@@ -122,7 +122,7 @@ type WorkspaceContext struct {
 	// background users.list fetch and any on-demand resolveUser calls.
 	// Used during channel construction to bucket app DMs into a separate
 	// "Apps" sidebar section.
-	BotUserIDs        map[string]bool
+	BotUserIDs map[string]bool
 	// SectionStore holds the user's Slack-native sidebar sections for
 	// this workspace. Nil when use_slack_sections is disabled, the
 	// REST bootstrap failed, or this workspace hasn't connected yet.
@@ -151,7 +151,7 @@ type WorkspaceContext struct {
 	// after a failed one. The UI uses it to decide whether to draw
 	// the "Threads list unavailable" banner.
 	SubscriptionsAvailable bool
-	Channels    []sidebar.ChannelItem
+	Channels               []sidebar.ChannelItem
 	// FinderItems is the merged list shown in the Ctrl+T finder. Initially
 	// contains only joined channels; the BrowseableChannelsLoadedMsg pipeline
 	// extends it with non-joined public channels in the background.
@@ -1598,19 +1598,19 @@ func run() error {
 			// Resolve unknown DM user names in background
 			if len(wctx.UnresolvedDMs) > 0 {
 				go func() {
-				for _, dm := range wctx.UnresolvedDMs {
-					resolved, isBot := resolveUser(wctx.Client, dm.UserID, wctx.UserNames, db, avatarCache)
-					if isBot {
-						wctx.BotUserIDs[dm.UserID] = true
+					for _, dm := range wctx.UnresolvedDMs {
+						resolved, isBot := resolveUser(wctx.Client, dm.UserID, wctx.UserNames, db, avatarCache)
+						if isBot {
+							wctx.BotUserIDs[dm.UserID] = true
+						}
+						if resolved != dm.UserID {
+							p.Send(ui.DMNameResolvedMsg{
+								ChannelID:   dm.ChannelID,
+								DisplayName: resolved,
+								IsBot:       isBot,
+							})
+						}
 					}
-					if resolved != dm.UserID {
-						p.Send(ui.DMNameResolvedMsg{
-							ChannelID:   dm.ChannelID,
-							DisplayName: resolved,
-							IsBot:       isBot,
-						})
-					}
-				}
 				}()
 			}
 		}(ot.Token)
@@ -1862,6 +1862,13 @@ func connectWorkspace(ctx context.Context, token slackclient.Token, db *cache.DB
 		finderItem.LastVisited = wctx.LastVisitedByChannel[ch.ID]
 		wctx.FinderItems = append(wctx.FinderItems, finderItem)
 	}
+
+	// Now that the DM peers are known, subscribe to their presence (plus
+	// self). The WebSocket is already connected (Connect above), so this
+	// runs on first boot; OnConnect re-runs it on each reconnect. Slack
+	// pushes each subscribed user's current presence back, which feeds the
+	// sidebar's online dots without a separate per-user fetch.
+	subscribeWorkspacePresence(wctx)
 
 	// Fetch unread counts
 	unreadCounts, threadsAgg, ucErr := client.GetUnreadCounts()
@@ -2302,12 +2309,12 @@ func markChannelReadAsync(
 // Allocated only when debuglog.Enabled(); enrichCachedRow checks for
 // nil and skips the time.Now() / time.Since() calls otherwise.
 type enrichPerfStats struct {
-	getUserCalls    int
-	getUserTotal    time.Duration
-	getReactCalls   int
-	getReactTotal   time.Duration
-	unmarshalCalls  int
-	unmarshalTotal  time.Duration
+	getUserCalls   int
+	getUserTotal   time.Duration
+	getReactCalls  int
+	getReactTotal  time.Duration
+	unmarshalCalls int
+	unmarshalTotal time.Duration
 }
 
 func loadCachedMessages(
@@ -2786,10 +2793,13 @@ func bootstrapPresenceAndDND(ctx context.Context, wctx *WorkspaceContext, progra
 		return
 	}
 
-	// Subscribe so future presence_change events for our own user arrive.
-	// Failure is non-fatal — manual_presence_change and dnd_updated work
-	// without an explicit subscription.
-	_ = wctx.Client.SubscribePresence([]string{wctx.UserID})
+	// Subscribe to presence for our own user plus every DM peer so the
+	// sidebar can show who is online. presence_sub REPLACES the prior
+	// subscription set, so self and peers must go in one call. Failure is
+	// non-fatal. Re-runs on every reconnect (this is called from
+	// OnConnect), which is required because the subscription is
+	// connection-scoped.
+	subscribeWorkspacePresence(wctx)
 
 	// Initial presence fetch
 	if p, err := wctx.Client.GetUserPresence(ctx, wctx.UserID); err == nil && p != nil {
@@ -2832,6 +2842,54 @@ func bootstrapPresenceAndDND(ctx context.Context, wctx *WorkspaceContext, progra
 			DNDEndTS:   wctx.DNDEndTS,
 		})
 	}
+}
+
+// subscribeWorkspacePresence subscribes over the WebSocket to presence
+// updates for the authenticated user plus every 1:1 DM peer, so the
+// sidebar can show who is online. Slack's presence_sub REPLACES the prior
+// subscription set and is connection-scoped, so this sends self + all DM
+// peers in a single call and must be re-run on each (re)connect.
+//
+// presence_sub also pushes each subscribed user's *current* presence back
+// as a presence_change event, so this doubles as the initial fetch — no
+// separate per-user query is needed. Safe to call repeatedly.
+func subscribeWorkspacePresence(wctx *WorkspaceContext) {
+	if wctx == nil || wctx.Client == nil {
+		return
+	}
+	ids := workspacePresenceIDs(wctx)
+	if len(ids) == 0 {
+		return
+	}
+	if err := wctx.Client.SubscribePresence(ids); err != nil {
+		debuglog.General("subscribeWorkspacePresence (%d ids): %v", len(ids), err)
+	}
+}
+
+// workspacePresenceIDs returns the deduped list of user IDs to subscribe
+// for presence: the authenticated user plus every 1:1 DM peer. Group DMs
+// and app/bot DMs (which carry no human presence dot in the sidebar) are
+// skipped. Pure function for testability.
+func workspacePresenceIDs(wctx *WorkspaceContext) []string {
+	seen := make(map[string]struct{})
+	ids := make([]string, 0, len(wctx.Channels)+1)
+	add := func(uid string) {
+		if uid == "" {
+			return
+		}
+		if _, ok := seen[uid]; ok {
+			return
+		}
+		seen[uid] = struct{}{}
+		ids = append(ids, uid)
+	}
+	add(wctx.UserID) // self — keeps the self presence subscription intact
+	for _, ch := range wctx.Channels {
+		if ch.Type == "dm" {
+			add(ch.DMUserID)
+		}
+	}
+	return ids
 }
 
 // rtmEventHandler bridges WebSocket events into bubbletea messages via p.Send()

--- a/cmd/slk/presence_test.go
+++ b/cmd/slk/presence_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gammons/slk/internal/ui/sidebar"
+)
+
+func TestWorkspacePresenceIDs(t *testing.T) {
+	wctx := &WorkspaceContext{
+		UserID: "USELF",
+		Channels: []sidebar.ChannelItem{
+			{Type: "dm", DMUserID: "U1"},
+			{Type: "channel"}, // not a DM — skipped
+			{Type: "dm", DMUserID: "U2"},
+			{Type: "dm", DMUserID: "U1"},     // duplicate peer — deduped
+			{Type: "app", DMUserID: "UBOT"},  // app/bot DM — no presence dot
+			{Type: "group_dm", DMUserID: ""}, // group DM — skipped
+			{Type: "dm", DMUserID: ""},       // malformed — skipped
+		},
+	}
+
+	got := workspacePresenceIDs(wctx)
+	want := []string{"USELF", "U1", "U2"} // self first, then DM peers in order, deduped
+	if len(got) != len(want) {
+		t.Fatalf("workspacePresenceIDs() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("workspacePresenceIDs()[%d] = %q, want %q (full %v)", i, got[i], want[i], got)
+		}
+	}
+}

--- a/internal/slack/events.go
+++ b/internal/slack/events.go
@@ -96,14 +96,14 @@ type wsEvent struct {
 
 // wsMessageEvent represents a message event from the WebSocket.
 type wsMessageEvent struct {
-	Type            string       `json:"type"`
-	SubType         string       `json:"subtype"`
-	Channel         string       `json:"channel"`
-	User            string       `json:"user"`
-	Text            string       `json:"text"`
-	TS              string       `json:"ts"`
-	ThreadTS        string       `json:"thread_ts"`
-	DeletedTS       string       `json:"deleted_ts"`
+	Type            string             `json:"type"`
+	SubType         string             `json:"subtype"`
+	Channel         string             `json:"channel"`
+	User            string             `json:"user"`
+	Text            string             `json:"text"`
+	TS              string             `json:"ts"`
+	ThreadTS        string             `json:"thread_ts"`
+	DeletedTS       string             `json:"deleted_ts"`
 	Files           []slack.File       `json:"files"`
 	Blocks          slack.Blocks       `json:"blocks"`
 	Attachments     []slack.Attachment `json:"attachments"`
@@ -133,11 +133,15 @@ type wsReactionEvent struct {
 	} `json:"item"`
 }
 
-// wsPresenceEvent represents a presence_change event.
+// wsPresenceEvent represents a presence_change event. Slack sends either
+// a single-user form ("user") or, when the connection is
+// batch_presence_aware, a batched form ("users") carrying several user
+// IDs that share the same presence. Both are parsed.
 type wsPresenceEvent struct {
-	Type     string `json:"type"`
-	User     string `json:"user"`
-	Presence string `json:"presence"`
+	Type     string   `json:"type"`
+	User     string   `json:"user"`
+	Users    []string `json:"users"`
+	Presence string   `json:"presence"`
 }
 
 // wsTypingEvent represents a user_typing event.
@@ -323,7 +327,15 @@ func dispatchWebSocketEvent(data []byte, handler EventHandler) {
 		if err := json.Unmarshal(data, &evt); err != nil {
 			return
 		}
-		handler.OnPresenceChange(evt.User, evt.Presence)
+		if len(evt.Users) > 0 {
+			for _, uid := range evt.Users {
+				debuglog.WS("presence_change (batch): user=%s presence=%q", uid, evt.Presence)
+				handler.OnPresenceChange(uid, evt.Presence)
+			}
+		} else if evt.User != "" {
+			debuglog.WS("presence_change: user=%s presence=%q", evt.User, evt.Presence)
+			handler.OnPresenceChange(evt.User, evt.Presence)
+		}
 
 	case "manual_presence_change":
 		var evt wsManualPresenceEvent

--- a/internal/slack/events_test.go
+++ b/internal/slack/events_test.go
@@ -211,6 +211,25 @@ func TestDispatchWebSocketPresenceChangeEvent(t *testing.T) {
 	}
 }
 
+func TestDispatchWebSocketPresenceChangeBatch(t *testing.T) {
+	handler := &mockEventHandler{}
+
+	// batch_presence_aware connections deliver a "users" array sharing one
+	// presence value instead of a single "user" — each must be dispatched.
+	data := []byte(`{"type":"presence_change","users":["U1","U2","U3"],"presence":"away"}`)
+	dispatchWebSocketEvent(data, handler)
+
+	want := []string{"U1:away", "U2:away", "U3:away"}
+	if len(handler.presenceChanges) != len(want) {
+		t.Fatalf("expected %d presence changes, got %d (%v)", len(want), len(handler.presenceChanges), handler.presenceChanges)
+	}
+	for i, w := range want {
+		if handler.presenceChanges[i] != w {
+			t.Errorf("presenceChanges[%d] = %q, want %q", i, handler.presenceChanges[i], w)
+		}
+	}
+}
+
 func TestDispatchWebSocketMessageDeletedEvent(t *testing.T) {
 	handler := &mockEventHandler{}
 


### PR DESCRIPTION
Closes #69.

## Problem

The Direct Messages list never showed who was online — every DM rendered the hollow `○` (away), even for active users.

## Root cause

Most of the presence pipeline already existed (WS `OnPresenceChange` → `PresenceChangeMsg` → `sidebar.UpdatePresenceByUser`, the `ChannelItem.Presence` field, and `●`/`○` rendering). Two pieces were missing:

1. **slk only subscribed to its own presence** (`SubscribePresence([]string{wctx.UserID})`), never DM peers — so Slack never sent their `presence_change` events.
2. **Batch `presence_change` events were dropped.** With `batch_presence_aware=1`, Slack sends `presence_change` carrying a `users` array, but the parser only read a single `user` field.

## Fix

- Add `subscribeWorkspacePresence`: subscribes self + every 1:1 DM peer in a single `presence_sub` (it replaces the prior subscription set, so self and peers must be sent together). Wired into `connectWorkspace` once the DM peers are known (initial boot) and `OnConnect` (re-subscribes per connection, required because the subscription is connection-scoped). App/bot and group DMs are skipped (no human presence dot).
- Parse both the single-user (`user`) and batched (`users[]`) forms of `presence_change`.
- `presence_sub` pushes each subscribed user's current presence back, so the subscription doubles as the initial fetch — no per-user query needed.

## Testing

- `go test ./...` passes; added `TestWorkspacePresenceIDs` (self + DM peers, dedup, skips channels/group/app DMs).
- Verified end-to-end in a kitty terminal: DM rows show `●` for online peers and `○` for away, updating live.
