### PR TITLE
Auto-detect sixel for iTerm2 image rendering

### DIFF
--- a/internal/image/capability.go
+++ b/internal/image/capability.go
@@ -107,5 +107,11 @@ func Detect(env Env, cfg string) Protocol {
 	if env.Term == "foot" || env.Term == "mlterm" {
 		return ProtoSixel
 	}
+	// iTerm2: no working kitty graphics implementation (its partial
+	// support fails the startup probe, landing on halfblock), but
+	// solid sixel support — so auto picks sixel for real pixels.
+	if env.TermProgram == "iTerm.app" {
+		return ProtoSixel
+	}
 	return ProtoHalfBlock
 }

--- a/internal/image/capability_test.go
+++ b/internal/image/capability_test.go
@@ -105,6 +105,11 @@ func TestDetect_Sixel(t *testing.T) {
 	cases := []Env{
 		{Term: "foot"},
 		{Term: "mlterm"},
+		// iTerm2 has no working kitty graphics implementation (the
+		// startup probe would time out and downgrade to halfblock),
+		// but it does support sixel — real pixels instead of the
+		// halfblock mosaic.
+		{TermProgram: "iTerm.app"},
 	}
 	for _, env := range cases {
 		if got := Detect(env, "auto"); got != ProtoSixel {


### PR DESCRIPTION
On iTerm2, `Detect`'s auto path falls through to halfblock, so inline images render as a blurry 2-pixels-per-cell mosaic. iTerm2 has no working kitty graphics implementation (its partial support fails the startup probe — see the note on `ProbeKittyGraphics`), but it does support sixel.

This adds `TERM_PROGRAM=iTerm.app` → `ProtoSixel` to the auto-detect chain, next to the existing foot/mlterm sixel cases. Images render as real pixels instead of the halfblock mosaic.

The tmux path is intentionally untouched: iTerm2 sets `TERM=xterm-256color`, so `#{client_termname}` can't identify it reliably, and sixel-under-tmux is already documented as conservative-halfblock territory.