### PR TITLE
fix(sections): repopulate stars inside Bootstrap so they survive reconnect

### DIFF
--- a/cmd/slk/channelitem_test.go
+++ b/cmd/slk/channelitem_test.go
@@ -99,6 +99,10 @@ func (f *fakeSectionsClient) GetChannelSections(_ context.Context) ([]slk.Sideba
 	return f.sections, nil
 }
 
+func (f *fakeSectionsClient) GetStarredChannels(_ context.Context) ([]string, error) {
+	return nil, nil
+}
+
 // bootstrappedStore returns a Ready() *service.SectionStore whose
 // channelToSection map is built from the supplied (sectionID -> []channelID)
 // pairs. All synthetic sections use Type="channels" so they pass

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -1978,17 +1978,11 @@ func connectWorkspace(ctx context.Context, token slackclient.Token, db *cache.DB
 		if err := store.Bootstrap(ctx, client); err != nil {
 			log.Printf("section store bootstrap for %s failed: %v (falling back to config sections)", token.TeamName, err)
 		} else {
-			// Slack's users.channelSections.list returns the stars section
-			// with an empty channel_ids array (it doesn't populate built-in
-			// section types). stars.list is the authoritative source for
-			// which channels the user has starred; fetch and inject so the
-			// sidebar can render the Starred header. Best-effort: on error
-			// the stars section stays empty and includeInSidebar hides it.
-			if starIDs, err := client.GetStarredChannels(ctx); err != nil {
-				log.Printf("stars.list for %s failed: %v (starred channels will be hidden)", token.TeamName, err)
-			} else if len(starIDs) > 0 {
-				store.PopulateStars(starIDs)
-			}
+			// Bootstrap repopulates the stars section from stars.list
+			// itself (channelSections.list returns built-in section
+			// types with empty channel_ids), so the Starred header is
+			// live at first render and survives reconnect-triggered
+			// re-bootstraps without caller help.
 			wctx.SectionStore = store
 			// One-time info log when the user has both Slack sections
 			// active AND a non-empty [sections.*] config — the latter

--- a/internal/service/sectionstore.go
+++ b/internal/service/sectionstore.go
@@ -14,6 +14,11 @@ import (
 // Defined as an interface so tests can pass fakes.
 type SectionsClient interface {
 	GetChannelSections(ctx context.Context) ([]slk.SidebarSection, error)
+	// GetStarredChannels backs the stars section membership.
+	// channelSections.list returns built-in section types (stars,
+	// recent_apps) with an empty channel_ids array; stars.list is the
+	// authoritative source Bootstrap uses to fill them.
+	GetStarredChannels(ctx context.Context) ([]string, error)
 }
 
 // SectionStore is the per-workspace authoritative cache of the user's
@@ -85,6 +90,25 @@ func (s *SectionStore) Bootstrap(ctx context.Context, client SectionsClient) err
 	s.ready = true
 	s.lastBootstrap = time.Now()
 	s.mu.Unlock()
+
+	// Slack's users.channelSections.list returns the stars section with
+	// an empty channel_ids array (it doesn't populate built-in section
+	// types). stars.list is the authoritative source for starred
+	// channels; fetch and inject here so EVERY Bootstrap — including
+	// reconnect-triggered re-bootstraps via MaybeRebootstrap — leaves
+	// the Starred header populated. Without this, a reconnect Bootstrap
+	// atomically replaced the store state and wiped the ChannelIDs that
+	// PopulateStars had filled, making includeInSidebar hide the header.
+	// Best-effort: on error the stars section stays empty and
+	// includeInSidebar hides it until the next bootstrap.
+	//
+	// PopulateStars re-locks internally; safe to call after unlock now
+	// that ready==true.
+	if stars, sErr := client.GetStarredChannels(ctx); sErr != nil {
+		log.Printf("section store: stars.list failed: %v (starred channels hidden until next bootstrap)", sErr)
+	} else if len(stars) > 0 {
+		s.PopulateStars(stars)
+	}
 	return nil
 }
 

--- a/internal/service/sectionstore_test.go
+++ b/internal/service/sectionstore_test.go
@@ -10,6 +10,8 @@ import (
 // fakeSectionsClient implements the subset of slk.Client SectionStore needs.
 type fakeSectionsClient struct {
 	sections []slk.SidebarSection
+	starIDs  []string
+	starErr  error
 	getErr   error
 }
 
@@ -18,6 +20,13 @@ func (f *fakeSectionsClient) GetChannelSections(ctx context.Context) ([]slk.Side
 		return nil, f.getErr
 	}
 	return f.sections, nil
+}
+
+func (f *fakeSectionsClient) GetStarredChannels(ctx context.Context) ([]string, error) {
+	if f.starErr != nil {
+		return nil, f.starErr
+	}
+	return f.starIDs, nil
 }
 
 func TestSectionStore_Bootstrap_Empty(t *testing.T) {
@@ -249,6 +258,60 @@ func TestSectionStore_PopulateStars_ReplacesPreviousStarList(t *testing.T) {
 	}
 }
 
+// TestBootstrap_PopulatesStars regresses a bug where the Starred header
+// disappeared after a WebSocket reconnect. Bootstrap atomically replaces
+// store state; channelSections.list returns the stars section with an
+// empty channel_ids array (built-in types aren't populated). Without
+// Bootstrap also fetching stars.list, a reconnect-triggered re-bootstrap
+// wiped the star list that PopulateStars had filled at startup and
+// includeInSidebar hid the header. Bootstrap now fetches stars.list
+// itself, so a single Bootstrap leaves stars populated — and any future
+// Bootstrap call site is automatically covered.
+func TestBootstrap_PopulatesStars(t *testing.T) {
+	c := &fakeSectionsClient{
+		sections: []slk.SidebarSection{
+			{ID: "ST", Type: "stars", Next: "U", LastUpdate: 1},
+			{ID: "U", Type: "standard", Name: "Mine", Next: "", LastUpdate: 1},
+		},
+		starIDs: []string{"C1", "C2"},
+	}
+	store := NewSectionStore()
+	if err := store.Bootstrap(context.Background(), c); err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	// Stars section now renders (non-empty ChannelIDs).
+	got := store.OrderedSections()
+	if len(got) != 2 || got[0].ID != "ST" {
+		t.Fatalf("OrderedSections = %+v, want [ST, U] (stars populated by Bootstrap)", got)
+	}
+	for _, cid := range []string{"C1", "C2"} {
+		id, ok := store.SectionForChannel(cid)
+		if !ok || id != "ST" {
+			t.Errorf("SectionForChannel(%s) = (%q,%v), want (ST,true)", cid, id, ok)
+		}
+	}
+}
+
+// TestBootstrap_StarsFetchErrorIsBestEffort verifies that a stars.list
+// failure does not fail Bootstrap itself — sections still load and the
+// store becomes Ready; the stars section just stays hidden until the
+// next successful bootstrap.
+func TestBootstrap_StarsFetchErrorIsBestEffort(t *testing.T) {
+	c := &fakeSectionsClient{
+		sections: []slk.SidebarSection{
+			{ID: "U", Type: "standard", Name: "Mine", Next: "", LastUpdate: 1},
+		},
+		starErr: context.DeadlineExceeded,
+	}
+	store := NewSectionStore()
+	if err := store.Bootstrap(context.Background(), c); err != nil {
+		t.Fatalf("Bootstrap should succeed despite stars.list error: %v", err)
+	}
+	if !store.Ready() {
+		t.Fatalf("Ready=false; sections should still be loaded")
+	}
+}
+
 func TestSectionStore_BootstrapFailure_NotReady(t *testing.T) {
 	c := &fakeSectionsClient{getErr: context.DeadlineExceeded}
 	store := NewSectionStore()
@@ -405,6 +468,10 @@ type countingClient struct {
 func (cc *countingClient) GetChannelSections(ctx context.Context) ([]slk.SidebarSection, error) {
 	cc.onCall()
 	return cc.inner.GetChannelSections(ctx)
+}
+
+func (cc *countingClient) GetStarredChannels(ctx context.Context) ([]string, error) {
+	return cc.inner.GetStarredChannels(ctx)
 }
 
 // TestSectionForChannel_HidesNonRenderableSections regresses a sidebar


### PR DESCRIPTION
Fixes #112.

## Summary
`SectionStore.Bootstrap` atomically replaces store state on every call. Since `users.channelSections.list` returns the built-in `stars` section with an empty `channel_ids` array, a reconnect-triggered Bootstrap wiped the `ChannelIDs` that `PopulateStars` had filled at startup — and `PopulateStars` was only ever called once at startup. `includeInSidebar` then hid the Starred header until the next restart.

This moves the `stars.list` fetch inside `Bootstrap`, so every Bootstrap (startup and reconnect) leaves stars populated. The startup call site drops its manual fetch, `MaybeRebootstrap` stays unchanged, and any future Bootstrap call site is automatically covered.

Builds on the already-merged #102; net simplification (one fewer call site).

## Changes
- `SectionsClient`: add `GetStarredChannels`
- `Bootstrap`: fetch `stars.list` + `PopulateStars` after state commit
- `connectWorkspace`: remove now-redundant startup stars fetch
- tests: `TestBootstrap_PopulatesStars`, `TestBootstrap_StarsFetchErrorIsBestEffort`

## Repro
1. `slk login`, star a channel
2. Confirm "Starred" appears
3. Force a WS reconnect
4. Before: vanishes. After: stays.

## Test plan
- [x] `go test ./internal/service/... ./cmd/slk/...` (132 passed)
- [x] `go build ./...`
- [x] Manual: starred section persists across WS reconnect