### PR TITLE
Add keep_focus_on_list: stay on the list when selecting a channel or opening a thread

### DIFF
--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -542,6 +542,7 @@ func run() error {
 	app := ui.NewApp()
 	app.SetHelpFooter(versionpkg.ModalFooter(version))
 	app.SetClipboardAvailable(clipboardOK)
+	app.SetKeepFocusOnList(cfg.General.KeepFocusOnList)
 	if useWaylandClipboard {
 		app.SetClipboardReader(ui.WaylandClipboardReader())
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,6 +67,12 @@ type General struct {
 	// instead of the config-glob [sections.*] system. Pointer so we
 	// can distinguish "unset" (default true) from explicit false.
 	UseSlackSections *bool `toml:"use_slack_sections"`
+	// KeepFocusOnList keeps keyboard focus on the list when you select a
+	// channel or open a thread, instead of moving focus into the content
+	// pane. Lets you browse with j/k + Enter without tabbing back to the
+	// list each time; step into the content with Tab / l / →. Default
+	// false (focus follows selection — the long-standing behavior).
+	KeepFocusOnList bool `toml:"keep_focus_on_list"`
 }
 
 type Appearance struct {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -147,6 +147,12 @@ type App struct {
 	// clipboard.Init(). When false, Ctrl+V smart-paste is a no-op.
 	clipboardAvailable bool
 
+	// keepFocusOnList, when true, keeps keyboard focus on the list
+	// (sidebar / threads list / message list) after selecting a channel
+	// or opening a thread, rather than moving focus into the content
+	// pane. Opt-in browse aid; see config [general] keep_focus_on_list.
+	keepFocusOnList bool
+
 	// clipboardRead is the function used by smartPaste to read OS
 	// clipboard contents. Tests inject fakes via SetClipboardReader.
 	clipboardRead clipboardReader
@@ -1330,9 +1336,10 @@ func (a *App) handleEnter() tea.Cmd {
 	// messagepane.SelectedMessage() and opens whatever was highlighted
 	// in the underlying channel. Enter also shifts keyboard focus to
 	// the thread pane (mirroring the channel-pane Enter semantics:
-	// "enter this thread to interact with it"), distinguishing it
-	// from the j/k navigation which preserves PanelMessages focus so
-	// the user can keep walking the list.
+	// "enter this thread to interact with it") — unless
+	// keep_focus_on_list is set, which keeps focus on the threads list.
+	// Either way this is distinct from j/k navigation, which always
+	// preserves PanelMessages focus so the user can keep walking the list.
 	if a.focusedPanel == PanelMessages && a.view == ViewThreads {
 		if _, ok := a.threadsView.SelectedSummary(); !ok {
 			return nil
@@ -1341,11 +1348,14 @@ func (a *App) handleEnter() tea.Cmd {
 		// otherwise dedup (because j/k or activation already loaded
 		// this thread): the user explicitly asked to enter it. We
 		// reset the dedup keys so the helper runs its full open
-		// path, then re-set focus to the thread pane.
+		// path, then move focus to the thread pane (unless
+		// keep_focus_on_list keeps it on the threads list).
 		a.lastOpenedChannelID = ""
 		a.lastOpenedThreadTS = ""
 		cmd := a.openSelectedThreadCmd(false)
-		a.focusedPanel = PanelThread
+		if !a.keepFocusOnList {
+			a.focusedPanel = PanelThread
+		}
 		return cmd
 	}
 
@@ -1383,7 +1393,9 @@ func (a *App) openThreadForSelectedMessage() tea.Cmd {
 func (a *App) openThreadPanel(parent messages.MessageItem, channelID, threadTS string) tea.Cmd {
 	a.threadVisible = true
 	a.statusbar.SetInThread(true)
-	a.focusedPanel = PanelThread
+	if !a.keepFocusOnList {
+		a.focusedPanel = PanelThread
+	}
 	a.threadPanel.SetThread(parent, nil, channelID, threadTS)
 	a.threadCompose.SetChannel("thread")
 	a.applyThreadUnreadBoundary(channelID)
@@ -1728,6 +1740,13 @@ func (a *App) SetUploader(fn UploadFunc) {
 // is short-circuited.
 func (a *App) SetClipboardAvailable(ok bool) {
 	a.clipboardAvailable = ok
+}
+
+// SetKeepFocusOnList toggles the browse-friendly mode where selecting a
+// channel or opening a thread loads the content but leaves keyboard
+// focus on the list. See config [general] keep_focus_on_list.
+func (a *App) SetKeepFocusOnList(v bool) {
+	a.keepFocusOnList = v
 }
 
 // SetClipboardReader replaces the clipboard read function. Used by

--- a/internal/ui/keep_focus_on_list_test.go
+++ b/internal/ui/keep_focus_on_list_test.go
@@ -1,0 +1,98 @@
+package ui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/gammons/slk/internal/cache"
+	"github.com/gammons/slk/internal/ui/messages"
+)
+
+// TestKeepFocusOnListChannelSelect is the headline of the
+// keep_focus_on_list config: selecting a channel keeps keyboard focus on
+// the sidebar when enabled, and moves it into the messages pane (the
+// long-standing default) when not. Drives the real ChannelSelectedMsg
+// reducer through Update so it exercises the production path.
+func TestKeepFocusOnListChannelSelect(t *testing.T) {
+	// Default: focus follows the selection into the messages pane.
+	a := NewApp()
+	_, _ = a.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+	a.focusedPanel = PanelSidebar
+	a.Update(ChannelSelectedMsg{ID: "C1", Name: "general", Type: "channel"})
+	if a.focusedPanel != PanelMessages {
+		t.Fatalf("default: expected focus to move to PanelMessages, got %v", a.focusedPanel)
+	}
+
+	// keep_focus_on_list: focus stays on the sidebar so the user can keep
+	// browsing channels with j/k + Enter.
+	b := NewApp()
+	_, _ = b.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+	b.SetKeepFocusOnList(true)
+	b.focusedPanel = PanelSidebar
+	b.Update(ChannelSelectedMsg{ID: "C1", Name: "general", Type: "channel"})
+	if b.focusedPanel != PanelSidebar {
+		t.Errorf("keep_focus_on_list: expected focus to stay on PanelSidebar, got %v", b.focusedPanel)
+	}
+}
+
+// TestKeepFocusOnListThreadFromMessage drives the real Enter keystroke
+// (handleEnter) on a selected channel message: by default it opens and
+// focuses the thread pane; with keep_focus_on_list the thread still opens
+// but focus stays on the message list.
+func TestKeepFocusOnListThreadFromMessage(t *testing.T) {
+	mk := func(keep bool) *App {
+		a := NewApp()
+		_, _ = a.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+		a.SetKeepFocusOnList(keep)
+		a.activeChannelID = "C1"
+		a.focusedPanel = PanelMessages
+		a.messagepane.SetMessages([]messages.MessageItem{{TS: "100.0", Text: "hi"}})
+		return a
+	}
+
+	a := mk(false)
+	a.handleEnter()
+	if a.focusedPanel != PanelThread {
+		t.Fatalf("default: Enter on a message should focus the thread pane, got %v", a.focusedPanel)
+	}
+
+	b := mk(true)
+	b.handleEnter()
+	if !b.threadVisible {
+		t.Fatal("keep_focus_on_list: thread should still open")
+	}
+	if b.focusedPanel != PanelMessages {
+		t.Errorf("keep_focus_on_list: Enter on a message should keep focus on the message list, got %v", b.focusedPanel)
+	}
+}
+
+// TestKeepFocusOnListThreadFromThreadsView drives Enter (handleEnter) on a
+// highlighted summary in the Threads view: by default it focuses the
+// thread pane; with keep_focus_on_list focus stays on the threads list so
+// the user can keep walking it.
+func TestKeepFocusOnListThreadFromThreadsView(t *testing.T) {
+	mk := func(keep bool) *App {
+		a := NewApp()
+		_, _ = a.Update(tea.WindowSizeMsg{Width: 200, Height: 60})
+		a.SetKeepFocusOnList(keep)
+		a.view = ViewThreads
+		a.focusedPanel = PanelMessages
+		a.threadsView.SetSummaries([]cache.ThreadSummary{
+			{ChannelID: "C1", ThreadTS: "100.0", ParentTS: "100.0", ParentText: "hi"},
+		})
+		return a
+	}
+
+	a := mk(false)
+	a.handleEnter()
+	if a.focusedPanel != PanelThread {
+		t.Fatalf("default: Enter in threads view should focus the thread pane, got %v", a.focusedPanel)
+	}
+
+	b := mk(true)
+	b.handleEnter()
+	if b.focusedPanel != PanelMessages {
+		t.Errorf("keep_focus_on_list: Enter in threads view should keep focus on the threads list, got %v", b.focusedPanel)
+	}
+}

--- a/internal/ui/reducer_channels.go
+++ b/internal/ui/reducer_channels.go
@@ -225,7 +225,11 @@ func reduceChannelSelected(a *App, m ChannelSelectedMsg) (tea.Cmd, bool) {
 	// Move focus to the messages pane so the user can immediately
 	// j/k through messages, react, open threads, etc. without first
 	// having to Tab/h-l out of the sidebar after picking a channel.
-	a.focusedPanel = PanelMessages
+	// With keep_focus_on_list set, focus stays on the sidebar so the
+	// user can keep browsing channels with j/k + Enter.
+	if !a.keepFocusOnList {
+		a.focusedPanel = PanelMessages
+	}
 	a.activeChannelID = m.ID
 	a.typingOut.ResetThrottle() // reset typing throttle for new channel
 	// Update local finder ordering immediately so the next Ctrl+T

--- a/internal/ui/reducer_threads.go
+++ b/internal/ui/reducer_threads.go
@@ -140,6 +140,11 @@ var reduceThreads reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
 		_ = m
 		a.view = ViewThreads
 		a.sidebar.SetThreadsActive(true)
+		// Focus the threads list (it renders in the messages slot) even
+		// under keep_focus_on_list: here the threads list IS the list you
+		// browse, so landing on it is the on-list behavior. The flag
+		// instead governs Enter-to-open *within* a list (see handleEnter
+		// and openThreadPanel), not which list you're browsing.
 		a.focusedPanel = PanelMessages
 		var batch []tea.Cmd
 		if a.activeTeamID != "" {

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -9,6 +9,9 @@ Config lives at `~/.config/slk/config.toml`.
 default_workspace = "work"      # the slug, not the team ID
 use_slack_sections = true       # use real Slack sidebar sections (default).
                                 # set false to use [sections.*] globs instead.
+keep_focus_on_list = false      # keep focus on the list when you select a
+                                # channel / open a thread (default false).
+                                # See "Browsing without losing focus" below.
 
 [appearance]
 theme = "dracula"
@@ -79,6 +82,21 @@ accent = "#50C878"
 background = "#1A1A2E"
 text = "#E0E0E0"
 ```
+
+## Browsing without losing focus
+
+By default, picking a channel from the sidebar — or opening a thread — moves
+keyboard focus into the content pane, so you can immediately `j/k` through
+messages, react, and reply. The trade-off: to try another channel you have
+to `Tab`/`h` back to the sidebar first.
+
+Set `keep_focus_on_list = true` under `[general]` to keep focus on the list
+instead. Selecting a channel or opening a thread still loads the content,
+but keyboard focus stays put — so you can keep walking the list with `j/k`
+and `Enter` without tabbing back each time. When you want to read or reply,
+step into the content with `Tab`, `l`, or `→`. This applies to all three
+list→content jumps: sidebar → channel, threads view → thread, and a channel
+message → its thread. The default is `false` (focus follows selection).
 
 ## Section resolution
 


### PR DESCRIPTION
Closes #83.

## What

A new `[general]` bool, `keep_focus_on_list` (default `false`). When enabled, selecting a channel or opening a thread loads the content but leaves keyboard focus on the list, so you can browse with `j/k` + `Enter` without tabbing back each time.

```toml
[general]
keep_focus_on_list = true
```

## Behavior (when `true`)

Selecting still loads the content; only the focus jump is suppressed:

- sidebar → channel: focus stays on the **sidebar**
- channel message → its thread: thread opens, focus stays on the **message list**
- threads view → thread: thread opens, focus stays on the **threads list**

Step into the content via the existing focus keys (`Tab` / `l` / `→`). Default (`false`) is the long-standing focus-follows-selection behavior, so nobody is affected unless they opt in.

## Implementation

- Gates the three selection-driven `focusedPanel` assignments — `reduceChannelSelected` (channel pick), `handleEnter` (threads-view Enter), and `openThreadPanel` (message → thread) — behind `!a.keepFocusOnList`.
- Wires `config.General.KeepFocusOnList` → `app.SetKeepFocusOnList(...)`, mirroring the other `[general]`/`[appearance]` bools.
- **Intentionally not gated:** `ThreadsViewActivatedMsg` still focuses the threads list — that list *is* what you browse in the threads view, so landing on it is the on-list behavior (commented inline). Mouse click-to-focus-a-pane is also untouched.

## Tests

Three tests, each driving a real production path and asserting default-vs-flag:
- channel select via the `ChannelSelectedMsg` reducer (`Update`)
- message → thread via the real `handleEnter` keystroke
- threads view → thread via the real `handleEnter` keystroke

Full suite + `go vet` green. Wiki `Configuration.md` updated ("Browsing without losing focus").