### PR TITLE
From issue #89, add a keybind to toggle the workspaces sidebar.

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -106,8 +106,9 @@ type App struct {
 	// State
 	mode           Mode
 	focusedPanel   Panel
-	sidebarVisible bool
-	threadVisible  bool
+	sidebarVisible    bool
+	workspacesVisible bool
+	threadVisible     bool
 	view           View
 	width          int
 	height         int
@@ -459,6 +460,7 @@ func NewApp() *App {
 		wins:                 wins,
 		focusedWin:           rootWin,
 		sidebarVisible:       true,
+		workspacesVisible:    true,
 		view:                 ViewChannels,
 		keys:                 DefaultKeyMap(),
 		selfSend:             newSelfSendDedup(),
@@ -1610,6 +1612,11 @@ func (a *App) ToggleSidebar() {
 	}
 }
 
+func (a *App) ToggleWorkspaces() {
+	a.clearSelections()
+	a.workspacesVisible = !a.workspacesVisible
+}
+
 func (a *App) ToggleThread() {
 	a.clearSelections()
 	if a.threadVisible {
@@ -2519,7 +2526,11 @@ func (a *App) View() tea.View {
 	// for subsequent mouse hit-testing (panelAt) and surfaces a
 	// ThreadAutoHidden flag when the available width can't fit the
 	// thread pane at its minimum.
-	frame := a.layout.Compute(a.width, a.height, a.workspaceRail.Width(), a.sidebar.Width(), a.sidebarVisible, a.threadVisible)
+	railWidth := 0
+	if a.workspacesVisible {
+		railWidth = a.workspaceRail.Width()
+	}
+	frame := a.layout.Compute(a.width, a.height, railWidth, a.sidebar.Width(), a.sidebarVisible, a.threadVisible)
 	if frame.ThreadAutoHidden {
 		a.threadVisible = false
 		if a.focusedPanel == PanelThread {
@@ -2537,7 +2548,9 @@ func (a *App) View() tea.View {
 	previewActive := a.preview.Active()
 
 	var panels []string
-	panels = append(panels, a.renderRail(frame.RailWidth, frame.ContentHeight, themeVer))
+	if frame.RailWidth > 0 {
+		panels = append(panels, a.renderRail(frame.RailWidth, frame.ContentHeight, themeVer))
+	}
 	if a.sidebarVisible {
 		panels = append(panels, a.renderSidebar(frame.SidebarWidth, frame.SidebarBorder, frame.ContentHeight, themeVer))
 	}

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -75,6 +75,24 @@ func TestAppToggleSidebar(t *testing.T) {
 	}
 }
 
+func TestAppToggleWorkspaces(t *testing.T) {
+	app := NewApp()
+
+	if !app.workspacesVisible {
+		t.Error("expected workspaces visible initially")
+	}
+
+	app.ToggleWorkspaces()
+	if app.workspacesVisible {
+		t.Error("expected workspaces hidden after toggle")
+	}
+
+	app.ToggleWorkspaces()
+	if !app.workspacesVisible {
+		t.Error("expected workspaces visible after second toggle")
+	}
+}
+
 func TestTypingStateAddAndExpire(t *testing.T) {
 	app := NewApp()
 	app.activeChannelID = "C1"

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -19,6 +19,7 @@ type KeyMap struct {
 	Tab                 key.Binding
 	ShiftTab            key.Binding
 	ToggleSidebar       key.Binding
+	ToggleWorkspaces    key.Binding
 	SidebarGrow         key.Binding
 	SidebarShrink       key.Binding
 	ToggleThread        key.Binding
@@ -78,6 +79,7 @@ func DefaultKeyMap() KeyMap {
 		Tab:             key.NewBinding(key.WithKeys("tab"), key.WithHelp("tab", "next panel")),
 		ShiftTab:        key.NewBinding(key.WithKeys("shift+tab"), key.WithHelp("shift+tab", "prev panel")),
 		ToggleSidebar:   key.NewBinding(key.WithKeys("ctrl+b"), key.WithHelp("ctrl+b", "toggle sidebar")),
+		ToggleWorkspaces: key.NewBinding(key.WithKeys("ctrl+l", "ctrl+\\"), key.WithHelp("ctrl+l", "toggle workspaces")),
 		SidebarGrow:     key.NewBinding(key.WithKeys("]"), key.WithHelp("]", "widen sidebar")),
 		SidebarShrink:   key.NewBinding(key.WithKeys("["), key.WithHelp("[", "narrow sidebar")),
 		ToggleThread:    key.NewBinding(key.WithKeys("ctrl+]"), key.WithHelp("ctrl+]", "toggle thread")),

--- a/internal/ui/mode_normal.go
+++ b/internal/ui/mode_normal.go
@@ -125,6 +125,9 @@ func handleNormalMode(a *App, msg tea.KeyMsg) tea.Cmd {
 	case key.Matches(msg, a.keys.ToggleSidebar):
 		a.ToggleSidebar()
 
+	case key.Matches(msg, a.keys.ToggleWorkspaces):
+		a.ToggleWorkspaces()
+
 	case key.Matches(msg, a.keys.SidebarGrow):
 		a.sidebar.GrowWidth()
 		if a.widthSaveFn != nil {

--- a/internal/ui/view_composite_test.go
+++ b/internal/ui/view_composite_test.go
@@ -45,8 +45,14 @@ func TestJoinPanelsHorizontal_MatchesLipgloss(t *testing.T) {
 // helpers can be checked against lipgloss on real rendered panels.
 func buildViewPanels(a *App) (panels []string, status string, contentHeight, width int) {
 	themeVer := int64(0)
-	frame := a.layout.Compute(a.width, a.height, a.workspaceRail.Width(), a.sidebar.Width(), a.sidebarVisible, a.threadVisible)
-	panels = append(panels, a.renderRail(frame.RailWidth, frame.ContentHeight, themeVer))
+	railWidth := 0
+	if a.workspacesVisible {
+		railWidth = a.workspaceRail.Width()
+	}
+	frame := a.layout.Compute(a.width, a.height, railWidth, a.sidebar.Width(), a.sidebarVisible, a.threadVisible)
+	if frame.RailWidth > 0 {
+		panels = append(panels, a.renderRail(frame.RailWidth, frame.ContentHeight, themeVer))
+	}
 	if a.sidebarVisible {
 		panels = append(panels, a.renderSidebar(frame.SidebarWidth, frame.SidebarBorder, frame.ContentHeight, themeVer))
 	}


### PR DESCRIPTION
### Summary of Changes:

  1. Defined Keybindings: Added  ToggleWorkspaces  to  KeyMap  inside keys.go, binding it to  ctrl+l  (and  ctrl+\  as an alias).
  2. Added State Field: Extended  App  inside app.go to track  workspacesVisible  state and default it to  true  on initialization.
  3. Implemented Toggle Action: Created  ToggleWorkspaces()  method in app.go.
  4. Wired Normal Mode Handler: Added a check for key match against  a.keys.ToggleWorkspaces  in mode_normal.go.
  5. Adjusted Layout & Assembly:
      • In  App.View() , the layout width for the rail defaults to  0  when  workspacesVisible  is  false , and rendering of the rail is skipped.
      • Updated the  buildViewPanels()  test helper in view_composite_test.go to match.
  6. Added Unit Tests: Added  TestAppToggleWorkspaces  to app_test.go verifying toggling and visibility state changes.

