### PR TITLE
fix(nix): update Go module vendor hash

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
           pname = "slk";
           version = "0.0.0";
           src = ./.;
-          vendorHash = "sha256-dPa469oNv6eYyDdly3uhc273DAGz+erc0E3K/am7WoY=";
+          vendorHash = "sha256-+eO1mgwuEkF+0rGEENzmJLOTaq82hP2LExGuOreypmc=";
           buildInputs = [pkgs.libX11];
         };
       in {


### PR DESCRIPTION
  ## Summary

  - update the `buildGo126Module` vendor hash to match the current Go dependencies
  - restore `nix build` and `nix run` from the repository flake

  ## Testing

  - `nix flake check`
  - `nix build --no-link .`
  - `nix run . -- --help`
