### PR TITLE
fix(wake): strip monotonic reading so suspend is actually detected

### DIFF
--- a/internal/wake/detector.go
+++ b/internal/wake/detector.go
@@ -74,7 +74,14 @@ func New(interval, threshold time.Duration, onWake func(time.Duration)) *Detecto
 // a goroutine and without relying on a real ticker. Run calls this
 // internally on every tick.
 func (d *Detector) Step() {
-	now := d.now()
+	// Round(0) strips the monotonic clock reading. time.Now carries
+	// one, and time.Time.Sub uses the monotonic clock alone when both
+	// operands have a reading. The monotonic clock does not advance
+	// while the OS is suspended (Linux CLOCK_MONOTONIC, macOS
+	// mach_absolute_time), so without stripping it the wall-clock jump
+	// on wake — the entire signal this detector relies on — would be
+	// invisible to the Sub below and onWake would never fire.
+	now := d.now().Round(0)
 	if !d.initialized {
 		d.last = now
 		d.initialized = true

--- a/internal/wake/detector_test.go
+++ b/internal/wake/detector_test.go
@@ -2,10 +2,20 @@ package wake
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 )
+
+// hasMonotonicReading reports whether t carries a monotonic clock
+// reading. time.Time.String appends " m=±<seconds>" when — and only
+// when — a monotonic reading is present (documented in the time
+// package), so this is a stable way to detect it without unsafe access
+// to unexported fields.
+func hasMonotonicReading(t time.Time) bool {
+	return strings.Contains(t.String(), " m=")
+}
 
 // fakeClock returns whatever its current field says. Tests advance
 // the clock via Advance or Set. The mutex is necessary for the
@@ -213,6 +223,37 @@ func TestStep_FirstCallSeedsWithoutFiring(t *testing.T) {
 	}
 	if !d.last.Equal(fc.Now()) {
 		t.Errorf("first Step did not store baseline; last=%v want=%v", d.last, fc.Now())
+	}
+}
+
+func TestStep_StripsMonotonicReading_SoWallJumpsAreDetected(t *testing.T) {
+	// Regression test for the suspend-detection bug.
+	//
+	// In production d.now is time.Now, whose results carry a monotonic
+	// clock reading. time.Time.Sub uses the monotonic clock alone when
+	// both operands have a reading. On Linux/macOS the monotonic clock
+	// does NOT advance while the system is suspended, so if Step stores
+	// a monotonic-carrying time, the wall-clock jump on wake is invisible
+	// to Sub and onWake never fires — exactly the "doesn't sync after
+	// lid close" symptom.
+	//
+	// The fix is for Step to strip the monotonic reading (Round(0)) so
+	// elapsed is computed from the wall clock. This test drives Step with
+	// the REAL clock (the only source of monotonic readings) and asserts
+	// the stored baseline has no monotonic reading.
+	d := New(10*time.Second, 5*time.Second, func(time.Duration) {})
+
+	if !hasMonotonicReading(d.now()) {
+		t.Skip("real clock does not carry a monotonic reading on this platform; " +
+			"the bug this guards against cannot occur here")
+	}
+
+	d.Step() // seeds d.last from the real clock
+
+	if hasMonotonicReading(d.last) {
+		t.Fatalf("Step stored a baseline with a monotonic reading (%v); "+
+			"Sub will then use the monotonic clock, which is frozen during "+
+			"OS suspend, so wall-clock jumps on wake go undetected", d.last)
 	}
 }
 


### PR DESCRIPTION
## Problem

The wake-from-sleep detector (`internal/wake`) is meant to catch laptop lid-close / suspend and trigger a catch-up backfill. In practice it was a **silent no-op in production** on Linux and macOS: with slk running, closing the laptop and reopening it did not re-sync.

## Root cause

`Detector.Step` observed time via `time.Now`, whose result carries a **monotonic clock reading**. [`time.Time.Sub` uses the monotonic clock alone](https://pkg.go.dev/time#hdr-Monotonic_Clocks) when both operands have a reading — and that clock does **not** advance while the OS is suspended (Linux `CLOCK_MONOTONIC`, macOS `mach_absolute_time`).

So on wake:
- Wall clock jumped forward by the sleep duration ✅
- Monotonic reading advanced ~0 ❌
- `now.Sub(d.last)` returned the tiny monotonic delta, never crossed the threshold, and `onWake` never fired.

The existing unit tests all passed because they inject a fake clock built from `time.Unix(...)`, which produces **wall-only** times with no monotonic reading — so `Sub` fell back to wall arithmetic and the jump was "seen." The one input that never appears in tests (a real monotonic reading) is exactly the one that breaks.

## Fix

`Round(0)` in `Step` strips the monotonic reading so `elapsed` is computed from the wall clock — the whole premise of the heuristic.

```go
now := d.now().Round(0)
```

## Test

Added `TestStep_StripsMonotonicReading_SoWallJumpsAreDetected`, which drives `Step` with the **real** clock (the only source of monotonic readings) and asserts the stored baseline carries none. It fails before the fix (`...m=+0.0005...`) and passes after. The 9 existing tests are unaffected (their wall-only fake clock makes `Round(0)` a no-op).

## Verification

- `go test ./internal/wake/` — all 12 tests pass
- `go vet ./internal/wake/` and `go build ./...` — clean

## Effect

On resume, the 10s ticker now sees the wall-clock jump and fires `triggerBackfill("wake")` across all workspaces within ~10s of wake, pulling missed history/read-state over HTTP.

## Related follow-up (not in this PR)

The WebSocket read deadline (`internal/slack/client.go`) is also monotonic-based, so for long sleeps that kill TCP, the reconnect path can still take up to ~60s of awake time to notice the dead socket. The wake backfill above covers the sync regardless; proactively bouncing the WebSocket on wake could be a separate change.