### PR TITLE
fix: Show notifications for '@here' '@channel' & '@everyone'

### DIFF
--- a/internal/notify/notifier.go
+++ b/internal/notify/notifier.go
@@ -61,7 +61,10 @@ func ShouldNotify(ctx NotifyContext, channelID, userID, text, channelType string
 	}
 
 	// Check mention trigger
-	if ctx.OnMention && strings.Contains(text, "<@"+ctx.CurrentUserID+">") {
+	if ctx.OnMention && (strings.Contains(text, "<@"+ctx.CurrentUserID+">") ||
+		strings.Contains(text, "<!here>") ||
+		strings.Contains(text, "<!channel>") ||
+		strings.Contains(text, "<!everyone>")) {
 		return true
 	}
 

--- a/internal/notify/notifier_test.go
+++ b/internal/notify/notifier_test.go
@@ -71,6 +71,30 @@ func TestShouldNotify_Mention_Disabled(t *testing.T) {
 	}
 }
 
+func TestShouldNotify_SpecialMentions(t *testing.T) {
+	ctx := NotifyContext{
+		CurrentUserID:   "U1",
+		ActiveChannelID: "C_OTHER",
+		IsActiveWS:      true,
+		OnMention:       true,
+	}
+	if !ShouldNotify(ctx, "C1", "U2", "hey <!here> check this", "channel") {
+		t.Error("should notify for @here mention")
+	}
+	if !ShouldNotify(ctx, "C1", "U2", "hey <!channel> check this", "channel") {
+		t.Error("should notify for @channel mention")
+	}
+	if !ShouldNotify(ctx, "C1", "U2", "hey <!everyone> check this", "channel") {
+		t.Error("should notify for @everyone mention")
+	}
+
+	ctxNoMention := ctx
+	ctxNoMention.OnMention = false
+	if ShouldNotify(ctxNoMention, "C1", "U2", "hey <!here> check this", "channel") {
+		t.Error("should not notify for @here when OnMention is false")
+	}
+}
+
 func TestShouldNotify_Keyword(t *testing.T) {
 	ctx := NotifyContext{
 		CurrentUserID:   "U1",


### PR DESCRIPTION
This PR adds support for '@here', '@channel', and '@everyone' in notifications.