### PR TITLE
Open threads scrolled to the latest reply

### DIFF
--- a/internal/ui/thread/model.go
+++ b/internal/ui/thread/model.go
@@ -309,6 +309,11 @@ func (m *Model) SetThread(parent messages.MessageItem, replies []messages.Messag
 	} else {
 		m.selected = 0
 	}
+	// Force the next View() to re-snap the viewport to the new selection.
+	// Without this, opening a thread whose newest-reply index matches the
+	// previously-viewed thread's snapped selection skips the snap and leaves
+	// the viewport scrolled to the top. Mirrors messages.Model.SetMessages.
+	m.hasSnapped = false
 	m.InvalidateCache()
 }
 

--- a/internal/ui/thread/open_bottom_test.go
+++ b/internal/ui/thread/open_bottom_test.go
@@ -1,0 +1,60 @@
+package thread
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gammons/slk/internal/config"
+	"github.com/gammons/slk/internal/ui/messages"
+	"github.com/gammons/slk/internal/ui/styles"
+)
+
+// TestSetThreadOpensAtBottom guards that opening a thread scrolls the
+// viewport to the newest reply (like the Slack app), even when the new
+// thread's newest-reply index matches the previously-viewed thread's
+// snapped selection — the case where the missing snap-state reset left the
+// viewport stuck at the top.
+func TestSetThreadOpensAtBottom(t *testing.T) {
+	styles.Apply("dark", config.Theme{})
+	t.Cleanup(func() { styles.Apply("dark", config.Theme{}) })
+
+	parent := messages.MessageItem{TS: "100.0", UserName: "alice", Text: "parent"}
+	mk := func(n int) []messages.MessageItem {
+		r := make([]messages.MessageItem, n)
+		for i := range r {
+			r[i] = messages.MessageItem{
+				TS:        fmt.Sprintf("%d.000000", 1700000000+i),
+				UserName:  "bob",
+				Text:      fmt.Sprintf("reply number %d", i),
+				Timestamp: "10:30 AM",
+			}
+		}
+		return r
+	}
+	const h, w = 12, 80
+
+	m := New()
+	// Thread A: a long thread opens scrolled to the bottom.
+	m.SetThread(parent, mk(25), "C1", "100.0")
+	m.View(h, w)
+	if m.vp.YOffset() == 0 {
+		t.Fatalf("thread A: expected to open scrolled to the bottom, got YOffset=0")
+	}
+
+	// Simulate scrolling thread A up to the top: leaves hasSnapped=true with
+	// snappedSelection == the newest-reply index.
+	m.vp.SetYOffset(0)
+	m.hasSnapped = true
+	m.snappedSelection = m.selected
+
+	// Thread B with the same reply count (so the newest-reply index matches).
+	// Pre-fix this skipped the re-snap and left the viewport at the top.
+	m.SetThread(parent, mk(25), "C2", "200.0")
+	if m.hasSnapped {
+		t.Fatalf("SetThread must reset hasSnapped so the next View re-snaps to the new selection")
+	}
+	m.View(h, w)
+	if m.vp.YOffset() == 0 {
+		t.Errorf("thread B opened at the top (YOffset=0); want scrolled to the latest reply")
+	}
+}


### PR DESCRIPTION
Closes #73.

## Problem

Opening a thread scrolls to the top (parent / first reply) instead of the newest reply, unlike the Slack app. `SetThread` already selects the last reply (`m.selected = len(replies)-1`) intending to open at the bottom, but the viewport's snap-to-selection only re-runs when the selection *index changes*. Because `SetThread` never resets the snap state, opening a thread whose newest-reply index matches the previously-viewed thread's snapped selection (very common) skips the re-snap and leaves the viewport at the top.

## Fix

Reset `hasSnapped` in `SetThread` so the next `View()` re-snaps the viewport to the newest-reply selection — mirroring `messages.Model.SetMessages`, which already does exactly this with the same rationale.

## Testing

`go test ./...` passes; added `TestSetThreadOpensAtBottom`, which reproduces the matching-index scenario and asserts the viewport scrolls to the bottom on open (it fails without the one-line reset).
