### PR TITLE
Restore the last-visited channel on startup

### DIFF
--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -2851,6 +2851,7 @@ func mostRecentlyVisitedChannel(visits map[string]int64) string {
 	}
 	return bestID
 }
+
 // rtmEventHandler bridges WebSocket events into bubbletea messages via p.Send()
 // and caches all incoming messages to the SQLite database.
 type rtmEventHandler struct {

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -1574,6 +1574,7 @@ func run() error {
 				CustomEmoji:      wctx.CustomEmoji, // empty at this point; filled by the goroutine below
 				SectionsProvider: sectionsProviderAdapter{store: wctx.SectionStore},
 				InitialActive:    isInitial,
+				LastChannelID:    mostRecentlyVisitedChannel(wctx.LastVisitedByChannel),
 			})
 
 			// Fetch workspace custom emojis in the background. When done,
@@ -2836,6 +2837,20 @@ func bootstrapPresenceAndDND(ctx context.Context, wctx *WorkspaceContext, progra
 	}
 }
 
+// mostRecentlyVisitedChannel returns the channel ID with the latest
+// last-visited timestamp, or "" when there are no recorded visits (e.g.
+// the first run). Drives last-channel restoration on startup.
+func mostRecentlyVisitedChannel(visits map[string]int64) string {
+	var bestID string
+	var bestTS int64
+	for id, ts := range visits {
+		if ts > bestTS {
+			bestTS = ts
+			bestID = id
+		}
+	}
+	return bestID
+}
 // rtmEventHandler bridges WebSocket events into bubbletea messages via p.Send()
 // and caches all incoming messages to the SQLite database.
 type rtmEventHandler struct {

--- a/internal/ui/msgs.go
+++ b/internal/ui/msgs.go
@@ -276,6 +276,12 @@ type (
 		// via sync.Once + atomic router (Task 14). App's handler treats
 		// InitialActive=false as "workspace is up; threads-list kick only".
 		InitialActive bool
+		// LastChannelID is the workspace's most-recently-visited channel
+		// (from the persisted channel_visits table). On the InitialActive
+		// workspace the App opens this channel on startup instead of the
+		// sidebar's first entry, so a restart lands the user back where
+		// they were. Empty (e.g. first ever run) falls back to Channels[0].
+		LastChannelID string
 	}
 	// CustomEmojisLoadedMsg is sent when a workspace's custom emoji list
 	// finishes loading in the background, after WorkspaceReadyMsg has

--- a/internal/ui/reducer_workspace.go
+++ b/internal/ui/reducer_workspace.go
@@ -6,37 +6,37 @@
 // per-workspace data resolution echoes, and the sidebar / read-state
 // refresh paths:
 //
-//   WorkspaceReadyMsg       - one of the configured workspaces
-//                             finished its initial connect. If
-//                             InitialActive (claimed exactly once),
-//                             activate it: apply theme, push
-//                             channels/users/emoji, open the first
-//                             channel. Always fires an initial
-//                             threads-list fetch.
-//   WorkspaceSwitchedMsg    - user picked a different workspace.
-//                             Tear down per-workspace transient
-//                             state (threads view, edit, selection,
-//                             compose draft), push new channels/users/
-//                             emoji, apply theme, restore the last
-//                             channel viewed for this workspace.
-//   ConversationOpenedMsg   - WS event: a DM/MPIM just opened.
-//                             Upsert into the active sidebar.
-//   SectionsRefreshedMsg    - cache notice: sidebar sections were
-//                             reorganized. Re-push channel items
-//                             for the active workspace.
-//   DMNameResolvedMsg       - DM display-name resolved (im.open
-//                             roundtrip): patch the sidebar entry
-//                             and re-render.
-//   UserResolvedMsg         - per-user display-name resolved:
-//                             patch any in-history references in
-//                             both messages pane and thread panel.
-//   UserExternalMsg         - per-user external/internal flag
-//                             resolved: update the cache + re-push
-//                             SetUserNames so styling refreshes.
-//   ReadStateChangedMsg     - persistent read-state changed in the
-//                             cache: refresh sidebar + workspace rail.
-//   CustomEmojisLoadedMsg   - per-workspace emoji list arrived.
-//                             Apply only to the active workspace.
+//	WorkspaceReadyMsg       - one of the configured workspaces
+//	                          finished its initial connect. If
+//	                          InitialActive (claimed exactly once),
+//	                          activate it: apply theme, push
+//	                          channels/users/emoji, open the first
+//	                          channel. Always fires an initial
+//	                          threads-list fetch.
+//	WorkspaceSwitchedMsg    - user picked a different workspace.
+//	                          Tear down per-workspace transient
+//	                          state (threads view, edit, selection,
+//	                          compose draft), push new channels/users/
+//	                          emoji, apply theme, restore the last
+//	                          channel viewed for this workspace.
+//	ConversationOpenedMsg   - WS event: a DM/MPIM just opened.
+//	                          Upsert into the active sidebar.
+//	SectionsRefreshedMsg    - cache notice: sidebar sections were
+//	                          reorganized. Re-push channel items
+//	                          for the active workspace.
+//	DMNameResolvedMsg       - DM display-name resolved (im.open
+//	                          roundtrip): patch the sidebar entry
+//	                          and re-render.
+//	UserResolvedMsg         - per-user display-name resolved:
+//	                          patch any in-history references in
+//	                          both messages pane and thread panel.
+//	UserExternalMsg         - per-user external/internal flag
+//	                          resolved: update the cache + re-push
+//	                          SetUserNames so styling refreshes.
+//	ReadStateChangedMsg     - persistent read-state changed in the
+//	                          cache: refresh sidebar + workspace rail.
+//	CustomEmojisLoadedMsg   - per-workspace emoji list arrived.
+//	                          Apply only to the active workspace.
 //
 // Free reducer (not controller-absorbed): these arms cooperate on
 // the sidebar, messagepane, threadPanel, statusbar, channelFinder,
@@ -199,12 +199,24 @@ func reduceWorkspaceReady(a *App, m WorkspaceReadyMsg) tea.Cmd {
 		a.statusbar.SetStatus(pres, dndEnabled, dndEnd)
 		a.workspaceRail.SelectByID(m.TeamID)
 		if len(m.Channels) > 0 {
-			first := m.Channels[0]
+			// Restore the last-visited channel across restarts (persisted in
+			// channel_visits). Falls back to the first sidebar entry when
+			// there's no recorded visit or the channel no longer exists.
+			target := m.Channels[0]
+			if m.LastChannelID != "" {
+				for _, ch := range m.Channels {
+					if ch.ID == m.LastChannelID {
+						target = ch
+						break
+					}
+				}
+			}
+			a.sidebar.SelectByID(target.ID)
 			a.messagepane.SetLoading(true)
 			a.messagepane.SetMessages(nil)
 			batch = append(batch, spinnerTickCmd())
 			batch = append(batch, func() tea.Msg {
-				return ChannelSelectedMsg{ID: first.ID, Name: first.Name, Type: first.Type}
+				return ChannelSelectedMsg{ID: target.ID, Name: target.Name, Type: target.Type}
 			})
 		}
 	}

--- a/internal/ui/reducer_workspace_lastchannel_test.go
+++ b/internal/ui/reducer_workspace_lastchannel_test.go
@@ -1,0 +1,47 @@
+package ui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/gammons/slk/internal/ui/sidebar"
+)
+
+// TestWorkspaceReadyRestoresLastChannel is the headline of the
+// restore-last-channel feature: on the InitialActive workspace, startup
+// opens the persisted most-recently-visited channel (LastChannelID) rather
+// than always snapping to the sidebar's first entry, falling back to the
+// first channel when there's no recorded visit or it no longer exists.
+func TestWorkspaceReadyRestoresLastChannel(t *testing.T) {
+	selectOnReady := func(lastID string) (ChannelSelectedMsg, bool) {
+		a := NewApp()
+		_, _ = a.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+		_, cmd := a.Update(WorkspaceReadyMsg{
+			TeamID:        "T1",
+			InitialActive: true,
+			Channels: []sidebar.ChannelItem{
+				{ID: "C1", Name: "general", Type: "channel"},
+				{ID: "C2", Name: "random", Type: "channel"},
+			},
+			LastChannelID: lastID,
+		})
+		if cmd == nil {
+			return ChannelSelectedMsg{}, false
+		}
+		return findChannelSelected(cmd())
+	}
+
+	// Persisted last channel is restored.
+	if sel, ok := selectOnReady("C2"); !ok || sel.ID != "C2" {
+		t.Errorf("LastChannelID=C2: want C2 opened, got ok=%v id=%q", ok, sel.ID)
+	}
+	// No recorded visit (e.g. first run) -> first channel.
+	if sel, ok := selectOnReady(""); !ok || sel.ID != "C1" {
+		t.Errorf("no LastChannelID: want C1, got ok=%v id=%q", ok, sel.ID)
+	}
+	// Channel was archived/left since the last visit -> first channel.
+	if sel, ok := selectOnReady("CGONE"); !ok || sel.ID != "C1" {
+		t.Errorf("stale LastChannelID: want C1 fallback, got ok=%v id=%q", ok, sel.ID)
+	}
+}


### PR DESCRIPTION
## What

On startup, the active workspace now opens the **most-recently-visited channel** instead of always snapping to the sidebar's first entry — so a restart lands you back where you left off.

## How

The `channel_visits` table already persists a per-channel `last_visited` timestamp (and is loaded into `WorkspaceContext.LastVisitedByChannel` at connect). This wires that existing data into the startup path:

- `mostRecentlyVisitedChannel(visits)` picks the channel with the latest timestamp; it's passed on `WorkspaceReadyMsg.LastChannelID`.
- `reduceWorkspaceReady` (the `InitialActive` branch) opens `LastChannelID` when it's set and still present in the sidebar, otherwise falls back to `Channels[0]`.

Only the startup path changed; the existing mid-session workspace-switch restore (`lastChannelByTeam`) is untouched.

## Edge cases

- **First run / no recorded visit** → `LastChannelID` is empty → opens `Channels[0]` (unchanged behavior).
- **Last channel archived/left** → lookup finds no match → falls back to `Channels[0]`.

## Testing

`go test ./...` passes; added `TestWorkspaceReadyRestoresLastChannel` covering restore, the empty-visit fallback, and the stale-channel fallback.
