### PR TITLE
Show online/away presence for DM peers in the sidebar

### DIFF
--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -3096,17 +3096,22 @@ func xdgCache() string {
 
 // bootstrapPresenceAndDND fetches the user's current presence and DND
 // state from Slack, populates the WorkspaceContext, and sends an initial
-// StatusChangeMsg. Also subscribes to presence_change events for the
-// self user so external state changes arrive over the WS.
+// StatusChangeMsg. Also subscribes to presence_change events for the self
+// user and every DM peer so external state changes arrive over the WS.
 func bootstrapPresenceAndDND(ctx context.Context, wctx *WorkspaceContext, program *tea.Program) {
 	if wctx == nil || wctx.Client == nil {
 		return
 	}
 
-	// Subscribe so future presence_change events for our own user arrive.
-	// Failure is non-fatal — manual_presence_change and dnd_updated work
-	// without an explicit subscription.
-	_ = wctx.Client.SubscribePresence([]string{wctx.UserID})
+	// Subscribe to presence for our own user plus every 1:1 DM peer so the
+	// sidebar can show who is online. presence_sub REPLACES the prior
+	// subscription set, so self and peers must go in one call. Failure is
+	// non-fatal — manual_presence_change and dnd_updated work without it.
+	//
+	// This runs from OnConnect, which fires on the initial connect AND on
+	// every reconnect. Re-subscribing per connection is required because
+	// the subscription is connection-scoped.
+	subscribeWorkspacePresence(wctx)
 
 	// Initial presence fetch
 	if p, err := wctx.Client.GetUserPresence(ctx, wctx.UserID); err == nil && p != nil {
@@ -3149,6 +3154,58 @@ func bootstrapPresenceAndDND(ctx context.Context, wctx *WorkspaceContext, progra
 			DNDEndTS:   wctx.DNDEndTS,
 		})
 	}
+}
+
+// subscribeWorkspacePresence subscribes over the WebSocket to presence
+// updates for the authenticated user plus every 1:1 DM peer, so the
+// sidebar can show who is online. Slack's presence_sub REPLACES the prior
+// subscription set and is connection-scoped, so this sends self + all DM
+// peers in a single call and must be re-run on each (re)connect.
+//
+// Note: the WS is opened with no_query_on_subscribe=1, so Slack does not
+// reply with each peer's current presence at subscribe time — DM rows are
+// seeded from the local cache at build time and then updated live by
+// presence_change events. Safe to call repeatedly.
+func subscribeWorkspacePresence(wctx *WorkspaceContext) {
+	if wctx == nil || wctx.Client == nil {
+		return
+	}
+	ids := workspacePresenceIDs(wctx)
+	if len(ids) == 0 {
+		debuglog.General("subscribeWorkspacePresence: no ids to subscribe")
+		return
+	}
+	if err := wctx.Client.SubscribePresence(ids); err != nil {
+		debuglog.General("subscribeWorkspacePresence (%d ids) FAILED: %v", len(ids), err)
+		return
+	}
+	debuglog.General("subscribeWorkspacePresence: sent presence_sub for %d ids (self+%d dm peers)", len(ids), len(ids)-1)
+}
+
+// workspacePresenceIDs returns the deduped list of user IDs to subscribe
+// for presence: the authenticated user plus every 1:1 DM peer. Group DMs
+// and app/bot DMs (which carry no human presence dot in the sidebar) are
+// skipped. Pure function for testability.
+func workspacePresenceIDs(wctx *WorkspaceContext) []string {
+	seen := make(map[string]struct{})
+	ids := make([]string, 0, len(wctx.Channels)+1)
+	add := func(uid string) {
+		if uid == "" {
+			return
+		}
+		if _, ok := seen[uid]; ok {
+			return
+		}
+		seen[uid] = struct{}{}
+		ids = append(ids, uid)
+	}
+	add(wctx.UserID) // self — keeps the self presence subscription intact
+	for _, ch := range wctx.Channels {
+		if ch.Type == "dm" {
+			add(ch.DMUserID)
+		}
+	}
+	return ids
 }
 
 // mostRecentlyVisitedChannel returns the channel ID with the latest

--- a/cmd/slk/presence_test.go
+++ b/cmd/slk/presence_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gammons/slk/internal/ui/sidebar"
+)
+
+func TestWorkspacePresenceIDs(t *testing.T) {
+	wctx := &WorkspaceContext{
+		UserID: "USELF",
+		Channels: []sidebar.ChannelItem{
+			{Type: "dm", DMUserID: "U1"},
+			{Type: "channel"}, // not a DM — skipped
+			{Type: "dm", DMUserID: "U2"},
+			{Type: "dm", DMUserID: "U1"},     // duplicate peer — deduped
+			{Type: "app", DMUserID: "UBOT"},  // app/bot DM — no presence dot
+			{Type: "group_dm", DMUserID: ""}, // group DM — skipped
+			{Type: "dm", DMUserID: ""},       // malformed — skipped
+		},
+	}
+
+	got := workspacePresenceIDs(wctx)
+	want := []string{"USELF", "U1", "U2"} // self first, then DM peers in order, deduped
+	if len(got) != len(want) {
+		t.Fatalf("workspacePresenceIDs() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("workspacePresenceIDs()[%d] = %q, want %q (full %v)", i, got[i], want[i], got)
+		}
+	}
+}

--- a/internal/slack/events.go
+++ b/internal/slack/events.go
@@ -137,11 +137,15 @@ type wsReactionEvent struct {
 	} `json:"item"`
 }
 
-// wsPresenceEvent represents a presence_change event.
+// wsPresenceEvent represents a presence_change event. Slack sends either
+// a single-user form ("user") or, on batch_presence_aware connections, a
+// batched form ("users") carrying several user IDs that share the same
+// presence value. Both are parsed.
 type wsPresenceEvent struct {
-	Type     string `json:"type"`
-	User     string `json:"user"`
-	Presence string `json:"presence"`
+	Type     string   `json:"type"`
+	User     string   `json:"user"`
+	Users    []string `json:"users"`
+	Presence string   `json:"presence"`
 }
 
 // wsTypingEvent represents a user_typing event.
@@ -327,7 +331,15 @@ func dispatchWebSocketEvent(data []byte, handler EventHandler) {
 		if err := json.Unmarshal(data, &evt); err != nil {
 			return
 		}
-		handler.OnPresenceChange(evt.User, evt.Presence)
+		if len(evt.Users) > 0 {
+			for _, uid := range evt.Users {
+				debuglog.WS("presence_change (batch): user=%s presence=%q", uid, evt.Presence)
+				handler.OnPresenceChange(uid, evt.Presence)
+			}
+		} else if evt.User != "" {
+			debuglog.WS("presence_change: user=%s presence=%q", evt.User, evt.Presence)
+			handler.OnPresenceChange(evt.User, evt.Presence)
+		}
 
 	case "manual_presence_change":
 		var evt wsManualPresenceEvent

--- a/internal/slack/events_test.go
+++ b/internal/slack/events_test.go
@@ -228,6 +228,25 @@ func TestDispatchWebSocketPresenceChangeEvent(t *testing.T) {
 	}
 }
 
+func TestDispatchWebSocketPresenceChangeBatch(t *testing.T) {
+	handler := &mockEventHandler{}
+
+	// batch_presence_aware connections deliver a "users" array sharing one
+	// presence value instead of a single "user" — each must be dispatched.
+	data := []byte(`{"type":"presence_change","users":["U1","U2","U3"],"presence":"away"}`)
+	dispatchWebSocketEvent(data, handler)
+
+	want := []string{"U1:away", "U2:away", "U3:away"}
+	if len(handler.presenceChanges) != len(want) {
+		t.Fatalf("expected %d presence changes, got %d (%v)", len(want), len(handler.presenceChanges), handler.presenceChanges)
+	}
+	for i, w := range want {
+		if handler.presenceChanges[i] != w {
+			t.Errorf("presenceChanges[%d] = %q, want %q", i, handler.presenceChanges[i], w)
+		}
+	}
+}
+
 func TestDispatchWebSocketMessageDeletedEvent(t *testing.T) {
 	handler := &mockEventHandler{}
 

--- a/internal/ui/reducer_workspace.go
+++ b/internal/ui/reducer_workspace.go
@@ -282,6 +282,11 @@ func reduceWorkspaceSwitched(a *App, m WorkspaceSwitchedMsg) tea.Cmd {
 	a.SetMode(ModeNormal)
 	a.compose.Blur()
 	a.sidebar.SetSectionsProvider(m.SectionsProvider)
+	// Forget the previous workspace's live DM presence before loading
+	// the new one, so its cache-seeded item presence isn't overwritten
+	// by a stale peer from the workspace we're leaving. The new
+	// workspace's own presence_change events repopulate it.
+	a.sidebar.ResetPresence()
 	a.SetChannels(m.Channels)
 	a.channelFinder.SetItems(m.FinderItems)
 	// SetExternalUsers re-pushes user-names; calling SetUserNames

--- a/internal/ui/sidebar/model.go
+++ b/internal/ui/sidebar/model.go
@@ -189,6 +189,16 @@ type Model struct {
 	filter   string
 	filtered []int // indices into items that match filter
 
+	// presenceByUser is the authoritative live presence for DM peers,
+	// keyed by DMUserID ("active"/"away"). It is updated by presence_change
+	// WS events (UpdatePresenceByUser) and re-applied onto items on every
+	// SetItems, so a sidebar rebuild (sections refresh, DM-name resolution,
+	// workspace-ready) can't wipe live presence back to the "away" default
+	// that freshly-built ChannelItems carry. Cleared on workspace switch
+	// via ResetPresence. Also remembers events that arrive before their DM
+	// item exists (startup race) so they apply once the item is set.
+	presenceByUser map[string]string
+
 	// Flat list of navigable stops in display order: threads row,
 	// section headers, and channel rows belonging to expanded sections.
 	// cursor indexes into nav and is the single source of truth for what
@@ -613,10 +623,36 @@ func (m *Model) ThreadsUnreadCount() int { return m.threadsUnread }
 // SelectThreadsRow() after SetItems.
 func (m *Model) SetItems(items []ChannelItem) {
 	m.items = items
+	m.applyPresence()
 	m.rebuildFilter()
 	m.rebuildNavPreserveCursor()
 	m.cacheValid = false
 	m.dirty()
+}
+
+// applyPresence overwrites each DM item's Presence with the authoritative
+// live value from presenceByUser, so a rebuild that supplies stale/default
+// presence doesn't clobber the real state. No-op when no presence is known.
+func (m *Model) applyPresence() {
+	if len(m.presenceByUser) == 0 {
+		return
+	}
+	for i := range m.items {
+		uid := m.items[i].DMUserID
+		if uid == "" {
+			continue
+		}
+		if p, ok := m.presenceByUser[uid]; ok {
+			m.items[i].Presence = p
+		}
+	}
+}
+
+// ResetPresence forgets all remembered per-user presence. Called on
+// workspace switch so the newly-active workspace starts from its own
+// cache-seeded item presence rather than the previous workspace's peers.
+func (m *Model) ResetPresence() {
+	m.presenceByUser = nil
 }
 
 // UpsertItem inserts a new ChannelItem keyed by ID, or updates an existing
@@ -630,6 +666,14 @@ func (m *Model) SetItems(items []ChannelItem) {
 // staleness state may have changed) is reflected in the visible list
 // immediately.
 func (m *Model) UpsertItem(item ChannelItem) {
+	// Seed the incoming item with known live presence so a DM opened at
+	// runtime shows the right dot immediately instead of the "away"
+	// default it was built with.
+	if item.DMUserID != "" {
+		if p, ok := m.presenceByUser[item.DMUserID]; ok {
+			item.Presence = p
+		}
+	}
 	for i := range m.items {
 		if m.items[i].ID == item.ID {
 			m.items[i] = item
@@ -774,8 +818,19 @@ func (m *Model) VisibleItems() []ChannelItem {
 	return result
 }
 
-// UpdatePresenceByUser updates the presence for any DM item whose DMUserID matches.
+// UpdatePresenceByUser records the authoritative live presence for a user
+// and updates any DM item whose DMUserID matches. Recording in
+// presenceByUser (even when no item matches yet) makes the value survive
+// later SetItems rebuilds and applies it to items that appear afterward
+// (startup race).
 func (m *Model) UpdatePresenceByUser(userID, presence string) {
+	if userID == "" {
+		return
+	}
+	if m.presenceByUser == nil {
+		m.presenceByUser = make(map[string]string)
+	}
+	m.presenceByUser[userID] = presence
 	for i := range m.items {
 		if m.items[i].DMUserID == userID {
 			if m.items[i].Presence != presence {

--- a/internal/ui/sidebar/presence_test.go
+++ b/internal/ui/sidebar/presence_test.go
@@ -1,0 +1,59 @@
+package sidebar
+
+import "testing"
+
+// presenceOf returns the Presence of the DM item with the given DMUserID.
+func presenceOf(m *Model, userID string) string {
+	for _, it := range m.Items() {
+		if it.DMUserID == userID {
+			return it.Presence
+		}
+	}
+	return "<not found>"
+}
+
+// A live presence update must survive a subsequent SetItems rebuild.
+// SectionsRefreshedMsg / WorkspaceReadyMsg push freshly-built items whose
+// Presence is the stale "away" default; without authoritative presence
+// state that rebuild wipes the live dots (the "everyone offline" bug).
+func TestSetItemsPreservesLivePresence(t *testing.T) {
+	m := New([]ChannelItem{{ID: "D1", Type: "dm", DMUserID: "U1", Presence: "away"}})
+
+	m.UpdatePresenceByUser("U1", "active")
+	if got := presenceOf(&m, "U1"); got != "active" {
+		t.Fatalf("after UpdatePresenceByUser: presence = %q, want active", got)
+	}
+
+	// Simulate a sidebar rebuild (e.g. sections refresh) carrying stale presence.
+	m.SetItems([]ChannelItem{{ID: "D1", Type: "dm", DMUserID: "U1", Presence: "away"}})
+	if got := presenceOf(&m, "U1"); got != "active" {
+		t.Errorf("after SetItems rebuild: presence = %q, want active (live presence must survive)", got)
+	}
+}
+
+// A presence event that arrives before the DM item exists must be applied
+// once the item is set (startup race: the presence burst lands right after
+// subscribe, potentially before WorkspaceReadyMsg populates the sidebar).
+func TestUpdatePresenceBeforeItemsIsAppliedOnSetItems(t *testing.T) {
+	m := New(nil)
+
+	m.UpdatePresenceByUser("U1", "active") // no items yet
+
+	m.SetItems([]ChannelItem{{ID: "D1", Type: "dm", DMUserID: "U1", Presence: "away"}})
+	if got := presenceOf(&m, "U1"); got != "active" {
+		t.Errorf("presence = %q, want active (early event must be remembered)", got)
+	}
+}
+
+// ResetPresence drops remembered presence so a workspace switch starts from
+// the new workspace's cache-seeded item presence rather than stale peers.
+func TestResetPresenceClearsRememberedState(t *testing.T) {
+	m := New(nil)
+	m.UpdatePresenceByUser("U1", "active")
+	m.ResetPresence()
+
+	m.SetItems([]ChannelItem{{ID: "D1", Type: "dm", DMUserID: "U1", Presence: "away"}})
+	if got := presenceOf(&m, "U1"); got != "away" {
+		t.Errorf("presence = %q, want away (reset must forget prior presence)", got)
+	}
+}


### PR DESCRIPTION
Closes #69.

## Problem

The Direct Messages list never showed who was online — every DM rendered the hollow `○` (away), even for active peers.

## Root causes (three, not two)

The presence pipeline mostly existed already (`OnPresenceChange` → `PresenceChangeMsg` → `sidebar.UpdatePresenceByUser`, the `ChannelItem.Presence` field, and `●`/`○` rendering). What was missing/broken:

1. **slk only subscribed to its own presence** (`SubscribePresence([]string{wctx.UserID})`), never DM peers — so Slack never sent their `presence_change` events.
2. **Batch `presence_change` events were dropped.** With `batch_presence_aware=1`, Slack sends `presence_change` carrying a `users` array, but the parser only read a single `user` field.
3. **Live presence was clobbered by sidebar rebuilds.** Even after 1+2, dots stayed hollow. Live presence lived only on the sidebar's `items`, and any rebuild — `SectionsRefreshedMsg` (fires on `OnConnect`, the exact moment the presence burst arrives), `DMNameResolvedMsg`, `WorkspaceReadyMsg` — calls `SetItems` with freshly built items carrying the stale `"away"` default, wiping the live values.

## Fix

- **Subscribe self + every 1:1 DM peer** in a single `presence_sub` (it replaces the prior set, so self and peers must go together). Routed through `bootstrapPresenceAndDND`, which runs from `OnConnect`, so it re-subscribes on every connection (the subscription is connection-scoped). App/bot and group DMs are skipped (no human presence dot). `workspacePresenceIDs` is a pure, unit-tested helper.
- **Parse both the single-user (`user`) and batched (`users[]`) forms** of `presence_change`.
- **Give the sidebar authoritative presence state** (`presenceByUser`, keyed by `DMUserID`): recorded on every `presence_change` and re-applied on `SetItems`/`UpsertItem`, so rebuilds no longer wipe it. Events that arrive before their DM item exists (startup race) are remembered and applied when the item is set. Cleared on workspace switch via `ResetPresence()`.

## Testing

- `go test ./...` passes.
- New tests: `TestWorkspacePresenceIDs` (self + DM peers, dedup, skips channel/group/app DMs); `TestDispatchWebSocketPresenceChangeBatch`; and sidebar `TestSetItemsPreservesLivePresence`, `TestUpdatePresenceBeforeItemsIsAppliedOnSetItems`, `TestResetPresenceClearsRememberedState`.
- Verified end-to-end with `SLK_DEBUG=1`: `presence_sub` is sent for self + peers, Slack pushes back `presence_change` events, and DM rows now render `●`/`○` correctly and update live.

## Credit

Root-cause diagnosis of #1 and #2 comes from the closed PR #70 by @Frodotus (Toni Leino). This PR adapts that work (dropping an initial-boot subscribe call that ran before the WebSocket was connected, and unrelated gofmt churn) and adds root cause #3, without which the dots never actually render.

## Out of scope

For multi-workspace users, presence on a *background* workspace isn't tracked while inactive (`PresenceChangeMsg` isn't team-scoped). Pre-existing; can be a follow-up.