### PR TITLE
Vim window tree: splits, ctrl+w chords, multi-window rendering (phase 2)

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2422,7 +2422,7 @@ func (a *App) View() tea.View {
 	if a.sidebarVisible {
 		panels = append(panels, a.renderSidebar(frame.SidebarWidth, frame.SidebarBorder, frame.ContentHeight, themeVer))
 	}
-	if s := a.renderMessagesRegion(frame, themeVer, previewActive); s != "" {
+	if s := a.renderWindowsRegion(frame, themeVer, previewActive); s != "" {
 		panels = append(panels, s)
 	}
 	if a.threadVisible && frame.ThreadWidth > 0 && !previewActive {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -46,6 +46,7 @@ import (
 	"github.com/gammons/slk/internal/ui/themeswitcher"
 	"github.com/gammons/slk/internal/ui/thread"
 	"github.com/gammons/slk/internal/ui/threadsview"
+	"github.com/gammons/slk/internal/ui/wintree"
 	"github.com/gammons/slk/internal/ui/workspace"
 	"github.com/gammons/slk/internal/ui/workspacefinder"
 	"golang.design/x/clipboard"
@@ -114,6 +115,13 @@ type App struct {
 	// while in ModeCommand. Owned by mode_command.go; always "" in
 	// every other mode.
 	cmdline string
+
+	// wins is the vim-style window tree subdividing the messages
+	// region; focusedWin is the active window within it. Phase 2:
+	// the focused window renders the single live messages model,
+	// unfocused windows render placeholders.
+	wins       *wintree.Tree
+	focusedWin wintree.LeafID
 
 	// layout owns the per-frame layout geometry (horizontal bands for
 	// mouse hit-testing + per-pane content heights for pageSize). See
@@ -382,6 +390,9 @@ type App struct {
 }
 
 func NewApp() *App {
+	// The window tree starts as a single window with no channel; the
+	// first ChannelSelectedMsg apply records the channel on it.
+	wins, rootWin := wintree.New(wintree.Channel{})
 	app := &App{
 		workspaceRail:        workspace.New(nil, 0),
 		sidebar:              sidebar.New(nil),
@@ -403,6 +414,8 @@ func NewApp() *App {
 		confirmPrompt:        confirmprompt.New(),
 		mode:                 ModeNormal,
 		focusedPanel:         PanelSidebar,
+		wins:                 wins,
+		focusedWin:           rootWin,
 		sidebarVisible:       true,
 		view:                 ViewChannels,
 		keys:                 DefaultKeyMap(),

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -123,6 +123,11 @@ type App struct {
 	wins       *wintree.Tree
 	focusedWin wintree.LeafID
 
+	// pendingWinCmd is true between a ctrl+w press and its chord key
+	// (vim window-command prefix). Esc or an unmapped key cancels;
+	// any mode change disarms (see SetMode).
+	pendingWinCmd bool
+
 	// layout owns the per-frame layout geometry (horizontal bands for
 	// mouse hit-testing + per-pane content heights for pageSize). See
 	// internal/ui/panellayout.go.
@@ -463,10 +468,18 @@ func NewApp() *App {
 	}})
 	// Seed the statusbar hint with the configured help key label so it
 	// stays accurate if the binding is ever changed.
-	if helpKey := app.keys.Help.Help().Key; helpKey != "" {
-		app.statusbar.SetHelpHint(helpKey + " for keybindings")
-	}
+	app.statusbar.SetHelpHint(app.defaultHelpHint())
 	return app
+}
+
+// defaultHelpHint is the resting statusbar hint ("? for keybindings").
+// Seeded at construction and restored when a transient hint (e.g. the
+// ctrl+w chord prefix) ends — clearing to "" would erase it for good.
+func (a *App) defaultHelpHint() string {
+	if helpKey := a.keys.Help.Help().Key; helpKey != "" {
+		return helpKey + " for keybindings"
+	}
+	return ""
 }
 
 func (a *App) Init() tea.Cmd {
@@ -1421,6 +1434,14 @@ func (a *App) openThreadPanel(parent messages.MessageItem, channelID, threadTS s
 }
 
 func (a *App) SetMode(mode Mode) {
+	// A mode change always disarms a pending ctrl+w chord — a global
+	// intercept (e.g. ctrl+c quit-confirm) must not strand it armed.
+	// The `if` guard scopes the hint restore to chord disarms only, so
+	// other helpHint states aren't clobbered by unrelated mode changes.
+	if a.pendingWinCmd {
+		a.pendingWinCmd = false
+		a.statusbar.SetHelpHint(a.defaultHelpHint())
+	}
 	if mode == ModeInsert {
 		a.clearSelections()
 	}

--- a/internal/ui/command.go
+++ b/internal/ui/command.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+
+	"github.com/gammons/slk/internal/ui/wintree"
 )
 
 // commandFunc executes a named :command. args holds the
@@ -23,7 +25,26 @@ type commandFunc func(a *App, args []string) tea.Cmd
 // commands maps a command name to its handler. Names are matched
 // exactly (no prefix matching); aliases get their own entries.
 var commands = map[string]commandFunc{
-	"ws": cmdWorkspaceFinder,
+	"ws":   cmdWorkspaceFinder,
+	"sp":   cmdSplit,
+	"vsp":  cmdVSplit,
+	"q":    cmdCloseWindow,
+	"only": cmdOnlyWindow,
+	"on":   cmdOnlyWindow,
+}
+
+// cmdSplit / cmdVSplit create a stacked / side-by-side split of the
+// focused window (window-management design §5).
+func cmdSplit(a *App, _ []string) tea.Cmd  { return a.splitWindow(wintree.SplitStacked) }
+func cmdVSplit(a *App, _ []string) tea.Cmd { return a.splitWindow(wintree.SplitSideBySide) }
+
+// cmdCloseWindow closes the focused window (never quits the app).
+func cmdCloseWindow(a *App, _ []string) tea.Cmd { return a.closeWindow() }
+
+// cmdOnlyWindow closes all other windows.
+func cmdOnlyWindow(a *App, _ []string) tea.Cmd {
+	a.onlyWindow()
+	return nil
 }
 
 // cmdWorkspaceFinder opens the workspace finder overlay —

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -49,6 +49,13 @@ type KeyMap struct {
 	Help                key.Binding
 	SaveThread          key.Binding
 	ListReactions       key.Binding
+	WindowPrefix        key.Binding
+	WinSplit            key.Binding
+	WinVSplit           key.Binding
+	WinNavigate         key.Binding
+	WinCycle            key.Binding
+	WinClose            key.Binding
+	WinOnly             key.Binding
 }
 
 func DefaultKeyMap() KeyMap {
@@ -102,5 +109,16 @@ func DefaultKeyMap() KeyMap {
 		Help:                key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "show keybindings")),
 		SaveThread:          key.NewBinding(key.WithKeys("S"), key.WithHelp("S", "save thread")),
 		ListReactions:       key.NewBinding(key.WithKeys("L"), key.WithHelp("L", "list reactions")),
+		// Window commands (design §4). WindowPrefix is the only real
+		// binding; the Win* entries are keyless help-only bindings
+		// (same trick as WorkspaceFinder above) — actual dispatch of
+		// the chord key happens in handleWindowChord.
+		WindowPrefix: key.NewBinding(key.WithKeys("ctrl+w"), key.WithHelp("ctrl+w", "window commands")),
+		WinSplit:     key.NewBinding(key.WithHelp("ctrl+w s / :sp", "split window")),
+		WinVSplit:    key.NewBinding(key.WithHelp("ctrl+w v / :vsp", "vertical split window")),
+		WinNavigate:  key.NewBinding(key.WithHelp("ctrl+w h/j/k/l", "focus window in direction")),
+		WinCycle:     key.NewBinding(key.WithHelp("ctrl+w w", "cycle windows")),
+		WinClose:     key.NewBinding(key.WithHelp("ctrl+w q / :q", "close window")),
+		WinOnly:      key.NewBinding(key.WithHelp("ctrl+w o / :only", "close other windows")),
 	}
 }

--- a/internal/ui/mode_normal.go
+++ b/internal/ui/mode_normal.go
@@ -14,6 +14,9 @@
 //     M (mark unread), O (open image preview)
 //   - reaction nav sub-state: r enters; arrows + Enter select
 //     (delegated to handleReactionNav / handleThreadReactionNav)
+//   - window commands: Ctrl-W prefix arms a pending sub-state; the
+//     next key is a window chord (s/v split, h/j/k/l focus, w cycle,
+//     q/c close, o only — delegated to handleWindowChord)
 //   - workspace switch: 1-9 number keys (handled in default arm)
 //   - quit confirm: q (close thread if visible, else no-op),
 //     Q (quit confirm)
@@ -32,6 +35,14 @@ import (
 )
 
 func handleNormalMode(a *App, msg tea.KeyMsg) tea.Cmd {
+	// ctrl+w pending sub-state: the next key is a window command
+	// (intercepted FIRST, like the reaction-nav sub-states below).
+	if a.pendingWinCmd {
+		a.pendingWinCmd = false
+		a.statusbar.SetHelpHint(a.defaultHelpHint())
+		return a.handleWindowChord(msg)
+	}
+
 	// Reaction-nav sub-state (intercept before normal keys).
 	if a.focusedPanel == PanelMessages && a.messagepane.ReactionNavActive() {
 		return a.handleReactionNav(msg)
@@ -64,6 +75,11 @@ func handleNormalMode(a *App, msg tea.KeyMsg) tea.Cmd {
 		if a.threadVisible {
 			a.CloseThread()
 		}
+
+	case key.Matches(msg, a.keys.WindowPrefix):
+		a.pendingWinCmd = true
+		a.statusbar.SetHelpHint("ctrl+w …")
+		return nil
 
 	case key.Matches(msg, a.keys.Tab):
 		a.FocusNext()

--- a/internal/ui/mode_normal_command_test.go
+++ b/internal/ui/mode_normal_command_test.go
@@ -31,8 +31,11 @@ func TestHelp_StillListsWorkspaceFinderViaWS(t *testing.T) {
 	entries := help.FromKeyMap(DefaultKeyMap())
 	found := false
 	for _, e := range entries {
-		if e.Key == "ctrl+w" {
-			t.Fatalf("help entry %+v still advertises ctrl+w (reserved as window prefix)", e)
+		// Phase 2: ctrl+w is the window-command prefix; the only help
+		// entry allowed to carry it is that one. It must never again
+		// advertise the workspace finder.
+		if e.Key == "ctrl+w" && e.Desc != "window commands" {
+			t.Fatalf("help entry %+v advertises ctrl+w for something other than window commands", e)
 		}
 		if e.Key == ":ws" && e.Desc == "switch workspace" {
 			found = true

--- a/internal/ui/reducer_channels.go
+++ b/internal/ui/reducer_channels.go
@@ -271,6 +271,9 @@ func reduceChannelSelected(a *App, m ChannelSelectedMsg) (tea.Cmd, bool) {
 	}
 	a.statusbar.SetChannel(m.Name)
 	a.statusbar.SetChannelType(m.Type)
+	// Record the applied selection on the focused window so window
+	// focus changes can re-dispatch it (see internal/ui/windows.go).
+	a.setFocusedWindowChannel(m.ID, m.Name, m.Type)
 
 	cached := a.channels.ReadCache(ids.ChannelID(m.ID))
 	syncedAt := a.channels.SyncedAt(ids.ChannelID(m.ID))

--- a/internal/ui/reducer_mouse.go
+++ b/internal/ui/reducer_mouse.go
@@ -226,6 +226,16 @@ func reduceMouseClick(a *App, m tea.MouseClickMsg) tea.Cmd {
 		return nil
 
 	case x < a.layout.MsgEnd():
+		// Interim Phase 2 guard: per-window mouse routing lands in
+		// Phase 4 (window-management design §6). With splits active,
+		// PanelAt still maps the entire messages region to the single
+		// live pane, so a click on a placeholder window would start a
+		// drag selection in the live channel at bogus coordinates.
+		// Swallow clicks (and therefore drags — they can only begin
+		// here); mouse-wheel scrolling of the live pane stays enabled.
+		if a.wins.Len() > 1 {
+			return nil
+		}
 		a.focusedPanel = PanelMessages
 		// In the threads-list view, the messages-pane region
 		// renders threadsView, not the channel messages. Route

--- a/internal/ui/reducer_mouse_test.go
+++ b/internal/ui/reducer_mouse_test.go
@@ -7,6 +7,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/gammons/slk/internal/ui/help"
+	"github.com/gammons/slk/internal/ui/wintree"
 )
 
 // TestReduceMouseWheel_ScrollsActiveModal verifies that when a modal
@@ -60,5 +61,30 @@ func TestReduceMouseWheel_NoModalLeavesModalUntouched(t *testing.T) {
 	reduceMouseWheel(app, tea.MouseWheelMsg{Button: tea.MouseWheelDown, X: 5})
 	if got := app.help.Selected(); got != 0 {
 		t.Fatalf("normal mode: help selection should stay 0, got %d", got)
+	}
+}
+
+// TestReduceMouseClick_IgnoredInMessagesRegionWhenSplit pins the
+// interim Phase 2 guard: with multiple windows, PanelAt still maps
+// the whole messages region to the single live pane, so a click on a
+// placeholder window would begin a drag selection in the live channel
+// at bogus coordinates. Clicks (and therefore drags, which can only
+// start from the click branch) must be swallowed until per-window
+// mouse routing lands in Phase 4.
+func TestReduceMouseClick_IgnoredInMessagesRegionWhenSplit(t *testing.T) {
+	a := newTestAppWithMessages(t)
+	a.width = 200 // wide enough for two ≥42-col windows (wintree.MinWidth)
+	if cmd := a.splitWindow(wintree.SplitSideBySide); cmd != nil {
+		t.Fatal("split refused at width 200")
+	}
+	_ = a.View() // recompute layout bands for the split layout
+
+	pressX := a.layout.sidebarEnd + 2
+	pressY := 4
+	_, _ = a.Update(tea.MouseClickMsg{X: pressX, Y: pressY, Button: tea.MouseLeft})
+	_, _ = a.Update(tea.MouseMotionMsg{X: pressX + 10, Y: pressY + 1, Button: tea.MouseLeft})
+	_, _ = a.Update(tea.MouseReleaseMsg{X: pressX + 10, Y: pressY + 1, Button: tea.MouseLeft})
+	if a.messagepane.HasSelection() {
+		t.Fatal("split mode: click+drag in the messages region must not start a selection")
 	}
 }

--- a/internal/ui/reducer_workspace.go
+++ b/internal/ui/reducer_workspace.go
@@ -61,6 +61,7 @@ import (
 
 	"github.com/gammons/slk/internal/ids"
 	"github.com/gammons/slk/internal/ui/styles"
+	"github.com/gammons/slk/internal/ui/wintree"
 )
 
 var reduceWorkspace reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
@@ -251,6 +252,12 @@ func reduceWorkspaceSwitched(a *App, m WorkspaceSwitchedMsg) tea.Cmd {
 	a.lastOpenedThreadTS = ""
 	a.CloseThread()
 	a.clearSelections()
+	// Window tree is per-workspace state in Phase 2: collapse to a
+	// single empty window so no leaf carries a cross-workspace channel.
+	// The queued ChannelSelectedMsg for this workspace re-populates it.
+	wins, rootWin := wintree.New(wintree.Channel{})
+	a.wins = wins
+	a.focusedWin = rootWin
 	a.compose.Reset()
 	a.statusbar.SetSyncing(false) // defensive: don't carry stale sync state across workspaces
 	// Pane is left as-is -- the queued ChannelSelectedMsg below

--- a/internal/ui/view_window_region.go
+++ b/internal/ui/view_window_region.go
@@ -1,0 +1,75 @@
+// internal/ui/view_window_region.go
+//
+// Multi-window messages-region renderer (window-management design
+// §6, Phase 2). With a single window the existing renderMessagesRegion
+// path runs untouched — identical output, identical caching. With
+// splits, the wintree layout is walked recursively: the FOCUSED
+// window renders the real (cached) messages panel sized to its rect;
+// every other window renders a cheap static placeholder (dimmed
+// border + channel name). Phase 3 replaces placeholders with live
+// per-window models.
+//
+// NAMING: this file would naturally be view_windows.go, but a
+// `_windows` filename suffix is a GOOS build constraint — Go would
+// silently exclude the file from every non-Windows build (it lands in
+// IgnoredGoFiles, no error). Hence view_window_region.go.
+package ui
+
+import (
+	"charm.land/lipgloss/v2"
+
+	"github.com/gammons/slk/internal/ui/styles"
+	"github.com/gammons/slk/internal/ui/wintree"
+)
+
+// renderWindowsRegion is the messages-region entry point called from
+// App.View. Preview mode and the single-window tree delegate to the
+// existing path unchanged.
+func (a *App) renderWindowsRegion(frame panelLayoutFrame, themeVer int64, previewActive bool) string {
+	if previewActive || a.wins.Len() == 1 {
+		return a.renderMessagesRegion(frame, themeVer, previewActive)
+	}
+	bounds := wintree.Rect{X: 0, Y: 0, W: frame.MsgWidth + frame.MsgBorder, H: frame.ContentHeight}
+	return a.renderWindowNode(a.wins.Layout(bounds), frame, themeVer)
+}
+
+// renderWindowNode renders one layout-tree node to a string of
+// exactly Rect.W x Rect.H cells.
+func (a *App) renderWindowNode(n wintree.LayoutNode, frame panelLayoutFrame, themeVer int64) string {
+	if n.Leaf {
+		if n.ID == a.focusedWin {
+			sub := frame
+			sub.MsgWidth = n.Rect.W - 2
+			sub.MsgBorder = 2
+			sub.ContentHeight = n.Rect.H
+			return exactSize(a.renderMessagesRegion(sub, themeVer, false), n.Rect.W, n.Rect.H)
+		}
+		return a.renderPlaceholderWindow(n)
+	}
+	parts := make([]string, 0, len(n.Children))
+	for _, c := range n.Children {
+		parts = append(parts, a.renderWindowNode(c, frame, themeVer))
+	}
+	if n.Dir == wintree.SplitSideBySide {
+		return lipgloss.JoinHorizontal(lipgloss.Top, parts...)
+	}
+	return lipgloss.JoinVertical(lipgloss.Left, parts...)
+}
+
+// renderPlaceholderWindow renders an unfocused window: dimmed border,
+// channel name centered. Static and cheap — no cache needed.
+func (a *App) renderPlaceholderWindow(n wintree.LayoutNode) string {
+	ch, _ := a.wins.Channel(n.ID)
+	name := ch.Name
+	if name == "" {
+		name = "(no channel)"
+	} else {
+		name = "# " + name
+	}
+	label := lipgloss.NewStyle().Foreground(styles.TextMuted).Render(name)
+	inner := lipgloss.Place(n.Rect.W-2, n.Rect.H-2, lipgloss.Center, lipgloss.Center, label)
+	return exactSize(
+		styles.UnfocusedBorder.Width(n.Rect.W-2).Render(inner),
+		n.Rect.W, n.Rect.H,
+	)
+}

--- a/internal/ui/view_window_region.go
+++ b/internal/ui/view_window_region.go
@@ -34,20 +34,52 @@ func (a *App) renderWindowsRegion(frame panelLayoutFrame, themeVer int64, previe
 }
 
 // renderWindowNode renders one layout-tree node to a string of
-// exactly Rect.W x Rect.H cells.
+// exactly Rect.W x Rect.H cells. Callers guarantee Rect.W >= 1 and
+// Rect.H >= 1 (zero-extent children are skipped below). exactSize
+// enforces a minimum width and exact height at every leaf; widths
+// can only exceed a rect on the sub-minimum focused leaf, which
+// hard-truncates back via MaxWidth. Sub-minimum windows thus degrade
+// to garbled-but-correctly-sized cells instead of corrupting the
+// region geometry.
 func (a *App) renderWindowNode(n wintree.LayoutNode, frame panelLayoutFrame, themeVer int64) string {
 	if n.Leaf {
 		if n.ID == a.focusedWin {
 			sub := frame
 			sub.MsgWidth = n.Rect.W - 2
+			// Floor: a hard shrink can leave rects narrower than the
+			// panel chrome (W-2 < 2). Below 2, renderMessagesTop's
+			// borderedTopPane computes strings.Repeat(top, MsgWidth-2)
+			// with a negative count and panics (mirrors the
+			// msgContentHeight < 3 clamp downstream). The over-wide
+			// result is wrapped back to Rect.W by exactSize.
+			if sub.MsgWidth < 2 {
+				sub.MsgWidth = 2
+			}
 			sub.MsgBorder = 2
 			sub.ContentHeight = n.Rect.H
-			return exactSize(a.renderMessagesRegion(sub, themeVer, false), n.Rect.W, n.Rect.H)
+			out := exactSize(a.renderMessagesRegion(sub, themeVer, false), n.Rect.W, n.Rect.H)
+			if sub.MsgWidth+sub.MsgBorder > n.Rect.W {
+				// The floored frame renders wider than the rect
+				// (exactSize pads to a minimum width but never
+				// shrinks). Hard-truncate each row back, ANSI-aware,
+				// so the column tiling stays exact.
+				out = lipgloss.NewStyle().MaxWidth(n.Rect.W).Render(out)
+			}
+			return out
 		}
 		return a.renderPlaceholderWindow(n)
 	}
 	parts := make([]string, 0, len(n.Children))
 	for _, c := range n.Children {
+		// Zero-extent rects (more windows than rows/cols after a hard
+		// shrink) contribute zero cells and are skipped: exactSize
+		// treats a 0 dimension as "unset" and would render at natural
+		// size, breaking the region dimension contract. childRects
+		// extents sum exactly to the parent extent along the split
+		// axis, so the remaining children still tile the parent.
+		if c.Rect.W < 1 || c.Rect.H < 1 {
+			continue
+		}
 		parts = append(parts, a.renderWindowNode(c, frame, themeVer))
 	}
 	if n.Dir == wintree.SplitSideBySide {
@@ -66,10 +98,18 @@ func (a *App) renderPlaceholderWindow(n wintree.LayoutNode) string {
 	} else {
 		name = "# " + name
 	}
+	innerW, innerH := n.Rect.W-2, n.Rect.H-2
+	if innerW < 1 || innerH < 1 {
+		// Too small for border + label: a blank block of exactly
+		// Rect.W x Rect.H keeps the tiling intact (caller guarantees
+		// both >= 1; negative inner dims would otherwise flow into
+		// lipgloss.Place / Style.Width).
+		return exactSize("", n.Rect.W, n.Rect.H)
+	}
 	label := lipgloss.NewStyle().Foreground(styles.TextMuted).Render(name)
-	inner := lipgloss.Place(n.Rect.W-2, n.Rect.H-2, lipgloss.Center, lipgloss.Center, label)
+	inner := lipgloss.Place(innerW, innerH, lipgloss.Center, lipgloss.Center, label)
 	return exactSize(
-		styles.UnfocusedBorder.Width(n.Rect.W-2).Render(inner),
+		styles.UnfocusedBorder.Width(innerW).Render(inner),
 		n.Rect.W, n.Rect.H,
 	)
 }

--- a/internal/ui/view_window_region_test.go
+++ b/internal/ui/view_window_region_test.go
@@ -32,11 +32,18 @@ func TestRegion_SplitRendersPlaceholderWithChannelName(t *testing.T) {
 	a := newWideTestApp(t)
 	_, _ = a.Update(ChannelSelectedMsg{ID: "C1", Name: "general", Type: "channel"})
 	_ = a.splitWindow(wintree.SplitSideBySide)
-	// Focused (new) window is live; the original window is a
-	// placeholder showing its channel name.
+	// Switch the focused (new) window to a different channel so the
+	// placeholder ("# general") and the live pane ("ops") are
+	// distinguishable in the output.
+	_, _ = a.Update(ChannelSelectedMsg{ID: "C2", Name: "ops", Type: "channel"})
 	out := ansi.Strip(renderRegion(a))
 	if !strings.Contains(out, "# general") {
 		t.Fatalf("placeholder should show channel name '# general':\n%s", out)
+	}
+	// The live pane follows the focused window's channel: the compose
+	// box's channel-aware placeholder names ops, not general.
+	if !strings.Contains(out, "Message #ops") {
+		t.Fatalf("live pane should render the focused window's channel (ops):\n%s", out)
 	}
 }
 
@@ -51,6 +58,64 @@ func TestRegion_SplitOutputDimensionsStable(t *testing.T) {
 	}
 	if lipgloss.Width(before) != lipgloss.Width(after) {
 		t.Fatalf("width changed after split: %d -> %d", lipgloss.Width(before), lipgloss.Width(after))
+	}
+}
+
+// TestRegion_SurvivesHardShrinkAfterSplits guards the resize-after-
+// split crash: with several side-by-side columns, a hard terminal
+// shrink produces leaf rects too narrow for the messages panel's
+// chrome (W-2 < 2), which used to flow a negative width into
+// borderedTopPane's strings.Repeat and panic. The render must
+// survive AND keep the exact region dimensions.
+func TestRegion_SurvivesHardShrinkAfterSplits(t *testing.T) {
+	a := NewApp()
+	a.width = 400
+	a.height = 50
+	for i := 0; i < 3; i++ {
+		if cmd := a.splitWindow(wintree.SplitSideBySide); cmd != nil {
+			t.Fatalf("split %d refused at width 400", i)
+		}
+	}
+	// Hard shrink: must not panic, must keep exact region dimensions.
+	a.width, a.height = 30, 10
+	frame := a.layout.Compute(a.width, a.height, a.workspaceRail.Width(), a.sidebar.Width(), a.sidebarVisible, a.threadVisible)
+	out := a.renderWindowsRegion(frame, 0, false) // panics before the fix
+	wantW := frame.MsgWidth + frame.MsgBorder
+	if lipgloss.Height(out) != frame.ContentHeight {
+		t.Fatalf("height = %d, want %d", lipgloss.Height(out), frame.ContentHeight)
+	}
+	for i, line := range strings.Split(out, "\n") {
+		if w := ansi.StringWidth(line); w != wantW {
+			t.Fatalf("line %d width = %d, want %d", i, w, wantW)
+		}
+	}
+}
+
+// TestRegion_SurvivesHardShrinkAfterStackedSplits is the vertical
+// twin: ContentHeight < window count yields zero-extent (H=0) rects,
+// which exactSize treats as "unset" (natural height) — breaking the
+// region height contract unless zero-extent leaves are skipped.
+func TestRegion_SurvivesHardShrinkAfterStackedSplits(t *testing.T) {
+	a := NewApp()
+	a.width = 200
+	a.height = 50
+	for i := 0; i < 3; i++ {
+		if cmd := a.splitWindow(wintree.SplitStacked); cmd != nil {
+			t.Fatalf("split %d refused at height 50", i)
+		}
+	}
+	// ContentHeight (3) < window count (4) → at least one H=0 rect.
+	a.width, a.height = 30, 4
+	frame := a.layout.Compute(a.width, a.height, a.workspaceRail.Width(), a.sidebar.Width(), a.sidebarVisible, a.threadVisible)
+	out := a.renderWindowsRegion(frame, 0, false)
+	wantW := frame.MsgWidth + frame.MsgBorder
+	if lipgloss.Height(out) != frame.ContentHeight {
+		t.Fatalf("height = %d, want %d", lipgloss.Height(out), frame.ContentHeight)
+	}
+	for i, line := range strings.Split(out, "\n") {
+		if w := ansi.StringWidth(line); w != wantW {
+			t.Fatalf("line %d width = %d, want %d", i, w, wantW)
+		}
 	}
 }
 

--- a/internal/ui/view_window_region_test.go
+++ b/internal/ui/view_window_region_test.go
@@ -1,0 +1,71 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/gammons/slk/internal/ui/wintree"
+)
+
+// renderRegion renders the messages region exactly as App.View does,
+// without depending on the tea.View wrapper API.
+func renderRegion(a *App) string {
+	frame := a.layout.Compute(a.width, a.height, a.workspaceRail.Width(), a.sidebar.Width(), a.sidebarVisible, a.threadVisible)
+	return a.renderWindowsRegion(frame, 0, false)
+}
+
+func TestRegion_SingleWindowUnchanged(t *testing.T) {
+	a := newWideTestApp(t)
+	_, _ = a.Update(ChannelSelectedMsg{ID: "C1", Name: "general", Type: "channel"})
+	frame := a.layout.Compute(a.width, a.height, a.workspaceRail.Width(), a.sidebar.Width(), a.sidebarVisible, a.threadVisible)
+	multi := a.renderWindowsRegion(frame, 0, false)
+	direct := a.renderMessagesRegion(frame, 0, false)
+	if multi != direct {
+		t.Fatal("single-window region must be byte-identical to the direct messages render")
+	}
+}
+
+func TestRegion_SplitRendersPlaceholderWithChannelName(t *testing.T) {
+	a := newWideTestApp(t)
+	_, _ = a.Update(ChannelSelectedMsg{ID: "C1", Name: "general", Type: "channel"})
+	_ = a.splitWindow(wintree.SplitSideBySide)
+	// Focused (new) window is live; the original window is a
+	// placeholder showing its channel name.
+	out := ansi.Strip(renderRegion(a))
+	if !strings.Contains(out, "# general") {
+		t.Fatalf("placeholder should show channel name '# general':\n%s", out)
+	}
+}
+
+func TestRegion_SplitOutputDimensionsStable(t *testing.T) {
+	a := newWideTestApp(t)
+	_, _ = a.Update(ChannelSelectedMsg{ID: "C1", Name: "general", Type: "channel"})
+	before := renderRegion(a)
+	_ = a.splitWindow(wintree.SplitSideBySide)
+	after := renderRegion(a)
+	if lipgloss.Height(before) != lipgloss.Height(after) {
+		t.Fatalf("row count changed after split: %d -> %d", lipgloss.Height(before), lipgloss.Height(after))
+	}
+	if lipgloss.Width(before) != lipgloss.Width(after) {
+		t.Fatalf("width changed after split: %d -> %d", lipgloss.Width(before), lipgloss.Width(after))
+	}
+}
+
+func TestRegion_CloseRestoresSingleWindowPath(t *testing.T) {
+	a := newWideTestApp(t)
+	_, _ = a.Update(ChannelSelectedMsg{ID: "C1", Name: "general", Type: "channel"})
+	_ = a.splitWindow(wintree.SplitStacked)
+	_ = a.closeWindow()
+	if a.wins.Len() != 1 {
+		t.Fatalf("Len = %d, want 1", a.wins.Len())
+	}
+	frame := a.layout.Compute(a.width, a.height, a.workspaceRail.Width(), a.sidebar.Width(), a.sidebarVisible, a.threadVisible)
+	multi := a.renderWindowsRegion(frame, 0, false)
+	direct := a.renderMessagesRegion(frame, 0, false)
+	if multi != direct {
+		t.Fatal("after closing back to one window the region must take the direct single-window path")
+	}
+}

--- a/internal/ui/windows.go
+++ b/internal/ui/windows.go
@@ -1,0 +1,91 @@
+// internal/ui/windows.go
+//
+// App-side window management (window-management design §1, §4).
+// Thin bridge between the wintree package and App state: tree ops,
+// focus movement, status-bar toasts, and the focused-window channel
+// contract. Phase 2: ONE live messages model — the focused window
+// renders it; focusing a window on a different channel re-dispatches
+// the standard ChannelSelectedMsg so the live pane follows focus.
+package ui
+
+import (
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/gammons/slk/internal/ui/wintree"
+)
+
+// windowBounds returns the messages-region rectangle the window tree
+// subdivides. Recomputing the layout frame here is safe: Compute is
+// deterministic for unchanged inputs and View re-runs it each frame.
+func (a *App) windowBounds() wintree.Rect {
+	frame := a.layout.Compute(a.width, a.height, a.workspaceRail.Width(), a.sidebar.Width(), a.sidebarVisible, a.threadVisible)
+	return wintree.Rect{X: 0, Y: 0, W: frame.MsgWidth + frame.MsgBorder, H: frame.ContentHeight}
+}
+
+// splitWindow creates a new window (cloning the focused window's
+// channel) and focuses it. Toasts "Not enough room" on refusal.
+func (a *App) splitWindow(dir wintree.Dir) tea.Cmd {
+	id, err := a.wins.Split(a.focusedWin, dir, a.windowBounds())
+	if err != nil {
+		return toastWithClear(a, "Not enough room", 2*time.Second)
+	}
+	a.focusedWin = id
+	a.focusedPanel = PanelMessages
+	return nil
+}
+
+// closeWindow closes the focused window; focus falls to its neighbor.
+// Toasts "Cannot close last window" instead of ever quitting.
+func (a *App) closeWindow() tea.Cmd {
+	next, err := a.wins.Close(a.focusedWin)
+	if err != nil {
+		return toastWithClear(a, "Cannot close last window", 2*time.Second)
+	}
+	return a.focusWindow(next)
+}
+
+// onlyWindow closes every window except the focused one.
+func (a *App) onlyWindow() {
+	_ = a.wins.Only(a.focusedWin)
+}
+
+// cycleWindow focuses the next window in tree order (ctrl+w w).
+func (a *App) cycleWindow() tea.Cmd {
+	return a.focusWindow(a.wins.Cycle(a.focusedWin, 1))
+}
+
+// navigateWindow focuses the geometric neighbor (ctrl+w h/j/k/l).
+// No neighbor is a silent no-op, like vim.
+func (a *App) navigateWindow(nd wintree.NavDir) tea.Cmd {
+	if id, ok := a.wins.NavigateDir(a.focusedWin, nd, a.windowBounds()); ok {
+		return a.focusWindow(id)
+	}
+	return nil
+}
+
+// focusWindow moves window focus to id. When the target window views
+// a different channel than the live model, the standard channel
+// selection is dispatched so the live pane loads it (Phase 2 single-
+// model semantics; Phase 3 replaces this with per-window models).
+func (a *App) focusWindow(id wintree.LeafID) tea.Cmd {
+	if id == a.focusedWin {
+		return nil
+	}
+	a.focusedWin = id
+	a.focusedPanel = PanelMessages
+	ch, ok := a.wins.Channel(id)
+	if !ok || ch.ID == "" || ch.ID == a.activeChannelID {
+		return nil
+	}
+	return func() tea.Msg {
+		return ChannelSelectedMsg{ID: ch.ID, Name: ch.Name, Type: ch.Type}
+	}
+}
+
+// setFocusedWindowChannel records the applied channel selection on
+// the focused window. Called from the ChannelSelectedMsg apply path.
+func (a *App) setFocusedWindowChannel(id, name, chType string) {
+	a.wins.SetChannel(a.focusedWin, wintree.Channel{ID: id, Name: name, Type: chType})
+}

--- a/internal/ui/windows.go
+++ b/internal/ui/windows.go
@@ -16,6 +16,34 @@ import (
 	"github.com/gammons/slk/internal/ui/wintree"
 )
 
+// handleWindowChord consumes the key following ctrl+w (vim window
+// commands, design §4). Unmapped keys — including Esc — cancel
+// silently, matching vim.
+func (a *App) handleWindowChord(msg tea.KeyMsg) tea.Cmd {
+	switch msg.String() {
+	case "s":
+		return a.splitWindow(wintree.SplitStacked)
+	case "v":
+		return a.splitWindow(wintree.SplitSideBySide)
+	case "h", "left":
+		return a.navigateWindow(wintree.NavLeft)
+	case "j", "down":
+		return a.navigateWindow(wintree.NavDown)
+	case "k", "up":
+		return a.navigateWindow(wintree.NavUp)
+	case "l", "right":
+		return a.navigateWindow(wintree.NavRight)
+	case "w", "ctrl+w":
+		return a.cycleWindow()
+	case "q", "c":
+		return a.closeWindow()
+	case "o":
+		a.onlyWindow()
+		return nil
+	}
+	return nil
+}
+
 // windowBounds returns the messages-region rectangle the window tree
 // subdivides. Recomputing the layout frame here is safe: Compute is
 // deterministic for unchanged inputs and View re-runs it each frame.

--- a/internal/ui/windows.go
+++ b/internal/ui/windows.go
@@ -86,6 +86,12 @@ func (a *App) focusWindow(id wintree.LeafID) tea.Cmd {
 
 // setFocusedWindowChannel records the applied channel selection on
 // the focused window. Called from the ChannelSelectedMsg apply path.
+//
+// KNOWN PHASE 2 LIMITATION: the selection applies to whichever window
+// is focused at APPLY time, not dispatch time. Rapid focus changes
+// (e.g. held ctrl+w w) can record a channel on the wrong window until
+// the next selection corrects it. Phase 3's per-window models replace
+// this path; do not inherit it silently.
 func (a *App) setFocusedWindowChannel(id, name, chType string) {
 	a.wins.SetChannel(a.focusedWin, wintree.Channel{ID: id, Name: name, Type: chType})
 }

--- a/internal/ui/windows_chord_test.go
+++ b/internal/ui/windows_chord_test.go
@@ -1,0 +1,125 @@
+// internal/ui/windows_chord_test.go
+//
+// ctrl+w window-command chord tests (window-management design §4).
+// The prefix arms a pending sub-state in normal mode; the next key is
+// dispatched through handleWindowChord. Unmapped keys and Esc cancel
+// silently; any mode change disarms (SetMode).
+package ui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/gammons/slk/internal/ui/wintree"
+)
+
+func pressCtrlW(a *App) {
+	_ = handleNormalMode(a, tea.KeyPressMsg{Code: 'w', Mod: tea.ModCtrl})
+}
+
+func press(a *App, r rune) tea.Cmd {
+	return handleNormalMode(a, tea.KeyPressMsg{Code: r, Text: string(r)})
+}
+
+func TestChord_CtrlWThenVSplits(t *testing.T) {
+	a := newWideTestApp(t)
+	pressCtrlW(a)
+	if !a.pendingWinCmd {
+		t.Fatal("ctrl+w should arm the pending window-command state")
+	}
+	_ = press(a, 'v')
+	if a.pendingWinCmd {
+		t.Fatal("chord key should disarm the pending state")
+	}
+	if a.wins.Len() != 2 {
+		t.Fatalf("Len = %d, want 2 after ctrl+w v", a.wins.Len())
+	}
+}
+
+func TestChord_SplitCloseCycleOnly(t *testing.T) {
+	a := newWideTestApp(t)
+	pressCtrlW(a)
+	_ = press(a, 's')
+	if a.wins.Len() != 2 {
+		t.Fatalf("ctrl+w s: Len = %d, want 2", a.wins.Len())
+	}
+	pressCtrlW(a)
+	_ = press(a, 'w')
+	first := a.wins.Leaves()[0]
+	if a.focusedWin != first {
+		t.Fatalf("ctrl+w w should cycle focus to %v, got %v", first, a.focusedWin)
+	}
+	pressCtrlW(a)
+	_ = press(a, 'q')
+	if a.wins.Len() != 1 {
+		t.Fatalf("ctrl+w q: Len = %d, want 1", a.wins.Len())
+	}
+	_ = a.splitWindow(wintree.SplitStacked)
+	pressCtrlW(a)
+	_ = press(a, 'o')
+	if a.wins.Len() != 1 {
+		t.Fatalf("ctrl+w o: Len = %d, want 1", a.wins.Len())
+	}
+}
+
+func TestChord_DirectionalFocus(t *testing.T) {
+	a := newWideTestApp(t)
+	left := a.focusedWin
+	pressCtrlW(a)
+	_ = press(a, 'v') // focus moves to new right-hand window
+	right := a.focusedWin
+	pressCtrlW(a)
+	_ = press(a, 'h')
+	if a.focusedWin != left {
+		t.Fatalf("ctrl+w h: focused %v, want %v", a.focusedWin, left)
+	}
+	pressCtrlW(a)
+	_ = press(a, 'l')
+	if a.focusedWin != right {
+		t.Fatalf("ctrl+w l: focused %v, want %v", a.focusedWin, right)
+	}
+}
+
+func TestChord_UnmappedKeyCancelsSilently(t *testing.T) {
+	a := newWideTestApp(t)
+	pressCtrlW(a)
+	_ = press(a, 'z')
+	if a.pendingWinCmd {
+		t.Fatal("unmapped chord key should cancel the pending state")
+	}
+	if a.wins.Len() != 1 {
+		t.Fatalf("Len = %d, want 1 (no side effects)", a.wins.Len())
+	}
+	// Esc cancels too:
+	pressCtrlW(a)
+	_ = handleNormalMode(a, tea.KeyPressMsg{Code: tea.KeyEscape})
+	if a.pendingWinCmd {
+		t.Fatal("esc should cancel the pending state")
+	}
+	if a.wins.Len() != 1 {
+		t.Fatalf("Len = %d, want 1", a.wins.Len())
+	}
+}
+
+func TestChord_CtrlWCtrlWCycles(t *testing.T) {
+	a := newWideTestApp(t)
+	_ = a.splitWindow(wintree.SplitSideBySide) // focus on second window
+	pressCtrlW(a)
+	pressCtrlW(a) // vim: ctrl+w ctrl+w == ctrl+w w
+	if a.focusedWin != a.wins.Leaves()[0] {
+		t.Fatalf("ctrl+w ctrl+w should cycle, focused %v", a.focusedWin)
+	}
+	if a.pendingWinCmd {
+		t.Fatal("pending state should be disarmed after the chord")
+	}
+}
+
+func TestChord_ModeChangeDisarms(t *testing.T) {
+	a := newWideTestApp(t)
+	pressCtrlW(a)
+	a.SetMode(ModeConfirm) // e.g. global ctrl+c intercept fires mid-chord
+	if a.pendingWinCmd {
+		t.Fatal("any mode change must disarm the pending chord state")
+	}
+}

--- a/internal/ui/windows_chord_test.go
+++ b/internal/ui/windows_chord_test.go
@@ -7,9 +7,11 @@
 package ui
 
 import (
+	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/gammons/slk/internal/ui/wintree"
 )
@@ -99,6 +101,60 @@ func TestChord_UnmappedKeyCancelsSilently(t *testing.T) {
 	}
 	if a.wins.Len() != 1 {
 		t.Fatalf("Len = %d, want 1", a.wins.Len())
+	}
+}
+
+func TestChord_EscMidChordDoesNotLeakToEscapeCase(t *testing.T) {
+	// Pins the intercept ORDER: the pending sub-state must swallow
+	// Esc before the main switch, whose Escape case would close a
+	// visible thread panel.
+	a := newWideTestApp(t)
+	a.threadVisible = true
+	pressCtrlW(a)
+	_ = handleNormalMode(a, tea.KeyPressMsg{Code: tea.KeyEscape})
+	if !a.threadVisible {
+		t.Fatal("esc mid-chord must be swallowed, not close the thread panel")
+	}
+	if a.pendingWinCmd {
+		t.Fatal("esc should still cancel the pending state")
+	}
+}
+
+// statusHint renders the statusbar wide enough that the help hint is
+// never dropped for lack of gap space, and strips ANSI for Contains.
+func statusHint(a *App) string {
+	return ansi.Strip(a.statusbar.View(200))
+}
+
+func TestChord_HintLifecycle(t *testing.T) {
+	a := newWideTestApp(t)
+	if !strings.Contains(statusHint(a), "? for keybindings") {
+		t.Fatalf("precondition: default hint missing, got %q", statusHint(a))
+	}
+
+	// Armed: prefix hint shown.
+	pressCtrlW(a)
+	if !strings.Contains(statusHint(a), "ctrl+w …") {
+		t.Fatalf("armed: want %q hint, got %q", "ctrl+w …", statusHint(a))
+	}
+
+	// (a) Completed chord restores the default hint (not blanked).
+	_ = press(a, 'v')
+	if strings.Contains(statusHint(a), "ctrl+w …") {
+		t.Fatalf("after chord: prefix hint must clear, got %q", statusHint(a))
+	}
+	if !strings.Contains(statusHint(a), "? for keybindings") {
+		t.Fatalf("after chord: default hint must be restored, got %q", statusHint(a))
+	}
+
+	// (b) SetMode disarm restores the default hint too.
+	pressCtrlW(a)
+	a.SetMode(ModeConfirm)
+	if strings.Contains(statusHint(a), "ctrl+w …") {
+		t.Fatalf("after SetMode disarm: prefix hint must clear, got %q", statusHint(a))
+	}
+	if !strings.Contains(statusHint(a), "? for keybindings") {
+		t.Fatalf("after SetMode disarm: default hint must be restored, got %q", statusHint(a))
 	}
 }
 

--- a/internal/ui/windows_test.go
+++ b/internal/ui/windows_test.go
@@ -100,6 +100,26 @@ func TestChannelSelected_UpdatesFocusedWindowChannel(t *testing.T) {
 	}
 }
 
+func TestWorkspaceSwitch_ResetsWindowTree(t *testing.T) {
+	a := newWideTestApp(t)
+	_, _ = a.Update(ChannelSelectedMsg{ID: "C1", Name: "general", Type: "channel"})
+	_ = a.splitWindow(wintree.SplitSideBySide)
+	if a.wins.Len() != 2 {
+		t.Fatalf("Len = %d, want 2", a.wins.Len())
+	}
+	// Simulate a workspace switch with the minimal msg the reducer
+	// accepts (nil Channels takes the empty-workspace branch; all
+	// other nil slices/maps are tolerated — see app_test.go's
+	// TestApp_WorkspaceSwitchResetsView).
+	_, _ = a.Update(WorkspaceSwitchedMsg{TeamID: "T2", TeamName: "Other", Channels: nil})
+	if a.wins.Len() != 1 {
+		t.Fatalf("Len = %d, want 1 (tree must reset on workspace switch)", a.wins.Len())
+	}
+	if ch, _ := a.wins.Channel(a.focusedWin); ch.ID != "" {
+		t.Fatalf("root window channel = %+v, want empty after reset", ch)
+	}
+}
+
 func TestCommands_SpVspQOnly(t *testing.T) {
 	a := newWideTestApp(t)
 	_ = executeCommand(a, "vsp")

--- a/internal/ui/windows_test.go
+++ b/internal/ui/windows_test.go
@@ -1,0 +1,126 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gammons/slk/internal/ui/wintree"
+)
+
+func newWideTestApp(t *testing.T) *App {
+	t.Helper()
+	a := NewApp()
+	a.width = 200
+	a.height = 50
+	return a
+}
+
+func TestSplitWindow_CreatesAndFocusesNewWindow(t *testing.T) {
+	a := newWideTestApp(t)
+	if cmd := a.splitWindow(wintree.SplitSideBySide); cmd != nil {
+		t.Fatal("successful split should not toast")
+	}
+	if a.wins.Len() != 2 {
+		t.Fatalf("Len = %d, want 2", a.wins.Len())
+	}
+	if got := a.wins.Leaves(); a.focusedWin != got[1] {
+		t.Fatalf("focusedWin = %v, want new window %v", a.focusedWin, got[1])
+	}
+	if a.focusedPanel != PanelMessages {
+		t.Fatalf("focusedPanel = %v, want PanelMessages", a.focusedPanel)
+	}
+}
+
+func TestSplitWindow_NoRoomToasts(t *testing.T) {
+	a := NewApp()
+	a.width = 60 // messages region too narrow for two columns
+	a.height = 50
+	cmd := a.splitWindow(wintree.SplitSideBySide)
+	if cmd == nil {
+		t.Fatal("expected toast-clear cmd")
+	}
+	if a.wins.Len() != 1 {
+		t.Fatalf("Len = %d, want 1 (split refused)", a.wins.Len())
+	}
+	if out := a.statusbar.View(120); !strings.Contains(out, "Not enough room") {
+		t.Fatalf("expected 'Not enough room' toast:\n%s", out)
+	}
+}
+
+func TestCloseWindow_LastWindowToasts(t *testing.T) {
+	a := newWideTestApp(t)
+	cmd := a.closeWindow()
+	if cmd == nil {
+		t.Fatal("expected toast-clear cmd")
+	}
+	if out := a.statusbar.View(120); !strings.Contains(out, "Cannot close last window") {
+		t.Fatalf("expected 'Cannot close last window' toast:\n%s", out)
+	}
+}
+
+func TestCloseWindow_FocusFallsToNeighbor(t *testing.T) {
+	a := newWideTestApp(t)
+	first := a.focusedWin
+	_ = a.splitWindow(wintree.SplitSideBySide)
+	_ = a.closeWindow()
+	if a.wins.Len() != 1 {
+		t.Fatalf("Len = %d, want 1", a.wins.Len())
+	}
+	if a.focusedWin != first {
+		t.Fatalf("focusedWin = %v, want %v", a.focusedWin, first)
+	}
+}
+
+func TestFocusWindow_DifferentChannelDispatchesSelection(t *testing.T) {
+	a := newWideTestApp(t)
+	// Window 1 views C1.
+	_, _ = a.Update(ChannelSelectedMsg{ID: "C1", Name: "general", Type: "channel"})
+	first := a.focusedWin
+	// Split (clone C1), then switch the new focused window to C2.
+	_ = a.splitWindow(wintree.SplitSideBySide)
+	_, _ = a.Update(ChannelSelectedMsg{ID: "C2", Name: "ops", Type: "channel"})
+	// Focus back to window 1: its channel (C1) differs from live (C2),
+	// so a ChannelSelectedMsg cmd must be returned.
+	cmd := a.focusWindow(first)
+	if cmd == nil {
+		t.Fatal("expected channel-selection cmd")
+	}
+	msg, ok := cmd().(ChannelSelectedMsg)
+	if !ok || msg.ID != "C1" || msg.Name != "general" {
+		t.Fatalf("cmd produced %+v, want ChannelSelectedMsg for C1", msg)
+	}
+}
+
+func TestChannelSelected_UpdatesFocusedWindowChannel(t *testing.T) {
+	a := newWideTestApp(t)
+	_, _ = a.Update(ChannelSelectedMsg{ID: "C9", Name: "incidents", Type: "channel"})
+	ch, ok := a.wins.Channel(a.focusedWin)
+	if !ok || ch.ID != "C9" || ch.Name != "incidents" {
+		t.Fatalf("focused window channel = %+v, want C9/incidents", ch)
+	}
+}
+
+func TestCommands_SpVspQOnly(t *testing.T) {
+	a := newWideTestApp(t)
+	_ = executeCommand(a, "vsp")
+	if a.wins.Len() != 2 {
+		t.Fatalf("after :vsp Len = %d, want 2", a.wins.Len())
+	}
+	_ = executeCommand(a, "sp")
+	if a.wins.Len() != 3 {
+		t.Fatalf("after :sp Len = %d, want 3", a.wins.Len())
+	}
+	_ = executeCommand(a, "q")
+	if a.wins.Len() != 2 {
+		t.Fatalf("after :q Len = %d, want 2", a.wins.Len())
+	}
+	_ = executeCommand(a, "only")
+	if a.wins.Len() != 1 {
+		t.Fatalf("after :only Len = %d, want 1", a.wins.Len())
+	}
+	_ = executeCommand(a, "vsp")
+	_ = executeCommand(a, "on") // alias
+	if a.wins.Len() != 1 {
+		t.Fatalf("after :on Len = %d, want 1", a.wins.Len())
+	}
+}

--- a/internal/ui/wintree/layout.go
+++ b/internal/ui/wintree/layout.go
@@ -23,27 +23,39 @@ func layoutNode(n *node, r Rect) LayoutNode {
 		return LayoutNode{Leaf: true, ID: n.id, Rect: r}
 	}
 	out := LayoutNode{Rect: r, Dir: n.dir, Children: make([]LayoutNode, 0, len(n.children))}
-	k := len(n.children)
-	if n.dir == SplitSideBySide {
+	for i, cr := range childRects(n.dir, len(n.children), r) {
+		out.Children = append(out.Children, layoutNode(n.children[i], cr))
+	}
+	return out
+}
+
+// childRects divides r among k children along dir: equal shares, with
+// the remainder going to the earliest children one cell each, so the
+// results always tile r exactly. This is the single source of truth
+// for split geometry — Layout, nodeRect, and Split's refusal math all
+// depend on it agreeing with itself.
+func childRects(dir Dir, k int, r Rect) []Rect {
+	out := make([]Rect, 0, k)
+	if dir == SplitSideBySide {
 		base, rem := r.W/k, r.W%k
 		x := r.X
-		for i, c := range n.children {
+		for i := 0; i < k; i++ {
 			w := base
 			if i < rem {
 				w++
 			}
-			out.Children = append(out.Children, layoutNode(c, Rect{X: x, Y: r.Y, W: w, H: r.H}))
+			out = append(out, Rect{X: x, Y: r.Y, W: w, H: r.H})
 			x += w
 		}
 	} else {
 		base, rem := r.H/k, r.H%k
 		y := r.Y
-		for i, c := range n.children {
+		for i := 0; i < k; i++ {
 			h := base
 			if i < rem {
 				h++
 			}
-			out.Children = append(out.Children, layoutNode(c, Rect{X: r.X, Y: y, W: r.W, H: h}))
+			out = append(out, Rect{X: r.X, Y: y, W: r.W, H: h})
 			y += h
 		}
 	}
@@ -72,39 +84,21 @@ func (t *Tree) ComputeRects(bounds Rect) map[LeafID]Rect {
 func (t *Tree) nodeRect(target *node, bounds Rect) (Rect, bool) {
 	var found Rect
 	var ok bool
-	var walk func(n *node, r Rect)
-	walk = func(n *node, r Rect) {
+	var walk func(n *node, r Rect) bool
+	walk = func(n *node, r Rect) bool {
 		if n == target {
 			found, ok = r, true
-			return
+			return true
 		}
 		if n.isLeaf() {
-			return
+			return false
 		}
-		k := len(n.children)
-		if n.dir == SplitSideBySide {
-			base, rem := r.W/k, r.W%k
-			x := r.X
-			for i, c := range n.children {
-				w := base
-				if i < rem {
-					w++
-				}
-				walk(c, Rect{X: x, Y: r.Y, W: w, H: r.H})
-				x += w
-			}
-		} else {
-			base, rem := r.H/k, r.H%k
-			y := r.Y
-			for i, c := range n.children {
-				h := base
-				if i < rem {
-					h++
-				}
-				walk(c, Rect{X: r.X, Y: y, W: r.W, H: h})
-				y += h
+		for i, cr := range childRects(n.dir, len(n.children), r) {
+			if walk(n.children[i], cr) {
+				return true
 			}
 		}
+		return false
 	}
 	walk(t.root, bounds)
 	return found, ok

--- a/internal/ui/wintree/layout.go
+++ b/internal/ui/wintree/layout.go
@@ -1,0 +1,111 @@
+package wintree
+
+// LayoutNode is the renderable shape of the tree: leaves carry their
+// window id and rect; splits carry direction and children. The UI
+// walks this to compose window panes (it never sees *node).
+type LayoutNode struct {
+	Leaf     bool
+	ID       LeafID
+	Rect     Rect
+	Dir      Dir
+	Children []LayoutNode
+}
+
+// Layout resolves every node's rect within bounds. Children of a
+// split divide the parent extent equally; remainders go to the
+// earliest children one cell each, so rects always tile exactly.
+func (t *Tree) Layout(bounds Rect) LayoutNode {
+	return layoutNode(t.root, bounds)
+}
+
+func layoutNode(n *node, r Rect) LayoutNode {
+	if n.isLeaf() {
+		return LayoutNode{Leaf: true, ID: n.id, Rect: r}
+	}
+	out := LayoutNode{Rect: r, Dir: n.dir, Children: make([]LayoutNode, 0, len(n.children))}
+	k := len(n.children)
+	if n.dir == SplitSideBySide {
+		base, rem := r.W/k, r.W%k
+		x := r.X
+		for i, c := range n.children {
+			w := base
+			if i < rem {
+				w++
+			}
+			out.Children = append(out.Children, layoutNode(c, Rect{X: x, Y: r.Y, W: w, H: r.H}))
+			x += w
+		}
+	} else {
+		base, rem := r.H/k, r.H%k
+		y := r.Y
+		for i, c := range n.children {
+			h := base
+			if i < rem {
+				h++
+			}
+			out.Children = append(out.Children, layoutNode(c, Rect{X: r.X, Y: y, W: r.W, H: h}))
+			y += h
+		}
+	}
+	return out
+}
+
+// ComputeRects flattens Layout into a per-window rect map.
+func (t *Tree) ComputeRects(bounds Rect) map[LeafID]Rect {
+	out := make(map[LeafID]Rect)
+	var walk func(LayoutNode)
+	walk = func(n LayoutNode) {
+		if n.Leaf {
+			out[n.ID] = n.Rect
+			return
+		}
+		for _, c := range n.Children {
+			walk(c)
+		}
+	}
+	walk(t.Layout(bounds))
+	return out
+}
+
+// nodeRect returns the rect of an internal *node within bounds
+// (used by Split's refusal check). Same division as Layout.
+func (t *Tree) nodeRect(target *node, bounds Rect) (Rect, bool) {
+	var found Rect
+	var ok bool
+	var walk func(n *node, r Rect)
+	walk = func(n *node, r Rect) {
+		if n == target {
+			found, ok = r, true
+			return
+		}
+		if n.isLeaf() {
+			return
+		}
+		k := len(n.children)
+		if n.dir == SplitSideBySide {
+			base, rem := r.W/k, r.W%k
+			x := r.X
+			for i, c := range n.children {
+				w := base
+				if i < rem {
+					w++
+				}
+				walk(c, Rect{X: x, Y: r.Y, W: w, H: r.H})
+				x += w
+			}
+		} else {
+			base, rem := r.H/k, r.H%k
+			y := r.Y
+			for i, c := range n.children {
+				h := base
+				if i < rem {
+					h++
+				}
+				walk(c, Rect{X: r.X, Y: y, W: r.W, H: h})
+				y += h
+			}
+		}
+	}
+	walk(t.root, bounds)
+	return found, ok
+}

--- a/internal/ui/wintree/navigate.go
+++ b/internal/ui/wintree/navigate.go
@@ -1,0 +1,54 @@
+package wintree
+
+// NavigateDir returns the window adjacent to id in the given
+// direction (vim ctrl+w h/j/k/l): among windows whose rect touches
+// id's rect edge-on in that direction WITH positive perpendicular
+// overlap (corner-only contact does not count), the one with the
+// largest overlap wins. Ties resolve to the earliest window in tree
+// order (deterministic). ok=false when there is no neighbor.
+func (t *Tree) NavigateDir(id LeafID, nd NavDir, bounds Rect) (LeafID, bool) {
+	rects := t.ComputeRects(bounds)
+	cur, ok := rects[id]
+	if !ok {
+		return id, false
+	}
+	best := id
+	bestOverlap := 0                 // require > 0: corner contact is not adjacency
+	for _, lid := range t.Leaves() { // tree order => deterministic ties
+		if lid == id {
+			continue
+		}
+		r := rects[lid]
+		var adjacent bool
+		var overlap int
+		switch nd {
+		case NavLeft:
+			adjacent = r.X+r.W == cur.X
+			overlap = overlap1D(r.Y, r.H, cur.Y, cur.H)
+		case NavRight:
+			adjacent = cur.X+cur.W == r.X
+			overlap = overlap1D(r.Y, r.H, cur.Y, cur.H)
+		case NavUp:
+			adjacent = r.Y+r.H == cur.Y
+			overlap = overlap1D(r.X, r.W, cur.X, cur.W)
+		case NavDown:
+			adjacent = cur.Y+cur.H == r.Y
+			overlap = overlap1D(r.X, r.W, cur.X, cur.W)
+		}
+		if adjacent && overlap > bestOverlap {
+			best, bestOverlap = lid, overlap
+		}
+	}
+	if best == id {
+		return id, false
+	}
+	return best, true
+}
+
+// overlap1D returns the overlap length of [a, a+alen) and [b, b+blen),
+// negative when disjoint.
+func overlap1D(a, alen, b, blen int) int {
+	lo := max(a, b)
+	hi := min(a+alen, b+blen)
+	return hi - lo
+}

--- a/internal/ui/wintree/navigate_test.go
+++ b/internal/ui/wintree/navigate_test.go
@@ -1,0 +1,70 @@
+package wintree
+
+import "testing"
+
+// grid3 builds: left column a (full height) | right column b over c.
+func grid3(t *testing.T) (*Tree, LeafID, LeafID, LeafID, Rect) {
+	t.Helper()
+	bounds := Rect{X: 0, Y: 0, W: 180, H: 48}
+	tr, a := New(Channel{})
+	b, err := tr.Split(a, SplitSideBySide, bounds)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := tr.Split(b, SplitStacked, bounds)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tr, a, b, c, bounds
+}
+
+func TestNavigateDir_LeftRight(t *testing.T) {
+	tr, a, b, c, bounds := grid3(t)
+	if got, ok := tr.NavigateDir(a, NavRight, bounds); !ok || got != b {
+		t.Fatalf("a right = %v %v, want %v (largest overlap: b is upper)", got, ok, b)
+	}
+	if got, ok := tr.NavigateDir(b, NavLeft, bounds); !ok || got != a {
+		t.Fatalf("b left = %v %v, want %v", got, ok, a)
+	}
+	if got, ok := tr.NavigateDir(c, NavLeft, bounds); !ok || got != a {
+		t.Fatalf("c left = %v %v, want %v", got, ok, a)
+	}
+}
+
+func TestNavigateDir_UpDown(t *testing.T) {
+	tr, _, b, c, bounds := grid3(t)
+	if got, ok := tr.NavigateDir(b, NavDown, bounds); !ok || got != c {
+		t.Fatalf("b down = %v %v, want %v", got, ok, c)
+	}
+	if got, ok := tr.NavigateDir(c, NavUp, bounds); !ok || got != b {
+		t.Fatalf("c up = %v %v, want %v", got, ok, b)
+	}
+}
+
+func TestNavigateDir_NoNeighbor(t *testing.T) {
+	tr, a, _, _, bounds := grid3(t)
+	if got, ok := tr.NavigateDir(a, NavLeft, bounds); ok || got != a {
+		t.Fatalf("a left should report no neighbor, got %v %v", got, ok)
+	}
+	if _, ok := tr.NavigateDir(a, NavUp, bounds); ok {
+		t.Fatal("a up should report no neighbor")
+	}
+}
+
+func TestNavigateDir_PicksLargestOverlap(t *testing.T) {
+	// left column split into two rows (a top, d bottom); right column
+	// b over c. From b going left, a (top row) overlaps b's Y-range
+	// more than d does.
+	bounds := Rect{X: 0, Y: 0, W: 180, H: 48}
+	tr, a := New(Channel{})
+	b, _ := tr.Split(a, SplitSideBySide, bounds)
+	c, _ := tr.Split(b, SplitStacked, bounds)
+	d, _ := tr.Split(a, SplitStacked, bounds)
+	_ = c
+	if got, ok := tr.NavigateDir(b, NavLeft, bounds); !ok || got != a {
+		t.Fatalf("b left = %v, want %v (top-left window)", got, a)
+	}
+	if got, ok := tr.NavigateDir(c, NavLeft, bounds); !ok || got != d {
+		t.Fatalf("c left = %v, want %v (bottom-left window)", got, d)
+	}
+}

--- a/internal/ui/wintree/ops.go
+++ b/internal/ui/wintree/ops.go
@@ -1,0 +1,134 @@
+package wintree
+
+// Split divides window id in the given direction within bounds. The
+// new window clones the source's channel, is placed after (below /
+// right of) the source, and its id is returned. Returns ErrNoRoom
+// when the resulting windows would violate MinWidth/MinHeight at the
+// current bounds, ErrNotFound for an unknown id.
+func (t *Tree) Split(id LeafID, dir Dir, bounds Rect) (LeafID, error) {
+	leaf, parent := t.findLeaf(id)
+	if leaf == nil {
+		return 0, ErrNotFound
+	}
+
+	min := MinWidth
+	if dir == SplitStacked {
+		min = MinHeight
+	}
+
+	// Refusal check. Inserting a sibling into a same-direction parent
+	// re-divides the PARENT's extent among k+1 children; otherwise the
+	// leaf's own rect divides in two.
+	sameDirParent := parent != nil && parent.dir == dir
+	if sameDirParent {
+		pr, ok := t.nodeRect(parent, bounds)
+		if !ok {
+			return 0, ErrNotFound
+		}
+		extent := pr.W
+		if dir == SplitStacked {
+			extent = pr.H
+		}
+		if extent/(len(parent.children)+1) < min {
+			return 0, ErrNoRoom
+		}
+	} else {
+		lr, ok := t.nodeRect(leaf, bounds)
+		if !ok {
+			return 0, ErrNotFound
+		}
+		extent := lr.W
+		if dir == SplitStacked {
+			extent = lr.H
+		}
+		if extent/2 < min {
+			return 0, ErrNoRoom
+		}
+	}
+
+	nid := t.next
+	t.next++
+	newLeaf := &node{id: nid, ch: leaf.ch}
+
+	if sameDirParent {
+		idx := childIndex(parent, leaf)
+		parent.children = append(parent.children, nil)
+		copy(parent.children[idx+2:], parent.children[idx+1:])
+		parent.children[idx+1] = newLeaf
+	} else {
+		// Replace the leaf in place with a split node so the parent's
+		// child pointer stays valid: the old window moves into child 0.
+		old := &node{id: leaf.id, ch: leaf.ch}
+		leaf.id = 0
+		leaf.ch = Channel{}
+		leaf.dir = dir
+		leaf.children = []*node{old, newLeaf}
+	}
+	return nid, nil
+}
+
+// Close removes window id, hands its space to its siblings, and
+// returns the window that should receive focus (the previous sibling
+// subtree's first leaf, or the new first sibling's). Returns
+// ErrLastWindow when id is the only window.
+func (t *Tree) Close(id LeafID) (LeafID, error) {
+	leaf, parent := t.findLeaf(id)
+	if leaf == nil {
+		return 0, ErrNotFound
+	}
+	if parent == nil {
+		return 0, ErrLastWindow
+	}
+	idx := childIndex(parent, leaf)
+	parent.children = append(parent.children[:idx], parent.children[idx+1:]...)
+
+	var focusNode *node
+	if idx > 0 {
+		focusNode = parent.children[idx-1]
+	} else {
+		focusNode = parent.children[0]
+	}
+	focusID := firstLeaf(focusNode).id
+
+	// A split with one child dissolves: the child takes its place.
+	if len(parent.children) == 1 {
+		only := parent.children[0]
+		parent.id = only.id
+		parent.ch = only.ch
+		parent.dir = only.dir
+		parent.children = only.children
+	}
+	return focusID, nil
+}
+
+// Only collapses the tree to just window id (vim ctrl+w o / :only).
+func (t *Tree) Only(id LeafID) error {
+	leaf, _ := t.findLeaf(id)
+	if leaf == nil {
+		return ErrNotFound
+	}
+	t.root = &node{id: leaf.id, ch: leaf.ch}
+	return nil
+}
+
+// Cycle returns the window delta steps from id in tree order,
+// wrapping (ctrl+w w). Unknown ids return id unchanged.
+func (t *Tree) Cycle(id LeafID, delta int) LeafID {
+	ls := t.Leaves()
+	for i, l := range ls {
+		if l == id {
+			n := len(ls)
+			return ls[((i+delta)%n+n)%n]
+		}
+	}
+	return id
+}
+
+func childIndex(parent, child *node) int {
+	for i, c := range parent.children {
+		if c == child {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/ui/wintree/ops.go
+++ b/internal/ui/wintree/ops.go
@@ -3,58 +3,33 @@ package wintree
 // Split divides window id in the given direction within bounds. The
 // new window clones the source's channel, is placed after (below /
 // right of) the source, and its id is returned. Returns ErrNoRoom
-// when the resulting windows would violate MinWidth/MinHeight at the
-// current bounds, ErrNotFound for an unknown id.
+// when ANY resulting window rect would violate MinWidth/MinHeight at
+// the current bounds (including leaves nested in shrunk sibling
+// subtrees), ErrNotFound for an unknown id. Refused splits leave the
+// tree unchanged and do not consume an id.
 func (t *Tree) Split(id LeafID, dir Dir, bounds Rect) (LeafID, error) {
 	leaf, parent := t.findLeaf(id)
 	if leaf == nil {
 		return 0, ErrNotFound
 	}
 
-	min := MinWidth
-	if dir == SplitStacked {
-		min = MinHeight
-	}
-
-	// Refusal check. Inserting a sibling into a same-direction parent
-	// re-divides the PARENT's extent among k+1 children; otherwise the
-	// leaf's own rect divides in two.
-	sameDirParent := parent != nil && parent.dir == dir
-	if sameDirParent {
-		pr, ok := t.nodeRect(parent, bounds)
-		if !ok {
-			return 0, ErrNotFound
-		}
-		extent := pr.W
-		if dir == SplitStacked {
-			extent = pr.H
-		}
-		if extent/(len(parent.children)+1) < min {
-			return 0, ErrNoRoom
-		}
-	} else {
-		lr, ok := t.nodeRect(leaf, bounds)
-		if !ok {
-			return 0, ErrNotFound
-		}
-		extent := lr.W
-		if dir == SplitStacked {
-			extent = lr.H
-		}
-		if extent/2 < min {
-			return 0, ErrNoRoom
-		}
-	}
-
 	nid := t.next
 	t.next++
 	newLeaf := &node{id: nid, ch: leaf.ch}
 
-	if sameDirParent {
+	// Perform the insertion, then validate the actual resulting rects;
+	// undo on violation. Checking real geometry (rather than predicting
+	// the division) catches nested same-axis leaves inside siblings
+	// that the insertion shrinks.
+	var undo func()
+	if parent != nil && parent.dir == dir {
 		idx := childIndex(parent, leaf)
 		parent.children = append(parent.children, nil)
 		copy(parent.children[idx+2:], parent.children[idx+1:])
 		parent.children[idx+1] = newLeaf
+		undo = func() {
+			parent.children = append(parent.children[:idx+1], parent.children[idx+2:]...)
+		}
 	} else {
 		// Replace the leaf in place with a split node so the parent's
 		// child pointer stays valid: the old window moves into child 0.
@@ -63,6 +38,20 @@ func (t *Tree) Split(id LeafID, dir Dir, bounds Rect) (LeafID, error) {
 		leaf.ch = Channel{}
 		leaf.dir = dir
 		leaf.children = []*node{old, newLeaf}
+		undo = func() {
+			leaf.id = old.id
+			leaf.ch = old.ch
+			leaf.dir = 0
+			leaf.children = nil
+		}
+	}
+
+	for _, r := range t.ComputeRects(bounds) {
+		if r.W < MinWidth || r.H < MinHeight {
+			undo()
+			t.next--
+			return 0, ErrNoRoom
+		}
 	}
 	return nid, nil
 }

--- a/internal/ui/wintree/ops_test.go
+++ b/internal/ui/wintree/ops_test.go
@@ -1,0 +1,226 @@
+package wintree
+
+import (
+	"errors"
+	"testing"
+)
+
+var testBounds = Rect{X: 0, Y: 0, W: 180, H: 48}
+
+func TestComputeRects_TilesExactly(t *testing.T) {
+	// Build: vsplit (side-by-side), then split the right window
+	// stacked. 3 windows; rects must tile bounds with no gaps or
+	// overlaps and odd extents must be fully distributed.
+	tr, a := New(Channel{ID: "C1"})
+	bounds := Rect{X: 0, Y: 0, W: 121, H: 41} // odd on purpose
+	b, err := tr.Split(a, SplitSideBySide, bounds)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := tr.Split(b, SplitStacked, bounds)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rects := tr.ComputeRects(bounds)
+	if len(rects) != 3 {
+		t.Fatalf("got %d rects, want 3", len(rects))
+	}
+	area := 0
+	for id, r := range rects {
+		if r.W < MinWidth || r.H < MinHeight {
+			t.Fatalf("window %v rect %+v below minimums", id, r)
+		}
+		area += r.W * r.H
+	}
+	if area != bounds.W*bounds.H {
+		t.Fatalf("rect areas sum to %d, want %d (gap or overlap)", area, bounds.W*bounds.H)
+	}
+	// a is the left column: full height, x=0.
+	if rects[a].X != 0 || rects[a].H != bounds.H {
+		t.Fatalf("left window rect = %+v", rects[a])
+	}
+	// b above c in the right column, same x/width.
+	if rects[b].X != rects[c].X || rects[b].W != rects[c].W {
+		t.Fatalf("right column rects misaligned: b=%+v c=%+v", rects[b], rects[c])
+	}
+	if rects[b].Y+rects[b].H != rects[c].Y {
+		t.Fatalf("b and c not vertically adjacent: b=%+v c=%+v", rects[b], rects[c])
+	}
+}
+
+func TestComputeRects_OffsetBoundsTile(t *testing.T) {
+	// Non-zero-origin bounds: child offsets must accumulate from the
+	// bounds origin, and tiling must still be exact.
+	tr, a := New(Channel{})
+	bounds := Rect{X: 5, Y: 3, W: 120, H: 40}
+	b, err := tr.Split(a, SplitSideBySide, bounds)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rects := tr.ComputeRects(bounds)
+	if rects[a].X != 5 || rects[a].Y != 3 {
+		t.Fatalf("first window must start at bounds origin, got %+v", rects[a])
+	}
+	if rects[a].X+rects[a].W != rects[b].X {
+		t.Fatalf("windows not horizontally adjacent: a=%+v b=%+v", rects[a], rects[b])
+	}
+	if rects[b].X+rects[b].W != bounds.X+bounds.W {
+		t.Fatalf("right window must end at bounds edge: %+v", rects[b])
+	}
+}
+
+func TestLayout_TreeShapeMatchesRects(t *testing.T) {
+	tr, a := New(Channel{})
+	bounds := Rect{X: 0, Y: 0, W: 120, H: 40}
+	b, _ := tr.Split(a, SplitSideBySide, bounds)
+	layout := tr.Layout(bounds)
+	if layout.Leaf {
+		t.Fatal("root layout node should be a split")
+	}
+	if layout.Dir != SplitSideBySide || len(layout.Children) != 2 {
+		t.Fatalf("layout = %+v", layout)
+	}
+	if !layout.Children[0].Leaf || layout.Children[0].ID != a {
+		t.Fatalf("first child = %+v, want leaf %v", layout.Children[0], a)
+	}
+	if layout.Children[1].ID != b {
+		t.Fatalf("second child = %+v, want leaf %v", layout.Children[1], b)
+	}
+	rects := tr.ComputeRects(bounds)
+	if layout.Children[0].Rect != rects[a] || layout.Children[1].Rect != rects[b] {
+		t.Fatal("Layout rects disagree with ComputeRects")
+	}
+}
+
+func TestSplit_ClonesChannelAndOrdersNewWindowAfter(t *testing.T) {
+	tr, a := New(Channel{ID: "C1", Name: "general", Type: "channel"})
+	b, err := tr.Split(a, SplitSideBySide, testBounds)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ch, _ := tr.Channel(b); ch != (Channel{ID: "C1", Name: "general", Type: "channel"}) {
+		t.Fatalf("new window channel = %+v, want clone of source", ch)
+	}
+	if got := tr.Leaves(); len(got) != 2 || got[0] != a || got[1] != b {
+		t.Fatalf("Leaves() = %v, want [%v %v] (new window after/right of source)", got, a, b)
+	}
+	rects := tr.ComputeRects(testBounds)
+	if rects[b].X <= rects[a].X {
+		t.Fatalf("vsp must place new window to the right: a=%+v b=%+v", rects[a], rects[b])
+	}
+}
+
+func TestSplit_StackedPlacesNewWindowBelow(t *testing.T) {
+	tr, a := New(Channel{ID: "C1"})
+	b, err := tr.Split(a, SplitStacked, testBounds)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rects := tr.ComputeRects(testBounds)
+	if rects[b].Y <= rects[a].Y {
+		t.Fatalf("sp must place new window below: a=%+v b=%+v", rects[a], rects[b])
+	}
+}
+
+func TestSplit_SameDirInsertsSiblingNotNested(t *testing.T) {
+	tr, a := New(Channel{})
+	b, _ := tr.Split(a, SplitSideBySide, testBounds)
+	c, err := tr.Split(b, SplitSideBySide, Rect{X: 0, Y: 0, W: 300, H: 48})
+	if err != nil {
+		t.Fatal(err)
+	}
+	layout := tr.Layout(Rect{X: 0, Y: 0, W: 300, H: 48})
+	if len(layout.Children) != 3 {
+		t.Fatalf("same-dir split should produce 3 siblings, got layout %+v", layout)
+	}
+	if got := tr.Leaves(); got[0] != a || got[1] != b || got[2] != c {
+		t.Fatalf("Leaves() = %v, want [a b c] order", got)
+	}
+}
+
+func TestSplit_RefusesWhenNoRoom(t *testing.T) {
+	tr, a := New(Channel{})
+	// Bounds too narrow for two side-by-side windows.
+	narrow := Rect{X: 0, Y: 0, W: 2*MinWidth - 1, H: 48}
+	if _, err := tr.Split(a, SplitSideBySide, narrow); !errors.Is(err, ErrNoRoom) {
+		t.Fatalf("err = %v, want ErrNoRoom", err)
+	}
+	// Stacked still fits in the same bounds.
+	if _, err := tr.Split(a, SplitStacked, narrow); err != nil {
+		t.Fatalf("stacked split should fit: %v", err)
+	}
+	// Unknown window.
+	if _, err := tr.Split(LeafID(999), SplitStacked, testBounds); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestSplit_SameDirRefusalCountsAllSiblings(t *testing.T) {
+	tr, a := New(Channel{})
+	bounds := Rect{X: 0, Y: 0, W: 3*MinWidth - 1, H: 48} // room for 2, not 3
+	b, err := tr.Split(a, SplitSideBySide, bounds)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tr.Split(b, SplitSideBySide, bounds); !errors.Is(err, ErrNoRoom) {
+		t.Fatalf("third column must be refused: err = %v", err)
+	}
+}
+
+func TestClose_CollapsesAndReturnsNeighbor(t *testing.T) {
+	tr, a := New(Channel{ID: "C1"})
+	b, _ := tr.Split(a, SplitSideBySide, testBounds)
+	c, _ := tr.Split(b, SplitStacked, testBounds)
+	// Close c: focus falls to its sibling b; b's column re-expands.
+	next, err := tr.Close(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if next != b {
+		t.Fatalf("focus candidate = %v, want %v", next, b)
+	}
+	rects := tr.ComputeRects(testBounds)
+	if len(rects) != 2 {
+		t.Fatalf("got %d windows, want 2", len(rects))
+	}
+	if rects[b].H != testBounds.H {
+		t.Fatalf("b should re-expand to full height, got %+v", rects[b])
+	}
+}
+
+func TestClose_LastWindowRefused(t *testing.T) {
+	tr, a := New(Channel{})
+	if _, err := tr.Close(a); !errors.Is(err, ErrLastWindow) {
+		t.Fatalf("err = %v, want ErrLastWindow", err)
+	}
+}
+
+func TestOnly_CollapsesToSingleWindow(t *testing.T) {
+	tr, a := New(Channel{ID: "C1"})
+	b, _ := tr.Split(a, SplitSideBySide, testBounds)
+	_, _ = tr.Split(b, SplitStacked, testBounds)
+	if err := tr.Only(b); err != nil {
+		t.Fatal(err)
+	}
+	if got := tr.Leaves(); len(got) != 1 || got[0] != b {
+		t.Fatalf("Leaves() = %v, want [%v]", got, b)
+	}
+	if ch, _ := tr.Channel(b); ch.ID != "C1" {
+		t.Fatalf("surviving window lost its channel: %+v", ch)
+	}
+}
+
+func TestCycle_WrapsInTreeOrder(t *testing.T) {
+	tr, a := New(Channel{})
+	b, _ := tr.Split(a, SplitSideBySide, testBounds)
+	c, _ := tr.Split(b, SplitStacked, testBounds)
+	if got := tr.Cycle(a, 1); got != b {
+		t.Fatalf("Cycle(a) = %v, want %v", got, b)
+	}
+	if got := tr.Cycle(c, 1); got != a {
+		t.Fatalf("Cycle(c) should wrap to %v, got %v", a, got)
+	}
+	if got := tr.Cycle(a, -1); got != c {
+		t.Fatalf("Cycle(a, -1) should wrap to %v, got %v", c, got)
+	}
+}

--- a/internal/ui/wintree/ops_test.go
+++ b/internal/ui/wintree/ops_test.go
@@ -167,6 +167,35 @@ func TestSplit_SameDirRefusalCountsAllSiblings(t *testing.T) {
 	}
 }
 
+func TestSplit_RefusesWhenNestedSiblingWouldShrinkBelowMin(t *testing.T) {
+	bounds := Rect{X: 0, Y: 0, W: 180, H: 48}
+	tr, a := New(Channel{})
+	b, err := tr.Split(a, SplitSideBySide, bounds) // [A | B]
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := tr.Split(b, SplitStacked, bounds) // [A | [B / C]]
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tr.Split(c, SplitSideBySide, bounds); err != nil { // [A | [B / [C|D]]]
+		t.Fatal(err)
+	}
+	// Adding a third top-level column would shrink C and D to W=30 < MinWidth.
+	if _, err := tr.Split(a, SplitSideBySide, bounds); !errors.Is(err, ErrNoRoom) {
+		t.Fatalf("err = %v, want ErrNoRoom (nested leaves would shrink below min)", err)
+	}
+	// Tree must be unchanged after the refusal.
+	if tr.Len() != 4 {
+		t.Fatalf("Len = %d, want 4 (refused split must roll back)", tr.Len())
+	}
+	for id, r := range tr.ComputeRects(bounds) {
+		if r.W < MinWidth || r.H < MinHeight {
+			t.Fatalf("window %v rect %+v below minimums after rollback", id, r)
+		}
+	}
+}
+
 func TestClose_CollapsesAndReturnsNeighbor(t *testing.T) {
 	tr, a := New(Channel{ID: "C1"})
 	b, _ := tr.Split(a, SplitSideBySide, testBounds)
@@ -185,6 +214,25 @@ func TestClose_CollapsesAndReturnsNeighbor(t *testing.T) {
 	}
 	if rects[b].H != testBounds.H {
 		t.Fatalf("b should re-expand to full height, got %+v", rects[b])
+	}
+}
+
+func TestClose_FirstChildFocusFallsToNewFirstSibling(t *testing.T) {
+	tr, a := New(Channel{})
+	b, _ := tr.Split(a, SplitSideBySide, testBounds)
+	next, err := tr.Close(a) // close FIRST child (idx==0 path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if next != b {
+		t.Fatalf("focus = %v, want %v", next, b)
+	}
+}
+
+func TestClose_UnknownIDNotFound(t *testing.T) {
+	tr, _ := New(Channel{})
+	if _, err := tr.Close(LeafID(999)); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
 	}
 }
 
@@ -207,6 +255,13 @@ func TestOnly_CollapsesToSingleWindow(t *testing.T) {
 	}
 	if ch, _ := tr.Channel(b); ch.ID != "C1" {
 		t.Fatalf("surviving window lost its channel: %+v", ch)
+	}
+}
+
+func TestCycle_SingleWindowReturnsSelf(t *testing.T) {
+	tr, a := New(Channel{})
+	if got := tr.Cycle(a, 1); got != a {
+		t.Fatalf("Cycle = %v, want %v", got, a)
 	}
 }
 

--- a/internal/ui/wintree/wintree.go
+++ b/internal/ui/wintree/wintree.go
@@ -1,0 +1,156 @@
+// Package wintree owns the vim-style window split tree for the
+// messages region (window-management design §1). Pure data + geometry:
+// no UI dependencies. Internal nodes are splits (direction + children,
+// always divided equally in Phase 2); leaves are windows identified by
+// a stable LeafID and carrying the channel they view.
+package wintree
+
+import "errors"
+
+// Dir is a split direction, named by visual result to avoid vim's
+// confusing horizontal/vertical terminology.
+type Dir int
+
+const (
+	// SplitStacked is vim's :sp — children stack top-to-bottom.
+	SplitStacked Dir = iota
+	// SplitSideBySide is vim's :vsp — children sit left-to-right.
+	SplitSideBySide
+)
+
+// NavDir is a geometric focus-navigation direction (ctrl+w h/j/k/l).
+type NavDir int
+
+const (
+	NavLeft NavDir = iota
+	NavDown
+	NavUp
+	NavRight
+)
+
+// LeafID identifies a window. IDs are stable for the window's
+// lifetime and never reused within a Tree.
+type LeafID int
+
+// Channel is the channel a window views. Mirrors the fields of
+// ui.ChannelSelectedMsg so focus changes can re-dispatch selection.
+type Channel struct {
+	ID   string
+	Name string
+	Type string
+}
+
+// Rect is a window rectangle in screen cells, including the window's
+// border rows/cols. Rects produced by ComputeRects tile the bounds
+// exactly.
+type Rect struct {
+	X, Y, W, H int
+}
+
+// Minimum window rect sizes, border inclusive. MinWidth matches the
+// messages pane's 40-col content minimum plus its 2 border cols.
+const (
+	MinWidth  = 42
+	MinHeight = 8
+)
+
+var (
+	ErrNotFound   = errors.New("wintree: no such window")
+	ErrNoRoom     = errors.New("wintree: not enough room")
+	ErrLastWindow = errors.New("wintree: cannot close last window")
+)
+
+// node is either a leaf (len(children) == 0; id/ch valid) or a split
+// (dir/children valid).
+type node struct {
+	id       LeafID
+	ch       Channel
+	dir      Dir
+	children []*node
+}
+
+func (n *node) isLeaf() bool { return len(n.children) == 0 }
+
+// Tree is the window tree. Zero value is not usable; construct with New.
+type Tree struct {
+	root *node
+	next LeafID
+}
+
+// New returns a tree with a single window viewing ch, and that
+// window's id.
+func New(ch Channel) (*Tree, LeafID) {
+	t := &Tree{next: 2}
+	t.root = &node{id: 1, ch: ch}
+	return t, 1
+}
+
+// Len returns the number of windows.
+func (t *Tree) Len() int { return len(t.Leaves()) }
+
+// Leaves returns all window ids in tree (depth-first, left-to-right /
+// top-to-bottom) order.
+func (t *Tree) Leaves() []LeafID {
+	var out []LeafID
+	var walk func(n *node)
+	walk = func(n *node) {
+		if n.isLeaf() {
+			out = append(out, n.id)
+			return
+		}
+		for _, c := range n.children {
+			walk(c)
+		}
+	}
+	walk(t.root)
+	return out
+}
+
+// findLeaf returns the leaf with the given id and its parent split
+// (parent == nil when the leaf is the root). nil leaf means not found.
+func (t *Tree) findLeaf(id LeafID) (leaf, parent *node) {
+	var walk func(n, p *node) (*node, *node)
+	walk = func(n, p *node) (*node, *node) {
+		if n.isLeaf() {
+			if n.id == id {
+				return n, p
+			}
+			return nil, nil
+		}
+		for _, c := range n.children {
+			if l, lp := walk(c, n); l != nil {
+				return l, lp
+			}
+		}
+		return nil, nil
+	}
+	return walk(t.root, nil)
+}
+
+// Channel returns the channel of the given window.
+func (t *Tree) Channel(id LeafID) (Channel, bool) {
+	l, _ := t.findLeaf(id)
+	if l == nil {
+		return Channel{}, false
+	}
+	return l.ch, true
+}
+
+// SetChannel updates the channel of the given window. Returns false
+// if the window does not exist.
+func (t *Tree) SetChannel(id LeafID, ch Channel) bool {
+	l, _ := t.findLeaf(id)
+	if l == nil {
+		return false
+	}
+	l.ch = ch
+	return true
+}
+
+// firstLeaf returns the first (tree-order) leaf under n.
+func firstLeaf(n *node) *node {
+	for !n.isLeaf() {
+		n = n.children[0]
+	}
+	return n
+}

--- a/internal/ui/wintree/wintree_test.go
+++ b/internal/ui/wintree/wintree_test.go
@@ -1,0 +1,42 @@
+package wintree
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNew_SingleLeaf(t *testing.T) {
+	tr, id := New(Channel{ID: "C1", Name: "general", Type: "channel"})
+	if got := tr.Leaves(); !reflect.DeepEqual(got, []LeafID{id}) {
+		t.Fatalf("Leaves() = %v, want [%v]", got, id)
+	}
+	if tr.Len() != 1 {
+		t.Fatalf("Len() = %d, want 1", tr.Len())
+	}
+	ch, ok := tr.Channel(id)
+	if !ok || ch.Name != "general" {
+		t.Fatalf("Channel(%v) = %+v, %v", id, ch, ok)
+	}
+}
+
+func TestSetChannel(t *testing.T) {
+	tr, id := New(Channel{ID: "C1", Name: "general"})
+	if !tr.SetChannel(id, Channel{ID: "C2", Name: "ops"}) {
+		t.Fatal("SetChannel returned false for existing leaf")
+	}
+	if ch, _ := tr.Channel(id); ch.ID != "C2" {
+		t.Fatalf("channel = %+v, want C2", ch)
+	}
+	if tr.SetChannel(LeafID(999), Channel{}) {
+		t.Fatal("SetChannel should return false for unknown leaf")
+	}
+}
+
+func TestComputeRects_SingleWindowFillsBounds(t *testing.T) {
+	tr, id := New(Channel{})
+	bounds := Rect{X: 0, Y: 0, W: 120, H: 40}
+	rects := tr.ComputeRects(bounds)
+	if rects[id] != bounds {
+		t.Fatalf("rect = %+v, want %+v", rects[id], bounds)
+	}
+}


### PR DESCRIPTION
> **Stacked on #81** (command mode + ctrl+w reclaim). Merge that first; this PR's base is `window-management-phase1`.

## Summary
- New pure-data `internal/ui/wintree` package: vim-style split tree with exact-tiling geometry, simulate-and-check minimum-size refusal (validates actual resulting rects, rolls back), Close/Only/Cycle, and geometric `ctrl+w h/j/k/l` neighbor lookup
- `:sp` / `:vsp` / `:q` / `:only` (`:on`) commands plus the full `ctrl+w` chord set (`s v h j k l w q c o`) behind a pending-key state with a status-bar hint — disarmed centrally on any mode change
- Multi-window rendering: the focused window renders the real (cached) messages pane at its rect; unfocused windows render placeholder panes (Phase 3 makes them live). Single-window rendering is byte-identical to today — test-pinned
- Phase 2 semantics: one live model; focusing a window on a different channel re-dispatches the standard channel selection (documented interim, replaced by per-window models in phase 3)
- Hardening from review: workspace-switch window-tree reset (cross-workspace state leak), resize-after-split crash clamps, interim mouse guard in split mode (full routing is phase 4)

Spec: `docs/superpowers/specs/2026-06-11-window-management-design.md` (§1, §4-6, Phasing item 2); plan: `docs/superpowers/plans/2026-06-11-window-management-phase2-window-tree.md` (on main).

## Test Plan
- [x] 27 wintree unit tests (tiling incl. odd/offset bounds, refusal incl. nested-sibling regression, rollback exactness, navigation overlap rules)
- [x] App-level tests: commands, chords (incl. esc-mid-chord swallow, hint lifecycle, mode-change disarm), workspace-switch reset, hard-shrink crash regressions, split-mode mouse guard
- [x] Full suite green (`go test ./... -count=1`), vet clean, every commit builds
- [ ] Manual smoke: `:vsp` → side-by-side with live focused pane + placeholder; `ctrl+w h/l` moves focus and live pane follows channel; `:q`/`ctrl+w o` collapse; shrink until "Not enough room"; `?` lists window commands