### PR TITLE
fix(mrkdwn): send @team mentions as usergroup elements, not broadcasts

### DIFF
--- a/internal/slack/mrkdwn/convert_test.go
+++ b/internal/slack/mrkdwn/convert_test.go
@@ -491,6 +491,43 @@ func TestConvert_Broadcast(t *testing.T) {
 	}
 }
 
+// TestConvert_Usergroup: @team mentions are a usergroup element, not a
+// broadcast range. Sending them as a broadcast makes Slack reject the
+// whole message with invalid_blocks.
+func TestConvert_Usergroup(t *testing.T) {
+	mr, blk := Convert("<!subteam^S01|@team> please review")
+	if mr != "<!subteam^S01|@team> please review" {
+		t.Errorf("mrkdwn = %q", mr)
+	}
+	ug := blk.Elements[0].(*slack.RichTextSection).Elements[0].(*slack.RichTextSectionUserGroupElement)
+	if ug.UsergroupID != "S01" {
+		t.Errorf("UsergroupID = %q, want S01", ug.UsergroupID)
+	}
+}
+
+func TestConvert_UsergroupPreservesStyle(t *testing.T) {
+	_, blk := Convert("**<!subteam^S01|@team>**")
+	ug := blk.Elements[0].(*slack.RichTextSection).Elements[0].(*slack.RichTextSectionUserGroupElement)
+	if ug.Style == nil || !ug.Style.Bold {
+		t.Fatalf("usergroup style = %+v, want bold", ug.Style)
+	}
+}
+
+// TestConvert_UnknownBroadcastStaysText: reBroadcast matches any
+// <!word>, but Slack only accepts here/channel/everyone as ranges.
+// Unknown ones must degrade to literal text, not fail the send.
+func TestConvert_UnknownBroadcastStaysText(t *testing.T) {
+	_, blk := Convert("<!bogus> hi")
+	el := blk.Elements[0].(*slack.RichTextSection).Elements[0]
+	te, ok := el.(*slack.RichTextSectionTextElement)
+	if !ok {
+		t.Fatalf("element = %T, want text element", el)
+	}
+	if te.Text != "<!bogus> hi" {
+		t.Errorf("Text = %q, want %q", te.Text, "<!bogus> hi")
+	}
+}
+
 func TestConvert_BoldContainingMention(t *testing.T) {
 	mr, blk := Convert("**Hi <@U1>**")
 	if mr != "*Hi <@U1>*" {

--- a/internal/slack/mrkdwn/walk.go
+++ b/internal/slack/mrkdwn/walk.go
@@ -652,9 +652,26 @@ func (w *walker) tokenElement(t token) slack.RichTextSectionElement {
 	case tokChannel:
 		return slack.NewRichTextSectionChannelElement(t.id, style)
 	case tokBroadcast:
-		// Broadcasts don't carry a style on the wire (slack-go's
-		// RichTextSectionBroadcastElement has no Style field).
-		return slack.NewRichTextSectionBroadcastElement(t.id)
+		// <!subteam^SID> is a usergroup (@team) mention, not a
+		// broadcast: it has its own rich_text element type. Sending it
+		// as a broadcast range gets the whole message rejected with
+		// invalid_blocks.
+		if id, ok := strings.CutPrefix(t.id, "subteam^"); ok {
+			el := slack.NewRichTextSectionUserGroupElement(id)
+			el.Style = style
+			return el
+		}
+		// Slack only accepts here / channel / everyone as broadcast
+		// ranges; anything else is invalid_blocks. reBroadcast matches
+		// any <!word> form, so keep unknown ones as literal text
+		// rather than letting them fail the send.
+		switch t.id {
+		case "here", "channel", "everyone":
+			// Broadcasts don't carry a style on the wire (slack-go's
+			// RichTextSectionBroadcastElement has no Style field).
+			return slack.NewRichTextSectionBroadcastElement(t.id)
+		}
+		return slack.NewRichTextSectionTextElement(wireForm(t), style)
 	case tokLink:
 		text := t.label
 		if text == "" {


### PR DESCRIPTION
## What's broken

Tagging a user group fails to send. When you `@team` and the message goes out through the
`rich_text` block path, slk emits `<!subteam^SID>` as a **broadcast** element. Slack only accepts
`here`, `channel` and `everyone` as broadcast ranges, so it rejects the whole message with
`invalid_blocks` and the send just fails.

This is a regression in my own merged #99, which added usergroup tagging but routed the mrkdwn
walker's `tokBroadcast` case straight to `NewRichTextSectionBroadcastElement` — correct for
`@here`/`@channel`, wrong for `<!subteam^…>`.

## Fix

- `<!subteam^SID>` now becomes a `RichTextSectionUserGroupElement` carrying the usergroup ID,
  which is the element type Slack actually expects for group mentions.
- The walker's inherited style is applied to that element, so a bold or italic `@team` keeps its
  formatting instead of silently losing it.
- `reBroadcast` matches any `<!word>` form, but only three are valid ranges. Unknown ones now
  degrade to literal text rather than taking the entire message down with them.

## Tests

Three cases added in `internal/slack/mrkdwn/convert_test.go`:

- `TestConvert_Usergroup` — `<!subteam^S01|@team>` produces a usergroup element with the right ID.
- `TestConvert_UsergroupPreservesStyle` — a bold `@team` keeps `Style.Bold`.
- `TestConvert_UnknownBroadcastStaysText` — `<!bogus>` stays literal text instead of failing.

Synthetic IDs only (`S01`, `@team`). `go vet ./...` and `go test ./...` pass.

Also verified by hand against a live workspace: tagging a group sends, a bold `@team` sends and
renders bold, and `@here`/`@channel` are unaffected.

## Related

Partially related to #44 — that issue is about group mentions rendering as raw
`<!subteam^S01JT...>`; this PR is the send-side half of the same area.

---

AI-assisted per the contributing guidelines: driven by Claude Opus 5 at high thinking effort,
with the diff reviewed and manually tested before opening.
