### PR TITLE
fix(app): switch to native clipboard library

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -909,6 +909,9 @@ func (a *App) copyPermalinkOfSelected() tea.Cmd {
 			return nil
 		}
 
+		if !a.clipboardAvailable {
+			return statusbar.PermalinkCopyFailedMsg{}
+		}
 		_ = clipboard.Write(clipboard.FmtText, []byte(url))
 
 		return statusbar.PermalinkCopiedMsg{}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -151,6 +151,11 @@ type App struct {
 	// clipboard contents. Tests inject fakes via SetClipboardReader.
 	clipboardRead clipboardReader
 
+	// clipboardWrite is the function used by copyPermalink and drag-copy
+	// to write OS clipboard contents. Tests inject fakes via
+	// SetClipboardWriter.
+	clipboardWrite clipboardWriter
+
 	// threads is the App's ThreadService collaborator (fetch / mark /
 	// reply / list-fetch + parent-channel last-read lookup for the
 	// unread boundary). See internal/ui/services.go. Defaulted to a
@@ -422,6 +427,7 @@ func NewApp() *App {
 		browserOpener:        openURLCmd,
 		navHistory:           newNavHistoryStore(),
 		clipboardRead:        defaultClipboardReader,
+		clipboardWrite:       defaultClipboardWriter,
 	}
 	app.editing = newEditController()
 	// typing tracker is referenced by typingOut so it must exist first;
@@ -912,7 +918,7 @@ func (a *App) copyPermalinkOfSelected() tea.Cmd {
 		if !a.clipboardAvailable {
 			return statusbar.PermalinkCopyFailedMsg{}
 		}
-		_ = clipboard.Write(clipboard.FmtText, []byte(url))
+		_ = a.clipboardWrite(clipboard.FmtText, []byte(url))
 
 		return statusbar.PermalinkCopiedMsg{}
 	}
@@ -1745,6 +1751,17 @@ func (a *App) SetClipboardReader(fn clipboardReader) {
 		return
 	}
 	a.clipboardRead = fn
+}
+
+// SetClipboardWriter replaces the clipboard write function. Used by
+// tests to inject a fake writer. Pass nil to restore the default
+// real clipboard writer.
+func (a *App) SetClipboardWriter(fn clipboardWriter) {
+	if fn == nil {
+		a.clipboardWrite = defaultClipboardWriter
+		return
+	}
+	a.clipboardWrite = fn
 }
 
 // SetThreadService wires the App's ThreadService collaborator

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -898,11 +898,11 @@ func (a *App) copyPermalinkOfSelected() tea.Cmd {
 	messageSvc := a.messageSvc
 	cID := ids.ChannelID(channelID)
 	mTS := ids.MessageTS(ts)
-	
+
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		
+
 		url, err := messageSvc.Permalink(ctx, cID, mTS)
 		if err != nil {
 			log.Printf("copy permalink: %v", err)
@@ -923,7 +923,6 @@ func (a *App) copyPermalinkOfSelected() tea.Cmd {
 		return statusbar.PermalinkCopiedMsg{}
 	}
 }
-
 
 // openLinksOfSelected implements the `o` keybinding: collect the
 // links in the selected message (messages pane or thread panel).

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -17,6 +17,8 @@ import (
 
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
+
+
 	"charm.land/lipgloss/v2"
 	"github.com/gammons/slk/internal/cache"
 	"github.com/gammons/slk/internal/config"
@@ -892,9 +894,11 @@ func (a *App) copyPermalinkOfSelected() tea.Cmd {
 	messageSvc := a.messageSvc
 	cID := ids.ChannelID(channelID)
 	mTS := ids.MessageTS(ts)
+	
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
+		
 		url, err := messageSvc.Permalink(ctx, cID, mTS)
 		if err != nil {
 			log.Printf("copy permalink: %v", err)
@@ -906,12 +910,13 @@ func (a *App) copyPermalinkOfSelected() tea.Cmd {
 			// false success toast.
 			return nil
 		}
-		return tea.BatchMsg{
-			tea.SetClipboard(url),
-			func() tea.Msg { return statusbar.PermalinkCopiedMsg{} },
-		}
+
+		_ = clipboard.Write(clipboard.FmtText, []byte(url))
+
+		return statusbar.PermalinkCopiedMsg{}
 	}
 }
+
 
 // openLinksOfSelected implements the `o` keybinding: collect the
 // links in the selected message (messages pane or thread panel).

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -17,8 +17,6 @@ import (
 
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
-
-
 	"charm.land/lipgloss/v2"
 	"github.com/gammons/slk/internal/cache"
 	"github.com/gammons/slk/internal/config"

--- a/internal/ui/app_selection_test.go
+++ b/internal/ui/app_selection_test.go
@@ -1,7 +1,6 @@
 package ui
 
 import (
-	"reflect"
 	"strings"
 	"testing"
 
@@ -9,6 +8,7 @@ import (
 	"github.com/gammons/slk/internal/ids"
 	"github.com/gammons/slk/internal/ui/messages"
 	"github.com/gammons/slk/internal/ui/statusbar"
+	"golang.design/x/clipboard"
 )
 
 func newTestAppWithMessages(t *testing.T) *App {
@@ -44,20 +44,14 @@ func drainBatch(cmd tea.Cmd) []tea.Msg {
 	}
 }
 
-// looksLikeSetClipboardMsg returns true when m is the unexported
-// setClipboardMsg type from bubbletea (a defined string type). It is
-// the only string-kind Msg that flows through App, so reflecting the
-// kind is sufficient to identify it.
-func looksLikeSetClipboardMsg(m tea.Msg) (string, bool) {
-	v := reflect.ValueOf(m)
-	if v.Kind() == reflect.String {
-		return v.String(), true
-	}
-	return "", false
-}
-
 func TestApp_DragInMessagesEmitsClipboardAndToast(t *testing.T) {
 	a := newTestAppWithMessages(t)
+	a.SetClipboardAvailable(true)
+	var gotData []byte
+	a.SetClipboardWriter(func(format clipboard.Format, data []byte) <-chan struct{} {
+		gotData = data
+		return nil
+	})
 	pressX := a.layout.sidebarEnd + 2
 	// Terminal Y = 4 → panelAt subtracts the 1-row panel border to give
 	// pane-local y=3, which is past the chrome (header + separator =
@@ -73,17 +67,8 @@ func TestApp_DragInMessagesEmitsClipboardAndToast(t *testing.T) {
 		t.Fatal("expected a command on release")
 	}
 	msgs := drainBatch(cmd)
-	var sawClipboard, sawCopiedToast bool
+	var sawCopiedToast bool
 	for _, m := range msgs {
-		if payload, ok := looksLikeSetClipboardMsg(m); ok {
-			if payload == "" {
-				t.Errorf("clipboard payload empty")
-			}
-			if strings.ContainsRune(payload, '▌') {
-				t.Errorf("clipboard contained border char")
-			}
-			sawClipboard = true
-		}
 		if v, ok := m.(statusbar.CopiedMsg); ok {
 			if v.N <= 0 {
 				t.Errorf("CopiedMsg.N = %d", v.N)
@@ -91,8 +76,11 @@ func TestApp_DragInMessagesEmitsClipboardAndToast(t *testing.T) {
 			sawCopiedToast = true
 		}
 	}
-	if !sawClipboard {
-		t.Errorf("expected setClipboardMsg in batched output (drained: %v)", msgs)
+	if len(gotData) == 0 {
+		t.Errorf("expected data written to clipboard")
+	}
+	if strings.ContainsRune(string(gotData), '▌') {
+		t.Errorf("clipboard contained border char: %q", string(gotData))
 	}
 	if !sawCopiedToast {
 		t.Errorf("expected statusbar.CopiedMsg in batched output (drained: %v)", msgs)
@@ -101,15 +89,24 @@ func TestApp_DragInMessagesEmitsClipboardAndToast(t *testing.T) {
 
 func TestApp_PlainClickDoesNotCopy(t *testing.T) {
 	a := newTestAppWithMessages(t)
+	a.SetClipboardAvailable(true)
+	var wrote bool
+	a.SetClipboardWriter(func(format clipboard.Format, data []byte) <-chan struct{} {
+		wrote = true
+		return nil
+	})
 	pressX := a.layout.sidebarEnd + 2
 	// Terminal Y past the chrome (panel border + 2-row chrome).
 	pressY := 4
 	_, _ = a.Update(tea.MouseClickMsg{X: pressX, Y: pressY, Button: tea.MouseLeft})
 	_, cmd := a.Update(tea.MouseReleaseMsg{X: pressX, Y: pressY, Button: tea.MouseLeft})
 	for _, m := range drainBatch(cmd) {
-		if _, ok := looksLikeSetClipboardMsg(m); ok {
-			t.Fatal("plain click must not write to clipboard")
+		if _, ok := m.(statusbar.CopiedMsg); ok {
+			t.Fatal("plain click must not emit CopiedMsg")
 		}
+	}
+	if wrote {
+		t.Fatal("plain click must not write to clipboard")
 	}
 	if a.messagepane.HasSelection() {
 		t.Fatal("plain click must not leave a pinned selection")
@@ -417,6 +414,12 @@ func TestDrag_MotionCoalescing_DefersExtendSelectionAt(t *testing.T) {
 // position even if the flush tick hasn't fired yet.
 func TestDrag_MotionCoalescing_ReleaseFlushesPending(t *testing.T) {
 	a := newTestAppWithMessages(t)
+	a.SetClipboardAvailable(true)
+	var gotData []byte
+	a.SetClipboardWriter(func(format clipboard.Format, data []byte) <-chan struct{} {
+		gotData = data
+		return nil
+	})
 	pressX := a.layout.sidebarEnd + 2
 	pressY := 4
 	_, _ = a.Update(tea.MouseClickMsg{X: pressX, Y: pressY, Button: tea.MouseLeft})
@@ -425,14 +428,19 @@ func TestDrag_MotionCoalescing_ReleaseFlushesPending(t *testing.T) {
 	// the 16 ms window" case.
 	_, cmd := a.Update(tea.MouseReleaseMsg{X: pressX + 10, Y: pressY + 1, Button: tea.MouseLeft})
 
-	var sawClipboard bool
-	for _, m := range drainBatch(cmd) {
-		if payload, ok := looksLikeSetClipboardMsg(m); ok && payload != "" {
-			sawClipboard = true
+	msgs := drainBatch(cmd)
+	if len(gotData) == 0 {
+		t.Errorf("Release must drain pending motion and write to clipboard; got data=%q", string(gotData))
+	}
+	found := false
+	for _, m := range msgs {
+		if _, ok := m.(statusbar.CopiedMsg); ok {
+			found = true
+			break
 		}
 	}
-	if !sawClipboard {
-		t.Errorf("Release must drain pending motion and emit clipboard cmd; got drained=%v", drainBatch(cmd))
+	if !found {
+		t.Errorf("Release must emit CopiedMsg; got %v", msgs)
 	}
 }
 

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -443,6 +443,10 @@ func TestHandleInsertMode_EmptyEnterStaysInInsert(t *testing.T) {
 
 func TestCopyPermalink_FromMessagesPane(t *testing.T) {
 	app := NewApp()
+	app.SetClipboardAvailable(true)
+	app.SetClipboardWriter(func(format clipboard.Format, data []byte) <-chan struct{} {
+		return nil
+	})
 	app.activeChannelID = "C123"
 	app.focusedPanel = PanelMessages
 	app.messagepane.SetMessages([]messages.MessageItem{
@@ -477,6 +481,10 @@ func TestCopyPermalink_FromMessagesPane(t *testing.T) {
 
 func TestCopyPermalink_FromThreadPane(t *testing.T) {
 	app := NewApp()
+	app.SetClipboardAvailable(true)
+	app.SetClipboardWriter(func(format clipboard.Format, data []byte) <-chan struct{} {
+		return nil
+	})
 	parent := messages.MessageItem{TS: "1700000000.000100"}
 	replies := []messages.MessageItem{
 		{TS: "1700000000.000100", UserName: "alice", Text: "parent"},
@@ -597,6 +605,10 @@ func drainForPermalinkCopied(t *testing.T, msg tea.Msg) bool {
 
 func TestCopyPermalink_ShiftYTriggersCopy(t *testing.T) {
 	app := NewApp()
+	app.SetClipboardAvailable(true)
+	app.SetClipboardWriter(func(format clipboard.Format, data []byte) <-chan struct{} {
+		return nil
+	})
 	app.activeChannelID = "C123"
 	app.focusedPanel = PanelMessages
 	app.messagepane.SetMessages([]messages.MessageItem{

--- a/internal/ui/callbacks.go
+++ b/internal/ui/callbacks.go
@@ -123,3 +123,11 @@ type clipboardReader func(format clipboard.Format) []byte
 // defaultClipboardReader is the real clipboard read function. It's
 // overridable per-App via SetClipboardReader for tests.
 var defaultClipboardReader clipboardReader = clipboard.Read
+
+// clipboardWriter abstracts clipboard.Write so tests can inject fake
+// clipboard writes. Production code uses the real clipboard.Write.
+type clipboardWriter func(format clipboard.Format, data []byte) <-chan struct{}
+
+// defaultClipboardWriter is the real clipboard write function. It's
+// overridable per-App via SetClipboardWriter for tests.
+var defaultClipboardWriter clipboardWriter = clipboard.Write

--- a/internal/ui/drag.go
+++ b/internal/ui/drag.go
@@ -376,7 +376,7 @@ func (d *dragState) Handle(a *App, msg tea.Msg) (tea.Cmd, bool) {
 			if !a.clipboardAvailable {
 				return statusbar.CopyFailedMsg{}
 			}
-			_ = clipboard.Write(clipboard.FmtText, []byte(text))
+			_ = a.clipboardWrite(clipboard.FmtText, []byte(text))
 			return statusbar.CopiedMsg{N: n}
 		}
 		return copyCmd, true

--- a/internal/ui/drag.go
+++ b/internal/ui/drag.go
@@ -32,6 +32,8 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/gammons/slk/internal/ui/statusbar"
+
+	"golang.design/x/clipboard"
 )
 
 // dragState captures an in-progress mouse drag. The originating panel
@@ -369,10 +371,12 @@ func (d *dragState) Handle(a *App, msg tea.Msg) (tea.Cmd, bool) {
 			return nil, true
 		}
 		n := len([]rune(text))
-		return tea.Batch(
-			tea.SetClipboard(text),
-			func() tea.Msg { return statusbar.CopiedMsg{N: n} },
-		), true
+
+		copyCmd := func() tea.Msg {
+			_ = clipboard.Write(clipboard.FmtText, []byte(text))
+			return statusbar.CopiedMsg{N: n}
+		}
+		return copyCmd, true
 	}
 	return nil, false
 }

--- a/internal/ui/drag.go
+++ b/internal/ui/drag.go
@@ -373,6 +373,9 @@ func (d *dragState) Handle(a *App, msg tea.Msg) (tea.Cmd, bool) {
 		n := len([]rune(text))
 
 		copyCmd := func() tea.Msg {
+			if !a.clipboardAvailable {
+				return statusbar.CopyFailedMsg{}
+			}
 			_ = clipboard.Write(clipboard.FmtText, []byte(text))
 			return statusbar.CopiedMsg{N: n}
 		}

--- a/internal/ui/reducer_io.go
+++ b/internal/ui/reducer_io.go
@@ -95,6 +95,9 @@ var reduceIO reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
 		a.statusbar.ShowCopied(m.N)
 		return copiedClearAfter(2 * time.Second), true
 
+	case statusbar.CopyFailedMsg:
+		return toastWithClear(a, "Failed to copy selection", 2*time.Second), true
+
 	case statusbar.CopiedClearMsg:
 		_ = m
 		a.statusbar.ClearCopied()

--- a/internal/ui/reducer_io.go
+++ b/internal/ui/reducer_io.go
@@ -4,38 +4,38 @@
 //
 // Owns the leftover arms that don't belong to any domain reducer:
 //
-//   tea.PasteMsg              - bracketed paste from the terminal.
-//                                Try clipboard image / file path
-//                                first, else forward to the
-//                                focused compose's textarea.
-//   UploadProgressMsg         - in-flight upload progress toast.
-//   UploadResultMsg           - upload finished: clear compose
-//                               attachments + Sent/Failed toast.
-//   ConnectionStateMsg        - WS connection state changed:
-//                               push to status bar.
-//   ToastMsg                  - generic toast (3s auto-clear).
-//   editEmptyToastMsg         - "Edit must have text" toast.
+//	tea.PasteMsg              - bracketed paste from the terminal.
+//	                             Try clipboard image / file path
+//	                             first, else forward to the
+//	                             focused compose's textarea.
+//	UploadProgressMsg         - in-flight upload progress toast.
+//	UploadResultMsg           - upload finished: clear compose
+//	                            attachments + Sent/Failed toast.
+//	ConnectionStateMsg        - WS connection state changed:
+//	                            push to status bar.
+//	ToastMsg                  - generic toast (3s auto-clear).
+//	editEmptyToastMsg         - "Edit must have text" toast.
 //
-//   imgrender.ImageReadyMsg   - lazy attachment-image fetch
-//                               landed: invalidate the affected
-//                               render caches.
-//   imgrender.ImageFailedMsg  - lazy attachment-image fetch
-//                               permanently failed: clear
-//                               in-flight bookkeeping.
-//   messages.AvatarReadyMsg   - lazy avatar fetch landed:
-//                               invalidate both pane caches.
+//	imgrender.ImageReadyMsg   - lazy attachment-image fetch
+//	                            landed: invalidate the affected
+//	                            render caches.
+//	imgrender.ImageFailedMsg  - lazy attachment-image fetch
+//	                            permanently failed: clear
+//	                            in-flight bookkeeping.
+//	messages.AvatarReadyMsg   - lazy avatar fetch landed:
+//	                            invalidate both pane caches.
 //
-//   statusbar.CopiedMsg               - "N chars copied"
-//   statusbar.CopiedClearMsg          - 2/3s expiry tick
-//   statusbar.PermalinkCopiedMsg      - "Copied permalink"
-//   statusbar.PermalinkCopyFailedMsg  - "Failed to copy link"
-//   statusbar.MarkedUnreadMsg         - "Marked unread"
-//   statusbar.MarkUnreadFailedMsg     - "Mark unread failed: ..."
-//   statusbar.EditFailedMsg           - "Edit failed: ..."
-//   statusbar.EditNotOwnMsg           - "Can only edit your own..."
-//   statusbar.DeleteFailedMsg         - "Delete failed: ..."
-//   statusbar.DeleteNotOwnMsg         - "Can only delete your own..."
-//   statusbar.SendFailedMsg           - "Send failed: ..."
+//	statusbar.CopiedMsg               - "N chars copied"
+//	statusbar.CopiedClearMsg          - 2/3s expiry tick
+//	statusbar.PermalinkCopiedMsg      - "Copied permalink"
+//	statusbar.PermalinkCopyFailedMsg  - "Failed to copy link"
+//	statusbar.MarkedUnreadMsg         - "Marked unread"
+//	statusbar.MarkUnreadFailedMsg     - "Mark unread failed: ..."
+//	statusbar.EditFailedMsg           - "Edit failed: ..."
+//	statusbar.EditNotOwnMsg           - "Can only edit your own..."
+//	statusbar.DeleteFailedMsg         - "Delete failed: ..."
+//	statusbar.DeleteNotOwnMsg         - "Can only delete your own..."
+//	statusbar.SendFailedMsg           - "Send failed: ..."
 //
 // Free reducer: these arms have no shared domain or invariant,
 // only the common "push to status bar / clear after N seconds"

--- a/internal/ui/statusbar/model.go
+++ b/internal/ui/statusbar/model.go
@@ -27,8 +27,8 @@ type Model struct {
 	unreadCount int
 	connState   ConnectionState
 	inThread    bool
-	toast       string    // "" == no toast; otherwise rendered verbatim in the right slot
-	presence    string    // "active", "away", or "" (unknown — segment hidden)
+	toast       string // "" == no toast; otherwise rendered verbatim in the right slot
+	presence    string // "active", "away", or "" (unknown — segment hidden)
 	dndEnabled  bool
 	dndEndTS    time.Time // zero if not in DND
 	syncing     bool      // true while a background cache-verify fetch is in flight

--- a/internal/ui/statusbar/model.go
+++ b/internal/ui/statusbar/model.go
@@ -337,6 +337,11 @@ type CopiedMsg struct {
 	N int
 }
 
+// CopyFailedMsg is delivered when a mouse-selection copy operation fails
+// (e.g. because the system clipboard driver is unavailable). App handles
+// it by setting the toast to "Failed to copy selection" and scheduling a CopiedClearMsg.
+type CopyFailedMsg struct{}
+
 // CopiedClearMsg is the follow-up tick that clears the toast.
 type CopiedClearMsg struct{}
 


### PR DESCRIPTION
Replaces `tea.SetClipboard` with `golang.design/x/clipboard` . Fixes copying failures on macOS (especially inside tmux environments). Works across macOS, Linux, and Windows.

Fixes #80 