### PR TITLE
fix(slack): use navigation-shaped headers for token minting (#111)

### DIFF
--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -492,6 +492,12 @@ func main() {
 				os.Exit(1)
 			}
 			os.Exit(0)
+		case "--dump-mint":
+			if err := dumpMint(); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				os.Exit(1)
+			}
+			os.Exit(0)
 		}
 	}
 
@@ -546,6 +552,7 @@ Usage:
   slk --remove-workspace  Remove a configured workspace (interactive)
   slk --list-workspaces   List configured workspaces (TeamID, Slug, Name)
   slk --dump-sections     Dump raw users.channelSections.list JSON (diagnostic)
+  slk --dump-mint         Diagnose token-minting failures (diagnostic)
   slk --version          Print version and exit
   slk --help             Show this help
 
@@ -4173,6 +4180,71 @@ func listWorkspaces() error {
 		strings.Repeat("-", nameW))
 	for _, ot := range orderedTokens {
 		fmt.Printf("%-*s  %-*s  %s\n", idW, ot.Token.TeamID, slugW, ot.Slug, ot.Token.TeamName)
+	}
+	return nil
+}
+
+// dumpMint is a diagnostic for token-minting failures (#111). Unlike the
+// other dumps it does NOT use saved tokens (minting is what's failing, so
+// onboarding never completed). It reads the desktop cookie + workspace list
+// directly, reports which Slack desktop profile(s) exist (to catch a
+// wrong/stale profile), and for each workspace performs the mint page load and
+// prints what Slack returned (status, final URL, whether api_token is present,
+// and any signed-out markers). Output is safe to paste — no secrets.
+func dumpMint() error {
+	fmt.Println("slk mint diagnostic (#111)")
+	fmt.Println()
+
+	fmt.Println("Slack desktop profiles (* = the one slk uses):")
+	for _, c := range slackdesktop.ProfileCandidates() {
+		marker := " "
+		if c.Active {
+			marker = "*"
+		}
+		fmt.Printf("  [%s] %-7s exists=%-5v cookieDB=%-5v %s\n", marker, c.Kind, c.Exists, c.HasCookie, c.Path)
+	}
+	fmt.Println()
+
+	dir, err := slackdesktop.ConfigDir()
+	if err != nil {
+		fmt.Printf("ConfigDir: ERROR: %v\n", err)
+		return nil
+	}
+	fmt.Printf("Using config dir: %s\n", dir)
+
+	cookie, err := slackdesktop.Cookie()
+	if err != nil {
+		fmt.Printf("Cookie: ERROR: %v\n", err)
+		return nil
+	}
+	format := "(not xoxd-)"
+	if strings.HasPrefix(cookie, "xoxd-") {
+		format = "xoxd-..."
+	}
+	fmt.Printf("Cookie: OK (len=%d, format=%s)\n\n", len(cookie), format)
+
+	workspaces, err := slackdesktop.Workspaces()
+	if err != nil {
+		fmt.Printf("Workspaces: ERROR: %v\n", err)
+		return nil
+	}
+
+	ctx := context.Background()
+	for _, ws := range workspaces {
+		fmt.Printf("=== %s (%s.slack.com) ===\n", ws.Name, ws.Domain)
+		d := slackclient.MintDiag(ctx, ws.Domain, cookie)
+		if d.Err != "" {
+			fmt.Printf("  request error: %s\n\n", d.Err)
+			continue
+		}
+		fmt.Printf("  status:      %d\n", d.Status)
+		fmt.Printf("  final URL:   %s\n", d.FinalURL)
+		fmt.Printf("  body bytes:  %d\n", d.BodyBytes)
+		fmt.Printf("  api_token:   %v\n", d.HasAPIToken)
+		if len(d.LoginMarkers) > 0 {
+			fmt.Printf("  login signs: %v\n", d.LoginMarkers)
+		}
+		fmt.Println()
 	}
 	return nil
 }

--- a/internal/slack/mint.go
+++ b/internal/slack/mint.go
@@ -15,6 +15,27 @@ import (
 
 var apiTokenRE = regexp.MustCompile(`"api_token":"([^"]+)"`)
 
+// newMintRequest builds the workspace page-load request used to scrape the
+// api_token. It attaches the `d` cookie and navigation-shaped headers: a real
+// browser loading a workspace page sends these, NOT the Origin/Sec-Fetch-Mode:
+// cors of an XHR call (which strict proxies reject with 403 — see #111).
+func newMintRequest(ctx context.Context, url, dCookie string) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.AddCookie(&http.Cookie{Name: "d", Value: dCookie})
+	req.Header.Set("User-Agent", slackhttp.UserAgent())
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8")
+	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
+	req.Header.Set("Sec-Fetch-Site", "none")
+	req.Header.Set("Sec-Fetch-Mode", "navigate")
+	req.Header.Set("Sec-Fetch-Dest", "document")
+	req.Header.Set("Sec-Fetch-User", "?1")
+	req.Header.Set("Upgrade-Insecure-Requests", "1")
+	return req, nil
+}
+
 // MintToken mints a fresh xoxc token for a workspace by loading its page with
 // the desktop `d` cookie and scraping the embedded api_token.
 //
@@ -47,21 +68,10 @@ func mintTokenAt(ctx context.Context, client *http.Client, baseURL, dCookie stri
 	const maxAttempts = 3
 
 	for attempt := 1; ; attempt++ {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL, nil)
+		req, err := newMintRequest(ctx, baseURL, dCookie)
 		if err != nil {
 			return "", err
 		}
-		req.AddCookie(&http.Cookie{Name: "d", Value: dCookie})
-		// Navigation-shaped headers: a real browser loading a workspace page
-		// sends these, NOT the Origin/Sec-Fetch-Mode: cors of an XHR call.
-		req.Header.Set("User-Agent", slackhttp.UserAgent())
-		req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8")
-		req.Header.Set("Accept-Language", "en-US,en;q=0.9")
-		req.Header.Set("Sec-Fetch-Site", "none")
-		req.Header.Set("Sec-Fetch-Mode", "navigate")
-		req.Header.Set("Sec-Fetch-Dest", "document")
-		req.Header.Set("Sec-Fetch-User", "?1")
-		req.Header.Set("Upgrade-Insecure-Requests", "1")
 
 		resp, err := client.Do(req)
 		if err != nil {
@@ -100,6 +110,78 @@ func mintTokenAt(ctx context.Context, client *http.Client, baseURL, dCookie stri
 		}
 		return string(m[1]), nil
 	}
+}
+
+// MintDiagnostics captures what a workspace page load returned, for
+// troubleshooting mint failures (#111). It never includes secrets.
+type MintDiagnostics struct {
+	Domain       string
+	RequestURL   string
+	Status       int
+	FinalURL     string // URL after following redirects
+	BodyBytes    int
+	HasAPIToken  bool
+	LoginMarkers []string // signs the page is a signed-out / login page
+	Err          string
+}
+
+// MintDiag performs the mint page load and returns diagnostics instead of the
+// token, using the exact same request shape as MintToken. Safe to print: it
+// reports sizes, status, and markers — never the cookie or token.
+func MintDiag(ctx context.Context, domain, dCookie string) MintDiagnostics {
+	client := &http.Client{Timeout: 15 * time.Second}
+	return mintDiagAt(ctx, client, fmt.Sprintf("https://%s.slack.com", domain), dCookie, domain)
+}
+
+func mintDiagAt(ctx context.Context, client *http.Client, url, dCookie, domain string) MintDiagnostics {
+	d := MintDiagnostics{Domain: domain, RequestURL: url}
+	req, err := newMintRequest(ctx, url, dCookie)
+	if err != nil {
+		d.Err = err.Error()
+		return d
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		d.Err = err.Error()
+		return d
+	}
+	defer resp.Body.Close()
+	d.Status = resp.StatusCode
+	if resp.Request != nil && resp.Request.URL != nil {
+		d.FinalURL = resp.Request.URL.String()
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		d.Err = err.Error()
+		return d
+	}
+	d.BodyBytes = len(body)
+	d.HasAPIToken = apiTokenRE.Match(body)
+	d.LoginMarkers = detectLoginMarkers(body, d.FinalURL)
+	return d
+}
+
+// detectLoginMarkers returns the names of any signed-out/login indicators
+// found in the response body or final URL.
+func detectLoginMarkers(body []byte, finalURL string) []string {
+	var found []string
+	lc := strings.ToLower(string(body))
+	lu := strings.ToLower(finalURL)
+
+	if strings.Contains(lu, "/signin") || strings.Contains(lu, "slack.com/signin") {
+		found = append(found, "redirected-to-signin")
+	}
+	for name, needle := range map[string]string{
+		"signin-prompt": "sign in to",
+		"signed-out":    "signed out",
+		"email-prompt":  "enter your email",
+		"workspace-url": "find your workspace",
+	} {
+		if strings.Contains(lc, needle) {
+			found = append(found, name)
+		}
+	}
+	return found
 }
 
 // parseRetryAfter reads a Retry-After header value (delay in seconds) and

--- a/internal/slack/mint.go
+++ b/internal/slack/mint.go
@@ -9,18 +9,30 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/gammons/slk/internal/slackhttp"
 )
 
 var apiTokenRE = regexp.MustCompile(`"api_token":"([^"]+)"`)
 
 // MintToken mints a fresh xoxc token for a workspace by loading its page with
-// the desktop `d` cookie and scraping the embedded api_token. It uses a
-// browser-shaped HTTP client with the cookie set.
+// the desktop `d` cookie and scraping the embedded api_token.
+//
+// Loading the workspace page is a top-level *navigation*, not an XHR/CORS
+// call, so we deliberately use a plain HTTP client here rather than the
+// browser XHR transport used for the ongoing API/WebSocket traffic. That
+// transport stamps every request with Origin: https://app.slack.com and
+// Sec-Fetch-Mode: cors — correct for a fetch from app.slack.com, but a
+// contradictory signature on a page navigation that strict corporate
+// edges/proxies reject with HTTP 403 (#111). mintTokenAt sets
+// navigation-appropriate headers instead. Using a plain client (no cookie
+// jar) also avoids sending the `d` cookie twice.
 func MintToken(ctx context.Context, domain, dCookie string) (string, error) {
-	client := newCookieHTTPClient(dCookie)
-	// Bound the request so a hung/half-open connection (captive portal,
-	// offline) can't stall onboarding or the startup re-mint indefinitely.
-	client.Timeout = 15 * time.Second
+	client := &http.Client{
+		// Bound the request so a hung/half-open connection (captive portal,
+		// offline) can't stall onboarding or the startup re-mint indefinitely.
+		Timeout: 15 * time.Second,
+	}
 	return mintTokenAt(ctx, client, fmt.Sprintf("https://%s.slack.com", domain), dCookie)
 }
 
@@ -40,6 +52,16 @@ func mintTokenAt(ctx context.Context, client *http.Client, baseURL, dCookie stri
 			return "", err
 		}
 		req.AddCookie(&http.Cookie{Name: "d", Value: dCookie})
+		// Navigation-shaped headers: a real browser loading a workspace page
+		// sends these, NOT the Origin/Sec-Fetch-Mode: cors of an XHR call.
+		req.Header.Set("User-Agent", slackhttp.UserAgent())
+		req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8")
+		req.Header.Set("Accept-Language", "en-US,en;q=0.9")
+		req.Header.Set("Sec-Fetch-Site", "none")
+		req.Header.Set("Sec-Fetch-Mode", "navigate")
+		req.Header.Set("Sec-Fetch-Dest", "document")
+		req.Header.Set("Sec-Fetch-User", "?1")
+		req.Header.Set("Upgrade-Insecure-Requests", "1")
 
 		resp, err := client.Do(req)
 		if err != nil {

--- a/internal/slack/mint_test.go
+++ b/internal/slack/mint_test.go
@@ -67,6 +67,36 @@ func TestMintTokenSendsNavigationHeaders(t *testing.T) {
 	}
 }
 
+func TestMintDiagDetectsToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`<html>boot_data = {"api_token":"xoxc-ok"}</html>`))
+	}))
+	defer srv.Close()
+
+	d := mintDiagAt(context.Background(), srv.Client(), srv.URL, "xoxd-abc", "acme")
+	if d.Status != 200 || !d.HasAPIToken {
+		t.Fatalf("expected 200 + api_token, got %+v", d)
+	}
+	if len(d.LoginMarkers) != 0 {
+		t.Errorf("unexpected login markers: %v", d.LoginMarkers)
+	}
+}
+
+func TestMintDiagDetectsLoginPage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`<html><h1>Sign in to Acme</h1> please enter your email</html>`))
+	}))
+	defer srv.Close()
+
+	d := mintDiagAt(context.Background(), srv.Client(), srv.URL, "xoxd-abc", "acme")
+	if d.HasAPIToken {
+		t.Fatalf("did not expect api_token on a login page: %+v", d)
+	}
+	if len(d.LoginMarkers) == 0 {
+		t.Errorf("expected login markers on a signed-out page, got none")
+	}
+}
+
 func TestMintTokenRetriesOn429(t *testing.T) {
 	var calls int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/slack/mint_test.go
+++ b/internal/slack/mint_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 )
@@ -33,6 +34,36 @@ func TestMintTokenNoToken(t *testing.T) {
 	defer srv.Close()
 	if _, err := mintTokenAt(context.Background(), srv.Client(), srv.URL, "xoxd-abc"); err == nil {
 		t.Error("expected error when api_token absent")
+	}
+}
+
+// Loading a workspace page is a top-level navigation, not an XHR/CORS call.
+// Sending API-XHR headers (Origin: app.slack.com, Sec-Fetch-Mode: cors) on
+// this GET can be rejected with 403 by strict corporate edges/proxies (#111).
+// Guard that the mint request is navigation-shaped.
+func TestMintTokenSendsNavigationHeaders(t *testing.T) {
+	got := make(chan http.Header, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got <- r.Header.Clone()
+		w.Write([]byte(`<html>"api_token":"xoxc-ok"</html>`))
+	}))
+	defer srv.Close()
+
+	if _, err := mintTokenAt(context.Background(), srv.Client(), srv.URL, "xoxd-abc"); err != nil {
+		t.Fatal(err)
+	}
+	h := <-got
+	if h.Get("Sec-Fetch-Mode") != "navigate" {
+		t.Errorf("Sec-Fetch-Mode = %q, want navigate", h.Get("Sec-Fetch-Mode"))
+	}
+	if h.Get("Sec-Fetch-Dest") != "document" {
+		t.Errorf("Sec-Fetch-Dest = %q, want document", h.Get("Sec-Fetch-Dest"))
+	}
+	if h.Get("Origin") != "" {
+		t.Errorf("Origin = %q, want empty (a navigation sends no Origin)", h.Get("Origin"))
+	}
+	if !strings.HasPrefix(h.Get("Accept"), "text/html") {
+		t.Errorf("Accept = %q, want a text/html navigation Accept", h.Get("Accept"))
 	}
 }
 

--- a/internal/slackdesktop/profiles.go
+++ b/internal/slackdesktop/profiles.go
@@ -1,0 +1,66 @@
+package slackdesktop
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// ProfileCandidate describes a possible Slack desktop profile location.
+type ProfileCandidate struct {
+	Path      string // config dir
+	Kind      string // "native" | "flatpak" | "snap"
+	Exists    bool   // the dir exists
+	HasCookie bool   // a Cookies DB exists under it
+	Active    bool   // the profile slk actually uses (ConfigDir)
+}
+
+// profileCandidatePaths returns the known Slack desktop config-dir locations
+// for a given OS. getenv is injected for testability. On Linux this includes
+// Flatpak and Snap install locations in addition to the native dir, since
+// reading the wrong (stale/signed-out) profile is a likely cause of mint
+// failures (#111).
+func profileCandidatePaths(goos string, getenv func(string) string) []ProfileCandidate {
+	home := getenv("HOME")
+	switch goos {
+	case "windows":
+		return []ProfileCandidate{{Path: filepath.Join(getenv("APPDATA"), "Slack"), Kind: "native"}}
+	case "darwin":
+		return []ProfileCandidate{
+			{Path: filepath.Join(home, "Library", "Application Support", "Slack"), Kind: "native"},
+			{Path: filepath.Join(home, "Library", "Containers", "com.tinyspeck.slackmacgap", "Data", "Library", "Application Support", "Slack"), Kind: "native"},
+		}
+	default: // linux
+		return []ProfileCandidate{
+			{Path: filepath.Join(home, ".config", "Slack"), Kind: "native"},
+			{Path: filepath.Join(home, ".var", "app", "com.slack.Slack", "config", "Slack"), Kind: "flatpak"},
+			{Path: filepath.Join(home, "snap", "slack", "current", ".config", "Slack"), Kind: "snap"},
+		}
+	}
+}
+
+// cookieDBPath returns the Cookies DB path under a Slack config dir for the OS.
+func cookieDBPath(goos, configDir string) string {
+	if goos == "windows" {
+		return filepath.Join(configDir, "Network", "Cookies")
+	}
+	return filepath.Join(configDir, "Cookies")
+}
+
+// ProfileCandidates lists known Slack desktop profile locations for this OS,
+// flagging which exist, which have a Cookies DB, and which one slk uses.
+// Diagnostic aid for "wrong/stale profile" mint failures (#111).
+func ProfileCandidates() []ProfileCandidate {
+	active, _ := ConfigDir() // "" if none found; that's fine for comparison
+	out := profileCandidatePaths(runtime.GOOS, os.Getenv)
+	for i := range out {
+		if info, err := os.Stat(out[i].Path); err == nil && info.IsDir() {
+			out[i].Exists = true
+		}
+		if info, err := os.Stat(cookieDBPath(runtime.GOOS, out[i].Path)); err == nil && !info.IsDir() {
+			out[i].HasCookie = true
+		}
+		out[i].Active = active != "" && out[i].Path == active
+	}
+	return out
+}

--- a/internal/slackdesktop/profiles_test.go
+++ b/internal/slackdesktop/profiles_test.go
@@ -1,0 +1,38 @@
+package slackdesktop
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestProfileCandidatePathsLinux(t *testing.T) {
+	env := func(k string) string {
+		if k == "HOME" {
+			return "/home/x"
+		}
+		return ""
+	}
+	got := profileCandidatePaths("linux", env)
+	want := map[string]string{
+		"/home/x/.config/Slack":                         "native",
+		"/home/x/.var/app/com.slack.Slack/config/Slack": "flatpak",
+		"/home/x/snap/slack/current/.config/Slack":      "snap",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d candidates, want %d: %+v", len(got), len(want), got)
+	}
+	for _, c := range got {
+		if want[c.Path] != c.Kind {
+			t.Errorf("path %q: kind=%q, want %q", c.Path, c.Kind, want[c.Path])
+		}
+	}
+}
+
+func TestCookieDBPath(t *testing.T) {
+	if got := cookieDBPath("linux", "/cfg/Slack"); got != filepath.Join("/cfg/Slack", "Cookies") {
+		t.Errorf("linux cookie path = %q", got)
+	}
+	if got, want := cookieDBPath("windows", "SlackDir"), filepath.Join("SlackDir", "Network", "Cookies"); got != want {
+		t.Errorf("windows cookie path = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Loading the workspace page to scrape api_token is a top-level navigation, but it went through the XHR BrowserTransport, which stamps it with Origin: https://app.slack.com and Sec-Fetch-Mode: cors. That contradictory signature (a page load wearing fetch/CORS headers) is rejected with HTTP 403 by strict corporate edges/proxies, so onboarding failed with 'mint token: status 403'.

Mint with a plain client and navigation-appropriate headers (Sec-Fetch-Mode: navigate, Sec-Fetch-Dest: document, no Origin, Accept: text/html) instead, matching what a browser sends on a page load (and what gh-slack does). Using a plain client with no cookie jar also stops sending the d cookie twice. The ongoing API/WebSocket traffic keeps the browser-header treatment (#5).