### PR TITLE
feat(sidebar): jump to next/prev unread channel with a/A

### DIFF
--- a/internal/ui/jump_unread_test.go
+++ b/internal/ui/jump_unread_test.go
@@ -1,0 +1,87 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/gammons/slk/internal/cache"
+	"github.com/gammons/slk/internal/ui/sidebar"
+)
+
+// Pressing `a` from a channel dispatches ChannelSelectedMsg for the next
+// unread channel, carrying its ID/Name/Type (Type drives the message-pane
+// glyph), and moves the sidebar cursor onto it.
+func TestJumpToUnread_EmitsChannelSelected(t *testing.T) {
+	a := NewApp()
+	a.sidebar.SetItems([]sidebar.ChannelItem{
+		{ID: "C1", Name: "one", Type: "channel", Section: "Eng"},
+		{ID: "C2", Name: "two", Type: "dm", Section: "Eng"},
+	})
+	a.SetReadStateReader(func() map[string]cache.ReadState {
+		return map[string]cache.ReadState{"C2": {HasUnread: true}}
+	})
+	a.activeChannelID = "C1"
+
+	cmd := a.handleNormalMode(tea.KeyPressMsg{Code: 'a', Text: "a"})
+	if cmd == nil {
+		t.Fatal("`a` should emit a command when an unread channel exists")
+	}
+	sel, ok := cmd().(ChannelSelectedMsg)
+	if !ok {
+		t.Fatalf("want ChannelSelectedMsg, got %T", cmd())
+	}
+	if sel.ID != "C2" || sel.Name != "two" || sel.Type != "dm" {
+		t.Fatalf("wrong target: %+v", sel)
+	}
+	if it, ok := a.sidebar.SelectedItem(); !ok || it.ID != "C2" {
+		t.Fatalf("sidebar cursor should be on C2, got %+v ok=%v", it, ok)
+	}
+}
+
+// `A` walks backward.
+func TestJumpToPrevUnread_EmitsChannelSelected(t *testing.T) {
+	a := NewApp()
+	a.sidebar.SetItems([]sidebar.ChannelItem{
+		{ID: "C1", Name: "one", Type: "channel", Section: "Eng"},
+		{ID: "C2", Name: "two", Type: "channel", Section: "Eng"},
+		{ID: "C3", Name: "three", Type: "channel", Section: "Eng"},
+	})
+	a.SetReadStateReader(func() map[string]cache.ReadState {
+		return map[string]cache.ReadState{"C1": {HasUnread: true}, "C3": {HasUnread: true}}
+	})
+	a.activeChannelID = "C3"
+
+	cmd := a.handleNormalMode(tea.KeyPressMsg{Code: 'A', Text: "A"})
+	if cmd == nil {
+		t.Fatal("`A` should emit a command")
+	}
+	sel, ok := cmd().(ChannelSelectedMsg)
+	if !ok || sel.ID != "C1" {
+		t.Fatalf("prev unread from C3 want C1, got %+v ok=%v", sel, ok)
+	}
+}
+
+// With nothing else unread, `a` shows a status toast and dispatches no
+// ChannelSelectedMsg.
+func TestJumpToUnread_NoUnread_Toasts(t *testing.T) {
+	a := NewApp()
+	a.sidebar.SetItems([]sidebar.ChannelItem{
+		{ID: "C1", Name: "one", Type: "channel", Section: "Eng"},
+	})
+	a.SetReadStateReader(func() map[string]cache.ReadState { return map[string]cache.ReadState{} })
+	a.activeChannelID = "C1"
+
+	// jumpToUnread returns the toast's clear-tick cmd on the empty path
+	// (not a ChannelSelectedMsg producer); don't invoke it -- it's a 2s
+	// timer. Asserting the toast text is enough, since the select and
+	// toast paths are mutually exclusive (early return on !ok).
+	a.handleNormalMode(tea.KeyPressMsg{Code: 'a', Text: "a"})
+	if !strings.Contains(a.statusbar.View(80), "No other unread channels") {
+		t.Fatalf("expected 'No other unread channels' toast; got %q", a.statusbar.View(80))
+	}
+	// The sidebar cursor must not have moved onto a phantom target.
+	if it, ok := a.sidebar.SelectedItem(); ok && it.ID != "C1" {
+		t.Fatalf("sidebar selection should be unchanged, got %+v", it)
+	}
+}

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -41,6 +41,8 @@ type KeyMap struct {
 	OpenPreview         key.Binding
 	OpenLink            key.Binding
 	MarkUnread          key.Binding
+	NextUnread          key.Binding
+	PrevUnread          key.Binding
 	WorkspaceFinder     key.Binding
 	NewMessage          key.Binding
 	ThemeSwitcher       key.Binding
@@ -100,6 +102,8 @@ func DefaultKeyMap() KeyMap {
 		OpenPreview:     key.NewBinding(key.WithKeys("O", "v"), key.WithHelp("O/v", "open image preview")),
 		OpenLink:        key.NewBinding(key.WithKeys("o"), key.WithHelp("o", "open link in message")),
 		MarkUnread:      key.NewBinding(key.WithKeys("U"), key.WithHelp("U", "mark unread")),
+		NextUnread:      key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "next unread channel")),
+		PrevUnread:      key.NewBinding(key.WithKeys("A"), key.WithHelp("A", "prev unread channel")),
 		// Keyless: ctrl+w is reserved as the window-command prefix
 		// (window-management design §4). The keyless binding never
 		// matches but keeps the help-overlay entry pointing at :ws

--- a/internal/ui/mode_normal.go
+++ b/internal/ui/mode_normal.go
@@ -324,7 +324,7 @@ func handleNormalMode(a *App, msg tea.KeyMsg) tea.Cmd {
 func (a *App) jumpToUnread(dir int) tea.Cmd {
 	id, name, chType, ok := a.sidebar.NextUnread(a.activeChannelID, dir)
 	if !ok {
-		return toastWithClear(a, "No unread channels", 2*time.Second)
+		return toastWithClear(a, "No other unread channels", 2*time.Second)
 	}
 	a.sidebar.SelectByID(id)
 	return func() tea.Msg {

--- a/internal/ui/mode_normal.go
+++ b/internal/ui/mode_normal.go
@@ -27,6 +27,8 @@
 package ui
 
 import (
+	"time"
+
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
@@ -273,6 +275,12 @@ func handleNormalMode(a *App, msg tea.KeyMsg) tea.Cmd {
 	case key.Matches(msg, a.keys.MarkUnread):
 		return a.markUnreadOfSelected()
 
+	case key.Matches(msg, a.keys.NextUnread):
+		return a.jumpToUnread(1)
+
+	case key.Matches(msg, a.keys.PrevUnread):
+		return a.jumpToUnread(-1)
+
 	case key.Matches(msg, a.keys.CloseThreadView):
 		// Lowercase q is "close thread view" when one is open; if
 		// no thread panel is visible it's a no-op (Q and Ctrl+C
@@ -304,4 +312,22 @@ func handleNormalMode(a *App, msg tea.KeyMsg) tea.Cmd {
 		}
 	}
 	return nil
+}
+
+// jumpToUnread selects and opens the next (dir>0) or previous (dir<0)
+// visibly-unread channel relative to the one currently open, wrapping
+// around the sidebar. Opening a channel marks it read (ChannelSelectedMsg
+// tier logic in reducer_channels), so repeated presses walk-and-clear the
+// unread set -- the TUI analogue of the native "all unreads" skim: glance,
+// press again, the previous one is already marked read. A no-op with a
+// transient status toast when nothing else is unread.
+func (a *App) jumpToUnread(dir int) tea.Cmd {
+	id, name, chType, ok := a.sidebar.NextUnread(a.activeChannelID, dir)
+	if !ok {
+		return toastWithClear(a, "No unread channels", 2*time.Second)
+	}
+	a.sidebar.SelectByID(id)
+	return func() tea.Msg {
+		return ChannelSelectedMsg{ID: id, Name: name, Type: chType}
+	}
 }

--- a/internal/ui/sidebar/model.go
+++ b/internal/ui/sidebar/model.go
@@ -323,6 +323,57 @@ func (m *Model) UnreadChannelCount() int {
 	return count
 }
 
+// NextUnread returns the visibly-unread channel (HasUnread && !IsMuted)
+// that follows afterID, wrapping around, and the fields the App needs to
+// raise a ChannelSelectedMsg. afterID itself is always skipped so
+// repeated calls advance through the unread set; pass the currently-open
+// channel ID. dir > 0 walks forward (next), dir < 0 walks backward
+// (previous). ok is false when no *other* channel is unread (an empty
+// inbox, or afterID is the only unread one).
+//
+// Walk order is m.filtered -- the section-sorted set the sidebar actually
+// renders -- so a/A traverse the visible unread dots top-to-bottom, the
+// way the eye expects, rather than raw feed order. Unread channels are
+// never removed by the staleness filter (IsStale returns false whenever
+// hasUnread), so every unread row present in the sidebar is reachable
+// here; equivalently, a/A visit exactly what the sidebar shows.
+func (m *Model) NextUnread(afterID string, dir int) (id, name, chType string, ok bool) {
+	if m.readStateReader == nil {
+		return "", "", "", false
+	}
+	n := len(m.filtered)
+	if n == 0 {
+		return "", "", "", false
+	}
+	state := m.readStateReader()
+	step := 1
+	if dir < 0 {
+		step = -1
+	}
+	// Anchor at afterID; when it isn't in the visible set, start from the
+	// top (forward) or bottom (backward) so the first press still lands.
+	start := 0
+	if step < 0 {
+		start = n - 1
+	}
+	for pos, idx := range m.filtered {
+		if m.items[idx].ID == afterID {
+			start = pos
+			break
+		}
+	}
+	for off := 1; off <= n; off++ {
+		item := m.items[m.filtered[((start+step*off)%n+n)%n]]
+		if item.ID == afterID {
+			continue
+		}
+		if item.IsVisiblyUnread(state[item.ID]) {
+			return item.ID, item.Name, item.Type, true
+		}
+	}
+	return "", "", "", false
+}
+
 // Invalidate forces the next View() call to re-read read state from
 // the installed reader. Called by App.Update on ReadStateChangedMsg.
 func (m *Model) Invalidate() {

--- a/internal/ui/sidebar/model.go
+++ b/internal/ui/sidebar/model.go
@@ -331,12 +331,21 @@ func (m *Model) UnreadChannelCount() int {
 // (previous). ok is false when no *other* channel is unread (an empty
 // inbox, or afterID is the only unread one).
 //
-// Walk order is m.filtered -- the section-sorted set the sidebar actually
-// renders -- so a/A traverse the visible unread dots top-to-bottom, the
-// way the eye expects, rather than raw feed order. Unread channels are
-// never removed by the staleness filter (IsStale returns false whenever
-// hasUnread), so every unread row present in the sidebar is reachable
-// here; equivalently, a/A visit exactly what the sidebar shows.
+// Walk order is m.filtered -- the section-sorted order the sidebar renders
+// in -- so a/A traverse unread channels top-to-bottom rather than raw feed
+// order. Unread channels are never removed by the staleness filter
+// (IsStale returns false whenever hasUnread), so every unread channel is
+// reachable.
+//
+// m.filtered is built by rebuildFilter, which does NOT apply collapse
+// state (collapse is handled later, in rebuildNav). So the walk deliberately
+// includes unread channels inside collapsed sections, even though those
+// rows aren't currently visible -- and since the default layout collapses
+// the "Channels" firehose, a/A will jump into it and the caller's
+// SelectByID expands that section to reveal the target. This matches the
+// desktop client, which also surfaces unread channels regardless of
+// section collapse; it's an intentional "catch up on all unreads" skim,
+// not just "what's on screen".
 func (m *Model) NextUnread(afterID string, dir int) (id, name, chType string, ok bool) {
 	if m.readStateReader == nil {
 		return "", "", "", false
@@ -350,11 +359,14 @@ func (m *Model) NextUnread(afterID string, dir int) (id, name, chType string, ok
 	if dir < 0 {
 		step = -1
 	}
-	// Anchor at afterID; when it isn't in the visible set, start from the
-	// top (forward) or bottom (backward) so the first press still lands.
-	start := 0
+	// Anchor one step *behind* afterID so the loop's first probe (off=1)
+	// is afterID's neighbour in the walk direction. When afterID isn't in
+	// the visible set, the sentinel (-1 forward / n backward) makes the
+	// first press land on the top / bottom row: the ((start+step*off)%n+n)%n
+	// normalization maps -1+1 -> 0 and n-1 -> n-1.
+	start := -1
 	if step < 0 {
-		start = n - 1
+		start = n
 	}
 	for pos, idx := range m.filtered {
 		if m.items[idx].ID == afterID {

--- a/internal/ui/sidebar/unread_nav_test.go
+++ b/internal/ui/sidebar/unread_nav_test.go
@@ -1,0 +1,105 @@
+package sidebar
+
+import (
+	"testing"
+
+	"github.com/gammons/slk/internal/cache"
+)
+
+// items C1..C4; C2 and C4 are unread, C3 is unread-but-muted (excluded),
+// C1 is read. NextUnread walks m.filtered (visible section order); a
+// single explicit Section on every item keeps that order == input order
+// so these assertions read cleanly.
+func unreadNavModel() Model {
+	m := New([]ChannelItem{
+		{ID: "C1", Name: "one", Type: "channel", Section: "Eng"},
+		{ID: "C2", Name: "two", Type: "channel", Section: "Eng"},
+		{ID: "C3", Name: "muted", Type: "channel", Section: "Eng", IsMuted: true},
+		{ID: "C4", Name: "four", Type: "channel", Section: "Eng"},
+	})
+	m.SetReadStateReader(func() map[string]cache.ReadState {
+		return map[string]cache.ReadState{
+			"C2": {HasUnread: true},
+			"C3": {HasUnread: true}, // muted -> not visibly unread
+			"C4": {HasUnread: true},
+		}
+	})
+	return m
+}
+
+func TestNextUnread_ForwardSkipsCurrentAndMuted(t *testing.T) {
+	m := unreadNavModel()
+
+	// From C1 (read): next unread forward is C2.
+	if id, _, _, ok := m.NextUnread("C1", 1); !ok || id != "C2" {
+		t.Fatalf("from C1 want C2, got id=%q ok=%v", id, ok)
+	}
+	// From C2: skip muted C3, land on C4.
+	if id, _, _, ok := m.NextUnread("C2", 1); !ok || id != "C4" {
+		t.Fatalf("from C2 want C4 (muted C3 skipped), got id=%q ok=%v", id, ok)
+	}
+	// From C4: wrap around to C2.
+	if id, _, _, ok := m.NextUnread("C4", 1); !ok || id != "C2" {
+		t.Fatalf("from C4 want wrap to C2, got id=%q ok=%v", id, ok)
+	}
+}
+
+func TestPrevUnread_Backward(t *testing.T) {
+	m := unreadNavModel()
+
+	// From C4: previous unread is C2 (C3 muted).
+	if id, _, _, ok := m.NextUnread("C4", -1); !ok || id != "C2" {
+		t.Fatalf("prev from C4 want C2, got id=%q ok=%v", id, ok)
+	}
+	// From C2: wrap backward to C4.
+	if id, _, _, ok := m.NextUnread("C2", -1); !ok || id != "C4" {
+		t.Fatalf("prev from C2 want wrap to C4, got id=%q ok=%v", id, ok)
+	}
+}
+
+func TestNextUnread_ReturnsNameAndType(t *testing.T) {
+	m := unreadNavModel()
+	id, name, chType, ok := m.NextUnread("C1", 1)
+	if !ok || id != "C2" || name != "two" || chType != "channel" {
+		t.Fatalf("want C2/two/channel, got %q/%q/%q ok=%v", id, name, chType, ok)
+	}
+}
+
+// The currently-open channel is always skipped even when it is itself
+// unread (e.g. just marked unread), so a press always advances.
+func TestNextUnread_SkipsCurrentEvenIfUnread(t *testing.T) {
+	m := unreadNavModel()
+	if id, _, _, ok := m.NextUnread("C2", 1); !ok || id != "C4" {
+		t.Fatalf("from unread C2 want advance to C4, got id=%q ok=%v", id, ok)
+	}
+}
+
+// Only the current channel is unread -> nothing else to jump to.
+func TestNextUnread_NoOtherUnread(t *testing.T) {
+	m := New([]ChannelItem{
+		{ID: "C1", Name: "one", Type: "channel"},
+		{ID: "C2", Name: "two", Type: "channel"},
+	})
+	m.SetReadStateReader(func() map[string]cache.ReadState {
+		return map[string]cache.ReadState{"C1": {HasUnread: true}}
+	})
+	if _, _, _, ok := m.NextUnread("C1", 1); ok {
+		t.Fatalf("only C1 unread and it is current: want ok=false")
+	}
+}
+
+// afterID not present (nothing open yet) still finds the first unread.
+func TestNextUnread_UnknownAfterID(t *testing.T) {
+	m := unreadNavModel()
+	if id, _, _, ok := m.NextUnread("", 1); !ok || id != "C2" {
+		t.Fatalf("from empty want first unread C2, got id=%q ok=%v", id, ok)
+	}
+}
+
+// No reader installed -> safe no-op.
+func TestNextUnread_NoReader(t *testing.T) {
+	m := New([]ChannelItem{{ID: "C1", Name: "one", Type: "channel"}})
+	if _, _, _, ok := m.NextUnread("", 1); ok {
+		t.Fatalf("no reader: want ok=false")
+	}
+}

--- a/internal/ui/sidebar/unread_nav_test.go
+++ b/internal/ui/sidebar/unread_nav_test.go
@@ -103,3 +103,98 @@ func TestNextUnread_NoReader(t *testing.T) {
 		t.Fatalf("no reader: want ok=false")
 	}
 }
+
+// Regression for the anchor off-by-one: with an anchor that isn't in the
+// visible set (fresh start before opening anything, or activeChannelID
+// dropped out of m.filtered after a rebuild), the first press must land on
+// the TOP unread row forward / BOTTOM unread row backward -- not the far
+// end after a full wrap. C1 and C3 unread, C2 read, afterID unknown.
+func TestNextUnread_UnknownAnchor_LandsOnNearestEnd(t *testing.T) {
+	m := New([]ChannelItem{
+		{ID: "C1", Name: "one", Type: "channel", Section: "Eng"},
+		{ID: "C2", Name: "two", Type: "channel", Section: "Eng"},
+		{ID: "C3", Name: "three", Type: "channel", Section: "Eng"},
+	})
+	m.SetReadStateReader(func() map[string]cache.ReadState {
+		return map[string]cache.ReadState{
+			"C1": {HasUnread: true},
+			"C3": {HasUnread: true},
+		}
+	})
+	if id, _, _, ok := m.NextUnread("", 1); !ok || id != "C1" {
+		t.Fatalf("forward from unknown anchor want first unread C1, got id=%q ok=%v", id, ok)
+	}
+	if id, _, _, ok := m.NextUnread("", -1); !ok || id != "C3" {
+		t.Fatalf("backward from unknown anchor want last unread C3, got id=%q ok=%v", id, ok)
+	}
+}
+
+// The walk intentionally includes unread channels inside collapsed
+// sections (m.filtered ignores collapse), and selecting the target
+// expands the section -- the documented "catch up on all unreads"
+// behavior. C1 has no Section, so it lands in the default "Channels"
+// section, which New() collapses.
+func TestNextUnread_ReachesCollapsedSectionAndExpands(t *testing.T) {
+	m := New([]ChannelItem{
+		{ID: "C1", Name: "hidden", Type: "channel"},
+	})
+	m.SetReadStateReader(func() map[string]cache.ReadState {
+		return map[string]cache.ReadState{"C1": {HasUnread: true}}
+	})
+	if !m.IsCollapsed(defaultChannelsSection) {
+		t.Fatalf("precondition: Channels section should start collapsed")
+	}
+	id, _, _, ok := m.NextUnread("", 1)
+	if !ok || id != "C1" {
+		t.Fatalf("unread inside a collapsed section must be reachable; got id=%q ok=%v", id, ok)
+	}
+	m.SelectByID(id)
+	if m.IsCollapsed(defaultChannelsSection) {
+		t.Fatalf("SelectByID should expand the collapsed section holding the target")
+	}
+}
+
+// Nothing unread anywhere (distinct from the only-unread-is-current case):
+// both an anchored and an unknown-anchor call report ok=false.
+func TestNextUnread_NoUnreadAtAll(t *testing.T) {
+	m := New([]ChannelItem{
+		{ID: "C1", Name: "one", Type: "channel", Section: "Eng"},
+		{ID: "C2", Name: "two", Type: "channel", Section: "Eng"},
+	})
+	m.SetReadStateReader(func() map[string]cache.ReadState { return map[string]cache.ReadState{} })
+	if _, _, _, ok := m.NextUnread("C1", 1); ok {
+		t.Fatalf("no unread channels: want ok=false from an anchored call")
+	}
+	if _, _, _, ok := m.NextUnread("", 1); ok {
+		t.Fatalf("no unread channels: want ok=false from an unknown anchor")
+	}
+}
+
+// Type is forwarded verbatim (it drives messagepane.SetChannelType via
+// ChannelSelectedMsg), including DM / group_dm.
+func TestNextUnread_ForwardsChannelType(t *testing.T) {
+	m := New([]ChannelItem{
+		{ID: "D1", Name: "dm-peer", Type: "dm", Section: "Eng"},
+	})
+	m.SetReadStateReader(func() map[string]cache.ReadState {
+		return map[string]cache.ReadState{"D1": {HasUnread: true}}
+	})
+	id, name, chType, ok := m.NextUnread("", 1)
+	if !ok || id != "D1" || name != "dm-peer" || chType != "dm" {
+		t.Fatalf("want D1/dm-peer/dm, got %q/%q/%q ok=%v", id, name, chType, ok)
+	}
+}
+
+// An active name filter narrows the walk to matching rows only.
+func TestNextUnread_RespectsActiveFilter(t *testing.T) {
+	m := unreadNavModel() // C2 + C4 unread (C3 muted)
+	m.SetFilter("four")   // only C4 matches by name
+	if id, _, _, ok := m.NextUnread("", 1); !ok || id != "C4" {
+		t.Fatalf("with filter 'four' want C4, got id=%q ok=%v", id, ok)
+	}
+	// C4 is now the only visible unread, so anchoring on it finds no
+	// *other* unread and reports ok=false (current is always skipped).
+	if _, _, _, ok := m.NextUnread("C4", 1); ok {
+		t.Fatalf("with filter 'four' C4 is the only unread; anchoring on it should find nothing else")
+	}
+}

--- a/wiki/Keybindings.md
+++ b/wiki/Keybindings.md
@@ -20,6 +20,7 @@
 | `gg` / `G` | Normal | Jump to top / bottom |
 | `/` | Normal | Search in channel (vim-style; searches cached history of the current channel) |
 | `n` / `N` | Normal | Next / previous search match (wraps) |
+| `a` / `A` | Normal | Jump to next / previous unread channel (wraps) |
 | `Esc` | Normal (search active) | Clear active search |
 | `Ctrl+f` | Any | Search workspace (Slack server-side; supports modifiers like `from:@user`, `in:#channel`, `before:YYYY-MM-DD`) |
 | `Ctrl+b` | Any | Toggle sidebar |


### PR DESCRIPTION
## What

Two normal-mode motions for working through unread **channels** without leaving the keyboard:

| key | action |
|-----|--------|
| `a` | open the **next** unread channel |
| `A` | open the **previous** unread channel |

They walk `m.filtered` — the section-sorted set the sidebar actually renders — so they traverse the visible unread dots top-to-bottom, skip the currently-open channel, and wrap around. Muted channels are excluded via the existing `ChannelItem.IsVisiblyUnread` predicate. Because opening a channel already marks it read, repeated presses become a walk-and-clear loop.

## Why

This is the one-keystroke "jump to unread" @jpeeler asked for in #12 (WeeChat's Alt+A, vs. Slack desktop's Ctrl+K + Enter).

To be clear about scope: this is deliberately the **unread-channels** firehose that @timwis noted is often too much to ever catch up on — so I'd treat it as an opt-in companion, not a replacement for the Activity view in #109 (which surfaces only what notified you). Two different takes on #12; happy for either or both.

## Design notes

- New `Sidebar.NextUnread(afterID, dir)` returns the next/prev visibly-unread channel in render order, wrapping, current-channel skipped. Unread channels are never dropped by the staleness filter (`IsStale` returns false whenever `hasUnread`), so `a`/`A` visit exactly what the sidebar shows.
- The handler reuses the existing channel-open path (`sidebar.SelectByID` + `ChannelSelectedMsg`), so focus, mark-read, and collapsed-section expansion behave identically to the fuzzy finder. A status toast shows `No unread channels` when there's nothing else to jump to.
- Keys are hardcoded in `DefaultKeyMap` like every other binding. `a`/`A` because `]`/`[` are already the sidebar-resize keys — happy to rebind.

## Testing

- `internal/ui/sidebar/unread_nav_test.go` (forward/backward, wrap, muted exclusion, current-channel skip, no-other-unread, unknown afterID, no reader).
- `go build ./...`, `go vet ./...`, `go test ./...` pass. Runnable via `gh pr checkout`.

Relates to #12; companion to #109.

_(Full disclosure: built with heavy AI assistance — frontier model, high effort — and reviewed + tested on my end, per the contributing notes.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
