### PR TITLE
Support transparent backgrounds in themes

### DIFF
--- a/internal/ui/messages/blockkit/color.go
+++ b/internal/ui/messages/blockkit/color.go
@@ -42,8 +42,13 @@ func ResolveAttachmentColor(c string) string {
 // go through the color.Color RGBA() interface method because the
 // concrete lipgloss.Color values land as image/color.RGBA, which
 // has no String method and whose %v formatting ("{r g b a}") is not
-// re-parseable by lipgloss.
+// re-parseable by lipgloss. A nil color (transparent theme value) has
+// no hex representation; fall back to the neutral gray used for subdued
+// attachment bars so the caller always gets a parseable color.
 func colorString(c color.Color) string {
+	if c == nil {
+		return "#333333"
+	}
 	r, g, b, _ := c.RGBA()
 	// RGBA returns 16-bit per channel; shift down to 8-bit.
 	return fmt.Sprintf("#%02x%02x%02x", r>>8, g>>8, b>>8)

--- a/internal/ui/messages/render.go
+++ b/internal/ui/messages/render.go
@@ -494,7 +494,12 @@ func isBasicBgParam(s string) bool {
 // \x1b[100m–\x1b[107m) so the user's terminal palette is honored.
 // For ansi.IndexedColor it emits the 256-color form (\x1b[48;5;Nm).
 // Otherwise it falls back to truecolor (\x1b[48;2;R;G;Bm).
+// A nil color (transparent theme value) emits the default-background
+// reset (\x1b[49m) so the terminal's own background shows through.
 func bgANSIFor(c color.Color) string {
+	if c == nil {
+		return "\x1b[49m"
+	}
 	switch v := c.(type) {
 	case ansi.BasicColor:
 		if v < 8 {
@@ -512,8 +517,12 @@ func bgANSIFor(c color.Color) string {
 }
 
 // fgANSIFor returns the ANSI foreground-color escape for c.
-// See bgANSIFor for the type-switch rationale.
+// See bgANSIFor for the type-switch rationale. A nil color emits the
+// default-foreground reset (\x1b[39m).
 func fgANSIFor(c color.Color) string {
+	if c == nil {
+		return "\x1b[39m"
+	}
 	switch v := c.(type) {
 	case ansi.BasicColor:
 		if v < 8 {

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -4,6 +4,7 @@ package styles
 import (
 	"hash/fnv"
 	"image/color"
+	"strings"
 
 	"charm.land/lipgloss/v2"
 	"github.com/gammons/slk/internal/config"
@@ -271,53 +272,68 @@ var version int64
 // Version returns the current theme version, incremented on every Apply call.
 func Version() int64 { return version }
 
+// parseColor converts a color string to a lipgloss color. It recognizes
+// "transparent", "none", and "default" as nil so terminal emulators with
+// background opacity (e.g. Ghostty) can show the underlying wallpaper
+// through slk's UI. A nil color makes lipgloss emit no color escape at
+// all, unlike lipgloss.NoColor{}, whose RGBA() reports opaque black and
+// gets painted as literal black by code paths that convert colors by
+// hand (bgANSIFor, mixColors, blockkit colorString).
+func parseColor(s string) color.Color {
+	switch strings.ToLower(s) {
+	case "transparent", "none", "default":
+		return nil
+	}
+	return lipgloss.Color(s)
+}
+
 // Apply sets the color palette from a named theme with optional overrides,
 // then rebuilds all composed styles.
 func Apply(themeName string, overrides config.Theme) {
 	version++
 	colors := lookupTheme(themeName)
 
-	Primary = lipgloss.Color(colors.Primary)
+	Primary = parseColor(colors.Primary)
 	Secondary = lipgloss.Color("#666666")
-	Accent = lipgloss.Color(colors.Accent)
-	Warning = lipgloss.Color(colors.Warning)
-	Error = lipgloss.Color(colors.Error)
-	Background = lipgloss.Color(colors.Background)
-	Surface = lipgloss.Color(colors.Surface)
-	SurfaceDark = lipgloss.Color(colors.SurfaceDark)
-	TextPrimary = lipgloss.Color(colors.Text)
-	TextMuted = lipgloss.Color(colors.TextMuted)
-	Border = lipgloss.Color(colors.Border)
+	Accent = parseColor(colors.Accent)
+	Warning = parseColor(colors.Warning)
+	Error = parseColor(colors.Error)
+	Background = parseColor(colors.Background)
+	Surface = parseColor(colors.Surface)
+	SurfaceDark = parseColor(colors.SurfaceDark)
+	TextPrimary = parseColor(colors.Text)
+	TextMuted = parseColor(colors.TextMuted)
+	Border = parseColor(colors.Border)
 
 	if overrides.Primary != "" {
-		Primary = lipgloss.Color(overrides.Primary)
+		Primary = parseColor(overrides.Primary)
 	}
 	if overrides.Accent != "" {
-		Accent = lipgloss.Color(overrides.Accent)
+		Accent = parseColor(overrides.Accent)
 	}
 	if overrides.Warning != "" {
-		Warning = lipgloss.Color(overrides.Warning)
+		Warning = parseColor(overrides.Warning)
 	}
 	if overrides.Error != "" {
-		Error = lipgloss.Color(overrides.Error)
+		Error = parseColor(overrides.Error)
 	}
 	if overrides.Background != "" {
-		Background = lipgloss.Color(overrides.Background)
+		Background = parseColor(overrides.Background)
 	}
 	if overrides.Surface != "" {
-		Surface = lipgloss.Color(overrides.Surface)
+		Surface = parseColor(overrides.Surface)
 	}
 	if overrides.SurfaceDark != "" {
-		SurfaceDark = lipgloss.Color(overrides.SurfaceDark)
+		SurfaceDark = parseColor(overrides.SurfaceDark)
 	}
 	if overrides.Text != "" {
-		TextPrimary = lipgloss.Color(overrides.Text)
+		TextPrimary = parseColor(overrides.Text)
 	}
 	if overrides.TextMuted != "" {
-		TextMuted = lipgloss.Color(overrides.TextMuted)
+		TextMuted = parseColor(overrides.TextMuted)
 	}
 	if overrides.Border != "" {
-		Border = lipgloss.Color(overrides.Border)
+		Border = parseColor(overrides.Border)
 	}
 
 	// Sidebar/rail colors fall back to their message-pane equivalents when
@@ -325,35 +341,35 @@ func Apply(themeName string, overrides config.Theme) {
 	// compute these AFTER overrides so a user override of Background also
 	// updates SidebarBackground (when not explicitly set on the theme).
 	if colors.SidebarBackground != "" {
-		SidebarBackground = lipgloss.Color(colors.SidebarBackground)
+		SidebarBackground = parseColor(colors.SidebarBackground)
 	} else {
 		SidebarBackground = Background
 	}
 	if colors.SidebarText != "" {
-		SidebarText = lipgloss.Color(colors.SidebarText)
+		SidebarText = parseColor(colors.SidebarText)
 	} else {
 		SidebarText = TextPrimary
 	}
 	if colors.SidebarTextMuted != "" {
-		SidebarTextMuted = lipgloss.Color(colors.SidebarTextMuted)
+		SidebarTextMuted = parseColor(colors.SidebarTextMuted)
 	} else {
 		SidebarTextMuted = TextMuted
 	}
 	if colors.RailBackground != "" {
-		RailBackground = lipgloss.Color(colors.RailBackground)
+		RailBackground = parseColor(colors.RailBackground)
 	} else {
 		RailBackground = SurfaceDark
 	}
 
 	if colors.SelectionBackground != "" {
-		SelectionBackground = lipgloss.Color(colors.SelectionBackground)
+		SelectionBackground = parseColor(colors.SelectionBackground)
 	} else {
 		// Default: Primary as the highlight bg gives readable contrast on
 		// every built-in theme.
 		SelectionBackground = Primary
 	}
 	if colors.SelectionForeground != "" {
-		SelectionForeground = lipgloss.Color(colors.SelectionForeground)
+		SelectionForeground = parseColor(colors.SelectionForeground)
 	} else {
 		// Default: theme background — paired with Primary bg this produces
 		// the inverse of the theme's normal text rendering.
@@ -361,14 +377,14 @@ func Apply(themeName string, overrides config.Theme) {
 	}
 
 	if colors.SearchHighlightBg != "" {
-		SearchHighlightBg = lipgloss.Color(colors.SearchHighlightBg)
+		SearchHighlightBg = parseColor(colors.SearchHighlightBg)
 	} else {
 		// Default: Warning is visible against message text in all
 		// built-in themes.
 		SearchHighlightBg = Warning
 	}
 	if colors.SearchHighlightFg != "" {
-		SearchHighlightFg = lipgloss.Color(colors.SearchHighlightFg)
+		SearchHighlightFg = parseColor(colors.SearchHighlightFg)
 	} else {
 		SearchHighlightFg = Background
 	}
@@ -376,7 +392,7 @@ func Apply(themeName string, overrides config.Theme) {
 	// Compose-insert background: explicit theme override wins, otherwise
 	// derive from Accent + Background at defaultTintAlpha.
 	if colors.ComposeInsertBG != "" {
-		ComposeInsertBG = lipgloss.Color(colors.ComposeInsertBG)
+		ComposeInsertBG = parseColor(colors.ComposeInsertBG)
 	} else {
 		ComposeInsertBG = mixColors(Accent, Background, defaultTintAlpha)
 	}
@@ -386,10 +402,10 @@ func Apply(themeName string, overrides config.Theme) {
 	// the next SelectionTintColor() call repopulates from the new theme.
 	resetDerivedTints()
 	if colors.SelectionBgFocused != "" {
-		selectionBgFocused = lipgloss.Color(colors.SelectionBgFocused)
+		selectionBgFocused = parseColor(colors.SelectionBgFocused)
 	}
 	if colors.SelectionBgUnfocused != "" {
-		selectionBgUnfocused = lipgloss.Color(colors.SelectionBgUnfocused)
+		selectionBgUnfocused = parseColor(colors.SelectionBgUnfocused)
 	}
 
 	buildStyles()

--- a/internal/ui/styles/styles_test.go
+++ b/internal/ui/styles/styles_test.go
@@ -9,8 +9,12 @@ import (
 	"github.com/gammons/slk/internal/config"
 )
 
-// colorEqual compares two color.Color values.
+// colorEqual compares two color.Color values. nil (transparent) only
+// equals nil.
 func colorEqual(a, b color.Color) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
 	r1, g1, b1, a1 := a.RGBA()
 	r2, g2, b2, a2 := b.RGBA()
 	return r1 == r2 && g1 == g2 && b1 == b2 && a1 == a2
@@ -52,6 +56,22 @@ func TestApplyOverrides(t *testing.T) {
 	}
 	if !colorEqual(Accent, lipgloss.Color("#50C878")) {
 		t.Errorf("expected dark accent #50C878")
+	}
+	Apply("dark", config.Theme{})
+}
+
+func TestParseColor_Transparent(t *testing.T) {
+	for _, input := range []string{"transparent", "none", "default", "TRANSPARENT", "None", "Default"} {
+		if c := parseColor(input); c != nil {
+			t.Errorf("parseColor(%q) expected nil, got %T", input, c)
+		}
+	}
+}
+
+func TestApplyOverrides_Transparent(t *testing.T) {
+	Apply("dark", config.Theme{Background: "transparent"})
+	if Background != nil {
+		t.Errorf("expected transparent background (nil), got %T", Background)
 	}
 	Apply("dark", config.Theme{})
 }

--- a/internal/ui/styles/tint.go
+++ b/internal/ui/styles/tint.go
@@ -55,6 +55,15 @@ func mixColors(fg, bg color.Color, alpha float64) color.Color {
 	if alpha >= 1 {
 		return fg
 	}
+	// If the background is transparent (nil), there's nothing to tint
+	// against; stay transparent.
+	if bg == nil {
+		return nil
+	}
+	// If the foreground is transparent, just return the background.
+	if fg == nil {
+		return bg
+	}
 	fr, fg2, fb, _ := fg.RGBA()
 	br, bg2, bb, _ := bg.RGBA()
 	// RGBA returns 16-bit channels; collapse to 8-bit before mixing.

--- a/internal/ui/styles/tint_test.go
+++ b/internal/ui/styles/tint_test.go
@@ -48,6 +48,21 @@ func TestMixColors_AlphaOneIsForeground(t *testing.T) {
 	}
 }
 
+func TestMixColors_TransparentBackgroundReturnsTransparent(t *testing.T) {
+	out := mixColors(lipgloss.Color("#FF0000"), nil, 0.5)
+	if out != nil {
+		t.Fatalf("mixing with transparent bg must return nil, got %T", out)
+	}
+}
+
+func TestMixColors_TransparentForegroundReturnsBackground(t *testing.T) {
+	out := mixColors(nil, lipgloss.Color("#0000FF"), 0.5)
+	r, g, b := rgb(out)
+	if r != 0x00 || g != 0x00 || b != 0xFF {
+		t.Fatalf("mixing with transparent fg must return bg, got #%02X%02X%02X", r, g, b)
+	}
+}
+
 func TestSelectionTintColor_FocusedIsAccentMix(t *testing.T) {
 	applyTheme(t, "dark", config.Theme{})
 	expected := mixColors(Accent, Background, defaultTintAlpha)


### PR DESCRIPTION
## Summary

- Theme colors now accept `"transparent"`, `"none"`, or `"default"` so terminal emulators with background opacity (Ghostty, kitty, alacritty, etc.) can show the wallpaper through slk's UI instead of painting opaque panels.
- Transparent values resolve to a nil color. lipgloss already skips styling for nil, but slk has a few hand-rolled color conversions that would otherwise render literal black (since `NoColor.RGBA()` reports opaque black). Those are guarded:
  - message-pane background fills emit the ANSI default-background reset (SGR 49) and foregrounds emit SGR 39
  - derived tints (compose insert background, selection rows) stay transparent when mixed against a transparent background
  - Block Kit attachment color bars fall back to a neutral gray

## Usage

```toml
[theme]
background = "transparent"
```

## Compatibility

Fully backwards compatible — existing hex/ANSI values parse exactly as before, and no built-in theme uses the new keywords. Covered by new tests in `styles_test.go` and `tint_test.go`; full suite passes with `-race`.