### PR TITLE
feat(sections): surface Slack's native stars section in the sidebar

### DIFF
--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -1869,6 +1869,17 @@ func connectWorkspace(ctx context.Context, token slackclient.Token, db *cache.DB
 		if err := store.Bootstrap(ctx, client); err != nil {
 			log.Printf("section store bootstrap for %s failed: %v (falling back to config sections)", token.TeamName, err)
 		} else {
+			// Slack's users.channelSections.list returns the stars section
+			// with an empty channel_ids array (it doesn't populate built-in
+			// section types). stars.list is the authoritative source for
+			// which channels the user has starred; fetch and inject so the
+			// sidebar can render the Starred header. Best-effort: on error
+			// the stars section stays empty and includeInSidebar hides it.
+			if starIDs, err := client.GetStarredChannels(ctx); err != nil {
+				log.Printf("stars.list for %s failed: %v (starred channels will be hidden)", token.TeamName, err)
+			} else if len(starIDs) > 0 {
+				store.PopulateStars(starIDs)
+			}
 			wctx.SectionStore = store
 			// One-time info log when the user has both Slack sections
 			// active AND a non-empty [sections.*] config — the latter

--- a/internal/service/sectionstore.go
+++ b/internal/service/sectionstore.go
@@ -88,12 +88,10 @@ func (s *SectionStore) Bootstrap(ctx context.Context, client SectionsClient) err
 	return nil
 }
 
-// SectionForChannel returns the section ID a channel belongs to. Returns
-// ok=false when the store isn't ready or the channel isn't in any section.
 // SectionForChannel returns the renderable section ID a channel belongs
 // to. Returns ok=false when the store isn't ready, the channel isn't
-// indexed, OR the indexed section is not renderable in the v1 sidebar
-// (e.g. stars, slack_connect, salesforce_records, agents). Hiding
+// indexed, OR the indexed section is not renderable in the sidebar
+// (e.g. slack_connect, salesforce_records, agents). Hiding
 // non-renderable sections at this boundary prevents the sidebar from
 // trying to bucket items into headers it never created — see
 // includeInSidebar for the renderability rule.
@@ -109,17 +107,18 @@ func (s *SectionStore) SectionForChannel(channelID string) (string, bool) {
 	}
 	sec, secOK := s.sectionsByID[id]
 	if !secOK || !includeInSidebar(sec) {
-		// Section was deleted, or has a non-renderable type (stars /
-		// slack_connect / etc.). Treat the channel as unclaimed so it
-		// falls into the appropriate type-default bucket.
+		// Section was deleted, or has a non-renderable type
+		// (slack_connect / salesforce_records / agents / etc.). Treat
+		// the channel as unclaimed so it falls into the appropriate
+		// type-default bucket.
 		return "", false
 	}
 	return id, true
 }
 
 // OrderedSections walks the linked-list (head-first) and returns the
-// sections that should render in the sidebar, filtered to the v1
-// type whitelist. Cycle protection: stops if a section is revisited.
+// sections that should render in the sidebar, filtered to the
+// renderable type whitelist. Cycle protection: stops if a section is revisited.
 //
 // Head detection: a section is the head if no other section's Next
 // points at it. When multiple candidate heads exist (orphans), the
@@ -167,11 +166,14 @@ func (s *SectionStore) OrderedSections() []*slk.SidebarSection {
 	return out
 }
 
-// includeInSidebar applies the v1 filter rules. Renderable types:
+// includeInSidebar applies the render filter rules. Renderable types:
 // standard (always, even when empty — user intent), channels (default
-// catch-all), direct_messages (default DM bucket). recent_apps is only
-// rendered when non-empty (slk has its own Apps logic for the empty
-// case). Everything else is hidden in v1.
+// catch-all), direct_messages (default DM bucket), stars (Slack's
+// Starred feature — only when non-empty, mirroring recent_apps so users
+// without starred channels don't see an empty header). recent_apps is
+// only rendered when non-empty (slk has its own Apps logic for the
+// empty case). Everything else is hidden (slack_connect,
+// salesforce_records, agents, anything new).
 func includeInSidebar(sec *slk.SidebarSection) bool {
 	if sec.IsRedacted {
 		return false
@@ -179,10 +181,10 @@ func includeInSidebar(sec *slk.SidebarSection) bool {
 	switch sec.Type {
 	case "standard", "channels", "direct_messages":
 		return true
-	case "recent_apps":
+	case "stars", "recent_apps":
 		return len(sec.ChannelIDs) > 0
 	default:
-		// stars, slack_connect, salesforce_records, agents, anything new.
+		// slack_connect, salesforce_records, agents, anything new.
 		return false
 	}
 }

--- a/internal/service/sectionstore.go
+++ b/internal/service/sectionstore.go
@@ -88,6 +88,46 @@ func (s *SectionStore) Bootstrap(ctx context.Context, client SectionsClient) err
 	return nil
 }
 
+// PopulateStars fills the stars section's ChannelIDs from stars.list,
+// the authoritative source for starred channels. Slack's
+// users.channelSections.list returns the stars section with an empty
+// channel_ids array (it doesn't populate built-in section types); without
+// this call the stars section stays empty and includeInSidebar hides it.
+//
+// Safe to call repeatedly — each call replaces the previous star list
+// and remaps the channelToSection index accordingly. No-op when the
+// workspace has no stars section (won't synthesize one).
+func (s *SectionStore) PopulateStars(channelIDs []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.ready {
+		return
+	}
+	var starsSectionID string
+	var stars *slk.SidebarSection
+	for id, sec := range s.sectionsByID {
+		if sec.Type == "stars" {
+			starsSectionID = id
+			stars = sec
+			break
+		}
+	}
+	if stars == nil {
+		return
+	}
+	// Drop the old stars→channel index entries.
+	for _, cid := range stars.ChannelIDs {
+		if existing, ok := s.channelToSection[cid]; ok && existing == starsSectionID {
+			delete(s.channelToSection, cid)
+		}
+	}
+	stars.ChannelIDs = append([]string(nil), channelIDs...)
+	stars.ChannelsCount = len(channelIDs)
+	for _, cid := range channelIDs {
+		s.channelToSection[cid] = starsSectionID
+	}
+}
+
 // SectionForChannel returns the renderable section ID a channel belongs
 // to. Returns ok=false when the store isn't ready, the channel isn't
 // indexed, OR the indexed section is not renderable in the sidebar

--- a/internal/service/sectionstore_test.go
+++ b/internal/service/sectionstore_test.go
@@ -90,8 +90,7 @@ func TestSectionStore_Bootstrap_TruncatedSection_LogsAndContinues(t *testing.T) 
 func TestSectionStore_OrderedSections_FiltersSystemTypes(t *testing.T) {
 	sections := []slk.SidebarSection{
 		{ID: "S", Type: "salesforce_records", Next: "G", LastUpdate: 1},
-		{ID: "G", Type: "agents", Next: "T", LastUpdate: 1},
-		{ID: "T", Type: "stars", Next: "K", LastUpdate: 1},
+		{ID: "G", Type: "agents", Next: "K", LastUpdate: 1},
 		{ID: "K", Type: "slack_connect", Next: "U", LastUpdate: 1},
 		{ID: "U", Type: "standard", Name: "Mine", Next: "", LastUpdate: 1, ChannelIDs: []string{"C1"}, ChannelsCount: 1},
 	}
@@ -104,6 +103,71 @@ func TestSectionStore_OrderedSections_FiltersSystemTypes(t *testing.T) {
 	}
 	if got[0].ID != "U" {
 		t.Errorf("got %q, want U", got[0].ID)
+	}
+}
+
+// stars is a Slack-native section type (the "Starred" feature). A
+// non-empty stars section must render in the sidebar, matching how the
+// official Slack client surfaces starred channels.
+func TestSectionStore_OrderedSections_StarsRenderWhenNonEmpty(t *testing.T) {
+	sections := []slk.SidebarSection{
+		{ID: "ST", Type: "stars", Name: "", Next: "U", LastUpdate: 1,
+			ChannelIDs: []string{"C1"}, ChannelsCount: 1},
+		{ID: "U", Type: "standard", Name: "Mine", Next: "", LastUpdate: 1},
+	}
+	c := &fakeSectionsClient{sections: sections}
+	store := NewSectionStore()
+	_ = store.Bootstrap(context.Background(), c)
+	got := store.OrderedSections()
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2 (stars + standard); got %+v", len(got), got)
+	}
+	if got[0].ID != "ST" {
+		t.Errorf("got[0].ID = %q, want ST (stars comes first in linked list)", got[0].ID)
+	}
+	if got[1].ID != "U" {
+		t.Errorf("got[1].ID = %q, want U", got[1].ID)
+	}
+}
+
+// An empty stars section must stay hidden so users who haven't starred
+// anything don't see an empty header — mirrors recent_apps semantics.
+func TestSectionStore_OrderedSections_StarsHiddenWhenEmpty(t *testing.T) {
+	sections := []slk.SidebarSection{
+		{ID: "ST", Type: "stars", Name: "", Next: "U", LastUpdate: 1},
+		{ID: "U", Type: "standard", Name: "Mine", Next: "", LastUpdate: 1,
+			ChannelIDs: []string{"C1"}, ChannelsCount: 1},
+	}
+	c := &fakeSectionsClient{sections: sections}
+	store := NewSectionStore()
+	_ = store.Bootstrap(context.Background(), c)
+	got := store.OrderedSections()
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1 (empty stars hidden); got %+v", len(got), got)
+	}
+	if got[0].ID != "U" {
+		t.Errorf("got[0].ID = %q, want U", got[0].ID)
+	}
+}
+
+// SectionForChannel must claim channels that Slack has placed in a
+// stars section, so they render under the Starred header rather than
+// falling through to the type-default bucket.
+func TestSectionStore_SectionForChannel_StarsClaimed(t *testing.T) {
+	sections := []slk.SidebarSection{
+		{ID: "ST", Type: "stars", Name: "", Next: "U", LastUpdate: 1,
+			ChannelIDs: []string{"C9"}, ChannelsCount: 1},
+		{ID: "U", Type: "standard", Name: "Mine", Next: "", LastUpdate: 1},
+	}
+	c := &fakeSectionsClient{sections: sections}
+	store := NewSectionStore()
+	_ = store.Bootstrap(context.Background(), c)
+	id, ok := store.SectionForChannel("C9")
+	if !ok {
+		t.Fatalf("SectionForChannel(C9) ok=false, want true (stars section should claim its channels)")
+	}
+	if id != "ST" {
+		t.Errorf("SectionForChannel(C9) = %q, want ST", id)
 	}
 }
 
@@ -275,10 +339,10 @@ func (cc *countingClient) GetChannelSections(ctx context.Context) ([]slk.Sidebar
 func TestSectionForChannel_HidesNonRenderableSections(t *testing.T) {
 	store := NewSectionStore()
 	c := &fakeSectionsClient{sections: []slk.SidebarSection{
-		// A starred channel: real, indexed, but the section type is
-		// hidden by the v1 renderability filter.
-		{ID: "L_STARS", Type: "stars", Next: "L_STD", LastUpdate: 100,
-			ChannelIDs: []string{"C_STARRED"}, ChannelsCount: 1},
+		// A channel in a slack_connect section: real, indexed, but the
+		// section type is hidden by the renderability filter.
+		{ID: "L_SC", Type: "slack_connect", Next: "L_STD", LastUpdate: 100,
+			ChannelIDs: []string{"C_EXTERNAL"}, ChannelsCount: 1},
 		// A regular standard section, fully renderable.
 		{ID: "L_STD", Type: "standard", Name: "Mine", Next: "", LastUpdate: 100,
 			ChannelIDs: []string{"C_STD"}, ChannelsCount: 1},
@@ -291,11 +355,11 @@ func TestSectionForChannel_HidesNonRenderableSections(t *testing.T) {
 	if id, ok := store.SectionForChannel("C_STD"); !ok || id != "L_STD" {
 		t.Errorf("C_STD → (%q, %v), want (L_STD, true)", id, ok)
 	}
-	// Channel in the non-renderable (stars) section — returns ("", false)
+	// Channel in the non-renderable (slack_connect) section — returns ("", false)
 	// even though the channelToSection index has it. This prevents the
 	// sidebar from receiving a Section ID it can't bucket against.
-	if id, ok := store.SectionForChannel("C_STARRED"); ok {
-		t.Errorf("C_STARRED → (%q, %v), want ('', false) for non-renderable section", id, ok)
+	if id, ok := store.SectionForChannel("C_EXTERNAL"); ok {
+		t.Errorf("C_EXTERNAL → (%q, %v), want ('', false) for non-renderable section", id, ok)
 	}
 }
 

--- a/internal/service/sectionstore_test.go
+++ b/internal/service/sectionstore_test.go
@@ -171,6 +171,84 @@ func TestSectionStore_SectionForChannel_StarsClaimed(t *testing.T) {
 	}
 }
 
+// Slack's users.channelSections.list returns the stars section with an
+// empty channel_ids array. PopulateStars fills it from stars.list, the
+// authoritative source for starred channels. Without this call, a
+// bootstrapped stars section stays empty and includeInSidebar hides it.
+func TestSectionStore_PopulateStars_FillsEmptyStarsSection(t *testing.T) {
+	sections := []slk.SidebarSection{
+		{ID: "ST", Type: "stars", Name: "", Next: "U", LastUpdate: 1},
+		{ID: "U", Type: "standard", Name: "Mine", Next: "", LastUpdate: 1},
+	}
+	c := &fakeSectionsClient{sections: sections}
+	store := NewSectionStore()
+	_ = store.Bootstrap(context.Background(), c)
+
+	// Before: stars section is empty → hidden by includeInSidebar.
+	// The standard section U renders regardless (standard always shows).
+	got := store.OrderedSections()
+	if len(got) != 1 || got[0].ID != "U" {
+		t.Fatalf("before PopulateStars: OrderedSections = %+v, want just [U] (empty stars hidden)", got)
+	}
+
+	store.PopulateStars([]string{"C1", "C2"})
+
+	// After: stars section renders, channels claimed.
+	got = store.OrderedSections()
+	if len(got) != 2 {
+		t.Fatalf("after PopulateStars: OrderedSections len = %d, want 2 (stars + standard); got %+v", len(got), got)
+	}
+	if got[0].ID != "ST" {
+		t.Errorf("got[0].ID = %q, want ST (stars is earlier in linked list)", got[0].ID)
+	}
+	for _, cid := range []string{"C1", "C2"} {
+		id, ok := store.SectionForChannel(cid)
+		if !ok || id != "ST" {
+			t.Errorf("SectionForChannel(%s) = (%q,%v), want (ST,true)", cid, id, ok)
+		}
+	}
+}
+
+// PopulateStars is a no-op when there is no stars section (workspace
+// doesn't have one, or it was deleted). It must not synthesize one.
+func TestSectionStore_PopulateStars_NoOpWithoutStarsSection(t *testing.T) {
+	sections := []slk.SidebarSection{
+		{ID: "U", Type: "standard", Name: "Mine", Next: "", LastUpdate: 1},
+	}
+	c := &fakeSectionsClient{sections: sections}
+	store := NewSectionStore()
+	_ = store.Bootstrap(context.Background(), c)
+	store.PopulateStars([]string{"C1", "C2"})
+	// Channel C1 is not in any real section.
+	if _, ok := store.SectionForChannel("C1"); ok {
+		t.Errorf("SectionForChannel(C1) ok=true, want false (no stars section to claim it)")
+	}
+}
+
+// PopulateStars replaces the stars section's channel list on re-call so
+// star/unstar events stay consistent. Re-starring the same channel and
+// un-starring another should reflect in the new state.
+func TestSectionStore_PopulateStars_ReplacesPreviousStarList(t *testing.T) {
+	sections := []slk.SidebarSection{
+		{ID: "ST", Type: "stars", Name: "", Next: "U", LastUpdate: 1},
+		{ID: "U", Type: "standard", Name: "Mine", Next: "", LastUpdate: 1},
+	}
+	c := &fakeSectionsClient{sections: sections}
+	store := NewSectionStore()
+	_ = store.Bootstrap(context.Background(), c)
+	store.PopulateStars([]string{"C1", "C2"})
+	store.PopulateStars([]string{"C2", "C3"})
+	// C1 un-starred, C3 newly starred.
+	if _, ok := store.SectionForChannel("C1"); ok {
+		t.Errorf("C1 should no longer be claimed after re-populate without it")
+	}
+	for _, cid := range []string{"C2", "C3"} {
+		if id, ok := store.SectionForChannel(cid); !ok || id != "ST" {
+			t.Errorf("SectionForChannel(%s) = (%q,%v), want (ST,true)", cid, id, ok)
+		}
+	}
+}
+
 func TestSectionStore_BootstrapFailure_NotReady(t *testing.T) {
 	c := &fakeSectionsClient{getErr: context.DeadlineExceeded}
 	store := NewSectionStore()

--- a/internal/slack/client.go
+++ b/internal/slack/client.go
@@ -1386,6 +1386,72 @@ func (c *Client) GetChannelSectionsRaw(ctx context.Context) ([]byte, error) {
 	return c.callChannelSectionsList(ctx, "")
 }
 
+// starsListResponse is the JSON shape returned by stars.list. Only the
+// channel-typed items are relevant for the sidebar; message/file/IM stars
+// are ignored.
+type starsListResponse struct {
+	OK     bool            `json:"ok"`
+	Error  string          `json:"error"`
+	Items  []starsListItem `json:"items"`
+	Paging starsListPaging `json:"paging"`
+}
+
+type starsListItem struct {
+	Type    string `json:"type"`
+	Channel string `json:"channel"` // populated when Type == "channel" or "im"
+}
+
+type starsListPaging struct {
+	Count int `json:"count"`
+	Total int `json:"total"`
+}
+
+// GetStarredChannels calls stars.list and returns the IDs of channels the
+// user has starred. Slack's users.channelSections.list returns the stars
+// section with an empty channel_ids array (it doesn't populate built-in
+// section types); stars.list is the authoritative source for starred
+// channels. Only type=="channel" items are returned — message/file/IM stars
+// don't belong in the channel sidebar.
+//
+// Best-effort: on error the caller proceeds with an empty star list and
+// the stars section stays hidden (no regression vs pre-fix behavior).
+func (c *Client) GetStarredChannels(ctx context.Context) ([]string, error) {
+	form := url.Values{"token": {c.token}, "limit": {"1000"}}
+	body := strings.NewReader(form.Encode())
+	endpoint := c.apiBaseURL + "stars.list"
+	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, body)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	httpClient := newCookieHTTPClient(c.cookie)
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("calling stars.list: %w", err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading stars.list response: %w", err)
+	}
+	var slr starsListResponse
+	if err := json.Unmarshal(raw, &slr); err != nil {
+		return nil, fmt.Errorf("parsing stars.list response: %w", err)
+	}
+	if !slr.OK {
+		return nil, fmt.Errorf("stars.list API error: %s", slr.Error)
+	}
+	var ids []string
+	for _, it := range slr.Items {
+		if it.Type == "channel" && it.Channel != "" {
+			ids = append(ids, it.Channel)
+		}
+	}
+	return ids, nil
+}
+
 // GetChannelSections calls users.channelSections.list and returns the
 // fully-paginated section list. Loops on the top-level cursor until the
 // server reports no more sections. Per-section channel_ids_page pagination

--- a/internal/slack/client_test.go
+++ b/internal/slack/client_test.go
@@ -1051,6 +1051,71 @@ func TestGetChannelSections_UsesAPIBaseURL(t *testing.T) {
 	}
 }
 
+// TestGetStarredChannels_ParsesItems verifies GetStarredChannels extracts
+// channel-typed starred items from stars.list. Slack's channelSections.list
+// returns the stars section with an empty channel_ids array; stars.list is
+// the authoritative source for which channels the user has starred.
+func TestGetStarredChannels_ParsesItems(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"ok": true,
+			"items": [
+				{"type": "channel", "channel": "C1", "date_create": 1700000001},
+				{"type": "channel", "channel": "C2", "date_create": 1700000002},
+				{"type": "message", "channel": "C9", "message": {"ts": "1.1"}, "date_create": 1700000003},
+				{"type": "im", "channel": "D1", "date_create": 1700000004}
+			],
+			"paging": {"count": 4, "total": 4}
+		}`))
+	}))
+	defer srv.Close()
+
+	c := &Client{
+		token:      "xoxc-test",
+		cookie:     "d-cookie",
+		apiBaseURL: srv.URL + "/api/",
+	}
+	got, err := c.GetStarredChannels(context.Background())
+	if err != nil {
+		t.Fatalf("GetStarredChannels: %v", err)
+	}
+	if gotPath != "/api/stars.list" {
+		t.Errorf("path = %q, want %q", gotPath, "/api/stars.list")
+	}
+	// Only type=="channel" items count; message/im stars are not sidebar channels.
+	want := []string{"C1", "C2"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("[%d] = %q, want %q", i, got[i], w)
+		}
+	}
+}
+
+// TestGetStarredChannels_APIError verifies the client surfaces Slack's
+// ok=false responses as errors rather than returning an empty list silently.
+func TestGetStarredChannels_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok": false, "error": "not_authed"}`))
+	}))
+	defer srv.Close()
+
+	c := &Client{
+		token:      "xoxc-test",
+		cookie:     "d-cookie",
+		apiBaseURL: srv.URL + "/api/",
+	}
+	if _, err := c.GetStarredChannels(context.Background()); err == nil {
+		t.Errorf("expected error on ok=false response")
+	}
+}
+
 // TestHandRolledEndpoints_FormBodyTokenNoBearer verifies that every
 // undocumented endpoint slk calls directly sends the xoxc token in the
 // form body (the browser-client convention) rather than as Authorization:

--- a/internal/ui/sidebar/model.go
+++ b/internal/ui/sidebar/model.go
@@ -1393,7 +1393,15 @@ func (m *Model) sectionDisplayMeta(sectionKey string) (name, emoji string) {
 			if meta.ID == sectionKey {
 				name = meta.Name
 				if name == "" {
-					name = "(unnamed)"
+					// Built-in sections Slack sends without a user-set
+					// name need a friendly fallback. Today only "stars"
+					// reaches this branch (other unnamed system types
+					// are filtered by SectionStore.includeInSidebar).
+					if meta.Type == "stars" {
+						name = "Starred"
+					} else {
+						name = "(unnamed)"
+					}
 				}
 				return name, meta.Emoji
 			}

--- a/internal/ui/sidebar/model_test.go
+++ b/internal/ui/sidebar/model_test.go
@@ -609,6 +609,26 @@ func TestSectionHeader_RendersEmojiPrefix(t *testing.T) {
 	}
 }
 
+// Slack sends the stars section with name="" (it's a built-in section,
+// not user-named). The sidebar must fall back to a friendly header
+// ("Starred") rather than rendering "(unnamed)".
+func TestSectionHeader_StarsSection_FallsBackToStarred(t *testing.T) {
+	items := []ChannelItem{{ID: "C1", Name: "ch1", Type: "channel", Section: "ST"}}
+	provider := &fakeProvider{
+		ready:    true,
+		sections: []SectionMeta{{ID: "ST", Name: "", Type: "stars"}},
+	}
+	m := New(items)
+	m.SetSectionsProvider(provider)
+	out := m.View(20, 40)
+	if !strings.Contains(out, "Starred") {
+		t.Errorf("stars section with empty name should fall back to \"Starred\"; got:\n%s", out)
+	}
+	if strings.Contains(out, "(unnamed)") {
+		t.Errorf("stars section should not render the generic \"(unnamed)\" fallback; got:\n%s", out)
+	}
+}
+
 func TestCollapseByID_PreservedAcrossRename(t *testing.T) {
 	items := []ChannelItem{{ID: "C1", Name: "ch1", Type: "channel", Section: "A"}}
 	p := &fakeProvider{

--- a/internal/ui/sidebar/sections_provider.go
+++ b/internal/ui/sidebar/sections_provider.go
@@ -18,5 +18,5 @@ type SectionMeta struct {
 	ID    string
 	Name  string
 	Emoji string // shortcode like "orange_book"; empty for none
-	Type  string // standard | channels | direct_messages | recent_apps
+	Type  string // standard | channels | direct_messages | recent_apps | stars
 }

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -119,12 +119,12 @@ glob mode). In Slack-native mode, channel order within a section
 comes from Slack and the `:<N>` suffix is ignored along with the
 rest of the `[sections.*]` block.
 
-### v1 limitations of Slack-native sections
+### Limitations of Slack-native sections
 
-v1 is read-only — section editing still happens in the official client; slk
-reflects the results. Sections of type `stars`, `slack_connect`,
-`salesforce_records`, and `agents` are hidden (matching the official
-client's filtering). Sections with more than 10 channels may be returned
+Slack-native sections are read-only — section editing still happens in the official client; slk
+reflects the results. The `stars` section type (Slack's "Starred" feature) is rendered
+when non-empty, with the header `Starred`. Sections of type `slack_connect`,
+`salesforce_records`, and `agents` are hidden. Sections with more than 10 channels may be returned
 only partially by Slack's API on initial load; the missing channels
 temporarily fall into the catch-all bucket and migrate into their correct
 section as WebSocket events fire or the workspace reconnects. A debug-log


### PR DESCRIPTION
Closes #101.

## What

Displays channels the user has starred in any Slack client under a `Starred` header at the top of the sidebar. Read-only: starring still happens in the official Slack client; slk reflects the result on workspace bootstrap. This matches how slk already treats sidebar structure — sections and mutes are also read-only mirrors of state managed elsewhere.

## Architecture

Slack's `users.channelSections.list` returns the stars section with an empty `channel_ids` array (it doesn't populate built-in section types). `stars.list` is the authoritative source for starred channels. After `SectionStore.Bootstrap`, we fetch starred IDs via `stars.list` and inject them into the stars section so `includeInSidebar` renders it and `buildChannelItem` routes starred channels under the header.

## Code map

- `internal/slack/client.go` — `GetStarredChannels` wraps `stars.list`, returns channel-typed IDs only.
- `internal/service/sectionstore.go` — `includeInSidebar` admits `stars` (hide-when-empty, mirrors `recent_apps`). `PopulateStars` fills the stars section's ChannelIDs post-bootstrap, idempotent.
- `cmd/slk/main.go` — `connectWorkspace` calls `stars.list` after `Bootstrap` (best-effort; on error stars stay hidden, no regression).
- `internal/ui/sidebar/model.go` — `sectionDisplayMeta` falls back to `"Starred"` for the stars type (Slack sends `name=""`).
- `wiki/Configuration.md` — drops `stars` from the hidden-types list.

## Tests

TDD throughout. 9 new tests covering client parsing, section store populate/filter/claim, sidebar header fallback. `go vet ./... && go test ./...` all green (48 packages).

## Verification

Live-tested against a real workspace: 13 of 16 starred channels correctly render under `Starred` (3 absent — non-member/archived).

## Out of scope (future follow-up)

- Star/unstar mutation from inside slk — would introduce per-channel sidebar actions, a new UX pattern. Tracked separately as a cousin to the v2 "move channel between sections" candidate.
- `slack_connect`, `salesforce_records`, `agents` — remain filtered.
- Live WS sync of star changes across clients.
