### PR TITLE
fix(slk): stop the cross-workspace conversations.members amplifier

### DIFF
--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -3884,13 +3884,31 @@ func (h *rtmEventHandler) OnConnect() {
 	// disconnect window; a fresh full fetch reconciles divergence.
 	// Inactive channels stay as-is — they'll re-fetch on their next
 	// EnsureFresh via the channel-switch fetcher path.
-	if h.wsCtx != nil && h.wsCtx.Membership != nil && h.activeChannelID != nil {
-		activeID := h.activeChannelID()
-		if activeID != "" {
-			h.wsCtx.Membership.ForceStale(activeID)
-			h.wsCtx.Membership.EnsureFresh(context.Background(), activeID)
-		}
+	h.refreshActiveMembership()
+}
+
+// refreshActiveMembership force-stales and re-fetches membership for
+// the channel on screen. Gated on isActive because activeChannelID
+// reads the GLOBAL UI active channel (app.ActiveChannelID), and every
+// workspace's handler runs OnConnect: without the gate, workspaces
+// that don't own the on-screen channel fetched it anyway, failed with
+// channel_not_found, and — because a failed fetch leaves the cache
+// stale — re-fired on every reconnect. Measured live: a flapping
+// session started 42 conversations.members in 25 seconds with no user
+// interaction.
+func (h *rtmEventHandler) refreshActiveMembership() {
+	if h.wsCtx == nil || h.wsCtx.Membership == nil || h.activeChannelID == nil {
+		return
 	}
+	if h.isActive != nil && !h.isActive() {
+		return
+	}
+	activeID := h.activeChannelID()
+	if activeID == "" {
+		return
+	}
+	h.wsCtx.Membership.ForceStale(activeID)
+	h.wsCtx.Membership.EnsureFresh(context.Background(), activeID)
 }
 
 // syncOnReconnect kicks off the bounded catch-up pass for this

--- a/cmd/slk/reconnect_sync_test.go
+++ b/cmd/slk/reconnect_sync_test.go
@@ -13,6 +13,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/gammons/slk/internal/cache"
 	slackclient "github.com/gammons/slk/internal/slack"
+	"github.com/gammons/slk/internal/slack/membership"
 	"github.com/gammons/slk/internal/ui"
 )
 
@@ -281,6 +282,82 @@ func TestReconnect_CountsFailureStillRefreshesTheActiveChannel(t *testing.T) {
 	}
 	if len(refreshed) != 1 {
 		t.Errorf("refreshed %v; want the active channel refreshed despite the counts failure", refreshed)
+	}
+}
+
+// fakeMemberAPI implements membership.ConversationMemberAPI and
+// records how many full fetches it was asked to perform.
+type fakeMemberAPI struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (f *fakeMemberAPI) GetUsersInConversation(_ context.Context, _ string) ([]string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	return []string{"U1"}, nil
+}
+
+func (f *fakeMemberAPI) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+func newMembershipHandler(t *testing.T, active bool) (*rtmEventHandler, *fakeMemberAPI, *cache.DB) {
+	t.Helper()
+	db := newTestDB(t)
+	if err := db.ReplaceChannelMembers("T1", "C1", []string{"U1"}, time.Now().Unix()); err != nil {
+		t.Fatalf("ReplaceChannelMembers: %v", err)
+	}
+	api := &fakeMemberAPI{}
+	mgr := membership.New("T1", api, db, nil, nil)
+	h := &rtmEventHandler{
+		wsCtx:           &WorkspaceContext{Membership: mgr},
+		isActive:        func() bool { return active },
+		activeChannelID: func() string { return "C1" },
+	}
+	return h, api, db
+}
+
+// TestOnConnectMembershipRefreshSkipsInactiveWorkspace pins the
+// cross-workspace bug behind the 42-conversations.members session.
+// Every workspace's handler reads the GLOBAL UI active channel via
+// app.ActiveChannelID(); without an isActive gate, OnConnect ran
+// ForceStale+EnsureFresh for that channel on EVERY workspace's
+// connect. The workspaces that don't own the channel fail with
+// channel_not_found, and a failing fetch leaves the cache stale, so
+// each reconnect re-fired the call — an unbounded amplifier with zero
+// user interaction. Measured live: both workspaces' OnConnect fetched
+// the same DM id 0.6 s apart; the non-owner's failed.
+func TestOnConnectMembershipRefreshSkipsInactiveWorkspace(t *testing.T) {
+	h, api, db := newMembershipHandler(t, false)
+	before, _, _ := db.GetChannelMembershipMeta("T1", "C1")
+
+	h.refreshActiveMembership()
+	time.Sleep(100 * time.Millisecond)
+
+	if c := api.callCount(); c != 0 {
+		t.Errorf("background workspace fetched membership %d times for a channel it does not own; want 0", c)
+	}
+	after, _, _ := db.GetChannelMembershipMeta("T1", "C1")
+	if after != before {
+		t.Errorf("ForceStale zeroed a background workspace's membership meta (%d -> %d); staleness must only be forced by the workspace on screen", before, after)
+	}
+}
+
+func TestOnConnectMembershipRefreshRunsForActiveWorkspace(t *testing.T) {
+	h, api, _ := newMembershipHandler(t, true)
+
+	h.refreshActiveMembership()
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) && api.callCount() == 0 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if c := api.callCount(); c != 1 {
+		t.Errorf("active workspace's membership refresh fetched %d times; want 1", c)
 	}
 }
 

--- a/internal/slack/membership/manager.go
+++ b/internal/slack/membership/manager.go
@@ -15,6 +15,17 @@ import (
 // triggers a background re-fetch. Spec: 24h.
 const TTL = 24 * time.Hour
 
+// FailureBackoff bounds how soon a FAILED fetch may be retried. A
+// failed fetch never bumps last_full_fetch_at, so without this every
+// EnsureFresh re-issues conversations.members — and OnConnect's
+// ForceStale+EnsureFresh pair fires on every websocket reconnect.
+// Measured live: the on-screen channel was one the workspace's token
+// could not see (channel_not_found), the socket flapped, and a
+// 25-second session started 42 conversations.members requests. 5
+// minutes throttles that loop without wedging a transiently failing
+// channel for the full TTL.
+const FailureBackoff = 5 * time.Minute
+
 // ConversationMemberAPI is the slack-client subset Manager needs.
 // Decoupled from *slackclient.Client for testability.
 type ConversationMemberAPI interface {
@@ -45,6 +56,7 @@ type Manager struct {
 	members     map[string]map[string]struct{} // channelID -> member set
 	fetching    map[string]struct{}            // in-flight sentinel by channelID
 	lastFetched map[string]time.Time           // last successful full-fetch (in-memory, for dedup)
+	lastFailed  map[string]time.Time           // last failed fetch; backs off retries
 }
 
 // New constructs a Manager bound to one workspace.
@@ -58,6 +70,7 @@ func New(workspaceID string, api ConversationMemberAPI, db *cache.DB, push PushF
 		members:     map[string]map[string]struct{}{},
 		fetching:    map[string]struct{}{},
 		lastFetched: map[string]time.Time{},
+		lastFailed:  map[string]time.Time{},
 	}
 }
 
@@ -148,6 +161,15 @@ func (m *Manager) backgroundFetch(ctx context.Context, channelID string) {
 		m.mu.Unlock()
 		return
 	}
+	// A recent failure suppresses the retry. ForceStale clears
+	// lastFetched but deliberately NOT lastFailed: ForceStale runs on
+	// every websocket reconnect, and a channel whose fetch keeps
+	// failing (e.g. one this workspace's token cannot see) would
+	// otherwise be re-fetched on every flap.
+	if last, ok := m.lastFailed[channelID]; ok && time.Since(last) < FailureBackoff {
+		m.mu.Unlock()
+		return
+	}
 	m.fetching[channelID] = struct{}{}
 	m.mu.Unlock()
 	defer func() {
@@ -158,6 +180,9 @@ func (m *Manager) backgroundFetch(ctx context.Context, channelID string) {
 
 	ids, err := m.api.GetUsersInConversation(ctx, channelID)
 	if err != nil {
+		m.mu.Lock()
+		m.lastFailed[channelID] = time.Now()
+		m.mu.Unlock()
 		return
 	}
 	// Deliberately no resolution pass over ids.
@@ -194,6 +219,7 @@ func (m *Manager) backgroundFetch(ctx context.Context, channelID string) {
 	m.mu.Lock()
 	m.members[channelID] = set
 	m.lastFetched[channelID] = time.Now()
+	delete(m.lastFailed, channelID)
 	m.mu.Unlock()
 	m.pushSnapshot(channelID)
 }

--- a/internal/slack/membership/manager_test.go
+++ b/internal/slack/membership/manager_test.go
@@ -336,6 +336,70 @@ func TestBackgroundFetchDoesNotResolveEveryMember(t *testing.T) {
 	}
 }
 
+// TestBackgroundFetchFailureSuppressesImmediateRefetch pins the
+// failure side of the fetch ledger. A failed conversations.members
+// never bumps last_full_fetch_at, so without a failure record every
+// EnsureFresh — and OnConnect's ForceStale+EnsureFresh pair fires on
+// every websocket reconnect — re-issues the call. Measured live: the
+// active channel was a DM the workspace's token could not see
+// (channel_not_found), the socket flapped, and a 25-second session
+// started 42 conversations.members requests, the exact amplification
+// shape this package's TTL exists to prevent.
+func TestBackgroundFetchFailureSuppressesImmediateRefetch(t *testing.T) {
+	mgr, api, sink, db := newManagerForTest(t)
+	defer db.Close()
+	api.err = fmt.Errorf("channel_not_found")
+
+	mgr.EnsureFresh(context.Background(), "C1")
+	waitForPush(t, sink, 1)
+	waitForCallCount(t, api, 1)
+
+	// A reconnect force-stales the channel and asks again. The fetch
+	// must not re-fire within the failure backoff window.
+	mgr.ForceStale("C1")
+	mgr.EnsureFresh(context.Background(), "C1")
+	time.Sleep(100 * time.Millisecond)
+
+	if c := api.callCount(); c != 1 {
+		t.Errorf("failed fetch re-issued within the backoff window: %d calls, want 1 — this is the reconnect-flap amplifier", c)
+	}
+}
+
+// TestBackgroundFetchRetriesAfterBackoffExpiry: the backoff throttles
+// retries, it does not cancel them. Once the window has passed a stale
+// channel must be fetched again — a transient error must not wedge
+// membership for the full 24h TTL.
+func TestBackgroundFetchRetriesAfterBackoffExpiry(t *testing.T) {
+	mgr, api, sink, db := newManagerForTest(t)
+	defer db.Close()
+	api.err = fmt.Errorf("channel_not_found")
+
+	mgr.EnsureFresh(context.Background(), "C1")
+	waitForPush(t, sink, 1)
+	waitForCallCount(t, api, 1)
+
+	// Simulate a failure far enough in the past that the backoff has
+	// expired, then recover.
+	mgr.mu.Lock()
+	mgr.lastFailed["C1"] = time.Now().Add(-2 * FailureBackoff)
+	mgr.mu.Unlock()
+	api.err = nil
+	api.result = []string{"U1"}
+
+	mgr.EnsureFresh(context.Background(), "C1")
+	waitForCallCount(t, api, 2)
+	waitForPush(t, sink, 2)
+
+	// A successful fetch clears the failure record, so the next
+	// EnsureFresh is governed by the normal TTL, not the backoff.
+	mgr.mu.Lock()
+	_, stillMarked := mgr.lastFailed["C1"]
+	mgr.mu.Unlock()
+	if stillMarked {
+		t.Error("lastFailed not cleared by a successful fetch; a recovered channel would stay throttled")
+	}
+}
+
 func TestEnsureFreshConcurrentDoesNotDuplicate(t *testing.T) {
 	mgr, api, _, db := newManagerForTest(t)
 	defer db.Close()


### PR DESCRIPTION
## Summary

Every workspace's `OnConnect` ran `ForceStale`+`EnsureFresh` for the **global** UI active channel (`app.ActiveChannelID()`, main.go:1788). Workspaces that don't own that channel failed with `channel_not_found`, and because a failed fetch never updated the dedup ledger, **every websocket reconnect re-fired the call**. Measured live: a flapping 25-second session started 42 `conversations.members` requests with zero user interaction — the request-amplification shape the boot-budget work exists to remove.

This surfaced while investigating a suspected regression on `fix/sidebar-from-userboot`; an instrumented A/B (6 runs, provenance-checked binaries) showed both binaries identical, and the caller-identifying logs pointed here instead. The bug is on `main`.

## Fixes

1. **`OnConnect`'s membership refresh is gated on `isActive()`** — extracted into `refreshActiveMembership()`; only the foreground workspace's handler refreshes the on-screen channel.
2. **`membership.Manager` keeps a failure ledger** (5-minute `FailureBackoff`) — a failed fetch suppresses immediate retries even across `ForceStale`; the backoff expires normally and is cleared by the next successful fetch.

## Verification

- 4 new tests (backoff suppresses refetch, retries after expiry, success clears the ledger, inactive workspace skips / active workspace still refreshes).
- Full `go test ./...` and `go vet` clean.
- Live 25s session: `conversations.members` at boot drops 2 → 1 (the second was the guaranteed-failing cross-workspace call); the rest of the 37-request tally is unchanged.