### PR TITLE
fix(mentionpicker): match @ queries on word boundaries, not just name prefix

### DIFF
--- a/internal/ui/mentionpicker/match.go
+++ b/internal/ui/mentionpicker/match.go
@@ -1,0 +1,81 @@
+package mentionpicker
+
+import (
+	"strings"
+
+	"github.com/gammons/slk/internal/text"
+)
+
+// matchRank describes how well a candidate name matches the query.
+// Lower is better: the picker sorts by rank before name, so a whole-name
+// prefix hit outranks a hit on a word in the middle of the name.
+//
+// The three matching modes mirror what Slack's own composer does — typing
+// "widg" finds @eng-widgets, and so does "engwidgets".
+type matchRank int
+
+const (
+	rankPrefix   matchRank = iota // query is a prefix of the whole name
+	rankWord                      // query is a prefix of a word inside the name
+	rankSquashed                  // query matches once separators are removed
+	rankNone                      // no match
+)
+
+// isSeparator reports whether b separates words in a display name or
+// handle. Slack handles allow "-", "_" and "."; display names add
+// spaces. All are ASCII, so byte-level tests are safe on UTF-8 input —
+// no continuation byte of a multi-byte rune can collide with them.
+func isSeparator(b byte) bool {
+	return b == ' ' || b == '-' || b == '_' || b == '.'
+}
+
+// squash removes every separator from s, so "eng-widgets" and
+// "engwidgets" compare equal.
+func squash(s string) string {
+	if !strings.ContainsAny(s, " -_.") {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		if !isSeparator(s[i]) {
+			b.WriteByte(s[i])
+		}
+	}
+	return b.String()
+}
+
+// matchName ranks name against an already-folded query. squashedQuery is
+// the query with separators removed; the caller computes it once per
+// keystroke rather than per candidate.
+func matchName(name, query, squashedQuery string) matchRank {
+	if query == "" {
+		return rankPrefix
+	}
+	n := text.Fold(name)
+	if strings.HasPrefix(n, query) {
+		return rankPrefix
+	}
+	// Word-boundary prefix: "widg" matches "eng-widgets". Runs of
+	// separators are handled naturally — each one starts a new word, and
+	// an empty word can only match an empty query, which returned above.
+	for i := 0; i < len(n); i++ {
+		if isSeparator(n[i]) && strings.HasPrefix(n[i+1:], query) {
+			return rankWord
+		}
+	}
+	if squashedQuery != "" && strings.HasPrefix(squash(n), squashedQuery) {
+		return rankSquashed
+	}
+	return rankNone
+}
+
+// rankUser returns the better of the user's display-name and username
+// ranks.
+func rankUser(u User, query, squashedQuery string) matchRank {
+	r := matchName(u.DisplayName, query, squashedQuery)
+	if ru := matchName(u.Username, query, squashedQuery); ru < r {
+		r = ru
+	}
+	return r
+}

--- a/internal/ui/mentionpicker/match_test.go
+++ b/internal/ui/mentionpicker/match_test.go
@@ -1,0 +1,171 @@
+package mentionpicker
+
+import "testing"
+
+// ids returns the filtered IDs in display order, for compact assertions.
+func ids(m Model) []string {
+	out := make([]string, 0, len(m.Filtered()))
+	for _, u := range m.Filtered() {
+		out = append(out, u.ID)
+	}
+	return out
+}
+
+// TestFilterMatchesWordInsideName: Slack's composer finds @eng-widgets
+// from "widg". Whole-name prefix matching alone forced users to know
+// the leading word.
+func TestFilterMatchesWordInsideName(t *testing.T) {
+	tests := []struct {
+		query string
+		want  bool
+	}{
+		{"eng", true},        // whole-name prefix
+		{"eng-widg", true},   // whole-name prefix spanning a separator
+		{"widg", true},       // word-boundary prefix
+		{"widgets", true},    // whole trailing word
+		{"engwidgets", true}, // separators removed
+		{"engwidg", true},    // separators removed, partial
+		{"idget", false},     // mid-word: Slack doesn't match this either
+		{"xyz", false},
+	}
+	for _, tt := range tests {
+		m := New()
+		m.SetUsers([]User{
+			{ID: "usergroup:S1", DisplayName: "eng-widgets", Username: "eng-widgets", InChannel: true},
+		})
+		m.Open()
+		m.SetQuery(tt.query)
+		got := len(m.Filtered()) == 1
+		if got != tt.want {
+			t.Errorf("query %q: matched = %v, want %v", tt.query, got, tt.want)
+		}
+	}
+}
+
+// TestFilterSeparatorVariants: spaces, dots and underscores split words
+// the same way hyphens do.
+func TestFilterSeparatorVariants(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{"Ada Lovelace", "love"},
+		{"ada.lovelace", "love"},
+		{"ada_lovelace", "love"},
+		{"ada-lovelace", "love"},
+		{"Ada Lovelace", "adalovelace"},
+	}
+	for _, tt := range tests {
+		m := New()
+		m.SetUsers([]User{{ID: "U1", DisplayName: tt.name, Username: "u", InChannel: true}})
+		m.Open()
+		m.SetQuery(tt.query)
+		if len(m.Filtered()) != 1 {
+			t.Errorf("name %q, query %q: got %d matches, want 1", tt.name, tt.query, len(m.Filtered()))
+		}
+	}
+}
+
+// TestFilterRanksWholeNamePrefixFirst: a user typing "widg" wants
+// @widgets-lead before @eng-widgets, even though both match.
+func TestFilterRanksWholeNamePrefixFirst(t *testing.T) {
+	m := New()
+	m.SetUsers([]User{
+		{ID: "U1", DisplayName: "eng-widgets", Username: "eng-widgets", InChannel: true},
+		{ID: "U2", DisplayName: "widgets-lead", Username: "widgets-lead", InChannel: true},
+	})
+	m.Open()
+	m.SetQuery("widg")
+	want := []string{"U2", "U1"}
+	got := ids(m)
+	if len(got) != 2 || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("order = %v, want %v", got, want)
+	}
+}
+
+// TestFilterOrdersEqualDisplayNamesByID guards sortRanked's final
+// tie-break: sort.Slice is unstable, so input order must not leak into the
+// picker when two candidates share a display name and match rank.
+func TestFilterOrdersEqualDisplayNamesByID(t *testing.T) {
+	m := New()
+	m.SetUsers([]User{
+		{ID: "U2", DisplayName: "Alex", Username: "alex-two", InChannel: true},
+		{ID: "U1", DisplayName: "Alex", Username: "alex-one", InChannel: true},
+	})
+	m.Open()
+	m.SetQuery("alex")
+
+	got := ids(m)
+	if len(got) != 2 || got[0] != "U1" || got[1] != "U2" {
+		t.Errorf("order = %v, want [U1 U2]", got)
+	}
+}
+
+// TestFilterMembershipTierBeatsRank: rank orders candidates within a
+// tier; it must not promote a not-in-channel user above an in-channel one.
+func TestFilterMembershipTierBeatsRank(t *testing.T) {
+	m := New()
+	m.SetUsers([]User{
+		{ID: "U1", DisplayName: "eng-widgets", Username: "eng-widgets", InChannel: true},
+		{ID: "U2", DisplayName: "widgets-lead", Username: "widgets-lead", InChannel: false},
+	})
+	m.Open()
+	m.SetQuery("widg")
+	got := ids(m)
+	if len(got) != 2 || got[0] != "U1" {
+		t.Errorf("order = %v, want in-channel U1 first", got)
+	}
+}
+
+// TestFilterAccentInsensitiveWordMatch: folding applies to word matches
+// too, not just whole-name prefixes.
+func TestFilterAccentInsensitiveWordMatch(t *testing.T) {
+	m := New()
+	m.SetUsers([]User{{ID: "U1", DisplayName: "Team Mélanie", Username: "tm", InChannel: true}})
+	m.Open()
+	m.SetQuery("mela")
+	if len(m.Filtered()) != 1 {
+		t.Errorf("got %d matches, want 1", len(m.Filtered()))
+	}
+}
+
+func TestMatchNameRanks(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+		want  matchRank
+	}{
+		{"eng-widgets", "eng", rankPrefix},
+		{"eng-widgets", "eng-widg", rankPrefix},
+		{"eng-widgets", "widg", rankWord},
+		{"eng-widgets", "engwidgets", rankSquashed},
+		{"eng-widgets", "idget", rankNone},
+		{"eng-widgets", "", rankPrefix},
+	}
+	for _, tt := range tests {
+		if got := matchName(tt.name, tt.query, squash(tt.query)); got != tt.want {
+			t.Errorf("matchName(%q, %q) = %v, want %v", tt.name, tt.query, got, tt.want)
+		}
+	}
+}
+
+// TestSquashLeavesSeparatorlessStringsAlone guards the fast path.
+func TestSquashLeavesSeparatorlessStringsAlone(t *testing.T) {
+	if got := squash("alice"); got != "alice" {
+		t.Errorf("squash = %q, want alice", got)
+	}
+	if got := squash("a b-c_d.e"); got != "abcde" {
+		t.Errorf("squash = %q, want abcde", got)
+	}
+}
+
+// TestMatchNameTrailingSeparator: a name ending in a separator must not
+// index past the end of the string.
+func TestMatchNameTrailingSeparator(t *testing.T) {
+	if got := matchName("team-", "x", "x"); got != rankNone {
+		t.Errorf("matchName = %v, want rankNone", got)
+	}
+	if got := matchName("team--lead", "lead", "lead"); got != rankWord {
+		t.Errorf("matchName = %v, want rankWord", got)
+	}
+}

--- a/internal/ui/mentionpicker/model.go
+++ b/internal/ui/mentionpicker/model.go
@@ -127,44 +127,63 @@ func (m *Model) Select() *MentionResult {
 	}
 }
 
+// rankedUser pairs a candidate with its match rank so the sort can put
+// stronger matches first within a membership tier.
+type rankedUser struct {
+	user User
+	rank matchRank
+}
+
+// sortRanked orders candidates by match rank, then display name, then ID.
+// sort.Slice is unstable, so the ID tie-break keeps the dropdown from
+// reshuffling between identical keystrokes when two entries share a
+// display name.
+func sortRanked(s []rankedUser) {
+	sort.Slice(s, func(i, j int) bool {
+		if s[i].rank != s[j].rank {
+			return s[i].rank < s[j].rank
+		}
+		if s[i].user.DisplayName != s[j].user.DisplayName {
+			return s[i].user.DisplayName < s[j].user.DisplayName
+		}
+		return s[i].user.ID < s[j].user.ID
+	})
+}
+
 func (m *Model) filter() {
 	q := text.Fold(m.query)
-	matches := func(u User) bool {
-		if q == "" {
-			return true
-		}
-		return strings.HasPrefix(text.Fold(u.DisplayName), q) ||
-			strings.HasPrefix(text.Fold(u.Username), q)
-	}
+	sq := squash(q)
 
-	var specials, inCh, notInCh []User
+	var specials []User
+	var inCh, notInCh []rankedUser
 	for _, u := range specialMentions {
-		if matches(u) {
+		if rankUser(u, q, sq) != rankNone {
 			specials = append(specials, u)
 		}
 	}
 	for _, u := range m.users {
-		if !matches(u) {
+		r := rankUser(u, q, sq)
+		if r == rankNone {
 			continue
 		}
 		if u.InChannel {
-			inCh = append(inCh, u)
+			inCh = append(inCh, rankedUser{user: u, rank: r})
 		} else {
-			notInCh = append(notInCh, u)
+			notInCh = append(notInCh, rankedUser{user: u, rank: r})
 		}
 	}
 
-	sort.Slice(inCh, func(i, j int) bool {
-		return inCh[i].DisplayName < inCh[j].DisplayName
-	})
-	sort.Slice(notInCh, func(i, j int) bool {
-		return notInCh[i].DisplayName < notInCh[j].DisplayName
-	})
+	sortRanked(inCh)
+	sortRanked(notInCh)
 
 	results := make([]User, 0, len(specials)+len(inCh)+len(notInCh))
 	results = append(results, specials...)
-	results = append(results, inCh...)
-	results = append(results, notInCh...)
+	for _, r := range inCh {
+		results = append(results, r.user)
+	}
+	for _, r := range notInCh {
+		results = append(results, r.user)
+	}
 
 	if len(results) > MaxVisible {
 		results = results[:MaxVisible]


### PR DESCRIPTION
## What's broken

`@` autocomplete only matched from the start of a name. Given a handle like `eng-widgets`, typing
`@widg` never found it — you had to know the leading word before the picker would help you, which
is not how Slack's own composer behaves.

There was also a second, quieter problem: the dropdown used `sort.Slice` (unstable) keyed on
display name alone, so two people sharing a display name could swap positions between identical
keystrokes.

## Fix

Matching now has three ranked modes, in `internal/ui/mentionpicker/match.go`:

| rank | mode | example |
|---|---|---|
| 1 | whole-name prefix | `eng` → `eng-widgets` |
| 2 | word-boundary prefix | `widg` → `eng-widgets` |
| 3 | separators squashed | `engwidgets` → `eng-widgets` |

Mid-word queries still don't match (`idget` finds nothing) — Slack doesn't match those either, and
allowing them makes the list noisy.

Separators are ` `, `-`, `_` and `.`, covering Slack handles and display names. They're all ASCII,
so the byte-level scan is safe on UTF-8: no continuation byte can collide with them. Queries are
folded through the existing `text.Fold`, so accent-insensitive matching keeps working on the new
paths.

Two ordering properties are preserved deliberately:

- **Membership still outranks match quality.** In-channel candidates stay above not-in-channel
  ones; rank only orders within a tier. A strong squashed match on a non-member must not jump
  ahead of an in-channel member.
- **Ordering is now deterministic.** The sort tie-breaks rank → display name → ID, so equal
  display names no longer let input order leak into the dropdown.

Applies to usergroup handles as well as people, since both flow through the same candidate list.

## Tests

Nine cases in `internal/ui/mentionpicker/match_test.go`, all on synthetic handles:

- word-inside-name, separator-variant and squashed matching, including the negative mid-word case
- whole-name prefix ranks above a word-boundary hit
- equal display names order by ID (guards the unstable-sort tie-break)
- membership tier beats rank
- accent-insensitive word match
- `matchName` rank table, separatorless fast path, trailing-separator edge case

`go vet ./...` and `go test ./...` pass. Also exercised by hand in a live workspace.

## Related

Partially addresses #44's second half — finding groups in the mention picker.

---

AI-assisted per the contributing guidelines: driven by Claude Opus 5 at high thinking effort,
with the diff reviewed and manually tested before opening.
