### PR TITLE
Add configurable identity cache TTL (refresh stale names/avatars)

### DIFF
--- a/cmd/slk/identity_ttl_test.go
+++ b/cmd/slk/identity_ttl_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// TestUserResolverFresh is the headline of the identity-TTL feature: the
+// resolver re-fetches a cached identity once it ages past the TTL, and a
+// zero TTL preserves the old "cache forever" behavior.
+func TestUserResolverFresh(t *testing.T) {
+	now := time.Now().Unix()
+	day := int64(24 * 60 * 60)
+
+	// TTL disabled (0): everything is fresh, nothing ever re-resolves.
+	off := &userResolver{ttl: 0}
+	if !off.fresh(0) || !off.fresh(now-365*day) {
+		t.Error("ttl=0 must treat all identities as fresh (no refresh)")
+	}
+
+	r := &userResolver{ttl: 7 * 24 * time.Hour}
+	if !r.fresh(now) {
+		t.Error("just-synced identity must be fresh")
+	}
+	if !r.fresh(now - 6*day) {
+		t.Error("6 days old must be fresh under a 7d TTL")
+	}
+	if r.fresh(now - 8*day) {
+		t.Error("8 days old must be stale under a 7d TTL")
+	}
+	// updated_at=0 (never stamped) reads as ancient -> stale, so unstamped
+	// rows refresh on next sight.
+	if r.fresh(0) {
+		t.Error("unstamped (updated_at=0) identity must be stale")
+	}
+}

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -223,7 +223,8 @@ type userResolver struct {
 	db       *cache.DB
 	avatars  *avatar.Cache
 	send     func(tea.Msg)
-	inflight sync.Map // userID -> struct{}
+	ttl      time.Duration // identity freshness window; 0 = never refresh
+	inflight sync.Map      // userID -> struct{}
 }
 
 func newUserResolver(
@@ -232,6 +233,7 @@ func newUserResolver(
 	db *cache.DB,
 	avatars *avatar.Cache,
 	send func(tea.Msg),
+	ttl time.Duration,
 ) *userResolver {
 	return &userResolver{
 		teamID:  teamID,
@@ -239,7 +241,18 @@ func newUserResolver(
 		db:      db,
 		avatars: avatars,
 		send:    send,
+		ttl:     ttl,
 	}
+}
+
+// fresh reports whether a cached identity stamped at updatedAt (unix
+// seconds) is still within the TTL. A non-positive TTL disables refresh
+// (identities are trusted forever), preserving the historical behavior.
+func (r *userResolver) fresh(updatedAt int64) bool {
+	if r.ttl <= 0 {
+		return true
+	}
+	return time.Since(time.Unix(updatedAt, 0)) < r.ttl
 }
 
 // Request enqueues a users.info fetch for userID. Returns immediately.
@@ -267,9 +280,15 @@ func (r *userResolver) Request(userID string) {
 	// both miss the cache, both then LoadOrStore (one wins, the loser
 	// silently returns). Store-first + check-second means at most one
 	// goroutine ever passes the cache check.
-	if _, err := r.db.GetUser(userID); err == nil {
-		r.inflight.Delete(userID)
-		return
+	refresh := false
+	if u, err := r.db.GetUser(userID); err == nil {
+		if r.fresh(u.UpdatedAt) {
+			r.inflight.Delete(userID)
+			return
+		}
+		// Cached but past the TTL — fall through to re-fetch so a rename
+		// or new avatar is picked up.
+		refresh = true
 	}
 	go func() {
 		defer r.inflight.Delete(userID)
@@ -306,6 +325,10 @@ func (r *userResolver) Request(userID string) {
 		// Subsequent resolveUserCached misses fall back to the DB
 		// row we just upserted, so we don't re-fetch on every miss
 		// in the small window before UserResolvedMsg lands.
+		if refresh {
+			// Bust the stale render/inflight/disk entry so Preload re-fetches.
+			r.avatars.Invalidate(userID)
+		}
 		r.avatars.Preload(userID, u.Profile.Image32)
 		_ = r.db.UpsertUser(cache.User{
 			ID:          userID,
@@ -345,9 +368,13 @@ func (r *userResolver) RequestBot(botID, username string) {
 	if _, exists := r.inflight.LoadOrStore(botID, struct{}{}); exists {
 		return
 	}
-	if _, err := r.db.GetUser(botID); err == nil {
-		r.inflight.Delete(botID)
-		return
+	refresh := false
+	if u, err := r.db.GetUser(botID); err == nil {
+		if r.fresh(u.UpdatedAt) {
+			r.inflight.Delete(botID)
+			return
+		}
+		refresh = true
 	}
 	go func() {
 		defer r.inflight.Delete(botID)
@@ -364,6 +391,9 @@ func (r *userResolver) RequestBot(botID, username string) {
 			name = botID
 		}
 		iconURL := bestBotIcon(bot.Icons)
+		if refresh {
+			r.avatars.Invalidate(botID)
+		}
 		r.avatars.Preload(botID, iconURL)
 		_ = r.db.UpsertUser(cache.User{
 			ID:          botID,
@@ -1777,6 +1807,10 @@ func connectWorkspace(ctx context.Context, token slackclient.Token, db *cache.DB
 	// UI goroutine via Model.PatchUserName (the single safe writer
 	// for that shared map). p may be nil in tests, in which case
 	// the resolver's send callback is a no-op.
+	identityTTL := time.Duration(cfg.Cache.IdentityTTLDays) * 24 * time.Hour
+	if identityTTL < 0 {
+		identityTTL = 0 // negative is nonsensical; treat as "never refresh" (= 0)
+	}
 	wctx.UserResolver = newUserResolver(
 		wctx.TeamID,
 		wctx.Client,
@@ -1787,6 +1821,7 @@ func connectWorkspace(ctx context.Context, token slackclient.Token, db *cache.DB
 				p.Send(msg)
 			}
 		},
+		identityTTL,
 	)
 
 	// Per-workspace channel-membership manager. *slackclient.Client

--- a/internal/avatar/avatar.go
+++ b/internal/avatar/avatar.go
@@ -207,6 +207,22 @@ func (c *Cache) Get(userID string) string {
 	return c.renders[userID]
 }
 
+// Invalidate drops the cached render for userID and clears the dedup
+// gate and the underlying fetcher entry, so the next Preload re-downloads
+// and re-renders the avatar. Used by the identity-TTL refresh when a
+// user's avatar URL may have changed (Preload alone would short-circuit
+// on the never-cleared inflight gate, and the fetcher would serve the
+// stale image for the stable "avatar-<id>" key).
+func (c *Cache) Invalidate(userID string) {
+	c.inflight.Delete(userID)
+	c.mu.Lock()
+	delete(c.renders, userID)
+	c.mu.Unlock()
+	if c.fetcher != nil {
+		c.fetcher.Delete("avatar-" + userID)
+	}
+}
+
 // renderAvatar produces the avatar's rendered string for the active
 // protocol. Kitty path: SetSource + RenderKey, immediately drain the
 // upload escape to the kitty side channel (the registry's fresh-flag

--- a/internal/cache/users.go
+++ b/internal/cache/users.go
@@ -1,6 +1,9 @@
 package cache
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 type User struct {
 	ID          string
@@ -22,6 +25,12 @@ type User struct {
 }
 
 func (db *DB) UpsertUser(u User) error {
+	// Stamp the sync time so the identity-TTL refresh can tell stale rows
+	// from fresh ones. Callers that set UpdatedAt explicitly (e.g. tests)
+	// are respected; everyone else records "synced now".
+	if u.UpdatedAt == 0 {
+		u.UpdatedAt = time.Now().Unix()
+	}
 	_, err := db.conn.Exec(`
 		INSERT INTO users (id, workspace_id, name, display_name, avatar_url, presence, is_bot, is_external, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)

--- a/internal/cache/users_ttl_test.go
+++ b/internal/cache/users_ttl_test.go
@@ -1,0 +1,45 @@
+package cache
+
+import (
+	"testing"
+	"time"
+)
+
+// TestUpsertUserStampsUpdatedAt verifies that UpsertUser records a sync
+// timestamp when the caller leaves UpdatedAt unset — the freshness signal
+// the identity-TTL refresh relies on. Without it every row would read as
+// epoch-old and re-resolve on every render.
+func TestUpsertUserStampsUpdatedAt(t *testing.T) {
+	db, err := New(":memory:")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer db.Close()
+	if err := db.UpsertWorkspace(Workspace{ID: "T1", Name: "team"}); err != nil {
+		t.Fatalf("UpsertWorkspace: %v", err)
+	}
+
+	before := time.Now().Unix()
+	if err := db.UpsertUser(User{ID: "U1", WorkspaceID: "T1", Name: "alice"}); err != nil {
+		t.Fatalf("UpsertUser: %v", err)
+	}
+	u, err := db.GetUser("U1")
+	if err != nil {
+		t.Fatalf("GetUser: %v", err)
+	}
+	if u.UpdatedAt < before {
+		t.Errorf("UpdatedAt not stamped: got %d, want >= %d", u.UpdatedAt, before)
+	}
+
+	// An explicit UpdatedAt is respected (not overwritten).
+	if err := db.UpsertUser(User{ID: "U2", WorkspaceID: "T1", Name: "bob", UpdatedAt: 12345}); err != nil {
+		t.Fatalf("UpsertUser explicit: %v", err)
+	}
+	u2, err := db.GetUser("U2")
+	if err != nil {
+		t.Fatalf("GetUser U2: %v", err)
+	}
+	if u2.UpdatedAt != 12345 {
+		t.Errorf("explicit UpdatedAt overwritten: got %d, want 12345", u2.UpdatedAt)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,15 +13,15 @@ import (
 )
 
 type Config struct {
-	General       General                      `toml:"general"`
-	Appearance    Appearance                   `toml:"appearance"`
-	Animations    Animations                   `toml:"animations"`
-	Notifications Notifications                `toml:"notifications"`
-	Cache         CacheConfig                  `toml:"cache"`
-	Sidebar       Sidebar                      `toml:"sidebar"`
-	Sections      map[string]SectionDef        `toml:"sections"`
-	Theme         Theme                        `toml:"theme"`
-	Workspaces    map[string]Workspace         `toml:"workspaces"`
+	General       General               `toml:"general"`
+	Appearance    Appearance            `toml:"appearance"`
+	Animations    Animations            `toml:"animations"`
+	Notifications Notifications         `toml:"notifications"`
+	Cache         CacheConfig           `toml:"cache"`
+	Sidebar       Sidebar               `toml:"sidebar"`
+	Sections      map[string]SectionDef `toml:"sections"`
+	Theme         Theme                 `toml:"theme"`
+	Workspaces    map[string]Workspace  `toml:"workspaces"`
 }
 
 // SectionDef defines a sidebar section with channel name patterns.
@@ -119,6 +119,11 @@ type CacheConfig struct {
 	MaxDBSizeMB          int `toml:"max_db_size_mb"`
 	// MaxImageCacheMB caps the on-disk/in-memory image cache size in MB.
 	MaxImageCacheMB int64 `toml:"max_image_cache_mb"`
+	// IdentityTTLDays controls how long a resolved user/bot identity
+	// (display name + avatar) is trusted before it is re-fetched on next
+	// sight. Catches renames and new avatars. 0 disables refresh (cached
+	// forever, the historical behavior).
+	IdentityTTLDays int `toml:"identity_ttl_days"`
 }
 
 // Sidebar holds preferences governing what appears in the channel
@@ -194,6 +199,7 @@ func Default() Config {
 			MessageRetentionDays: 30,
 			MaxDBSizeMB:          500,
 			MaxImageCacheMB:      200,
+			IdentityTTLDays:      7,
 		},
 		Sidebar: Sidebar{
 			HideInactiveAfterDays: 30,

--- a/internal/image/fetcher.go
+++ b/internal/image/fetcher.go
@@ -168,6 +168,16 @@ func (f *Fetcher) SetAuths(auths []TeamAuth) {
 	f.learnedAuths = sync.Map{} // reset learned mappings on reconfig
 }
 
+// Delete evicts a cached entry by key, forcing the next Fetch for that
+// key to re-download from its URL. Used by avatar refresh when an
+// identity's avatar URL has changed (the cache is keyed by a stable
+// id like "avatar-U123", so a new URL alone wouldn't re-fetch).
+func (f *Fetcher) Delete(key string) {
+	if f.cache != nil {
+		f.cache.Delete(key)
+	}
+}
+
 // ConfigurePrerender enables eager protocol encoding in the fetch
 // goroutine. After every successful Fetch whose request carries a
 // non-zero CellTarget, the decoded image is run through

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -32,6 +32,8 @@ quiet_hours = "22:00-08:00"   # planned
 message_retention_days = 30
 max_db_size_mb = 500
 max_image_cache_mb = 200
+identity_ttl_days = 7     # re-fetch a user/bot's name + avatar after N days
+                          # so renames and new avatars show up; 0 = never refresh
 
 # Glob-based channel sections — only consulted when use_slack_sections
 # is false (globally or per-workspace), or when Slack's section API is


### PR DESCRIPTION
Closes #78.

## What

Adds a configurable freshness window so resolved user/bot identities (name + avatar) are re-fetched once stale, instead of being cached forever.

```toml
[cache]
identity_ttl_days = 7   # 0 disables refresh (current behavior)
```

## How

- `CacheConfig.IdentityTTLDays` (default 7); `0` keeps the historical "cache forever".
- `UpsertUser` stamps `updated_at` (when the caller leaves it unset) so freshness is tracked.
- `userResolver` gains a TTL: `Request`/`RequestBot` skip only when cached **and** fresh; past the TTL they re-fetch (`users.info` / `bots.info`) and pick up renames + new avatars.
- Real avatar refresh: `avatar.Cache.Invalidate` + `image.Fetcher.Delete` bust the never-cleared inflight gate, the cached render, and the fetcher's stable `avatar-<id>` entry, so a changed URL actually re-downloads.

## Testing

`go test ./...` passes. Added `TestUserResolverFresh` (TTL decision incl. `0`=off and unstamped=stale) and `TestUpsertUserStampsUpdatedAt` (stamping + explicit value respected).