### PR TITLE
fix: reliable initial read-state sync for channels, DMs, and threads

### DIFF
--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -1982,17 +1982,27 @@ func connectWorkspace(ctx context.Context, token slackclient.Token, db *cache.DB
 		debuglog.Cache("workspace_unread_bootstrap: team=%s GetUnreadCounts failed: %v", token.TeamName, ucErr)
 	}
 	wctx.ThreadsHasUnreads = threadsAgg.HasUnreads
-	if ucErr == nil && len(unreadCounts) > 0 {
+	// Boot applies an authoritative FULL snapshot: reset every channel
+	// in the workspace to read, then set the ones client.counts reports
+	// unread. This runs BEFORE the WebSocket goes live (ConnMgr.Run is
+	// started by the caller after connectWorkspace returns), so the
+	// reset cannot race an inbound *_marked event.
+	//
+	// Guard on ucErr only (not len>0): a successful call returning zero
+	// unreads legitimately means "everything is read" and must clear
+	// stale dots carried over from a prior session. A FAILED call must
+	// NOT reset — that would wipe every dot with no data to restore.
+	if ucErr == nil {
 		updates := make([]cache.ChannelReadStateUpdate, 0, len(unreadCounts))
 		for _, u := range unreadCounts {
 			updates = append(updates, cache.ChannelReadStateUpdate{
 				ChannelID:  u.ChannelID,
-				LastReadTS: u.LastRead, // may be ""; BatchUpdate preserves existing in that case
+				LastReadTS: u.LastRead, // may be ""; ReplaceWorkspaceReadState preserves existing in that case
 				HasUnread:  u.HasUnread,
 			})
 		}
-		if err := db.BatchUpdateChannelReadState(updates); err != nil {
-			log.Printf("Warning: bootstrap BatchUpdateChannelReadState for team=%s: %v", token.TeamName, err)
+		if err := db.ReplaceWorkspaceReadState(client.TeamID(), updates); err != nil {
+			log.Printf("Warning: bootstrap ReplaceWorkspaceReadState for team=%s: %v", token.TeamName, err)
 		}
 	}
 	mutedItemCount := 0

--- a/cmd/slk/reconnect_backfill.go
+++ b/cmd/slk/reconnect_backfill.go
@@ -366,6 +366,10 @@ func (b *backfiller) runSubscriptionPhase(ctx context.Context) error {
 			ChannelID:   v.Subscription.ChannelID,
 			ThreadTS:    v.Subscription.ThreadTS,
 			LastRead:    v.Subscription.LastRead,
+			// Authoritative newest-reply watermark from the getView
+			// root_msg. Lets the threads view compute unread state
+			// without the thread's replies being cached locally.
+			LatestReply: v.RootMessage.LatestReply,
 			Active:      true,
 		})
 	}
@@ -410,22 +414,48 @@ func (b *backfiller) runSubscriptionPhase(ctx context.Context) error {
 	return nil
 }
 
-// run executes the full backfill pass: channel phase, thread phase,
-// subscription phase, then a ThreadsListDirtyMsg dispatch so the UI
-// re-queries the threads view from the now-current cache. Phase
-// errors are logged but do not abort subsequent work — best-effort
-// overall.
+// run executes the full backfill pass. The subscription phase runs
+// CONCURRENTLY with the channel→thread history phases because it is the
+// authoritative source for the Threads view and has no dependency on
+// the (potentially multi-second) history backfill. It fires a
+// ThreadsListDirtyMsg the moment it lands so the Threads view shows
+// correct unread state within ~1s of connect instead of after the whole
+// backfill — or never, if the user quits mid-backfill (the bug this
+// ordering fixes). A final ThreadsListDirtyMsg after the thread phase
+// picks up any replies it cached that post-date the getView snapshot.
+//
+// The channel→thread phases stay ordered relative to each other
+// (runThreadPhase consumes discoveredThreads from runChannelPhase).
+// Phase errors are logged but do not abort sibling work — best-effort.
 func (b *backfiller) run(ctx context.Context) error {
 	start := time.Now()
+
+	var subWG sync.WaitGroup
+	subWG.Add(1)
+	go func() {
+		defer subWG.Done()
+		if err := b.runSubscriptionPhase(ctx); err != nil {
+			debuglog.Backfill("team=%s subscription-phase err=%v", b.workspaceID, err)
+			return
+		}
+		// Early refresh: authoritative thread-unread state is ready,
+		// don't wait for the channel-history backfill.
+		if b.program != nil {
+			b.program.Send(ui.ThreadsListDirtyMsg{TeamID: b.workspaceID})
+		}
+	}()
+
 	if err := b.runChannelPhase(ctx); err != nil {
 		debuglog.Backfill("team=%s channel-phase err=%v", b.workspaceID, err)
 	}
 	if err := b.runThreadPhase(ctx); err != nil {
 		debuglog.Backfill("team=%s thread-phase err=%v", b.workspaceID, err)
 	}
-	if err := b.runSubscriptionPhase(ctx); err != nil {
-		debuglog.Backfill("team=%s subscription-phase err=%v", b.workspaceID, err)
-	}
+
+	// run() completing must still mean "all catch-up work is done" —
+	// callers and tests depend on that. Wait for the subscription phase.
+	subWG.Wait()
+
 	if b.program != nil {
 		b.program.Send(ui.ThreadsListDirtyMsg{TeamID: b.workspaceID})
 	}

--- a/cmd/slk/reconnect_backfill_test.go
+++ b/cmd/slk/reconnect_backfill_test.go
@@ -25,6 +25,10 @@ type fakeHistory struct {
 	inFlight         int32
 	maxInFlight      int32
 	delay            time.Duration
+	// historyGate, when non-nil, blocks every GetHistorySince call
+	// until the channel is closed. Lets a test hold the channel phase
+	// open while asserting other phases proceed independently.
+	historyGate chan struct{}
 	responses        map[string][]*slack.GetConversationHistoryResponse
 	history          map[string][]slack.Message // alternate flat input: channelID → messages
 	calls            map[string]int
@@ -66,6 +70,9 @@ func (f *fakeHistory) ListThreadSubscriptions(ctx context.Context) ([]slackclien
 // more convenient. Capped is true when the returned slice was
 // truncated by maxTotal or when the queued response had HasMore set.
 func (f *fakeHistory) GetHistorySince(ctx context.Context, channelID, oldest string, maxTotal int) (slackclient.HistorySinceResult, error) {
+	if f.historyGate != nil {
+		<-f.historyGate
+	}
 	cur := atomic.AddInt32(&f.inFlight, 1)
 	defer atomic.AddInt32(&f.inFlight, -1)
 	for {
@@ -276,8 +283,11 @@ func TestBackfillThreads_FetchesRepliesForInvolvedThreads(t *testing.T) {
 }
 
 // TestBackfill_FiresThreadsListDirtyMsg verifies that run() dispatches
-// exactly one ThreadsListDirtyMsg into the program, carrying the
-// workspace ID so the UI knows which team's threads view to re-query.
+// ThreadsListDirtyMsg(s) into the program, each carrying the workspace
+// ID so the UI knows which team's threads view to re-query. run() now
+// fires an early refresh when the (concurrent) subscription phase lands
+// plus a final one after the thread phase, so there is at least one and
+// every dispatched message is a ThreadsListDirtyMsg for this workspace.
 func TestBackfill_FiresThreadsListDirtyMsg(t *testing.T) {
 	db := newTestDB(t)
 	db.UpsertChannel(cache.Channel{ID: "C1", WorkspaceID: "T1", Name: "a", Type: "channel"})
@@ -300,15 +310,101 @@ func TestBackfill_FiresThreadsListDirtyMsg(t *testing.T) {
 
 	captured.mu.Lock()
 	defer captured.mu.Unlock()
-	if len(captured.sent) != 1 {
-		t.Fatalf("expected 1 sent msg, got %d", len(captured.sent))
+	if len(captured.sent) == 0 {
+		t.Fatalf("expected at least one ThreadsListDirtyMsg, got none")
 	}
-	dirty, ok := captured.sent[0].(ui.ThreadsListDirtyMsg)
-	if !ok {
-		t.Fatalf("expected ThreadsListDirtyMsg, got %T", captured.sent[0])
+	for i, m := range captured.sent {
+		dirty, ok := m.(ui.ThreadsListDirtyMsg)
+		if !ok {
+			t.Fatalf("sent[%d]: expected ThreadsListDirtyMsg, got %T", i, m)
+		}
+		if dirty.TeamID != "T1" {
+			t.Errorf("sent[%d]: TeamID = %s, want T1", i, dirty.TeamID)
+		}
 	}
-	if dirty.TeamID != "T1" {
-		t.Errorf("TeamID = %s, want T1", dirty.TeamID)
+}
+
+// TestBackfill_SubscriptionRefreshNotGatedByChannelPhase pins the fix
+// for the "threads take ~45s to sync on launch" bug: the subscription
+// phase (the authoritative source for the Threads view) must run
+// independently of the slow channel-history phase and fire a Threads
+// refresh as soon as it lands — not wait for the whole backfill.
+//
+// The test holds the channel phase open (historyGate) and asserts the
+// subscription reconcile + ThreadsListDirtyMsg happen while it's still
+// blocked.
+func TestBackfill_SubscriptionRefreshNotGatedByChannelPhase(t *testing.T) {
+	db := newTestDB(t)
+	db.UpsertChannel(cache.Channel{ID: "C1", WorkspaceID: "T1", Name: "a", Type: "channel"})
+	db.UpsertMessage(cache.Message{TS: "1.000000", ChannelID: "C1", WorkspaceID: "T1", UserID: "U", Text: "x"})
+	db.SetChannelSyncedAt("C1", 100)
+
+	gate := make(chan struct{})
+	fh := &fakeHistory{
+		responses:   map[string][]*slack.GetConversationHistoryResponse{"C1": {{}}},
+		calls:       map[string]int{},
+		oldestSeen:  map[string][]string{},
+		historyGate: gate, // channel phase blocks here until we close it
+		subscriptionsResponse: []slackclient.ThreadSubscriptionView{{
+			Subscription: slackclient.ThreadSubscription{
+				ChannelID: "C1", ThreadTS: "100.000000", LastRead: "100.000000", Active: true,
+			},
+		}},
+	}
+
+	captured := &captureSender{}
+	bf := newBackfiller(fh, db, "T1", "USELF", captured, 4, 500, nil)
+
+	done := make(chan struct{})
+	go func() { _ = bf.run(context.Background()); close(done) }()
+
+	// Wait (bounded) for a Threads refresh WHILE the channel phase is
+	// still blocked in GetHistorySince.
+	dirtyFired := func() bool {
+		deadline := time.After(2 * time.Second)
+		for {
+			select {
+			case <-deadline:
+				return false
+			default:
+			}
+			captured.mu.Lock()
+			for _, m := range captured.sent {
+				if d, ok := m.(ui.ThreadsListDirtyMsg); ok && d.TeamID == "T1" {
+					captured.mu.Unlock()
+					return true
+				}
+			}
+			captured.mu.Unlock()
+			time.Sleep(5 * time.Millisecond)
+		}
+	}()
+	if !dirtyFired {
+		close(gate) // release goroutine before failing
+		<-done
+		t.Fatal("Threads refresh did not fire while channel phase was blocked; subscription phase is still gated behind the channel backfill")
+	}
+
+	// The subscription must have been reconciled independently of the
+	// (still-blocked) channel phase.
+	subs, err := db.ListActiveThreadSubscriptions("T1")
+	if err != nil {
+		close(gate)
+		<-done
+		t.Fatalf("ListActiveThreadSubscriptions: %v", err)
+	}
+	if len(subs) != 1 {
+		close(gate)
+		<-done
+		t.Fatalf("expected 1 reconciled subscription while channel phase blocked, got %d", len(subs))
+	}
+
+	// Release the channel phase and let run() finish cleanly.
+	close(gate)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("run() did not complete after releasing the channel gate")
 	}
 }
 

--- a/internal/cache/channels_read_state.go
+++ b/internal/cache/channels_read_state.go
@@ -83,6 +83,70 @@ func (db *DB) BatchUpdateChannelReadState(updates []ChannelReadStateUpdate) erro
 	return nil
 }
 
+// ReplaceWorkspaceReadState applies an authoritative full snapshot of
+// unread state for a workspace. In a single transaction it first
+// resets has_unread=0 for EVERY channel in the workspace, then applies
+// the given updates (has_unread + last_read_ts). Channels absent from
+// updates are therefore treated as read.
+//
+// This is the boot/bootstrap path. Unlike BatchUpdateChannelReadState
+// (which only touches rows named in the batch), the reset step clears
+// stale unread flags for channels the user read in another client
+// while slk was closed — channels that Slack's client.counts response
+// omits entirely (the unread-counts endpoint need not list read
+// channels). last_read_ts of an absent channel is left untouched:
+// there is no fresh value to apply and has_unread=0 already suppresses
+// the dot.
+//
+// Callers MUST only invoke this with a snapshot they trust to list
+// every currently-unread channel (i.e. a successful client.counts
+// call). On fetch failure, do NOT call this — a reset with no data
+// would wrongly clear every dot.
+func (db *DB) ReplaceWorkspaceReadState(workspaceID string, updates []ChannelReadStateUpdate) error {
+	if workspaceID == "" {
+		return fmt.Errorf("ReplaceWorkspaceReadState: workspaceID required")
+	}
+	tx, err := db.conn.Begin()
+	if err != nil {
+		return fmt.Errorf("begin replace read-state tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	if _, err := tx.Exec(
+		`UPDATE channels SET has_unread = 0 WHERE workspace_id = ?`,
+		workspaceID,
+	); err != nil {
+		return fmt.Errorf("reset workspace unread: %w", err)
+	}
+
+	stmtBoth, err := tx.Prepare(`UPDATE channels SET last_read_ts = ?, has_unread = ? WHERE id = ?`)
+	if err != nil {
+		return fmt.Errorf("prepare both: %w", err)
+	}
+	defer stmtBoth.Close()
+	stmtFlag, err := tx.Prepare(`UPDATE channels SET has_unread = ? WHERE id = ?`)
+	if err != nil {
+		return fmt.Errorf("prepare flag: %w", err)
+	}
+	defer stmtFlag.Close()
+
+	for _, u := range updates {
+		if u.LastReadTS == "" {
+			if _, err := stmtFlag.Exec(boolToInt(u.HasUnread), u.ChannelID); err != nil {
+				return fmt.Errorf("replace flag for %s: %w", u.ChannelID, err)
+			}
+		} else {
+			if _, err := stmtBoth.Exec(u.LastReadTS, boolToInt(u.HasUnread), u.ChannelID); err != nil {
+				return fmt.Errorf("replace both for %s: %w", u.ChannelID, err)
+			}
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit replace read-state: %w", err)
+	}
+	return nil
+}
+
 // GetChannelReadState returns the read state for a single channel.
 // A missing row yields a zero-valued ReadState and a nil error.
 func (db *DB) GetChannelReadState(channelID string) (ReadState, error) {

--- a/internal/cache/channels_read_state_test.go
+++ b/internal/cache/channels_read_state_test.go
@@ -206,6 +206,82 @@ func TestWorkspacesWithUnreads(t *testing.T) {
 	}
 }
 
+func TestReplaceWorkspaceReadState_ClearsChannelsAbsentFromSnapshot(t *testing.T) {
+	db, err := New(":memory:")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer db.Close()
+	newRSChannel(t, db, "C1", "T1")
+	newRSChannel(t, db, "C2", "T1")
+	newRSChannel(t, db, "C3", "T1")
+	newRSChannel(t, db, "D1", "T2") // different workspace
+
+	// Prior-session state: C1, C2 unread; D1 (other workspace) unread.
+	_ = db.UpdateChannelReadState("C1", "1.0001", true)
+	_ = db.UpdateChannelReadState("C2", "1.0002", true)
+	_ = db.UpdateChannelReadState("D1", "1.0003", true)
+
+	// Fresh authoritative snapshot for T1: only C3 is unread now.
+	// C1 was read in the official client while slk was closed and is
+	// therefore ABSENT from the snapshot; it must be cleared. C2 is
+	// explicitly reported read. C3 becomes unread.
+	updates := []ChannelReadStateUpdate{
+		{ChannelID: "C2", LastReadTS: "1.0100", HasUnread: false},
+		{ChannelID: "C3", LastReadTS: "1.0101", HasUnread: true},
+	}
+	if err := db.ReplaceWorkspaceReadState("T1", updates); err != nil {
+		t.Fatalf("ReplaceWorkspaceReadState: %v", err)
+	}
+
+	s1, _ := db.GetChannelReadState("C1")
+	if s1.HasUnread {
+		t.Errorf("C1 HasUnread = true; absent-from-snapshot channel must be cleared (Symptom 2)")
+	}
+	// last_read_ts of an absent channel is left untouched (no fresh value to apply).
+	if s1.LastReadTS != "1.0001" {
+		t.Errorf("C1 LastReadTS = %q, want preserved %q", s1.LastReadTS, "1.0001")
+	}
+	s2, _ := db.GetChannelReadState("C2")
+	if s2.HasUnread || s2.LastReadTS != "1.0100" {
+		t.Errorf("C2 = %+v, want {1.0100 false}", s2)
+	}
+	s3, _ := db.GetChannelReadState("C3")
+	if !s3.HasUnread || s3.LastReadTS != "1.0101" {
+		t.Errorf("C3 = %+v, want {1.0101 true}", s3)
+	}
+
+	// Other workspace is untouched by a T1 replace.
+	d1, _ := db.GetChannelReadState("D1")
+	if !d1.HasUnread || d1.LastReadTS != "1.0003" {
+		t.Errorf("D1 (other workspace) = %+v, want {1.0003 true} untouched", d1)
+	}
+}
+
+func TestReplaceWorkspaceReadState_EmptySnapshotClearsAll(t *testing.T) {
+	db, err := New(":memory:")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer db.Close()
+	newRSChannel(t, db, "C1", "T1")
+	newRSChannel(t, db, "C2", "T1")
+	_ = db.UpdateChannelReadState("C1", "1.0", true)
+	_ = db.UpdateChannelReadState("C2", "1.0", true)
+
+	// A successful client.counts call that reports zero unreads means
+	// everything is read.
+	if err := db.ReplaceWorkspaceReadState("T1", nil); err != nil {
+		t.Fatalf("ReplaceWorkspaceReadState: %v", err)
+	}
+	for _, id := range []string{"C1", "C2"} {
+		s, _ := db.GetChannelReadState(id)
+		if s.HasUnread {
+			t.Errorf("%s HasUnread = true after empty snapshot; want cleared", id)
+		}
+	}
+}
+
 func TestUpsertChannel_DoesNotClobberReadState(t *testing.T) {
 	db, err := New(":memory:")
 	if err != nil {

--- a/internal/cache/db.go
+++ b/internal/cache/db.go
@@ -228,6 +228,10 @@ func (db *DB) migrate() error {
 		"ALTER TABLE users ADD COLUMN is_external INTEGER NOT NULL DEFAULT 0"); err != nil {
 		return err
 	}
+	if err := db.addColumnIfMissing("thread_subscriptions", "latest_reply",
+		"ALTER TABLE thread_subscriptions ADD COLUMN latest_reply TEXT NOT NULL DEFAULT ''"); err != nil {
+		return err
+	}
 
 	// Full-text search index. FTS5 may be unavailable in unusual
 	// driver builds; search degrades to LIKE rather than failing

--- a/internal/cache/db_test.go
+++ b/internal/cache/db_test.go
@@ -295,7 +295,7 @@ func TestMigrate_CreatesThreadSubscriptionsTable(t *testing.T) {
 	if count == 0 {
 		t.Fatalf("thread_subscriptions table missing after migrate()")
 	}
-	const wantCols = 6 // workspace_id, channel_id, thread_ts, last_read, active, updated_at
+	const wantCols = 7 // workspace_id, channel_id, thread_ts, last_read, latest_reply, active, updated_at
 	if count != wantCols {
 		t.Fatalf("thread_subscriptions: want %d cols, got %d", wantCols, count)
 	}

--- a/internal/cache/thread_subscriptions.go
+++ b/internal/cache/thread_subscriptions.go
@@ -14,6 +14,15 @@ type ThreadSubscription struct {
 	ChannelID   string
 	ThreadTS    string
 	LastRead    string
+	// LatestReply is the ts of the newest reply in the thread as
+	// reported by subscriptions.thread.getView (root_msg.latest_reply).
+	// It is the authoritative "newest activity" watermark and lets the
+	// threads view compute unread state (LatestReply > LastRead)
+	// WITHOUT requiring the thread's replies to be cached locally.
+	// Empty when unknown (e.g. rows created by a live thread_subscribed
+	// event before the next getView reconcile); the threads query then
+	// falls back to MAX(cached reply ts).
+	LatestReply string
 	Active      bool
 	UpdatedAt   int64 // unix seconds; bumped on every upsert
 }
@@ -116,18 +125,21 @@ func (db *DB) ReconcileThreadSubscriptions(workspaceID string, fresh []ThreadSub
 		freshKeys[key{s.ChannelID, s.ThreadTS}] = struct{}{}
 	}
 
-	// 1. Upsert each fresh entry as active=1.
+	// 1. Upsert each fresh entry as active=1. latest_reply comes from
+	// the authoritative getView snapshot and drives thread-unread
+	// without needing replies cached (see ThreadSubscription docs).
 	const upsertQ = `
 INSERT INTO thread_subscriptions
-    (workspace_id, channel_id, thread_ts, last_read, active, updated_at)
-VALUES (?, ?, ?, ?, 1, ?)
+    (workspace_id, channel_id, thread_ts, last_read, latest_reply, active, updated_at)
+VALUES (?, ?, ?, ?, ?, 1, ?)
 ON CONFLICT(workspace_id, channel_id, thread_ts) DO UPDATE SET
-    last_read  = excluded.last_read,
-    active     = 1,
-    updated_at = excluded.updated_at
+    last_read    = excluded.last_read,
+    latest_reply = excluded.latest_reply,
+    active       = 1,
+    updated_at   = excluded.updated_at
 `
 	for _, s := range fresh {
-		if _, err := tx.Exec(upsertQ, workspaceID, s.ChannelID, s.ThreadTS, s.LastRead, now); err != nil {
+		if _, err := tx.Exec(upsertQ, workspaceID, s.ChannelID, s.ThreadTS, s.LastRead, s.LatestReply, now); err != nil {
 			return fmt.Errorf("upserting fresh subscription (%s/%s): %w", s.ChannelID, s.ThreadTS, err)
 		}
 	}

--- a/internal/cache/threads.go
+++ b/internal/cache/threads.go
@@ -35,8 +35,14 @@ type ThreadSummary struct {
 // Ordering: newest LastReplyTS first.
 //
 // Unread is computed from the subscription's per-thread LastRead
-// (not the per-channel channels.last_read_ts): unread iff a reply
-// exists later than LastRead AND the last reply isn't by self.
+// (not the per-channel channels.last_read_ts): unread iff the newest
+// activity is later than LastRead. "Newest activity" is the max of the
+// authoritative latest_reply watermark (from subscriptions.thread.getView)
+// and the newest locally-cached reply — so a subscribed thread with
+// unread replies renders unread even when those replies have not been
+// fetched into the cache yet (the boot case). The only suppression is
+// the optimistic just-sent window: a locally-cached newest reply known
+// to be authored by self does not count as unread.
 func (db *DB) ListSubscribedThreads(workspaceID, selfUserID string) ([]ThreadSummary, error) {
 	const q = `
 SELECT
@@ -45,6 +51,7 @@ SELECT
     COALESCE(c.name, ''),
     COALESCE(c.type, ''),
     s.last_read,
+    s.latest_reply,
     COALESCE((SELECT user_id FROM messages
               WHERE channel_id = s.channel_id AND ts = s.thread_ts AND is_deleted = 0), ''),
     COALESCE((SELECT text FROM messages
@@ -56,8 +63,8 @@ SELECT
     COALESCE(
         (SELECT MAX(ts) FROM messages
          WHERE channel_id = s.channel_id AND thread_ts = s.thread_ts AND is_deleted = 0),
-        s.last_read
-    ) AS last_reply_ts,
+        ''
+    ) AS cached_max_ts,
     COALESCE(
         (SELECT user_id FROM messages
          WHERE channel_id = s.channel_id AND thread_ts = s.thread_ts AND is_deleted = 0
@@ -77,23 +84,50 @@ WHERE s.workspace_id = ? AND s.active = 1
 	var out []ThreadSummary
 	for rows.Next() {
 		var s ThreadSummary
-		var lastRead string
+		var lastRead, latestReply, cachedMaxTS string
 		if err := rows.Scan(
 			&s.ChannelID,
 			&s.ThreadTS,
 			&s.ChannelName,
 			&s.ChannelType,
 			&lastRead,
+			&latestReply,
 			&s.ParentUserID,
 			&s.ParentText,
 			&s.ReplyCount,
-			&s.LastReplyTS,
+			&cachedMaxTS,
 			&s.LastReplyBy,
 		); err != nil {
 			return nil, fmt.Errorf("scanning subscribed thread row: %w", err)
 		}
 		s.ParentTS = s.ThreadTS
-		s.Unread = s.LastReplyTS > lastRead && s.LastReplyBy != selfUserID && s.LastReplyBy != ""
+
+		// Effective newest activity = the max of the authoritative
+		// getView watermark (latest_reply) and the newest reply we've
+		// cached locally, falling back to last_read so uncached/read
+		// threads still sort sensibly. Comparing string ts is valid:
+		// Slack ts are fixed-width "secs.micros".
+		effLatest := lastRead
+		if cachedMaxTS > effLatest {
+			effLatest = cachedMaxTS
+		}
+		if latestReply > effLatest {
+			effLatest = latestReply
+		}
+		s.LastReplyTS = effLatest
+
+		// Unread when the newest activity is past our read watermark.
+		// Suppress only when that newest activity is a locally-cached
+		// reply we know was authored by self (the optimistic just-sent
+		// window, before last_read catches up). When the newest activity
+		// comes from the authoritative latest_reply (author unknown /
+		// uncached), we trust the ts comparison — this is the boot case
+		// the old cached-reply-only heuristic got wrong.
+		unread := effLatest > lastRead
+		if unread && cachedMaxTS == effLatest && s.LastReplyBy == selfUserID {
+			unread = false
+		}
+		s.Unread = unread
 		out = append(out, s)
 	}
 	if err := rows.Err(); err != nil {

--- a/internal/cache/threads_test.go
+++ b/internal/cache/threads_test.go
@@ -223,6 +223,87 @@ func TestListSubscribedThreads_UnreadUsesPerThreadLastRead(t *testing.T) {
 	}
 }
 
+func TestListSubscribedThreads_UnreadFromLatestReplyWithoutCachedReplies(t *testing.T) {
+	const selfID = "U1"
+	db := setupDBWithWorkspace(t)
+	if err := db.UpsertChannel(Channel{ID: "C1", WorkspaceID: "T1", Name: "general", Type: "channel"}); err != nil {
+		t.Fatalf("UpsertChannel: %v", err)
+	}
+	// Authoritative snapshot from subscriptions.thread.getView: the
+	// server reports a latest_reply at ...200 newer than our per-thread
+	// last_read ...150, but NO replies are cached locally (the boot
+	// case). The thread must still render unread — the old heuristic
+	// wrongly showed it read because MAX(cached reply ts) was empty.
+	fresh := []ThreadSubscription{{
+		WorkspaceID: "T1", ChannelID: "C1", ThreadTS: "1700000100.000000",
+		LastRead: "1700000150.000000", LatestReply: "1700000200.000000", Active: true,
+	}}
+	if err := db.ReconcileThreadSubscriptions("T1", fresh); err != nil {
+		t.Fatalf("ReconcileThreadSubscriptions: %v", err)
+	}
+
+	got, err := db.ListSubscribedThreads("T1", selfID)
+	if err != nil {
+		t.Fatalf("ListSubscribedThreads: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1, got %d", len(got))
+	}
+	if !got[0].Unread {
+		t.Fatalf("expected Unread=true from authoritative latest_reply > last_read with no cached replies")
+	}
+}
+
+func TestListSubscribedThreads_ReadWhenLatestReplyNotNewerThanLastRead(t *testing.T) {
+	const selfID = "U1"
+	db := setupDBWithWorkspace(t)
+	if err := db.UpsertChannel(Channel{ID: "C1", WorkspaceID: "T1", Name: "general", Type: "channel"}); err != nil {
+		t.Fatalf("UpsertChannel: %v", err)
+	}
+	// Server reports latest_reply == last_read: the user has read the
+	// whole thread. No cached replies. Must render read.
+	fresh := []ThreadSubscription{{
+		WorkspaceID: "T1", ChannelID: "C1", ThreadTS: "1700000100.000000",
+		LastRead: "1700000200.000000", LatestReply: "1700000200.000000", Active: true,
+	}}
+	if err := db.ReconcileThreadSubscriptions("T1", fresh); err != nil {
+		t.Fatalf("ReconcileThreadSubscriptions: %v", err)
+	}
+
+	got, err := db.ListSubscribedThreads("T1", selfID)
+	if err != nil {
+		t.Fatalf("ListSubscribedThreads: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1, got %d", len(got))
+	}
+	if got[0].Unread {
+		t.Fatalf("expected Unread=false when latest_reply == last_read")
+	}
+}
+
+func TestReconcileThreadSubscriptions_PersistsLatestReply(t *testing.T) {
+	db := setupDBWithWorkspace(t)
+	defer db.Close()
+	fresh := []ThreadSubscription{{
+		WorkspaceID: "T1", ChannelID: "C1", ThreadTS: "1700000100.000000",
+		LastRead: "1700000150.000000", LatestReply: "1700000200.000000", Active: true,
+	}}
+	if err := db.ReconcileThreadSubscriptions("T1", fresh); err != nil {
+		t.Fatalf("ReconcileThreadSubscriptions: %v", err)
+	}
+	var latestReply string
+	if err := db.conn.QueryRow(
+		`SELECT latest_reply FROM thread_subscriptions WHERE workspace_id=? AND channel_id=? AND thread_ts=?`,
+		"T1", "C1", "1700000100.000000",
+	).Scan(&latestReply); err != nil {
+		t.Fatalf("query latest_reply: %v", err)
+	}
+	if latestReply != "1700000200.000000" {
+		t.Errorf("latest_reply = %q, want %q", latestReply, "1700000200.000000")
+	}
+}
+
 func TestListSubscribedThreads_ParentMissingShowsEmpty(t *testing.T) {
 	const selfID = "U1"
 	db := setupDBWithWorkspace(t)


### PR DESCRIPTION
## Summary

Receiving updates was not bulletproof during the **initial sync after launch** — channels/DMs/threads could show stale unreads, or miss unreads entirely — while live updates stayed correct. This fixes three distinct root causes in the boot/backfill read-state path.

### 1. Channels/DMs — stale unreads never cleared on boot
Boot only wrote read-state for channels **present** in the `client.counts` response and never reset the rest. Combined with `UpsertChannel` preserving `has_unread` across sessions, a channel/DM you read in another client while slk was closed kept its stale `has_unread` from the prior session forever.

- New `cache.ReplaceWorkspaceReadState`: in one transaction, reset every channel in the workspace to read, then apply the `client.counts` unread entries. Robust whether or not `client.counts` lists read channels.
- `connectWorkspace` uses it, runs **before** the WebSocket goes live (no race with `*_marked` events), and is guarded on `ucErr` only so a zero-unread response correctly clears stale dots.

### 2. Threads — unread derived from cached replies
Thread unread was computed from locally-cached replies, so a subscribed thread whose replies weren't cached yet rendered **read**.

- Persist the authoritative `latest_reply` from `subscriptions.thread.getView` (new `thread_subscriptions.latest_reply` column + additive migration).
- `ListSubscribedThreads` now computes `unread = max(latest_reply, cached_reply) > last_read`, so unread is correct without the replies being cached.

### 3. Threads — subscription sync ran dead-last, took ~45s
`backfiller.run()` ran `channel → thread → subscription` sequentially, so the authoritative thread sync (`getView`) sat behind a multi-second channel-history backfill. The Threads view took tens of seconds to reflect reality — or never, if you quit first.

- Run the subscription phase **concurrently** with the channel/thread phases and fire a `ThreadsListDirtyMsg` the moment it lands. Threads now sync ~1s after connect. `run()` still waits for all phases before returning.

## Test Plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./...` passes
- [x] `go test ./cmd/slk/ -run TestBackfill -race` passes (new concurrency)
- [x] New unit tests: workspace read-state reset (absent-from-snapshot + empty snapshot), authoritative thread unread (with/without cached replies), `latest_reply` persistence
- [x] New deterministic test: subscription refresh fires while the channel phase is blocked (proves phases are decoupled)
- [x] Manually verified against a live multi-workspace account: an unread thread that previously took ~45s (or never) to appear now shows within ~1s of launch

## Notes
- DB is `SetMaxOpenConns(1)` + `busy_timeout`, so the added concurrent writer serializes safely.
- One known follow-up (out of scope): the very first Threads render still briefly shows prior-session data for ~1s until `getView` lands; could be suppressed if desired.