### PR TITLE
Resolve usergroup mentions to @handles and support tagging groups

### DIFF
--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -165,7 +165,20 @@ type WorkspaceContext struct {
 	UserID        string
 	UnresolvedDMs []UnresolvedDM
 	CustomEmoji   map[string]string // emoji name -> URL or "alias:target"
-	UserGroups    map[string]string // usergroup ID -> handle
+	// userGroups holds this workspace's usergroup ID -> handle map.
+	// Access it via UserGroups/SetUserGroups, never directly.
+	//
+	// atomic.Pointer (not a plain map) because the write happens on the
+	// background usergroups.list fetch goroutine while reads happen on
+	// the bubbletea Update/cmd goroutines (workspace switch, search) and
+	// on the RTM event loop (notification body stripping). This is where
+	// UserGroups differs from the CustomEmoji field it otherwise mirrors:
+	// CustomEmoji is only ever consumed through the tea message loop, so
+	// its single background write is never read cross-goroutine.
+	//
+	// The stored map is published once and never mutated afterwards, so
+	// readers need no further synchronization.
+	userGroups atomic.Pointer[map[string]string]
 	// Self presence and DND state for this workspace. Populated on connect
 	// and updated by manual_presence_change / dnd_updated WS events plus
 	// optimistic writes from the presence menu.
@@ -192,6 +205,22 @@ type WorkspaceContext struct {
 	// in connectWorkspace alongside UserResolver (it depends on the
 	// resolver to trigger external-user lookups for newly-seen IDs).
 	Membership *membership.Manager
+}
+
+// UserGroups returns this workspace's usergroup ID -> handle map, or an
+// empty map before usergroups.list has returned. Safe to call from any
+// goroutine; the result must be treated as read-only.
+func (w *WorkspaceContext) UserGroups() map[string]string {
+	if m := w.userGroups.Load(); m != nil {
+		return *m
+	}
+	return map[string]string{}
+}
+
+// SetUserGroups publishes a usergroup ID -> handle map for this
+// workspace. The caller must not mutate the map afterwards.
+func (w *WorkspaceContext) SetUserGroups(groups map[string]string) {
+	w.userGroups.Store(&groups)
 }
 
 // workspaceRouter holds the program-wide "active workspace" pointer.
@@ -1529,7 +1558,7 @@ func run() error {
 			ExternalUsers:    external,
 			UserID:           wctx.UserID,
 			CustomEmoji:      wctx.CustomEmoji,
-			UserGroups:       wctx.UserGroups,
+			UserGroups:       wctx.UserGroups(),
 			SectionsProvider: sectionsProviderAdapter{store: wctx.SectionStore},
 		}
 	})
@@ -1683,8 +1712,8 @@ func run() error {
 				UserNames:        wctx.UserNames,
 				ExternalUsers:    external,
 				UserID:           wctx.UserID,
-				CustomEmoji:      wctx.CustomEmoji, // empty at this point; filled by the goroutine below
-				UserGroups:       wctx.UserGroups,  // empty at this point; filled by the goroutine below
+				CustomEmoji:      wctx.CustomEmoji,  // empty at this point; filled by the goroutine below
+				UserGroups:       wctx.UserGroups(), // empty at this point; filled by the goroutine below
 				SectionsProvider: sectionsProviderAdapter{store: wctx.SectionStore},
 				InitialActive:    isInitial,
 				LastChannelID:    mostRecentlyVisitedChannel(wctx.LastVisitedByChannel),
@@ -1717,7 +1746,7 @@ func run() error {
 					return
 				}
 				byID := usergroupHandles(groups)
-				wctx.UserGroups = byID
+				wctx.SetUserGroups(byID)
 				p.Send(ui.UserGroupsLoadedMsg{
 					TeamID:     teamID,
 					UserGroups: byID,
@@ -1784,13 +1813,41 @@ func usergroupHandles(groups []slack.UserGroup) map[string]string {
 	for _, g := range groups {
 		handle := g.Handle
 		if handle == "" {
-			handle = g.Name
+			// Fall back to the display name, slugified: a name like
+			// "Platform Team" would otherwise become a handle with a
+			// space in it, which neither the @-token composer
+			// autocomplete nor the word-boundary send translation can
+			// round-trip.
+			handle = slugifyHandle(g.Name)
 		}
 		if handle != "" {
 			byID[g.ID] = handle
 		}
 	}
 	return byID
+}
+
+// slugifyHandle turns a usergroup display name into a mention-safe
+// handle: lowercased, with every run of characters Slack handles don't
+// use collapsed to a single "-" ("Platform Team" -> "platform-team").
+// Returns "" when nothing usable survives, so the caller can skip the
+// group entirely rather than register an unmentionable handle.
+func slugifyHandle(name string) string {
+	var b strings.Builder
+	pendingDash := false
+	for _, r := range strings.ToLower(name) {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' || r == '.':
+			if pendingDash && b.Len() > 0 {
+				b.WriteByte('-')
+			}
+			pendingDash = false
+			b.WriteRune(r)
+		default:
+			pendingDash = true
+		}
+	}
+	return b.String()
 }
 
 func connectWorkspace(ctx context.Context, token slackclient.Token, db *cache.DB, cfg config.Config, avatarCache *avatar.Cache, p *tea.Program) (*WorkspaceContext, error) {
@@ -1809,7 +1866,6 @@ func connectWorkspace(ctx context.Context, token slackclient.Token, db *cache.DB
 		UserNamesByHandle:    make(map[string]string),
 		BotUserIDs:           make(map[string]bool),
 		CustomEmoji:          make(map[string]string),
-		UserGroups:           make(map[string]string),
 		LastVisitedByChannel: make(map[string]int64),
 	}
 	wctx.SubscriptionsAvailable = true
@@ -3013,7 +3069,7 @@ func searchWorkspaceFunc(router *workspaceRouter, db *cache.DB, tsFormat string)
 			}
 			return "", false
 		}
-		items := searchResultItems(res.Matches, tsFormat, time.Now(), resolveUser, resolveChannel, wctx.UserGroups)
+		items := searchResultItems(res.Matches, tsFormat, time.Now(), resolveUser, resolveChannel, wctx.UserGroups())
 		return ui.WorkspaceSearchResultsMsg{Query: query, Items: items, Total: res.Total}
 	}
 }
@@ -3325,7 +3381,7 @@ func (h *rtmEventHandler) OnMessage(channelID, userID, ts, text, threadTS, subty
 			}
 			var groupNames map[string]string
 			if h.wsCtx != nil {
-				groupNames = h.wsCtx.UserGroups
+				groupNames = h.wsCtx.UserGroups()
 			}
 			body := senderName + ": " + notify.StripSlackMarkupWithUserGroups(text, h.userNames, groupNames)
 			go h.notifier.Notify(title, body)

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -165,6 +165,7 @@ type WorkspaceContext struct {
 	UserID        string
 	UnresolvedDMs []UnresolvedDM
 	CustomEmoji   map[string]string // emoji name -> URL or "alias:target"
+	UserGroups    map[string]string // usergroup ID -> handle
 	// Self presence and DND state for this workspace. Populated on connect
 	// and updated by manual_presence_change / dnd_updated WS events plus
 	// optimistic writes from the presence menu.
@@ -1528,6 +1529,7 @@ func run() error {
 			ExternalUsers:    external,
 			UserID:           wctx.UserID,
 			CustomEmoji:      wctx.CustomEmoji,
+			UserGroups:       wctx.UserGroups,
 			SectionsProvider: sectionsProviderAdapter{store: wctx.SectionStore},
 		}
 	})
@@ -1682,6 +1684,7 @@ func run() error {
 				ExternalUsers:    external,
 				UserID:           wctx.UserID,
 				CustomEmoji:      wctx.CustomEmoji, // empty at this point; filled by the goroutine below
+				UserGroups:       wctx.UserGroups,  // empty at this point; filled by the goroutine below
 				SectionsProvider: sectionsProviderAdapter{store: wctx.SectionStore},
 				InitialActive:    isInitial,
 				LastChannelID:    mostRecentlyVisitedChannel(wctx.LastVisitedByChannel),
@@ -1700,6 +1703,24 @@ func run() error {
 				p.Send(ui.CustomEmojisLoadedMsg{
 					TeamID:      teamID,
 					CustomEmoji: emojis,
+				})
+			}(wctx.TeamID)
+
+			// Fetch workspace usergroups in the background. When done,
+			// send a follow-up so render caches and compose pickers can
+			// refresh for the active workspace. Best-effort: failure leaves
+			// bare subteam mentions rendered as "@group".
+			go func(teamID string) {
+				groups, err := wctx.Client.GetUserGroups(ctx)
+				if err != nil {
+					log.Printf("usergroups fetch for %s failed: %v (subteam mentions will render as @group)", wctx.TeamName, err)
+					return
+				}
+				byID := usergroupHandles(groups)
+				wctx.UserGroups = byID
+				p.Send(ui.UserGroupsLoadedMsg{
+					TeamID:     teamID,
+					UserGroups: byID,
 				})
 			}(wctx.TeamID)
 
@@ -1758,6 +1779,20 @@ func run() error {
 	return err
 }
 
+func usergroupHandles(groups []slack.UserGroup) map[string]string {
+	byID := make(map[string]string, len(groups))
+	for _, g := range groups {
+		handle := g.Handle
+		if handle == "" {
+			handle = g.Name
+		}
+		if handle != "" {
+			byID[g.ID] = handle
+		}
+	}
+	return byID
+}
+
 func connectWorkspace(ctx context.Context, token slackclient.Token, db *cache.DB, cfg config.Config, avatarCache *avatar.Cache, p *tea.Program) (*WorkspaceContext, error) {
 	client := slackclient.NewClient(token.AccessToken, token.Cookie)
 	if err := client.Connect(ctx); err != nil {
@@ -1774,6 +1809,7 @@ func connectWorkspace(ctx context.Context, token slackclient.Token, db *cache.DB
 		UserNamesByHandle:    make(map[string]string),
 		BotUserIDs:           make(map[string]bool),
 		CustomEmoji:          make(map[string]string),
+		UserGroups:           make(map[string]string),
 		LastVisitedByChannel: make(map[string]int64),
 	}
 	wctx.SubscriptionsAvailable = true
@@ -2977,7 +3013,7 @@ func searchWorkspaceFunc(router *workspaceRouter, db *cache.DB, tsFormat string)
 			}
 			return "", false
 		}
-		items := searchResultItems(res.Matches, tsFormat, time.Now(), resolveUser, resolveChannel)
+		items := searchResultItems(res.Matches, tsFormat, time.Now(), resolveUser, resolveChannel, wctx.UserGroups)
 		return ui.WorkspaceSearchResultsMsg{Query: query, Items: items, Total: res.Total}
 	}
 }
@@ -2992,7 +3028,7 @@ var userIDShapeRe = regexp.MustCompile(`^[UW][A-Z0-9]{5,}$`)
 // channel names (raw user IDs on the wire) are resolved to the
 // counterpart's display name, and thread TSes are recovered from
 // permalinks. Pure: all lookups go through the supplied resolvers.
-func searchResultItems(matches []slack.SearchMessage, tsFormat string, now time.Time, resolveUser, resolveChannel func(id string) (string, bool)) []searchresults.Item {
+func searchResultItems(matches []slack.SearchMessage, tsFormat string, now time.Time, resolveUser, resolveChannel func(id string) (string, bool), userGroups map[string]string) []searchresults.Item {
 	items := make([]searchresults.Item, 0, len(matches))
 	for _, match := range matches {
 		// ThreadTS comes from the hit's permalink. Known v1
@@ -3023,7 +3059,7 @@ func searchResultItems(matches []slack.SearchMessage, tsFormat string, now time.
 			UserName:    match.Username,
 			TS:          match.Timestamp,
 			ThreadTS:    threadTS,
-			Text:        messages.FlattenMrkdwn(match.Text, resolveUser, resolveChannel),
+			Text:        messages.FlattenMrkdwnWithUserGroups(match.Text, resolveUser, resolveChannel, userGroups),
 			Timestamp:   formatSearchTimestamp(match.Timestamp, tsFormat, now),
 			IsDM:        isDM,
 		})
@@ -3287,7 +3323,11 @@ func (h *rtmEventHandler) OnMessage(channelID, userID, ts, text, threadTS, subty
 			if chType == "dm" || chType == "group_dm" {
 				title = h.workspaceName + ": " + senderName
 			}
-			body := senderName + ": " + notify.StripSlackMarkup(text, h.userNames)
+			var groupNames map[string]string
+			if h.wsCtx != nil {
+				groupNames = h.wsCtx.UserGroups
+			}
+			body := senderName + ": " + notify.StripSlackMarkupWithUserGroups(text, h.userNames, groupNames)
 			go h.notifier.Notify(title, body)
 		}
 	}

--- a/cmd/slk/search_items_test.go
+++ b/cmd/slk/search_items_test.go
@@ -45,7 +45,7 @@ func testResolveChannel(id string) (string, bool) {
 var testNow = time.Date(2026, time.June, 11, 12, 0, 0, 0, time.Local)
 
 func convert(matches ...slack.SearchMessage) []searchItemsOut {
-	items := searchResultItems(matches, "15:04", testNow, testResolveUser, testResolveChannel)
+	items := searchResultItems(matches, "15:04", testNow, testResolveUser, testResolveChannel, nil)
 	out := make([]searchItemsOut, len(items))
 	for i, it := range items {
 		out[i] = searchItemsOut{it.ChannelName, it.Text, it.IsDM}
@@ -68,6 +68,21 @@ func TestSearchResultItemsFlattensMrkdwn(t *testing.T) {
 	}
 	if got[0].IsDM {
 		t.Error("regular channel must not be flagged IsDM")
+	}
+}
+
+func TestSearchResultItemsFlattensUsergroupMentions(t *testing.T) {
+	m := searchMatch("C1", "general", "grant", "cc <!subteam^S0TESTGRP01>")
+	items := searchResultItems(
+		[]slack.SearchMessage{m},
+		"15:04",
+		testNow,
+		testResolveUser,
+		testResolveChannel,
+		map[string]string{"S0TESTGRP01": "platform-team"},
+	)
+	if items[0].Text != "cc @platform-team" {
+		t.Errorf("Text = %q, want %q", items[0].Text, "cc @platform-team")
 	}
 }
 
@@ -121,7 +136,7 @@ func TestSearchResultItemsRegularChannelNameNotTreatedAsUser(t *testing.T) {
 func TestSearchResultItemsThreadTSFromPermalink(t *testing.T) {
 	m := searchMatch("C1", "general", "grant", "reply")
 	m.Permalink = "https://x.slack.com/archives/C1/p1700000002000200?thread_ts=1700000001.000100&cid=C1"
-	items := searchResultItems([]slack.SearchMessage{m}, "15:04", testNow, testResolveUser, testResolveChannel)
+	items := searchResultItems([]slack.SearchMessage{m}, "15:04", testNow, testResolveUser, testResolveChannel, nil)
 	if items[0].ThreadTS != "1700000001.000100" {
 		t.Errorf("ThreadTS = %q, want %q", items[0].ThreadTS, "1700000001.000100")
 	}
@@ -156,7 +171,7 @@ func TestSearchResultItemsTimestampIncludesDate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			m := searchMatch("C1", "general", "grant", "hello")
 			m.Timestamp = slackTS(tc.when)
-			items := searchResultItems([]slack.SearchMessage{m}, "15:04", testNow, testResolveUser, testResolveChannel)
+			items := searchResultItems([]slack.SearchMessage{m}, "15:04", testNow, testResolveUser, testResolveChannel, nil)
 			if items[0].Timestamp != tc.want {
 				t.Errorf("Timestamp = %q, want %q", items[0].Timestamp, tc.want)
 			}
@@ -167,7 +182,7 @@ func TestSearchResultItemsTimestampIncludesDate(t *testing.T) {
 func TestSearchResultItemsTimestampUnparseableFallsBack(t *testing.T) {
 	m := searchMatch("C1", "general", "grant", "hello")
 	m.Timestamp = "garbage"
-	items := searchResultItems([]slack.SearchMessage{m}, "15:04", testNow, testResolveUser, testResolveChannel)
+	items := searchResultItems([]slack.SearchMessage{m}, "15:04", testNow, testResolveUser, testResolveChannel, nil)
 	if items[0].Timestamp != "garbage" {
 		t.Errorf("Timestamp = %q, want raw value kept", items[0].Timestamp)
 	}

--- a/cmd/slk/usergroups_test.go
+++ b/cmd/slk/usergroups_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/slack-go/slack"
+)
+
+func TestUsergroupHandlesPrefersHandle(t *testing.T) {
+	byID := usergroupHandles([]slack.UserGroup{
+		{ID: "S1", Handle: "platform-team", Name: "Platform Team"},
+	})
+	if byID["S1"] != "platform-team" {
+		t.Errorf("handle = %q, want platform-team", byID["S1"])
+	}
+}
+
+func TestUsergroupHandlesSlugifiesNameFallback(t *testing.T) {
+	byID := usergroupHandles([]slack.UserGroup{
+		{ID: "S1", Name: "Platform Team"},
+	})
+	if byID["S1"] != "platform-team" {
+		t.Errorf("name fallback = %q, want platform-team (no spaces)", byID["S1"])
+	}
+}
+
+func TestUsergroupHandlesSkipsUnmentionableGroups(t *testing.T) {
+	byID := usergroupHandles([]slack.UserGroup{
+		{ID: "S1"},
+		{ID: "S2", Name: "   "},
+		{ID: "S3", Name: "!!!"},
+	})
+	if len(byID) != 0 {
+		t.Errorf("byID = %v, want empty (nothing mentionable)", byID)
+	}
+}
+
+func TestSlugifyHandle(t *testing.T) {
+	cases := map[string]string{
+		"Platform Team":     "platform-team",
+		"  Data   Eng  ":    "data-eng",
+		"Design/Research":   "design-research",
+		"on-call_rota.v2":   "on-call_rota.v2",
+		"Team (EU) — North": "team-eu-north",
+		"":                  "",
+		"???":               "",
+	}
+	for in, want := range cases {
+		if got := slugifyHandle(in); got != want {
+			t.Errorf("slugifyHandle(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestWorkspaceContextUserGroupsDefaultsEmpty(t *testing.T) {
+	var wctx WorkspaceContext
+	if got := wctx.UserGroups(); got == nil || len(got) != 0 {
+		t.Errorf("UserGroups() before load = %v, want empty non-nil map", got)
+	}
+}
+
+// The usergroups.list fetch publishes the map from a background
+// goroutine while the RTM event loop and bubbletea cmds read it. Run
+// under -race to catch a regression back to a plain map field.
+func TestWorkspaceContextUserGroupsConcurrentAccess(t *testing.T) {
+	wctx := &WorkspaceContext{}
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			wctx.SetUserGroups(map[string]string{"S1": "platform-team"})
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			_ = wctx.UserGroups()["S1"]
+		}
+	}()
+	wg.Wait()
+	if got := wctx.UserGroups()["S1"]; got != "platform-team" {
+		t.Errorf("UserGroups()[S1] = %q, want platform-team", got)
+	}
+}

--- a/internal/notify/notifier.go
+++ b/internal/notify/notifier.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/gammons/slk/internal/usergroups"
 	"github.com/gen2brain/beeep"
 )
 
@@ -84,7 +85,10 @@ func ShouldNotify(ctx NotifyContext, channelID, userID, text, channelType string
 var (
 	userMentionRe    = regexp.MustCompile(`<@([A-Z0-9]+)>`)
 	channelMentionRe = regexp.MustCompile(`<#[A-Z0-9]+\|([^>]+)>`)
-	subteamMentionRe = regexp.MustCompile(`<!subteam\^[A-Z0-9]+\|([^>]+)>`)
+	// Group 1 is the ID; group 2 the optional embedded label. Labeled
+	// forms are normalized to "@label"; bare forms resolve through the
+	// caller's workspace-scoped usergroup map.
+	subteamMentionRe = regexp.MustCompile(`<!subteam\^([A-Z0-9]+)(?:\|([^>]+))?>`)
 	broadcastRe      = regexp.MustCompile(`<!(here|channel|everyone)>`)
 	// Match both http(s) URLs and mailto: addresses; Slack
 	// auto-linkifies typed emails into <mailto:X|X>. Bare-link
@@ -100,6 +104,12 @@ var (
 // a user ID is missing from the map (or the map is nil) the raw user ID is
 // used as a fallback. Output is truncated to 100 characters with "..." suffix.
 func StripSlackMarkup(text string, userNames map[string]string) string {
+	return StripSlackMarkupWithUserGroups(text, userNames, nil)
+}
+
+// StripSlackMarkupWithUserGroups is StripSlackMarkup with a workspace-scoped
+// Slack usergroup map for resolving bare <!subteam^SID> tokens.
+func StripSlackMarkupWithUserGroups(text string, userNames map[string]string, userGroups map[string]string) string {
 	text = channelMentionRe.ReplaceAllString(text, "#$1")
 	text = linkWithLabelRe.ReplaceAllString(text, "$2")
 	// Bare links: drop the mailto: scheme so notification bodies read
@@ -108,7 +118,10 @@ func StripSlackMarkup(text string, userNames map[string]string) string {
 		url := linkBareRe.FindStringSubmatch(match)[1]
 		return strings.TrimPrefix(url, "mailto:")
 	})
-	text = subteamMentionRe.ReplaceAllString(text, "$1")
+	text = subteamMentionRe.ReplaceAllStringFunc(text, func(match string) string {
+		groups := subteamMentionRe.FindStringSubmatch(match)
+		return usergroups.Display(userGroups, groups[1], groups[2])
+	})
 	text = broadcastRe.ReplaceAllString(text, "@$1")
 	text = userMentionRe.ReplaceAllStringFunc(text, func(match string) string {
 		userID := userMentionRe.FindStringSubmatch(match)[1]

--- a/internal/notify/notifier_usergroup_test.go
+++ b/internal/notify/notifier_usergroup_test.go
@@ -1,0 +1,28 @@
+package notify
+
+import "testing"
+
+func TestStripSlackMarkupBareSubteamResolved(t *testing.T) {
+	got := StripSlackMarkupWithUserGroups(
+		"dear <!subteam^S0TESTGRP01> hello",
+		nil,
+		map[string]string{"S0TESTGRP01": "platform-team"},
+	)
+	if got != "dear @platform-team hello" {
+		t.Errorf("StripSlackMarkupWithUserGroups = %q; want %q", got, "dear @platform-team hello")
+	}
+}
+
+func TestStripSlackMarkupBareSubteamUnresolved(t *testing.T) {
+	got := StripSlackMarkupWithUserGroups("dear <!subteam^S0MISSING> hello", nil, nil)
+	if got != "dear @group hello" {
+		t.Errorf("StripSlackMarkupWithUserGroups = %q; want %q", got, "dear @group hello")
+	}
+}
+
+func TestStripSlackMarkupSubteamLabelWithoutAt(t *testing.T) {
+	got := StripSlackMarkupWithUserGroups("dear <!subteam^S123|eng> hello", nil, nil)
+	if got != "dear @eng hello" {
+		t.Errorf("StripSlackMarkupWithUserGroups = %q; want %q", got, "dear @eng hello")
+	}
+}

--- a/internal/slack/client.go
+++ b/internal/slack/client.go
@@ -28,6 +28,7 @@ type SlackAPI interface {
 	GetConversationReplies(params *slack.GetConversationRepliesParameters) ([]slack.Message, bool, string, error)
 	SearchMessagesContext(ctx context.Context, query string, params slack.SearchParameters) (*slack.SearchMessages, error)
 	GetUsersContext(ctx context.Context, options ...slack.GetUsersOption) ([]slack.User, error)
+	GetUserGroupsContext(ctx context.Context, options ...slack.GetUserGroupsOption) ([]slack.UserGroup, error)
 	GetUsersInConversationContext(ctx context.Context, params *slack.GetUsersInConversationParameters) ([]string, string, error)
 	GetUserInfo(user string) (*slack.User, error)
 	GetBotInfoContext(ctx context.Context, parameters slack.GetBotInfoParameters) (*slack.Bot, error)
@@ -729,6 +730,16 @@ func (c *Client) GetUsers(ctx context.Context) ([]slack.User, error) {
 		return nil, fmt.Errorf("getting users: %w", err)
 	}
 	return users, nil
+}
+
+// GetUserGroups retrieves the workspace's usergroups (the @team
+// handles behind <!subteam^S…> mentions) via usergroups.list.
+func (c *Client) GetUserGroups(ctx context.Context) ([]slack.UserGroup, error) {
+	groups, err := c.api.GetUserGroupsContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getting usergroups: %w", err)
+	}
+	return groups, nil
 }
 
 // ListCustomEmoji fetches the workspace's custom emoji list via Slack's

--- a/internal/slack/client_test.go
+++ b/internal/slack/client_test.go
@@ -150,6 +150,14 @@ type mockSlackAPI struct {
 	getUsersInConversationContextFn func(ctx context.Context, params *slack.GetUsersInConversationParameters) ([]string, string, error)
 	openConversationContextFn       func(ctx context.Context, params *slack.OpenConversationParameters) (*slack.Channel, bool, bool, error)
 	searchMessagesFn                func(ctx context.Context, query string, params slack.SearchParameters) (*slack.SearchMessages, error)
+	getUserGroupsContextFn          func(ctx context.Context, options ...slack.GetUserGroupsOption) ([]slack.UserGroup, error)
+}
+
+func (m *mockSlackAPI) GetUserGroupsContext(ctx context.Context, options ...slack.GetUserGroupsOption) ([]slack.UserGroup, error) {
+	if m.getUserGroupsContextFn != nil {
+		return m.getUserGroupsContextFn(ctx, options...)
+	}
+	return nil, nil
 }
 
 func (m *mockSlackAPI) SearchMessagesContext(ctx context.Context, query string, params slack.SearchParameters) (*slack.SearchMessages, error) {

--- a/internal/slack/usergroups_test.go
+++ b/internal/slack/usergroups_test.go
@@ -1,0 +1,41 @@
+package slackclient
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/slack-go/slack"
+)
+
+func TestGetUserGroups(t *testing.T) {
+	mock := &mockSlackAPI{
+		getUserGroupsContextFn: func(ctx context.Context, options ...slack.GetUserGroupsOption) ([]slack.UserGroup, error) {
+			return []slack.UserGroup{
+				{ID: "S0TESTGRP01", Handle: "platform-team", Name: "Platform Team"},
+			}, nil
+		},
+	}
+	c := &Client{api: mock}
+
+	groups, err := c.GetUserGroups(context.Background())
+	if err != nil {
+		t.Fatalf("GetUserGroups: %v", err)
+	}
+	if len(groups) != 1 || groups[0].Handle != "platform-team" {
+		t.Errorf("groups = %+v; want one group with handle platform-team", groups)
+	}
+}
+
+func TestGetUserGroupsError(t *testing.T) {
+	mock := &mockSlackAPI{
+		getUserGroupsContextFn: func(ctx context.Context, options ...slack.GetUserGroupsOption) ([]slack.UserGroup, error) {
+			return nil, errors.New("missing_scope")
+		},
+	}
+	c := &Client{api: mock}
+
+	if _, err := c.GetUserGroups(context.Background()); err == nil {
+		t.Error("expected error to propagate")
+	}
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -50,6 +50,7 @@ import (
 	"github.com/gammons/slk/internal/ui/wintree"
 	"github.com/gammons/slk/internal/ui/workspace"
 	"github.com/gammons/slk/internal/ui/workspacefinder"
+	"github.com/gammons/slk/internal/usergroups"
 	"golang.design/x/clipboard"
 )
 
@@ -211,6 +212,7 @@ type App struct {
 	emojiCtx     messages.EmojiContext
 	emojiCustoms map[string]string
 	channelNames map[string]string
+	userGroups   map[string]string
 
 	// externalUsers tracks which user IDs are Slack Connect / shared-channel
 	// guests. Populated by main.go via SetExternalUsers as users are
@@ -2238,6 +2240,19 @@ func (a *App) SetUserNames(names map[string]string) {
 	}
 	a.compose.SetUsers(users)
 	a.threadCompose.SetUsers(users)
+}
+
+// SetUserGroups passes the active workspace's usergroup map to every
+// surface that renders, previews, or composes usergroup mentions.
+func (a *App) SetUserGroups(groups map[string]string) {
+	a.userGroups = usergroups.Copy(groups)
+	a.threadsView.SetUserGroups(a.userGroups)
+	for _, m := range a.allWinModels() {
+		m.SetUserGroups(a.userGroups)
+	}
+	a.threadPanel.SetUserGroups(a.userGroups)
+	a.compose.SetUserGroups(a.userGroups)
+	a.threadCompose.SetUserGroups(a.userGroups)
 }
 
 // seedNewMessagePicker snapshots the current workspace's user list

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -3894,6 +3894,53 @@ func TestUserResolvedMsg_DropsForOtherWorkspace(t *testing.T) {
 	}
 }
 
+func TestUserGroupsLoadedMsgPatchesActiveWorkspace(t *testing.T) {
+	app := NewApp()
+	app.activeTeamID = "T1"
+	app.messagepane.SetMessages([]messages.MessageItem{
+		{TS: "1.0", UserID: "U1", UserName: "alice", Text: "ping <!subteam^S0TESTGRP01>"},
+	})
+	messageVersion := app.messagepane.Version()
+	threadVersion := app.threadPanel.Version()
+
+	app.Update(UserGroupsLoadedMsg{
+		TeamID:     "T1",
+		UserGroups: map[string]string{"S0TESTGRP01": "platform-team"},
+	})
+
+	found := false
+	for _, u := range app.compose.MentionUsers() {
+		if u.ID == "usergroup:S0TESTGRP01" && u.DisplayName == "platform-team" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("active workspace usergroup missing from compose picker: %+v", app.compose.MentionUsers())
+	}
+	if app.messagepane.Version() == messageVersion {
+		t.Error("message pane version did not change after active usergroups loaded")
+	}
+	if app.threadPanel.Version() == threadVersion {
+		t.Error("thread panel version did not change after active usergroups loaded")
+	}
+}
+
+func TestUserGroupsLoadedMsgDropsOtherWorkspace(t *testing.T) {
+	app := NewApp()
+	app.activeTeamID = "T1"
+
+	app.Update(UserGroupsLoadedMsg{
+		TeamID:     "T-other",
+		UserGroups: map[string]string{"S0TESTGRP01": "side-team"},
+	})
+
+	for _, u := range app.compose.MentionUsers() {
+		if u.ID == "usergroup:S0TESTGRP01" {
+			t.Fatalf("inactive workspace usergroup leaked into compose picker: %+v", app.compose.MentionUsers())
+		}
+	}
+}
+
 func TestUserExternalMsgFlagsPickerEntry(t *testing.T) {
 	app := NewApp()
 	app.activeTeamID = "T1"

--- a/internal/ui/compose/model.go
+++ b/internal/ui/compose/model.go
@@ -893,24 +893,33 @@ func (m *Model) CloseMention() {
 func (m Model) TranslateMentionsForSend(text string) string {
 	// trigger is the leading character ('@' for users/specials, '#' for
 	// channels); name is what follows; replacement is the wire form.
+	// rank breaks ties when two kinds of mention share a name (a user
+	// and a usergroup can both be "@design") -- lower wins.
 	type entry struct {
 		trigger     byte
 		name        string
 		replacement string
+		rank        int
 	}
+	const (
+		rankSpecial = iota
+		rankUser
+		rankUserGroup
+		rankChannel
+	)
 
 	var entries []entry
 
 	// Special @ mentions
 	entries = append(entries,
-		entry{'@', "here", "<!here>"},
-		entry{'@', "channel", "<!channel>"},
-		entry{'@', "everyone", "<!everyone>"},
+		entry{'@', "here", "<!here>", rankSpecial},
+		entry{'@', "channel", "<!channel>", rankSpecial},
+		entry{'@', "everyone", "<!everyone>", rankSpecial},
 	)
 
 	// User mentions
 	for name, userID := range m.reverseNames {
-		entries = append(entries, entry{'@', name, "<@" + userID + ">"})
+		entries = append(entries, entry{'@', name, "<@" + userID + ">", rankUser})
 	}
 
 	// Usergroup mentions. Like channels below, we emit the labeled
@@ -918,7 +927,7 @@ func (m Model) TranslateMentionsForSend(text string) string {
 	// echo renders the handle even if the server echo arrives before
 	// usergroups.list refreshes this workspace's map.
 	for id, handle := range m.userGroups {
-		entries = append(entries, entry{'@', handle, "<!subteam^" + id + "|@" + handle + ">"})
+		entries = append(entries, entry{'@', handle, "<!subteam^" + id + "|@" + handle + ">", rankUserGroup})
 	}
 
 	// Channel mentions. We emit <#CHANNELID|name> rather than the
@@ -929,7 +938,7 @@ func (m Model) TranslateMentionsForSend(text string) string {
 	// Slack accepts both forms on the wire and normalizes echoes
 	// to the |name form anyway.
 	for name, channelID := range m.reverseChannels {
-		entries = append(entries, entry{'#', name, "<#" + channelID + "|" + name + ">"})
+		entries = append(entries, entry{'#', name, "<#" + channelID + "|" + name + ">", rankChannel})
 	}
 
 	// Sort by name length descending. This lives across both trigger
@@ -937,8 +946,27 @@ func (m Model) TranslateMentionsForSend(text string) string {
 	// the loop below builds the search needle as trigger+name, so a
 	// longer @name still won't collide with a shorter #name even when
 	// they share the same suffix.
+	//
+	// sort.Slice is unstable and the entries above come out of map
+	// iteration, so equal-length names need an explicit tie-break or
+	// the same text translates to different wire forms run to run.
+	// Earlier entries win: the loop below rewrites every occurrence, so
+	// by the time a later entry with the same name is tried, the text
+	// no longer contains it. Precedence is rank (a name shared by a
+	// person and a usergroup resolves to the person), then name, then
+	// replacement to settle same-rank duplicates.
 	sort.Slice(entries, func(i, j int) bool {
-		return len(entries[i].name) > len(entries[j].name)
+		a, b := entries[i], entries[j]
+		if len(a.name) != len(b.name) {
+			return len(a.name) > len(b.name)
+		}
+		if a.rank != b.rank {
+			return a.rank < b.rank
+		}
+		if a.name != b.name {
+			return a.name < b.name
+		}
+		return a.replacement < b.replacement
 	})
 
 	for _, e := range entries {

--- a/internal/ui/compose/model.go
+++ b/internal/ui/compose/model.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gammons/slk/internal/ui/emojipicker"
 	"github.com/gammons/slk/internal/ui/mentionpicker"
 	"github.com/gammons/slk/internal/ui/styles"
+	"github.com/gammons/slk/internal/usergroups"
 )
 
 // PendingAttachment is a file (or in-memory image) waiting to be
@@ -40,6 +41,7 @@ type Model struct {
 	mentionStartCol int // cursor column where @ was typed
 	users           []mentionpicker.User
 	reverseNames    map[string]string // displayName -> userID
+	userGroups      map[string]string // usergroup ID -> handle for active workspace
 
 	// activeChannelID is the channel currently shown in the messages
 	// pane. Drives the InChannel computation when rebuilding the
@@ -447,6 +449,11 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			if atPos == 0 || val[atPos-1] == ' ' || val[atPos-1] == '\n' {
 				m.mentionActive = true
 				m.mentionStartCol = cursorAbsPos // cursor is after the @
+				// Rebuild on open so usergroup entries reflect the
+				// registry's current contents — the background
+				// usergroups.list fetch may have landed after the
+				// last SetUsers/SetActiveChannel rebuild.
+				m.rebuildMentionUsers()
 				m.mentionPicker.Open()
 			}
 		}
@@ -768,6 +775,13 @@ func (m *Model) SetUsers(users []mentionpicker.User) {
 	m.rebuildMentionUsers()
 }
 
+// SetUserGroups provides the active workspace's Slack usergroups for
+// @handle autocomplete and send-time <!subteam^SID|@handle> translation.
+func (m *Model) SetUserGroups(groups map[string]string) {
+	m.userGroups = usergroups.Copy(groups)
+	m.rebuildMentionUsers()
+}
+
 // SetActiveChannel tells the compose model which channel context to
 // use when computing InChannel for the mention picker. Called from
 // App on every ChannelSelectedMsg. Idempotent: a no-op if the channel
@@ -841,6 +855,21 @@ func (m *Model) rebuildMentionUsers() {
 		u.InChannel = inCh
 		derived = append(derived, u)
 	}
+	// Usergroups (@backend-team etc.) come from the active workspace's
+	// usergroup map rather than m.users: they aren't channel members,
+	// and pinging one is channel-agnostic, so they bypass the membership
+	// filter and always rank in the in-channel tier. The "usergroup:"
+	// ID prefix keeps them out of the <@UID> translation path —
+	// TranslateMentionsForSend maps their handle via m.userGroups
+	// instead.
+	for id, handle := range m.userGroups {
+		derived = append(derived, mentionpicker.User{
+			ID:          "usergroup:" + id,
+			DisplayName: handle,
+			Username:    handle,
+			InChannel:   true,
+		})
+	}
 	m.mentionPicker.SetUsers(derived)
 }
 
@@ -882,6 +911,14 @@ func (m Model) TranslateMentionsForSend(text string) string {
 	// User mentions
 	for name, userID := range m.reverseNames {
 		entries = append(entries, entry{'@', name, "<@" + userID + ">"})
+	}
+
+	// Usergroup mentions. Like channels below, we emit the labeled
+	// wire form <!subteam^SID|@handle> so the optimistically-added
+	// echo renders the handle even if the server echo arrives before
+	// usergroups.list refreshes this workspace's map.
+	for id, handle := range m.userGroups {
+		entries = append(entries, entry{'@', handle, "<!subteam^" + id + "|@" + handle + ">"})
 	}
 
 	// Channel mentions. We emit <#CHANNELID|name> rather than the

--- a/internal/ui/compose/usergroup_test.go
+++ b/internal/ui/compose/usergroup_test.go
@@ -1,0 +1,101 @@
+package compose
+
+import (
+	"testing"
+
+	"github.com/gammons/slk/internal/ui/mentionpicker"
+)
+
+// Usergroup mentions: the per-workspace usergroup map feeds both the
+// send-time translation (@handle -> <!subteam^SID|@handle>) and the
+// mention picker's group entries.
+
+func TestTranslateUsergroupMentionForSend(t *testing.T) {
+	m := New("general")
+	m.SetUserGroups(map[string]string{"S0TESTGRP01": "platform-team"})
+	m.SetUsers([]mentionpicker.User{
+		{ID: "U1234", DisplayName: "Alice", Username: "alice"},
+	})
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"hey @platform-team look", "hey <!subteam^S0TESTGRP01|@platform-team> look"},
+		{"@platform-team and @Alice", "<!subteam^S0TESTGRP01|@platform-team> and <@U1234>"},
+		// Word boundary: a longer non-group word must not match.
+		{"@platform-teammates hi", "@platform-teammates hi"},
+	}
+	for _, tt := range tests {
+		result := m.TranslateMentionsForSend(tt.input)
+		if result != tt.expected {
+			t.Errorf("TranslateMentionsForSend(%q) = %q, want %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+func TestUsergroupsAreScopedPerComposeModel(t *testing.T) {
+	work := New("general")
+	work.SetUserGroups(map[string]string{"S0TESTGRP01": "work-team"})
+	side := New("general")
+	side.SetUserGroups(map[string]string{"S0TESTGRP01": "side-team"})
+
+	workOut := work.TranslateMentionsForSend("ping @work-team")
+	sideOut := side.TranslateMentionsForSend("ping @side-team")
+
+	if workOut != "ping <!subteam^S0TESTGRP01|@work-team>" {
+		t.Errorf("work TranslateMentionsForSend = %q", workOut)
+	}
+	if sideOut != "ping <!subteam^S0TESTGRP01|@side-team>" {
+		t.Errorf("side TranslateMentionsForSend = %q", sideOut)
+	}
+	if got := work.TranslateMentionsForSend("ping @side-team"); got != "ping @side-team" {
+		t.Errorf("work model translated side workspace group: %q", got)
+	}
+}
+
+func TestMentionPickerIncludesUsergroups(t *testing.T) {
+	m := New("general")
+	m.SetUserGroups(map[string]string{"S0AB12CD3": "backend"})
+	m.SetUsers([]mentionpicker.User{
+		{ID: "U1234", DisplayName: "Alice", Username: "alice"},
+	})
+
+	found := false
+	for _, u := range m.MentionUsers() {
+		if u.ID == "usergroup:S0AB12CD3" {
+			found = true
+			if u.DisplayName != "backend" {
+				t.Errorf("group DisplayName = %q, want %q", u.DisplayName, "backend")
+			}
+			if !u.InChannel {
+				t.Error("group entry should have InChannel=true")
+			}
+		}
+	}
+	if !found {
+		t.Errorf("mention picker missing usergroup entry; got %+v", m.MentionUsers())
+	}
+}
+
+// Groups must survive channel-membership filtering: they are not
+// members of any channel, but pinging them is channel-agnostic.
+func TestMentionPickerKeepsGroupsWithMembershipLoaded(t *testing.T) {
+	m := New("general")
+	m.SetUserGroups(map[string]string{"S0AB12CD3": "backend"})
+	m.SetActiveChannel("C1")
+	m.SetUsers([]mentionpicker.User{
+		{ID: "U1234", DisplayName: "Alice", Username: "alice"},
+	})
+	m.SetChannelMembership("C1", []string{"U1234"})
+
+	for _, u := range m.MentionUsers() {
+		if u.ID == "usergroup:S0AB12CD3" {
+			if !u.InChannel {
+				t.Error("group entry should stay InChannel=true under membership filtering")
+			}
+			return
+		}
+	}
+	t.Errorf("usergroup entry dropped by membership filtering; got %+v", m.MentionUsers())
+}

--- a/internal/ui/compose/usergroup_test.go
+++ b/internal/ui/compose/usergroup_test.go
@@ -34,6 +34,27 @@ func TestTranslateUsergroupMentionForSend(t *testing.T) {
 	}
 }
 
+// A user and a usergroup can share a name. The entry sort must resolve
+// the collision the same way on every call -- sort.Slice is unstable and
+// the entries come out of map iteration, so an unbroken tie would pick a
+// different wire form run to run.
+func TestTranslateMentionsForSendResolvesNameCollisionDeterministically(t *testing.T) {
+	m := New("general")
+	m.SetUserGroups(map[string]string{"S0TESTGRP01": "design"})
+	m.SetUsers([]mentionpicker.User{
+		{ID: "U1234", DisplayName: "design", Username: "design"},
+	})
+
+	// The person wins: a name that resolves to a human should not ping
+	// a whole group.
+	const want = "ping <@U1234>"
+	for i := 0; i < 50; i++ {
+		if got := m.TranslateMentionsForSend("ping @design"); got != want {
+			t.Fatalf("iteration %d: TranslateMentionsForSend = %q, want %q", i, got, want)
+		}
+	}
+}
+
 func TestUsergroupsAreScopedPerComposeModel(t *testing.T) {
 	work := New("general")
 	work.SetUserGroups(map[string]string{"S0TESTGRP01": "work-team"})

--- a/internal/ui/messages/flatten.go
+++ b/internal/ui/messages/flatten.go
@@ -3,6 +3,8 @@ package messages
 import (
 	"regexp"
 	"strings"
+
+	"github.com/gammons/slk/internal/usergroups"
 )
 
 // Regexes for the entity forms FlattenMrkdwn handles beyond the shared
@@ -14,10 +16,19 @@ var (
 	userMentionWithLabelRe = regexp.MustCompile(`<@([A-Z0-9]+)\|([^>]+)>`)
 	specialMentionRe       = regexp.MustCompile(`<!(here|channel|everyone)(?:\|[^>]*)?>`)
 	// Usergroup mentions: <!subteam^SID|@label> or bare <!subteam^SID>.
-	// Group 1 is the optional label (conventionally already "@"-prefixed
-	// on the wire, but not guaranteed).
-	usergroupMentionRe = regexp.MustCompile(`<!subteam\^[A-Z0-9]+(?:\|([^>]+))?>`)
+	// Group 1 is the ID; group 2 is the optional label (conventionally
+	// already "@"-prefixed on the wire, but not guaranteed).
+	usergroupMentionRe = regexp.MustCompile(`<!subteam\^([A-Z0-9]+)(?:\|([^>]+))?>`)
 )
+
+// usergroupDisplay returns the "@handle" display text for a subteam
+// token. The embedded label wins when present; bare tokens resolve
+// through the provided workspace-scoped usergroup map; unresolvable IDs
+// fall back to a generic "@group" rather than leaking the raw
+// <!subteam^S...> wire form.
+func usergroupDisplay(groups map[string]string, id, label string) string {
+	return usergroups.Display(groups, id, label)
+}
 
 // FlattenMrkdwn converts Slack mrkdwn entity tokens into plain text for
 // single-style contexts (e.g. search-result snippets) where the styled
@@ -36,6 +47,12 @@ var (
 //
 // Either resolver may be nil; unknown IDs fall back to the raw ID.
 func FlattenMrkdwn(text string, resolveUser, resolveChannel func(id string) (string, bool)) string {
+	return FlattenMrkdwnWithUserGroups(text, resolveUser, resolveChannel, nil)
+}
+
+// FlattenMrkdwnWithUserGroups is FlattenMrkdwn with a workspace-scoped
+// Slack usergroup map for resolving bare <!subteam^SID> tokens.
+func FlattenMrkdwnWithUserGroups(text string, resolveUser, resolveChannel func(id string) (string, bool), userGroups map[string]string) string {
 	// Date tokens first: their payload never contains other entity
 	// forms, and handling them up front keeps specialMentionRe from
 	// having to exclude `<!date...>`.
@@ -85,14 +102,8 @@ func FlattenMrkdwn(text string, resolveUser, resolveChannel func(id string) (str
 	})
 
 	text = usergroupMentionRe.ReplaceAllStringFunc(text, func(match string) string {
-		label := usergroupMentionRe.FindStringSubmatch(match)[1]
-		if label == "" {
-			// Bare token: there's no local usergroup cache to resolve
-			// SIDs against, so a generic placeholder beats leaking the
-			// raw <!subteam^S...> wire form into a snippet.
-			return "@group"
-		}
-		return "@" + strings.TrimPrefix(label, "@")
+		groups := usergroupMentionRe.FindStringSubmatch(match)
+		return usergroupDisplay(userGroups, groups[1], groups[2])
 	})
 
 	// Wire-format escapes, decoded last so they can't be reinterpreted

--- a/internal/ui/messages/model.go
+++ b/internal/ui/messages/model.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gammons/slk/internal/ui/scrollbar"
 	"github.com/gammons/slk/internal/ui/selection"
 	"github.com/gammons/slk/internal/ui/styles"
+	"github.com/gammons/slk/internal/usergroups"
 )
 
 type MessageItem struct {
@@ -231,6 +232,7 @@ type Model struct {
 	avatarFn     AvatarFunc        // optional: returns half-block avatar for a userID
 	userNames    map[string]string // user ID -> display name for mention resolution
 	channelNames map[string]string // channel ID -> name for bare <#CID> resolution
+	userGroups   map[string]string // usergroup ID -> handle for bare subteam resolution
 
 	// searchTerms are folded word-prefix terms of the active in-channel
 	// search; non-empty enables highlight rendering. nil = no search.
@@ -1369,6 +1371,14 @@ func (m *Model) SetChannelNames(names map[string]string) {
 	m.dirty()
 }
 
+// SetUserGroups sets the workspace-scoped usergroup ID -> handle map used
+// to resolve bare <!subteam^SID> mentions.
+func (m *Model) SetUserGroups(groups map[string]string) {
+	m.userGroups = usergroups.Copy(groups)
+	m.cache = nil
+	m.dirty()
+}
+
 // EmojiContext bundles the emoji-image rendering dependencies. Held
 // by the Model and threaded through RenderSlackMarkdownWith when
 // building each message's body and reaction pills.
@@ -1857,6 +1867,7 @@ func (m *Model) blockkitContext(msg MessageItem, userNames, channelNames map[str
 			return RenderSlackMarkdownWith(s, RenderSlackMarkdownOpts{
 				UserNames:    un,
 				ChannelNames: channelNames,
+				UserGroups:   m.userGroups,
 				PlaceCtx:     m.emojiCtx.PlaceCtx,
 				EmojiCells:   m.emojiCtx.Cells,
 				Customs:      m.emojiCtx.Customs,
@@ -1914,6 +1925,7 @@ func (m *Model) renderMessagePlain(msg MessageItem, width int, avatarStr string,
 	bodyOpts := RenderSlackMarkdownOpts{
 		UserNames:    userNames,
 		ChannelNames: channelNames,
+		UserGroups:   m.userGroups,
 		PlaceCtx:     m.emojiCtx.PlaceCtx,
 		EmojiCells:   m.emojiCtx.Cells,
 		Customs:      m.emojiCtx.Customs,

--- a/internal/ui/messages/model.go
+++ b/internal/ui/messages/model.go
@@ -1372,8 +1372,13 @@ func (m *Model) SetChannelNames(names map[string]string) {
 }
 
 // SetUserGroups sets the workspace-scoped usergroup ID -> handle map used
-// to resolve bare <!subteam^SID> mentions.
+// to resolve bare <!subteam^SID> mentions. No-op when the new map matches
+// the current one -- App.SetUserGroups fires on every workspace switch,
+// and busting the render cache for an identical set is pure waste.
 func (m *Model) SetUserGroups(groups map[string]string) {
+	if usergroups.Equal(m.userGroups, groups) {
+		return
+	}
 	m.userGroups = usergroups.Copy(groups)
 	m.cache = nil
 	m.dirty()

--- a/internal/ui/messages/render.go
+++ b/internal/ui/messages/render.go
@@ -750,6 +750,15 @@ func renderInlineFormattingWith(text string, opts RenderSlackMarkdownOpts) strin
 		return mentionStyle().Render(usergroupDisplay(opts.UserGroups, groups[1], groups[2]))
 	})
 
+	// Broadcast mentions: <!here> / <!channel> / <!everyone> (labels,
+	// when present, duplicate the keyword and are dropped) -> styled
+	// @here / @channel / @everyone. Shares specialMentionRe with
+	// FlattenMrkdwn (flatten.go). Runs after the date and subteam
+	// passes so their `<!...>` forms are already consumed.
+	text = specialMentionRe.ReplaceAllStringFunc(text, func(match string) string {
+		return mentionStyle().Render("@" + specialMentionRe.FindStringSubmatch(match)[1])
+	})
+
 	// Channel mentions: <#C1234|channel-name> -> #channel-name, or
 	// <#C1234> -> #resolved-name (via channelNames map). When the
 	// channel can't be resolved we render "#unknown" so the user sees
@@ -967,6 +976,10 @@ func slackMrkdwnToCommonMarkInline(text string, userNames map[string]string, cha
 	text = usergroupMentionRe.ReplaceAllStringFunc(text, func(match string) string {
 		groups := usergroupMentionRe.FindStringSubmatch(match)
 		return usergroupDisplay(userGroups, groups[1], groups[2])
+	})
+
+	text = specialMentionRe.ReplaceAllStringFunc(text, func(match string) string {
+		return "@" + specialMentionRe.FindStringSubmatch(match)[1]
 	})
 
 	text = resolveShortcodesCommonMark(emojiutil.StripSkinToneFromText(text))

--- a/internal/ui/messages/render.go
+++ b/internal/ui/messages/render.go
@@ -615,6 +615,7 @@ func SidebarMutedFgANSI() string {
 type RenderSlackMarkdownOpts struct {
 	UserNames    map[string]string
 	ChannelNames map[string]string
+	UserGroups   map[string]string
 
 	// Emoji-image opts (zero values disable the image path).
 	PlaceCtx     emojiutil.PlaceContext
@@ -740,6 +741,15 @@ func renderInlineFormattingWith(text string, opts RenderSlackMarkdownOpts) strin
 		return dateTokenRe.FindStringSubmatch(match)[1]
 	})
 
+	// Usergroup mentions: <!subteam^SID|@label> -> @label, or bare
+	// <!subteam^SID> -> @handle via the workspace-scoped usergroup map
+	// (fallback "@group"). Shares usergroupMentionRe / usergroupDisplay
+	// with FlattenMrkdwn (flatten.go).
+	text = usergroupMentionRe.ReplaceAllStringFunc(text, func(match string) string {
+		groups := usergroupMentionRe.FindStringSubmatch(match)
+		return mentionStyle().Render(usergroupDisplay(opts.UserGroups, groups[1], groups[2]))
+	})
+
 	// Channel mentions: <#C1234|channel-name> -> #channel-name, or
 	// <#C1234> -> #resolved-name (via channelNames map). When the
 	// channel can't be resolved we render "#unknown" so the user sees
@@ -853,6 +863,12 @@ func renderEmojiTokensInline(
 // markdown. It is the plain-text sibling of RenderSlackMarkdown: same input
 // format, but the output is CommonMark rather than lipgloss-styled ANSI.
 func SlackMrkdwnToCommonMark(text string, userNames map[string]string, channelNames map[string]string) string {
+	return SlackMrkdwnToCommonMarkWithUserGroups(text, userNames, channelNames, nil)
+}
+
+// SlackMrkdwnToCommonMarkWithUserGroups is SlackMrkdwnToCommonMark with
+// a workspace-scoped Slack usergroup map for resolving bare subteam IDs.
+func SlackMrkdwnToCommonMarkWithUserGroups(text string, userNames map[string]string, channelNames map[string]string, userGroups map[string]string) string {
 	// Protect code blocks: extract, convert, and replace with placeholders.
 	var codeBlocks []string
 	text = codeBlockRe.ReplaceAllStringFunc(text, func(match string) string {
@@ -881,7 +897,7 @@ func SlackMrkdwnToCommonMark(text string, userNames map[string]string, channelNa
 			quoted = slackEntityDecoder.Replace(quoted)
 			line = "> " + quoted
 		} else {
-			line = slackMrkdwnToCommonMarkInline(line, userNames, channelNames)
+			line = slackMrkdwnToCommonMarkInline(line, userNames, channelNames, userGroups)
 			line = slackEntityDecoder.Replace(line)
 		}
 		result = append(result, line)
@@ -903,7 +919,7 @@ func SlackMrkdwnToCommonMark(text string, userNames map[string]string, channelNa
 
 // slackMrkdwnToCommonMarkInline converts inline Slack formatting tokens
 // to their CommonMark equivalents without any ANSI styling.
-func slackMrkdwnToCommonMarkInline(text string, userNames map[string]string, channelNames map[string]string) string {
+func slackMrkdwnToCommonMarkInline(text string, userNames map[string]string, channelNames map[string]string, userGroups map[string]string) string {
 	text = boldRe.ReplaceAllString(text, "**$1**")
 
 	text = strikethroughRe.ReplaceAllString(text, "~~$1~~")
@@ -946,6 +962,11 @@ func slackMrkdwnToCommonMarkInline(text string, userNames map[string]string, cha
 			}
 		}
 		return "@" + name
+	})
+
+	text = usergroupMentionRe.ReplaceAllStringFunc(text, func(match string) string {
+		groups := usergroupMentionRe.FindStringSubmatch(match)
+		return usergroupDisplay(userGroups, groups[1], groups[2])
 	})
 
 	text = resolveShortcodesCommonMark(emojiutil.StripSkinToneFromText(text))

--- a/internal/ui/messages/render_broadcast_test.go
+++ b/internal/ui/messages/render_broadcast_test.go
@@ -1,0 +1,42 @@
+package messages
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// Broadcast mentions (<!here>, <!channel>, <!everyone>, optionally
+// labeled <!channel|@channel>) must render as @here/@channel/@everyone
+// in the styled message view and the CommonMark export — the snippet
+// flattener and notifications already handle them; the raw wire token
+// must never leak into the message pane.
+
+func TestRenderBroadcastMentions(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"<!channel> Team support this week", "@channel Team support this week"},
+		{"heads up <!here> now", "heads up @here now"},
+		{"<!everyone> announcement", "@everyone announcement"},
+		{"labeled <!channel|@channel> form", "labeled @channel form"},
+	}
+	for _, tc := range cases {
+		out := ansi.Strip(RenderSlackMarkdown(tc.in, nil, nil))
+		if !strings.Contains(out, tc.want) {
+			t.Errorf("RenderSlackMarkdown(%q) = %q, want to contain %q", tc.in, out, tc.want)
+		}
+		if strings.Contains(out, "<!") {
+			t.Errorf("raw broadcast token leaked: %q", out)
+		}
+	}
+}
+
+func TestCommonMarkBroadcastMentions(t *testing.T) {
+	out := SlackMrkdwnToCommonMark("<!channel> support this week by <!here>", nil, nil)
+	if out != "@channel support this week by @here" {
+		t.Errorf("SlackMrkdwnToCommonMark = %q, want %q", out, "@channel support this week by @here")
+	}
+}

--- a/internal/ui/messages/render_usergroup_test.go
+++ b/internal/ui/messages/render_usergroup_test.go
@@ -96,3 +96,21 @@ func TestFlattenUsergroupBareResolved(t *testing.T) {
 		t.Errorf("FlattenMrkdwnWithUserGroups = %q; want %q", out, "ping @backend please")
 	}
 }
+
+// App.SetUserGroups fires on every workspace switch, so an unchanged
+// map must not bust the render cache.
+func TestSetUserGroupsSkipsCacheBustWhenUnchanged(t *testing.T) {
+	m := New(nil, "general")
+	m.SetUserGroups(map[string]string{"S1": "platform-team"})
+	m.cache = []viewEntry{{}}
+
+	m.SetUserGroups(map[string]string{"S1": "platform-team"})
+	if m.cache == nil {
+		t.Error("identical usergroup map busted the render cache")
+	}
+
+	m.SetUserGroups(map[string]string{"S1": "platform-team", "S2": "design"})
+	if m.cache != nil {
+		t.Error("changed usergroup map left a stale render cache")
+	}
+}

--- a/internal/ui/messages/render_usergroup_test.go
+++ b/internal/ui/messages/render_usergroup_test.go
@@ -1,0 +1,98 @@
+package messages
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// Usergroup mentions arrive as <!subteam^SID|@label> (labeled) or
+// <!subteam^SID> (bare). The renderer must never leak the raw wire
+// token: labeled forms use the embedded label, bare forms resolve
+// through the per-workspace usergroup map, and unresolvable bare forms
+// fall back to a generic "@group".
+
+func TestRenderUsergroupMentionLabeled(t *testing.T) {
+	out := ansi.Strip(RenderSlackMarkdown("ping <!subteam^S123|@team> please", nil, nil))
+	if !strings.Contains(out, "@team") {
+		t.Errorf("expected @team in output, got %q", out)
+	}
+	if strings.Contains(out, "<!subteam") {
+		t.Errorf("raw subteam token leaked: %q", out)
+	}
+}
+
+func TestRenderUsergroupMentionBareResolved(t *testing.T) {
+	out := ansi.Strip(RenderSlackMarkdownWith("dear <!subteam^S0TESTGRP01> hello", RenderSlackMarkdownOpts{
+		UserGroups: map[string]string{"S0TESTGRP01": "platform-team"},
+	}))
+	if !strings.Contains(out, "@platform-team") {
+		t.Errorf("expected @platform-team in output, got %q", out)
+	}
+	if strings.Contains(out, "<!subteam") {
+		t.Errorf("raw subteam token leaked: %q", out)
+	}
+}
+
+func TestRenderUsergroupMentionBareUnresolved(t *testing.T) {
+	out := ansi.Strip(RenderSlackMarkdown("dear <!subteam^S0MISSING> hello", nil, nil))
+	if !strings.Contains(out, "@group") {
+		t.Errorf("expected @group fallback in output, got %q", out)
+	}
+	if strings.Contains(out, "<!subteam") {
+		t.Errorf("raw subteam token leaked: %q", out)
+	}
+}
+
+func TestRenderUsergroupMentionBareScopedPerCall(t *testing.T) {
+	input := "dear <!subteam^S0TESTGRP01> hello"
+	work := ansi.Strip(RenderSlackMarkdownWith(input, RenderSlackMarkdownOpts{
+		UserGroups: map[string]string{"S0TESTGRP01": "work-team"},
+	}))
+	side := ansi.Strip(RenderSlackMarkdownWith(input, RenderSlackMarkdownOpts{
+		UserGroups: map[string]string{"S0TESTGRP01": "side-team"},
+	}))
+	if !strings.Contains(work, "@work-team") {
+		t.Errorf("work output = %q; want @work-team", work)
+	}
+	if !strings.Contains(side, "@side-team") {
+		t.Errorf("side output = %q; want @side-team", side)
+	}
+}
+
+// Labels arrive conventionally "@"-prefixed on the wire but that is
+// not guaranteed; the renderer must not double the "@".
+func TestRenderUsergroupMentionLabelWithoutAt(t *testing.T) {
+	out := ansi.Strip(RenderSlackMarkdown("ping <!subteam^S123|eng>", nil, nil))
+	if !strings.Contains(out, "@eng") {
+		t.Errorf("expected @eng in output, got %q", out)
+	}
+	if strings.Contains(out, "@@eng") {
+		t.Errorf("doubled @ in output: %q", out)
+	}
+}
+
+func TestCommonMarkUsergroupMention(t *testing.T) {
+	out := SlackMrkdwnToCommonMarkWithUserGroups(
+		"ping <!subteam^S0AB12CD3> and <!subteam^S9|@qa>",
+		nil,
+		nil,
+		map[string]string{"S0AB12CD3": "backend"},
+	)
+	if out != "ping @backend and @qa" {
+		t.Errorf("SlackMrkdwnToCommonMarkWithUserGroups = %q; want %q", out, "ping @backend and @qa")
+	}
+}
+
+func TestFlattenUsergroupBareResolved(t *testing.T) {
+	out := FlattenMrkdwnWithUserGroups(
+		"ping <!subteam^S0AB12CD3> please",
+		nil,
+		nil,
+		map[string]string{"S0AB12CD3": "backend"},
+	)
+	if out != "ping @backend please" {
+		t.Errorf("FlattenMrkdwnWithUserGroups = %q; want %q", out, "ping @backend please")
+	}
+}

--- a/internal/ui/msgs.go
+++ b/internal/ui/msgs.go
@@ -249,6 +249,7 @@ type (
 		ExternalUsers map[string]bool
 		UserID        string
 		CustomEmoji   map[string]string
+		UserGroups    map[string]string
 		// SectionsProvider supplies Slack-native sidebar sections for this
 		// workspace. Nil means "use config-glob behavior" (the App's
 		// sidebar reverts to its existing name-keyed buckets).
@@ -313,6 +314,7 @@ type (
 		ExternalUsers map[string]bool
 		UserID        string
 		CustomEmoji   map[string]string
+		UserGroups    map[string]string
 		// SectionsProvider supplies Slack-native sidebar sections for this
 		// workspace. Nil means "use config-glob behavior" (the App's
 		// sidebar reverts to its existing name-keyed buckets).
@@ -339,6 +341,13 @@ type (
 	CustomEmojisLoadedMsg struct {
 		TeamID      string
 		CustomEmoji map[string]string
+	}
+	// UserGroupsLoadedMsg is sent when a workspace's usergroups.list
+	// fetch finishes in the background. App refreshes render caches and
+	// compose mention entries only when TeamID matches the active workspace.
+	UserGroupsLoadedMsg struct {
+		TeamID     string
+		UserGroups map[string]string
 	}
 	WorkspaceFailedMsg struct {
 		TeamName string

--- a/internal/ui/reducer_workspace.go
+++ b/internal/ui/reducer_workspace.go
@@ -145,6 +145,12 @@ var reduceWorkspace reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
 			a.SetCustomEmoji(m.CustomEmoji)
 		}
 		return nil, true
+
+	case UserGroupsLoadedMsg:
+		if m.TeamID == a.activeTeamID {
+			a.SetUserGroups(m.UserGroups)
+		}
+		return nil, true
 	}
 	return nil, false
 }
@@ -195,6 +201,7 @@ func reduceWorkspaceReady(a *App, m WorkspaceReadyMsg) tea.Cmd {
 		a.SetExternalUsers(m.ExternalUsers)
 		a.SetUserNames(m.UserNames)
 		a.SetCustomEmoji(m.CustomEmoji)
+		a.SetUserGroups(m.UserGroups)
 		// Route through the setter so messagepane/threadPanel also learn
 		// the current user — production never calls SetCurrentUserID
 		// otherwise, which would leave live self-reactions unstyled.
@@ -289,6 +296,7 @@ func reduceWorkspaceSwitched(a *App, m WorkspaceSwitchedMsg) tea.Cmd {
 	a.SetExternalUsers(m.ExternalUsers)
 	a.SetUserNames(m.UserNames)
 	a.SetCustomEmoji(m.CustomEmoji)
+	a.SetUserGroups(m.UserGroups)
 	// Route through the setter so messagepane/threadPanel also learn the
 	// current user (see WorkspaceReadyMsg above).
 	a.SetCurrentUserID(m.UserID)

--- a/internal/ui/thread/model.go
+++ b/internal/ui/thread/model.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gammons/slk/internal/ui/scrollbar"
 	"github.com/gammons/slk/internal/ui/selection"
 	"github.com/gammons/slk/internal/ui/styles"
+	"github.com/gammons/slk/internal/usergroups"
 )
 
 var thickLeftBorder = lipgloss.Border{Left: "▌"}
@@ -145,6 +146,7 @@ type Model struct {
 	// cache that depends on these maps) to detect changes without hashing.
 	userNamesV    uint64
 	channelNamesV uint64
+	userGroups    map[string]string
 
 	// Mouse selection state. selRange is the user's drag selection.
 	// replyIDToIdx maps reply TS -> entry index in m.cache for O(1)
@@ -584,6 +586,13 @@ func (m *Model) SetAvatarFunc(fn messages.AvatarFunc) {
 func (m *Model) SetUserNames(names map[string]string) {
 	m.userNames = names
 	m.userNamesV++
+	m.InvalidateCache()
+}
+
+// SetUserGroups sets the workspace-scoped usergroup ID -> handle map used
+// to resolve bare <!subteam^SID> mentions in the parent and replies.
+func (m *Model) SetUserGroups(groups map[string]string) {
+	m.userGroups = usergroups.Copy(groups)
 	m.InvalidateCache()
 }
 
@@ -1755,6 +1764,7 @@ func (m *Model) blockkitContext(msg messages.MessageItem, userNames, channelName
 			return messages.RenderSlackMarkdownWith(s, messages.RenderSlackMarkdownOpts{
 				UserNames:    un,
 				ChannelNames: channelNames,
+				UserGroups:   m.userGroups,
 				PlaceCtx:     m.emojiCtx.PlaceCtx,
 				EmojiCells:   m.emojiCtx.Cells,
 				Customs:      m.emojiCtx.Customs,
@@ -1786,6 +1796,7 @@ func (m *Model) renderThreadMessage(msg messages.MessageItem, width int, userNam
 	bodyOpts := messages.RenderSlackMarkdownOpts{
 		UserNames:    userNames,
 		ChannelNames: channelNames,
+		UserGroups:   m.userGroups,
 		PlaceCtx:     m.emojiCtx.PlaceCtx,
 		EmojiCells:   m.emojiCtx.Cells,
 		Customs:      m.emojiCtx.Customs,

--- a/internal/ui/thread/model.go
+++ b/internal/ui/thread/model.go
@@ -591,7 +591,13 @@ func (m *Model) SetUserNames(names map[string]string) {
 
 // SetUserGroups sets the workspace-scoped usergroup ID -> handle map used
 // to resolve bare <!subteam^SID> mentions in the parent and replies.
+// No-op when the new map matches the current one -- App.SetUserGroups
+// fires on every workspace switch, and busting the render cache for an
+// identical set is pure waste.
 func (m *Model) SetUserGroups(groups map[string]string) {
+	if usergroups.Equal(m.userGroups, groups) {
+		return
+	}
 	m.userGroups = usergroups.Copy(groups)
 	m.InvalidateCache()
 }

--- a/internal/ui/threadsview/model.go
+++ b/internal/ui/threadsview/model.go
@@ -181,14 +181,15 @@ func (m *Model) SetChannelNames(names map[string]string) {
 }
 
 // SetUserGroups sets the workspace-scoped usergroup ID -> handle map used
-// to resolve bare <!subteam^SID> mentions in thread previews.
+// to resolve bare <!subteam^SID> mentions in thread previews. No-op when
+// the new map matches the current one.
 func (m *Model) SetUserGroups(groups map[string]string) {
+	if usergroups.Equal(m.userGroups, groups) {
+		return
+	}
 	copied := usergroups.Copy(groups)
 	if copied == nil {
 		copied = map[string]string{}
-	}
-	if stringMapsEqual(m.userGroups, copied) {
-		return
 	}
 	m.userGroups = copied
 	m.dirty()

--- a/internal/ui/threadsview/model.go
+++ b/internal/ui/threadsview/model.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gammons/slk/internal/cache"
 	"github.com/gammons/slk/internal/ui/messages"
 	"github.com/gammons/slk/internal/ui/styles"
+	"github.com/gammons/slk/internal/usergroups"
 	"github.com/muesli/reflow/truncate"
 )
 
@@ -82,10 +83,11 @@ func borderFillStyle() lipgloss.Style {
 
 // Model holds the threads-list state.
 type Model struct {
-	summaries  []cache.ThreadSummary
+	summaries    []cache.ThreadSummary
 	userNames    map[string]string
 	channelNames map[string]string
-	selfUserID string
+	userGroups   map[string]string
+	selfUserID   string
 
 	selected int
 	yOffset  int
@@ -175,6 +177,20 @@ func (m *Model) SetChannelNames(names map[string]string) {
 		return
 	}
 	m.channelNames = names
+	m.dirty()
+}
+
+// SetUserGroups sets the workspace-scoped usergroup ID -> handle map used
+// to resolve bare <!subteam^SID> mentions in thread previews.
+func (m *Model) SetUserGroups(groups map[string]string) {
+	copied := usergroups.Copy(groups)
+	if copied == nil {
+		copied = map[string]string{}
+	}
+	if stringMapsEqual(m.userGroups, copied) {
+		return
+	}
+	m.userGroups = copied
 	m.dirty()
 }
 
@@ -640,7 +656,11 @@ func (m *Model) renderCard(s cache.ThreadSummary, width int, selected bool) []st
 	if s.ParentText == "" && s.ParentUserID == "" {
 		previewBody = mutedStyle().Render("(parent not loaded)")
 	} else {
-		preview := messages.RenderSlackMarkdown(s.ParentText, m.userNames, m.channelNames)
+		preview := messages.RenderSlackMarkdownWith(s.ParentText, messages.RenderSlackMarkdownOpts{
+			UserNames:    m.userNames,
+			ChannelNames: m.channelNames,
+			UserGroups:   m.userGroups,
+		})
 		preview = strings.ReplaceAll(preview, "\n", " ")
 		previewMax := contentWidth - 4
 		if previewMax < 0 {

--- a/internal/ui/winmodels.go
+++ b/internal/ui/winmodels.go
@@ -23,6 +23,7 @@ func (a *App) newWindowModel(chName string) *messages.Model {
 	m.SetAvatarFunc(a.avatarFn)
 	m.SetUserNames(a.userNames)
 	m.SetChannelNames(a.channelNames)
+	m.SetUserGroups(a.userGroups)
 	m.SetEmojiContext(a.emojiCtx)
 	if a.emojiCustoms != nil {
 		// SetCustomEmoji ran after SetEmojiContext: its customs map

--- a/internal/usergroups/registry.go
+++ b/internal/usergroups/registry.go
@@ -18,6 +18,21 @@ func Copy(m map[string]string) map[string]string {
 	return out
 }
 
+// Equal reports whether two id -> handle maps hold the same entries.
+// nil and empty compare equal: both mean "no groups loaded", and the
+// setters that use this treat them identically.
+func Equal(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for id, handle := range a {
+		if other, ok := b[id]; !ok || other != handle {
+			return false
+		}
+	}
+	return true
+}
+
 // Display returns the "@handle" display text for a subteam token. The
 // embedded label wins when present; bare tokens resolve through the
 // provided workspace-scoped map; unresolved IDs fall back to "@group".

--- a/internal/usergroups/registry.go
+++ b/internal/usergroups/registry.go
@@ -1,0 +1,32 @@
+// Package usergroups contains pure helpers for workspace-scoped Slack
+// usergroup mention maps.
+package usergroups
+
+import "strings"
+
+// Copy returns an independent copy of an id -> handle map. Nil input
+// returns nil so callers can preserve zero-value "no groups loaded"
+// state without allocating.
+func Copy(m map[string]string) map[string]string {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for id, handle := range m {
+		out[id] = handle
+	}
+	return out
+}
+
+// Display returns the "@handle" display text for a subteam token. The
+// embedded label wins when present; bare tokens resolve through the
+// provided workspace-scoped map; unresolved IDs fall back to "@group".
+func Display(groups map[string]string, id, label string) string {
+	if label != "" {
+		return "@" + strings.TrimPrefix(label, "@")
+	}
+	if handle := groups[id]; handle != "" {
+		return "@" + handle
+	}
+	return "@group"
+}

--- a/internal/usergroups/registry_test.go
+++ b/internal/usergroups/registry_test.go
@@ -1,0 +1,34 @@
+package usergroups
+
+import "testing"
+
+func TestCopyReturnsIndependentMap(t *testing.T) {
+	src := map[string]string{"S1": "eng"}
+	got := Copy(src)
+	got["S1"] = "mutated"
+	if src["S1"] != "eng" {
+		t.Errorf("Copy result aliases source map: source S1 = %q", src["S1"])
+	}
+}
+
+func TestDisplayPrefersLabelAndNormalizesAt(t *testing.T) {
+	groups := map[string]string{"S1": "eng"}
+	if got := Display(groups, "S1", "ops"); got != "@ops" {
+		t.Errorf("Display label without @ = %q, want @ops", got)
+	}
+	if got := Display(groups, "S1", "@ops"); got != "@ops" {
+		t.Errorf("Display label with @ = %q, want @ops", got)
+	}
+}
+
+func TestDisplayResolvesBareID(t *testing.T) {
+	if got := Display(map[string]string{"S1": "eng"}, "S1", ""); got != "@eng" {
+		t.Errorf("Display bare ID = %q, want @eng", got)
+	}
+}
+
+func TestDisplayFallsBackForUnknownID(t *testing.T) {
+	if got := Display(map[string]string{"S1": "eng"}, "S2", ""); got != "@group" {
+		t.Errorf("Display unknown ID = %q, want @group", got)
+	}
+}

--- a/internal/usergroups/registry_test.go
+++ b/internal/usergroups/registry_test.go
@@ -32,3 +32,23 @@ func TestDisplayFallsBackForUnknownID(t *testing.T) {
 		t.Errorf("Display unknown ID = %q, want @group", got)
 	}
 }
+
+func TestEqual(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b map[string]string
+		want bool
+	}{
+		{"both nil", nil, nil, true},
+		{"nil vs empty", nil, map[string]string{}, true},
+		{"same entries", map[string]string{"S1": "eng"}, map[string]string{"S1": "eng"}, true},
+		{"changed handle", map[string]string{"S1": "eng"}, map[string]string{"S1": "ops"}, false},
+		{"changed id", map[string]string{"S1": "eng"}, map[string]string{"S2": "eng"}, false},
+		{"extra entry", map[string]string{"S1": "eng"}, map[string]string{"S1": "eng", "S2": "ops"}, false},
+	}
+	for _, tc := range cases {
+		if got := Equal(tc.a, tc.b); got != tc.want {
+			t.Errorf("%s: Equal(%v, %v) = %v, want %v", tc.name, tc.a, tc.b, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## What this fixes

When someone tags a team in Slack (like `@platform-team`), slk shows the raw wire token instead of the team name:

> dear `<!subteam^S0TESTGRP01>` please delete the recurring event

You can't tell who's being addressed without opening the official client. The same tokens leak into search results, thread exports, and desktop notifications. And there's no way to tag a team from slk at all — typing `@backend-teams` sends plain text that pings nobody.

## What changes for users

- **Team mentions render as names**: `<!subteam^S0TESTGRP01>` shows as **@platform-team** everywhere — message pane, thread panel, search snippets, markdown export, and desktop notifications.
- **You can tag teams**: the `@` autocomplete in the composer now lists your workspace's user groups alongside people. Selecting one sends a real mention — members get notified, same as tagging from the official client.
- **Zero configuration**: group names load automatically per workspace on connect. If the fetch fails, mentions degrade to a readable `@group` placeholder instead of the raw token.
- **Broadcast mentions render too**: `<!channel>`, `<!here>`, and `<!everyone>` were also leaking as raw tokens in the message pane and markdown export (the snippet flattener and notifications already handled them) — they now render as styled **@channel** / **@here** / **@everyone** everywhere.

## How it works

- Each workspace fetches its user groups via `usergroups.list` in the background on connect (works with the xoxc browser token slk already uses).
- The ID → handle map is workspace-scoped, carried in `WorkspaceContext` and propagated to the UI via a `UserGroupsLoadedMsg` (guarded by team ID, mirroring the existing `CustomEmoji`/`UserNames` flow). Groups from one workspace never leak into another's picker or send-time translation.
- `internal/usergroups` holds pure helpers (`Copy`, `Display`); rendering falls back embedded label → workspace map → `@group`.
- Outgoing mentions are translated `@handle` → `<!subteam^SID|@handle>` (labeled form, so the optimistic echo renders without waiting for a lookup).

Test coverage: all render paths, picker entries, membership filtering, send translation, and workspace collision/leak regressions (inactive workspace's groups must not appear in the active picker).

