### PR TITLE
Show name and avatar for bot messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bin/
 dist/
+/slk
 *.db
 *.db-journal
 .superpowers/

--- a/cmd/slk/bot_identity_test.go
+++ b/cmd/slk/bot_identity_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/slack-go/slack"
+)
+
+// TestMessageAuthorBotIdentity is the headline of the bot-avatar fix: a
+// bot_message (no user, only bot_id + username) is keyed on the bot_id and
+// uses the message's username, so a name and avatar can attach — while
+// human messages keep resolving by user ID.
+func TestMessageAuthorBotIdentity(t *testing.T) {
+	userNames := map[string]string{}
+
+	// Bot message: empty user, bot_id + username present.
+	bot := slack.Message{Msg: slack.Msg{User: "", BotID: "B123", Username: "Deploybot"}}
+	uid, name := messageAuthor(bot, userNames, nil, nil)
+	if uid != "B123" {
+		t.Errorf("bot author ID: want B123, got %q", uid)
+	}
+	if name != "Deploybot" {
+		t.Errorf("bot author name: want Deploybot, got %q", name)
+	}
+
+	// Human message: user present, name pre-cached (so no db/resolver needed).
+	userNames["U1"] = "Alice"
+	human := slack.Message{Msg: slack.Msg{User: "U1"}}
+	uid2, name2 := messageAuthor(human, userNames, nil, nil)
+	if uid2 != "U1" {
+		t.Errorf("human author ID: want U1, got %q", uid2)
+	}
+	if name2 != "Alice" {
+		t.Errorf("human author name: want Alice, got %q", name2)
+	}
+}

--- a/cmd/slk/event_handler_test.go
+++ b/cmd/slk/event_handler_test.go
@@ -154,7 +154,7 @@ func TestOnMessage_InactiveChannel_SetsHasUnread(t *testing.T) {
 		isActive:        func() bool { return true },
 		activeChannelID: func() string { return "C2" }, // viewing a different channel
 	}
-	h.OnMessage("C1", "U1", "1.001", "hi", "", "", false, nil, slack.Blocks{}, nil)
+	h.OnMessage("C1", "U1", "1.001", "hi", "", "", false, nil, slack.Blocks{}, nil, "", "")
 
 	s, _ := db.GetChannelReadState("C1")
 	if !s.HasUnread {
@@ -171,7 +171,7 @@ func TestOnMessage_ActiveChannel_DoesNotSetHasUnread(t *testing.T) {
 		isActive:        func() bool { return true },
 		activeChannelID: func() string { return "C1" }, // viewing the same channel
 	}
-	h.OnMessage("C1", "U1", "1.001", "hi", "", "", false, nil, slack.Blocks{}, nil)
+	h.OnMessage("C1", "U1", "1.001", "hi", "", "", false, nil, slack.Blocks{}, nil, "", "")
 
 	s, _ := db.GetChannelReadState("C1")
 	if s.HasUnread {
@@ -189,7 +189,7 @@ func TestOnMessage_InactiveWorkspace_StillSetsHasUnread(t *testing.T) {
 		activeChannelID: func() string { return "" },
 		workspaceID:     "T1",
 	}
-	h.OnMessage("C1", "U1", "1.001", "hi", "", "", false, nil, slack.Blocks{}, nil)
+	h.OnMessage("C1", "U1", "1.001", "hi", "", "", false, nil, slack.Blocks{}, nil, "", "")
 
 	s, _ := db.GetChannelReadState("C1")
 	if !s.HasUnread {
@@ -207,7 +207,7 @@ func TestOnMessage_ThreadReply_DoesNotSetHasUnread(t *testing.T) {
 		activeChannelID: func() string { return "C2" },
 	}
 	// threadTS != ts and not a broadcast subtype = non-broadcast thread reply.
-	h.OnMessage("C1", "U1", "1.002", "reply", "1.001", "", false, nil, slack.Blocks{}, nil)
+	h.OnMessage("C1", "U1", "1.002", "reply", "1.001", "", false, nil, slack.Blocks{}, nil, "", "")
 
 	s, _ := db.GetChannelReadState("C1")
 	if s.HasUnread {
@@ -224,7 +224,7 @@ func TestOnMessage_ThreadBroadcast_SetsHasUnread(t *testing.T) {
 		isActive:        func() bool { return true },
 		activeChannelID: func() string { return "C2" },
 	}
-	h.OnMessage("C1", "U1", "1.002", "ALL", "1.001", "thread_broadcast", false, nil, slack.Blocks{}, nil)
+	h.OnMessage("C1", "U1", "1.002", "ALL", "1.001", "thread_broadcast", false, nil, slack.Blocks{}, nil, "", "")
 
 	s, _ := db.GetChannelReadState("C1")
 	if !s.HasUnread {

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -385,9 +385,11 @@ func (r *userResolver) RequestBot(botID, username string) {
 	}()
 }
 
-// bestBotIcon returns the largest reasonable bot icon URL. The avatar
-// fetcher downscales to the avatar cell grid, so a larger source renders
-// sharper; fall back through the available sizes.
+// bestBotIcon returns the best bot icon URL for the avatar grid. The
+// avatar fetcher downscales to the avatar cell size, so we prefer the
+// 72px icon — large enough to render sharp yet almost always present —
+// then fall back through the other sizes by availability rather than
+// strictly by pixel size.
 func bestBotIcon(ic slack.Icons) string {
 	for _, u := range []string{ic.Image72, ic.Image48, ic.Image132, ic.Image36, ic.Image230} {
 		if u != "" {
@@ -3047,6 +3049,10 @@ func (h *rtmEventHandler) OnMessage(channelID, userID, ts, text, threadTS, subty
 			IsDND:           h.wsCtx != nil && h.wsCtx.DNDEnabled && (h.wsCtx.DNDEndTS.IsZero() || time.Now().Before(h.wsCtx.DNDEndTS)),
 		}
 		chType := h.channelTypes[channelID]
+		// Pass the raw userID (not authorID): ShouldNotify's self-message
+		// suppression keys on the human sender, and a bot message
+		// (userID == "", authorID == botID) can never be "you" — so the
+		// empty userID is intentional, not a bug to "fix" later.
 		if notify.ShouldNotify(ctx, channelID, userID, text, chType) {
 			senderName := authorID
 			if resolved, ok := h.userNames[authorID]; ok {

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -331,6 +331,72 @@ func (r *userResolver) Request(userID string) {
 	}()
 }
 
+// RequestBot enqueues a bots.info fetch for a bot author (bot_message has
+// no `user`, only a `bot_id`). Keyed by botID so the resolved name +
+// avatar attach to messages whose UserID was set to the bot_id. username
+// is the name carried on the message (used as a fallback / immediate
+// value); bots.info supplies the icon (and a name if the message had
+// none). Mirrors Request: inflight dedup, cache-skip, async fetch,
+// Preload + UpsertUser + UserResolvedMsg (which AvatarReadyMsg follows).
+func (r *userResolver) RequestBot(botID, username string) {
+	if r == nil || botID == "" {
+		return
+	}
+	if _, exists := r.inflight.LoadOrStore(botID, struct{}{}); exists {
+		return
+	}
+	if _, err := r.db.GetUser(botID); err == nil {
+		r.inflight.Delete(botID)
+		return
+	}
+	go func() {
+		defer r.inflight.Delete(botID)
+		bot, err := r.client.GetBotInfo(context.Background(), botID)
+		if err != nil {
+			debuglog.Cache("userResolver: GetBotInfo team=%s bot=%s err=%v", r.teamID, botID, err)
+			return
+		}
+		name := username
+		if name == "" {
+			name = bot.Name
+		}
+		if name == "" {
+			name = botID
+		}
+		iconURL := bestBotIcon(bot.Icons)
+		r.avatars.Preload(botID, iconURL)
+		_ = r.db.UpsertUser(cache.User{
+			ID:          botID,
+			WorkspaceID: r.teamID,
+			Name:        name,
+			DisplayName: name,
+			AvatarURL:   iconURL,
+			Presence:    "away",
+			IsBot:       true,
+		})
+		if r.send != nil {
+			r.send(ui.UserResolvedMsg{
+				TeamID:      r.teamID,
+				UserID:      botID,
+				DisplayName: name,
+				IsBot:       true,
+			})
+		}
+	}()
+}
+
+// bestBotIcon returns the largest reasonable bot icon URL. The avatar
+// fetcher downscales to the avatar cell grid, so a larger source renders
+// sharper; fall back through the available sizes.
+func bestBotIcon(ic slack.Icons) string {
+	for _, u := range []string{ic.Image72, ic.Image48, ic.Image132, ic.Image36, ic.Image230} {
+		if u != "" {
+			return u
+		}
+	}
+	return ""
+}
+
 func main() {
 	// Debug log: when SLK_DEBUG is set, debuglog.Init opens
 	// slk-debug.log in cwd (truncating any prior session) and routes
@@ -2147,6 +2213,45 @@ func resolveUser(client *slackclient.Client, userID string, userNames map[string
 	return userID, false
 }
 
+// messageAuthor resolves the display identity for a fetched message.
+// Human messages carry a `user` ID, resolved (and lazily fetched) the
+// usual way. Bot messages (bot_message) have an empty `user` and only a
+// `bot_id` + `username`; those are keyed on the bot_id, use the message's
+// username for the name, and enqueue a bots.info lookup for the avatar
+// (and a name fallback). The returned userID is what both the cache row
+// and the MessageItem are keyed on so the avatar pipeline can attach.
+func messageAuthor(m slack.Message, userNames map[string]string, db *cache.DB, router *workspaceRouter) (userID, userName string) {
+	if m.User != "" {
+		name, ok := resolveUserCached(m.User, userNames, db)
+		if !ok {
+			name = m.User
+			if router != nil {
+				if wctx := router.Active(); wctx != nil && wctx.UserResolver != nil {
+					wctx.UserResolver.Request(m.User)
+				}
+			}
+		}
+		return m.User, name
+	}
+	if m.BotID != "" {
+		name := m.Username
+		if name == "" {
+			if cached, ok := resolveUserCached(m.BotID, userNames, db); ok {
+				name = cached
+			} else {
+				name = m.BotID
+			}
+		}
+		if router != nil {
+			if wctx := router.Active(); wctx != nil && wctx.UserResolver != nil {
+				wctx.UserResolver.RequestBot(m.BotID, m.Username)
+			}
+		}
+		return m.BotID, name
+	}
+	return m.User, m.User
+}
+
 func fetchOlderMessages(client *slackclient.Client, channelID, latestTS string, db *cache.DB, userNames map[string]string, tsFormat string, avatarCache *avatar.Cache, router *workspaceRouter) []messages.MessageItem {
 	ctx := context.Background()
 	debuglog.Cache("fetchOlderMessages: channel=%s latest_ts=%s entry", channelID, latestTS)
@@ -2163,11 +2268,12 @@ func fetchOlderMessages(client *slackclient.Client, channelID, latestTS string, 
 		rawBytes, _ := json.Marshal(m)
 		debuglog.Cache("fetchOlderMessages: upsert channel=%s ts=%s subtype=%q reply_count=%d files=%d",
 			channelID, m.Timestamp, m.SubType, m.ReplyCount, len(m.Files))
+		authorID, userName := messageAuthor(m, userNames, db, router)
 		db.UpsertMessage(cache.Message{
 			TS:          m.Timestamp,
 			ChannelID:   channelID,
 			WorkspaceID: client.TeamID(),
-			UserID:      m.User,
+			UserID:      authorID,
 			Text:        m.Text,
 			ThreadTS:    m.ThreadTimestamp,
 			ReplyCount:  m.ReplyCount,
@@ -2175,16 +2281,6 @@ func fetchOlderMessages(client *slackclient.Client, channelID, latestTS string, 
 			RawJSON:     string(rawBytes),
 			CreatedAt:   time.Now().Unix(),
 		})
-
-		userName, ok := resolveUserCached(m.User, userNames, db)
-		if !ok {
-			userName = m.User
-			if router != nil {
-				if wctx := router.Active(); wctx != nil && wctx.UserResolver != nil {
-					wctx.UserResolver.Request(m.User)
-				}
-			}
-		}
 
 		// Convert reactions
 		var reactions []messages.ReactionItem
@@ -2207,7 +2303,7 @@ func fetchOlderMessages(client *slackclient.Client, channelID, latestTS string, 
 
 		msgItems = append(msgItems, messages.MessageItem{
 			TS:                m.Timestamp,
-			UserID:            m.User,
+			UserID:            authorID,
 			UserName:          userName,
 			Text:              m.Text,
 			Timestamp:         formatTimestamp(m.Timestamp, tsFormat),
@@ -2390,19 +2486,42 @@ func enrichCachedRow(
 	router *workspaceRouter,
 	stats *enrichPerfStats,
 ) messages.MessageItem {
+	// Bot rows cached before the bot-identity fix have an empty UserID but
+	// carry bot_id + username in raw_json. Re-key them on the bot_id and
+	// resolve the avatar/name via bots.info so cached bot messages render
+	// like freshly-fetched ones (without this they stay blank until a
+	// live re-fetch, which never reaches messages older than the latest 50).
+	effUserID := m.UserID
+	botUsername := ""
+	if effUserID == "" && m.RawJSON != "" {
+		var rawBot struct {
+			BotID    string `json:"bot_id"`
+			Username string `json:"username"`
+		}
+		if json.Unmarshal([]byte(m.RawJSON), &rawBot) == nil && rawBot.BotID != "" {
+			effUserID = rawBot.BotID
+			botUsername = rawBot.Username
+			if router != nil {
+				if wctx := router.Active(); wctx != nil && wctx.UserResolver != nil {
+					wctx.UserResolver.RequestBot(rawBot.BotID, rawBot.Username)
+				}
+			}
+		}
+	}
+
 	// Resolve username from the in-memory map first; fall back to
-	// the cached users table; finally fall back to the user ID
-	// itself so the row still renders something readable.
+	// the cached users table; finally fall back to the bot username /
+	// user ID so the row still renders something readable.
 	var userName string
 	if userNames != nil {
-		userName = userNames[m.UserID]
+		userName = userNames[effUserID]
 	}
-	if userName == "" && m.UserID != "" {
+	if userName == "" && effUserID != "" {
 		var t0 time.Time
 		if stats != nil {
 			t0 = time.Now()
 		}
-		u, err := db.GetUser(m.UserID)
+		u, err := db.GetUser(effUserID)
 		if stats != nil {
 			stats.getUserCalls++
 			stats.getUserTotal += time.Since(t0)
@@ -2414,18 +2533,24 @@ func enrichCachedRow(
 				userName = u.Name
 			}
 			if userName != "" && userNames != nil {
-				userNames[m.UserID] = userName
+				userNames[effUserID] = userName
 			}
 		}
 	}
 	if userName == "" {
-		userName = m.UserID
-		// Cache had no entry for this user. Enqueue an async resolver
-		// fetch so the next render after UserResolvedMsg lands shows
-		// the real display name instead of the raw user ID.
-		if router != nil && m.UserID != "" {
-			if wctx := router.Active(); wctx != nil && wctx.UserResolver != nil {
-				wctx.UserResolver.Request(m.UserID)
+		if botUsername != "" {
+			userName = botUsername
+		} else {
+			userName = effUserID
+			// Cache had no entry for this user. Enqueue an async resolver
+			// fetch so the next render after UserResolvedMsg lands shows
+			// the real display name instead of the raw user ID. Guarded on
+			// m.UserID (the original) so bot rows — already handled via
+			// RequestBot above — don't hit the users.info path.
+			if router != nil && m.UserID != "" {
+				if wctx := router.Active(); wctx != nil && wctx.UserResolver != nil {
+					wctx.UserResolver.Request(m.UserID)
+				}
 			}
 		}
 	}
@@ -2493,7 +2618,7 @@ func enrichCachedRow(
 
 	return messages.MessageItem{
 		TS:                m.TS,
-		UserID:            m.UserID,
+		UserID:            effUserID,
 		UserName:          userName,
 		Text:              m.Text,
 		Timestamp:         formatTimestamp(m.TS, tsFormat),
@@ -2576,11 +2701,12 @@ func fetchChannelMessages(client *slackclient.Client, channelID string, db *cach
 		rawBytes, _ := json.Marshal(m)
 		debuglog.Cache("fetchChannelMessages: upsert channel=%s ts=%s subtype=%q reply_count=%d files=%d",
 			channelID, m.Timestamp, m.SubType, m.ReplyCount, len(m.Files))
+		authorID, userName := messageAuthor(m, userNames, db, router)
 		db.UpsertMessage(cache.Message{
 			TS:          m.Timestamp,
 			ChannelID:   channelID,
 			WorkspaceID: client.TeamID(),
-			UserID:      m.User,
+			UserID:      authorID,
 			Text:        m.Text,
 			ThreadTS:    m.ThreadTimestamp,
 			ReplyCount:  m.ReplyCount,
@@ -2588,16 +2714,6 @@ func fetchChannelMessages(client *slackclient.Client, channelID string, db *cach
 			RawJSON:     string(rawBytes),
 			CreatedAt:   time.Now().Unix(),
 		})
-
-		userName, ok := resolveUserCached(m.User, userNames, db)
-		if !ok {
-			userName = m.User
-			if router != nil {
-				if wctx := router.Active(); wctx != nil && wctx.UserResolver != nil {
-					wctx.UserResolver.Request(m.User)
-				}
-			}
-		}
 
 		// Convert reactions
 		var reactions []messages.ReactionItem
@@ -2620,7 +2736,7 @@ func fetchChannelMessages(client *slackclient.Client, channelID string, db *cach
 
 		msgItems = append(msgItems, messages.MessageItem{
 			TS:                m.Timestamp,
-			UserID:            m.User,
+			UserID:            authorID,
 			UserName:          userName,
 			Text:              m.Text,
 			Timestamp:         formatTimestamp(m.Timestamp, tsFormat),
@@ -2668,11 +2784,12 @@ func fetchThreadReplies(client *slackclient.Client, channelID, threadTS string, 
 		rawBytes, _ := json.Marshal(m)
 		debuglog.Cache("fetchThreadReplies: upsert channel=%s ts=%s subtype=%q reply_count=%d files=%d",
 			channelID, m.Timestamp, m.SubType, m.ReplyCount, len(m.Files))
+		authorID, userName := messageAuthor(m, userNames, db, router)
 		db.UpsertMessage(cache.Message{
 			TS:          m.Timestamp,
 			ChannelID:   channelID,
 			WorkspaceID: client.TeamID(),
-			UserID:      m.User,
+			UserID:      authorID,
 			Text:        m.Text,
 			ThreadTS:    m.ThreadTimestamp,
 			ReplyCount:  m.ReplyCount,
@@ -2680,16 +2797,6 @@ func fetchThreadReplies(client *slackclient.Client, channelID, threadTS string, 
 			RawJSON:     string(rawBytes),
 			CreatedAt:   time.Now().Unix(),
 		})
-
-		userName, ok := resolveUserCached(m.User, userNames, db)
-		if !ok {
-			userName = m.User
-			if router != nil {
-				if wctx := router.Active(); wctx != nil && wctx.UserResolver != nil {
-					wctx.UserResolver.Request(m.User)
-				}
-			}
-		}
 
 		// Convert reactions
 		var reactions []messages.ReactionItem
@@ -2712,7 +2819,7 @@ func fetchThreadReplies(client *slackclient.Client, channelID, threadTS string, 
 
 		msgItems = append(msgItems, messages.MessageItem{
 			TS:                m.Timestamp,
-			UserID:            m.User,
+			UserID:            authorID,
 			UserName:          userName,
 			Text:              m.Text,
 			Timestamp:         formatTimestamp(m.Timestamp, tsFormat),
@@ -2868,7 +2975,17 @@ type rtmEventHandler struct {
 	backfillGate dedupeGate
 }
 
-func (h *rtmEventHandler) OnMessage(channelID, userID, ts, text, threadTS, subtype string, edited bool, files []slack.File, blocks slack.Blocks, attachments []slack.Attachment) {
+func (h *rtmEventHandler) OnMessage(channelID, userID, ts, text, threadTS, subtype string, edited bool, files []slack.File, blocks slack.Blocks, attachments []slack.Attachment, botID, username string) {
+	// Bot messages (bot_message) carry no user, only a bot_id + username.
+	// Key the row on the bot_id and resolve its avatar/name via bots.info,
+	// mirroring the fetch-path messageAuthor helper.
+	authorID := userID
+	if authorID == "" && botID != "" {
+		authorID = botID
+		if h.wsCtx != nil && h.wsCtx.UserResolver != nil {
+			h.wsCtx.UserResolver.RequestBot(botID, username)
+		}
+	}
 	// Cache every message to SQLite, regardless of active workspace.
 	// Guard against nil db so handlers constructed in tests (without
 	// real persistence) don't panic.
@@ -2876,7 +2993,7 @@ func (h *rtmEventHandler) OnMessage(channelID, userID, ts, text, threadTS, subty
 		synthetic := slack.Message{Msg: slack.Msg{
 			Type:            "message",
 			Timestamp:       ts,
-			User:            userID,
+			User:            authorID,
 			Text:            text,
 			ThreadTimestamp: threadTS,
 			SubType:         subtype,
@@ -2889,7 +3006,7 @@ func (h *rtmEventHandler) OnMessage(channelID, userID, ts, text, threadTS, subty
 			TS:          ts,
 			ChannelID:   channelID,
 			WorkspaceID: h.workspaceID,
-			UserID:      userID,
+			UserID:      authorID,
 			Text:        text,
 			ThreadTS:    threadTS,
 			Subtype:     subtype,
@@ -2931,9 +3048,11 @@ func (h *rtmEventHandler) OnMessage(channelID, userID, ts, text, threadTS, subty
 		}
 		chType := h.channelTypes[channelID]
 		if notify.ShouldNotify(ctx, channelID, userID, text, chType) {
-			senderName := userID
-			if resolved, ok := h.userNames[userID]; ok {
+			senderName := authorID
+			if resolved, ok := h.userNames[authorID]; ok {
 				senderName = resolved
+			} else if username != "" {
+				senderName = username
 			}
 			chName := h.channelNames[channelID]
 			title := h.workspaceName + ": #" + chName
@@ -2992,11 +3111,17 @@ func (h *rtmEventHandler) OnMessage(channelID, userID, ts, text, threadTS, subty
 		return
 	}
 
-	userName, ok := resolveUserCached(userID, h.userNames, h.db)
+	userName, ok := resolveUserCached(authorID, h.userNames, h.db)
 	if !ok {
-		userName = userID
-		if h.wsCtx != nil && h.wsCtx.UserResolver != nil {
-			h.wsCtx.UserResolver.Request(userID)
+		userName = authorID
+		if userID != "" {
+			if h.wsCtx != nil && h.wsCtx.UserResolver != nil {
+				h.wsCtx.UserResolver.Request(userID)
+			}
+		} else if username != "" {
+			// Bot author: show its name immediately; bots.info (already
+			// requested above) fills in the avatar.
+			userName = username
 		}
 	}
 	debuglog.Cache("OnMessage: team=%s channel=%s ts=%s subtype=%q thread_ts=%s decision=dispatched_to_app",
@@ -3006,7 +3131,7 @@ func (h *rtmEventHandler) OnMessage(channelID, userID, ts, text, threadTS, subty
 			ChannelID: channelID,
 			Message: messages.MessageItem{
 				TS:                ts,
-				UserID:            userID,
+				UserID:            authorID,
 				UserName:          userName,
 				Text:              text,
 				Timestamp:         formatTimestamp(ts, h.tsFormat),

--- a/internal/slack/client.go
+++ b/internal/slack/client.go
@@ -29,6 +29,7 @@ type SlackAPI interface {
 	GetUsersContext(ctx context.Context, options ...slack.GetUsersOption) ([]slack.User, error)
 	GetUsersInConversationContext(ctx context.Context, params *slack.GetUsersInConversationParameters) ([]string, string, error)
 	GetUserInfo(user string) (*slack.User, error)
+	GetBotInfoContext(ctx context.Context, parameters slack.GetBotInfoParameters) (*slack.Bot, error)
 	GetEmoji() (map[string]string, error)
 	PostMessage(channelID string, options ...slack.MsgOption) (string, string, error)
 	UpdateMessage(channelID, timestamp string, options ...slack.MsgOption) (string, string, string, error)
@@ -513,6 +514,17 @@ func (c *Client) GetUserProfile(userID string) (*slack.User, error) {
 		return nil, fmt.Errorf("getting user info: %w", err)
 	}
 	return user, nil
+}
+
+// GetBotInfo fetches a bot's name and icon by bot ID (the `bot_id` on a
+// bot_message). Used to resolve the display name and avatar for messages
+// posted by bots/apps, which carry no `user` field.
+func (c *Client) GetBotInfo(ctx context.Context, botID string) (*slack.Bot, error) {
+	bot, err := c.api.GetBotInfoContext(ctx, slack.GetBotInfoParameters{Bot: botID})
+	if err != nil {
+		return nil, fmt.Errorf("getting bot info: %w", err)
+	}
+	return bot, nil
 }
 
 // GetHistory retrieves message history for a channel.

--- a/internal/slack/client_test.go
+++ b/internal/slack/client_test.go
@@ -180,6 +180,10 @@ func (m *mockSlackAPI) GetUserInfo(user string) (*slack.User, error) {
 	return nil, fmt.Errorf("user not found")
 }
 
+func (m *mockSlackAPI) GetBotInfoContext(ctx context.Context, parameters slack.GetBotInfoParameters) (*slack.Bot, error) {
+	return nil, fmt.Errorf("bot not found")
+}
+
 func (m *mockSlackAPI) GetUsersContext(ctx context.Context, options ...slack.GetUsersOption) ([]slack.User, error) {
 	return nil, nil
 }

--- a/internal/slack/events.go
+++ b/internal/slack/events.go
@@ -16,7 +16,7 @@ type EventHandler interface {
 	// for bot posts, "thread_broadcast" for thread replies that the
 	// author also sent to the main channel. files carries any file
 	// attachments on the message (empty for plain text messages).
-	OnMessage(channelID, userID, ts, text, threadTS, subtype string, edited bool, files []slack.File, blocks slack.Blocks, attachments []slack.Attachment)
+	OnMessage(channelID, userID, ts, text, threadTS, subtype string, edited bool, files []slack.File, blocks slack.Blocks, attachments []slack.Attachment, botID, username string)
 	OnMessageDeleted(channelID, ts string)
 	OnReactionAdded(channelID, ts, userID, emoji string)
 	OnReactionRemoved(channelID, ts, userID, emoji string)
@@ -96,14 +96,16 @@ type wsEvent struct {
 
 // wsMessageEvent represents a message event from the WebSocket.
 type wsMessageEvent struct {
-	Type            string       `json:"type"`
-	SubType         string       `json:"subtype"`
-	Channel         string       `json:"channel"`
-	User            string       `json:"user"`
-	Text            string       `json:"text"`
-	TS              string       `json:"ts"`
-	ThreadTS        string       `json:"thread_ts"`
-	DeletedTS       string       `json:"deleted_ts"`
+	Type            string             `json:"type"`
+	SubType         string             `json:"subtype"`
+	Channel         string             `json:"channel"`
+	User            string             `json:"user"`
+	BotID           string             `json:"bot_id"`   // set on bot_message (no User)
+	Username        string             `json:"username"` // bot display name on bot_message
+	Text            string             `json:"text"`
+	TS              string             `json:"ts"`
+	ThreadTS        string             `json:"thread_ts"`
+	DeletedTS       string             `json:"deleted_ts"`
 	Files           []slack.File       `json:"files"`
 	Blocks          slack.Blocks       `json:"blocks"`
 	Attachments     []slack.Attachment `json:"attachments"`
@@ -114,6 +116,8 @@ type wsMessageEvent struct {
 // wsSubMsg is the inner message for message_changed events.
 type wsSubMsg struct {
 	User        string             `json:"user"`
+	BotID       string             `json:"bot_id"`
+	Username    string             `json:"username"`
 	Text        string             `json:"text"`
 	TS          string             `json:"ts"`
 	ThreadTS    string             `json:"thread_ts"`
@@ -288,12 +292,12 @@ func dispatchWebSocketEvent(data []byte, handler EventHandler) {
 			// this subtype).
 			debuglog.WS("message: channel=%s user=%s ts=%s subtype=%q thread_ts=%s files=%d",
 				msg.Channel, msg.User, msg.TS, msg.SubType, msg.ThreadTS, len(msg.Files))
-			handler.OnMessage(msg.Channel, msg.User, msg.TS, msg.Text, msg.ThreadTS, msg.SubType, false, msg.Files, msg.Blocks, msg.Attachments)
+			handler.OnMessage(msg.Channel, msg.User, msg.TS, msg.Text, msg.ThreadTS, msg.SubType, false, msg.Files, msg.Blocks, msg.Attachments, msg.BotID, msg.Username)
 		case "message_changed":
 			if msg.Message != nil {
 				debuglog.WS("message_changed: channel=%s user=%s ts=%s thread_ts=%s edited=true",
 					msg.Channel, msg.Message.User, msg.Message.TS, msg.Message.ThreadTS)
-				handler.OnMessage(msg.Channel, msg.Message.User, msg.Message.TS, msg.Message.Text, msg.Message.ThreadTS, "", true, msg.Message.Files, msg.Message.Blocks, msg.Message.Attachments)
+				handler.OnMessage(msg.Channel, msg.Message.User, msg.Message.TS, msg.Message.Text, msg.Message.ThreadTS, "", true, msg.Message.Files, msg.Message.Blocks, msg.Message.Attachments, msg.Message.BotID, msg.Message.Username)
 			}
 		case "message_deleted":
 			debuglog.WS("message_deleted: channel=%s deleted_ts=%s", msg.Channel, msg.DeletedTS)

--- a/internal/slack/events_test.go
+++ b/internal/slack/events_test.go
@@ -26,6 +26,9 @@ type mockEventHandler struct {
 	dndChanges          []dndChangeRecord
 	lastBlocks          slack.Blocks
 	lastAttachments     []slack.Attachment
+	lastUserID          string
+	lastBotID           string
+	lastUsername        string
 
 	channelMarks     []channelMarkRecord
 	threadMarks      []threadMarkRecord
@@ -72,11 +75,14 @@ type threadSubChangeRecord struct {
 	active                        bool
 }
 
-func (m *mockEventHandler) OnMessage(channelID, userID, ts, text, threadTS, subtype string, edited bool, files []slack.File, blocks slack.Blocks, attachments []slack.Attachment) {
+func (m *mockEventHandler) OnMessage(channelID, userID, ts, text, threadTS, subtype string, edited bool, files []slack.File, blocks slack.Blocks, attachments []slack.Attachment, botID, username string) {
 	m.messages = append(m.messages, text)
 	m.subtypes = append(m.subtypes, subtype)
 	m.lastBlocks = blocks
 	m.lastAttachments = attachments
+	m.lastUserID = userID
+	m.lastBotID = botID
+	m.lastUsername = username
 }
 
 func (m *mockEventHandler) OnMessageDeleted(channelID, ts string) {
@@ -149,7 +155,7 @@ func TestEventHandlerInterface(t *testing.T) {
 	handler := &mockEventHandler{}
 	var _ EventHandler = handler
 
-	handler.OnMessage("C1", "U1", "123.456", "hello", "", "", false, nil, slack.Blocks{}, nil)
+	handler.OnMessage("C1", "U1", "123.456", "hello", "", "", false, nil, slack.Blocks{}, nil, "", "")
 	if len(handler.messages) != 1 || handler.messages[0] != "hello" {
 		t.Error("expected message to be recorded")
 	}
@@ -172,7 +178,7 @@ func TestDispatchWebSocketMessageEvent(t *testing.T) {
 func TestDispatchWebSocketBotMessageEvent(t *testing.T) {
 	handler := &mockEventHandler{}
 
-	data := []byte(`{"type":"message","subtype":"bot_message","channel":"C1","text":"bot says hi","ts":"123.456","bot_id":"B123"}`)
+	data := []byte(`{"type":"message","subtype":"bot_message","channel":"C1","text":"bot says hi","ts":"123.456","bot_id":"B123","username":"Deploybot"}`)
 	dispatchWebSocketEvent(data, handler)
 
 	if len(handler.messages) != 1 {
@@ -180,6 +186,17 @@ func TestDispatchWebSocketBotMessageEvent(t *testing.T) {
 	}
 	if handler.messages[0] != "bot says hi" {
 		t.Errorf("expected 'bot says hi', got %q", handler.messages[0])
+	}
+	// bot_message has no user; the bot_id + username must flow through so
+	// the handler can key identity/avatar on the bot.
+	if handler.lastUserID != "" {
+		t.Errorf("expected empty userID on bot_message, got %q", handler.lastUserID)
+	}
+	if handler.lastBotID != "B123" {
+		t.Errorf("expected bot_id B123, got %q", handler.lastBotID)
+	}
+	if handler.lastUsername != "Deploybot" {
+		t.Errorf("expected username Deploybot, got %q", handler.lastUsername)
 	}
 }
 
@@ -326,8 +343,8 @@ func TestDispatchWebSocketDNDUpdatedUserEvent_NoDND(t *testing.T) {
 func TestDispatchWebSocketDNDUpdatedEvent_InScheduledWindow(t *testing.T) {
 	// User is currently inside the scheduled DND window.
 	now := time.Now().Unix()
-	start := now - 600           // 10 min ago
-	end := now + 3600             // 1h from now
+	start := now - 600 // 10 min ago
+	end := now + 3600  // 1h from now
 	handler := &mockEventHandler{}
 	data := []byte(fmt.Sprintf(
 		`{"type":"dnd_updated","dnd_status":{"dnd_enabled":true,"snooze_enabled":false,"snooze_endtime":0,"next_dnd_start_ts":%d,"next_dnd_end_ts":%d}}`,
@@ -347,8 +364,8 @@ func TestDispatchWebSocketDNDUpdatedEvent_BetweenSchedules(t *testing.T) {
 	// the next scheduled window starts. dnd_enabled=true is just "schedule
 	// exists" — must NOT be interpreted as "currently in DND".
 	now := time.Now().Unix()
-	start := now + 3600  // 1h from now
-	end := now + 7200    // 2h from now
+	start := now + 3600 // 1h from now
+	end := now + 7200   // 2h from now
 	handler := &mockEventHandler{}
 	data := []byte(fmt.Sprintf(
 		`{"type":"dnd_updated","dnd_status":{"dnd_enabled":true,"snooze_enabled":false,"snooze_endtime":0,"next_dnd_start_ts":%d,"next_dnd_end_ts":%d}}`,


### PR DESCRIPTION
Closes #76.

## Problem

Bot/app messages (`bot_message`) carry no `user` — only `bot_id`, `username`, and sometimes `icons`. The conversion read only `m.User`, so bot messages got `UserID == ""`: the avatar lookup missed and the author name was dropped. This hit every bot, since even apps with a bot user post as `bot_message` with an empty `user`.

## Fix

- **Identity:** key bot messages on `bot_id` and use the message's `username`, in all three fetch paths (new `messageAuthor` helper) and the live WebSocket path (`OnMessage` now receives `bot_id`/`username`, threaded through the event struct + dispatch).
- **Avatar:** a new `userResolver.RequestBot` resolves the icon via **`bots.info`** once per bot (deduped, persisted) and preloads it via `avatars.Preload(bot_id, …)`; `AvatarURLs[bot_id]` is then populated on the resolve/connect path — mirroring the `users.info` path for humans. Added `GetBotInfo` to the client.
- **Cached rows:** messages cached with `UserID == ""` before this change are re-keyed by parsing `bot_id`/`username` out of `raw_json` in `enrichCachedRow`, so existing cached bot messages render without a cache wipe.

## Testing

`go test ./...` passes. Added `TestMessageAuthorBotIdentity` (fetch-path identity) and extended `TestDispatchWebSocketBotMessageEvent` to assert `bot_id`/`username` flow through the WS dispatch.

