### PR TITLE
fix(slk): Enterprise Grid support — sidebar fallback + team-scoped edge revalidation

### DIFF
--- a/cmd/slk/bootstrap_adapters.go
+++ b/cmd/slk/bootstrap_adapters.go
@@ -375,6 +375,85 @@ func applyBootUsers(wctx *WorkspaceContext, res *bootstrap.Result) {
 	}
 }
 
+// bootConversations converts what client.userBoot returned into the
+// slack.Channel values the sidebar builder consumes.
+//
+// It exists because users.conversations is not reliably available. On
+// the Enterprise Grid org in gammons/slk#5 that call is rejected, and
+// because connectWorkspace treated the failure as fatal the whole
+// workspace was dropped: no channels, no threads, and no active
+// workspace at all. userBoot had already returned all 217 of that
+// user's conversations moments earlier, so slk was discarding a
+// session over data it already held.
+//
+// The mapping only has to satisfy buildChannelItem, which reads ID,
+// Name, Topic, IsIM, IsMpIM, IsPrivate, IsMember and User. Everything
+// else on slack.Channel is left zero deliberately: a field invented
+// here would read as measured downstream.
+//
+// IsMember is true for every channels[] entry because userBoot returns
+// the user's OWN conversation list -- there is no is_member on the
+// entries and none is needed. IMs are filtered to the open ones, since
+// a closed DM does not belong in the sidebar; both the per-IM is_open
+// flag and userBoot's top-level is_open list are consulted, because
+// either alone would silently empty the DM list if that response shape
+// varies.
+func bootConversations(res *bootstrap.Result) []slack.Channel {
+	if res == nil {
+		return nil
+	}
+	out := make([]slack.Channel, 0, len(res.Channels)+len(res.IMs))
+	for _, ch := range res.Channels {
+		if ch.IsArchived {
+			continue
+		}
+		out = append(out, slack.Channel{
+			GroupConversation: slack.GroupConversation{
+				Conversation: slack.Conversation{
+					ID:          ch.ID,
+					IsGroup:     ch.IsGroup,
+					IsPrivate:   ch.IsPrivate,
+					IsMpIM:      ch.IsMPIM,
+					IsShared:    ch.IsShared,
+					IsOrgShared: ch.IsOrgShared,
+					IsExtShared: ch.IsExtShared,
+				},
+				Name:    ch.Name,
+				Creator: ch.Creator,
+				Topic:   slack.Topic{Value: ch.Topic.Value},
+				Purpose: slack.Purpose{Value: ch.Purpose.Value},
+			},
+			IsChannel: ch.IsChannel,
+			IsGeneral: ch.IsGeneral,
+			IsMember:  true,
+		})
+	}
+	open := make(map[string]bool, len(res.IsOpen))
+	for _, id := range res.IsOpen {
+		open[id] = true
+	}
+	for _, im := range res.IMs {
+		if im.IsArchived {
+			continue
+		}
+		if !im.IsOpen && !open[im.ID] {
+			continue
+		}
+		out = append(out, slack.Channel{
+			GroupConversation: slack.GroupConversation{
+				Conversation: slack.Conversation{
+					ID:          im.ID,
+					IsIM:        true,
+					User:        im.UserID,
+					IsOrgShared: im.IsOrgShared,
+				},
+			},
+			IsMember: true,
+		})
+	}
+	return out
+}
+
 // hydrateFirstSight inserts cache rows for the conversations and users
 // this boot learned about that the cache has never seen.
 //

--- a/cmd/slk/bootstrap_adapters_test.go
+++ b/cmd/slk/bootstrap_adapters_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"errors"
+	"github.com/slack-go/slack"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -746,5 +747,93 @@ func TestBootMutedChannels_MergesBothPrefs(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestBootConversations_MapsWhatTheSidebarBuilderReads(t *testing.T) {
+	// buildChannelItem reads ID, Name, Topic, IsIM, IsMpIM, IsPrivate,
+	// IsMember and User. Every one of those has to survive the trip
+	// from client.userBoot, or the sidebar renders wrong rather than
+	// empty -- which is harder to notice.
+	res := &bootstrap.Result{
+		Channels: []boot.Channel{
+			{ID: "C1", Name: "general", IsChannel: true, IsGeneral: true,
+				Topic: boot.TextBlock{Value: "company wide"}},
+			{ID: "C2", Name: "secret", IsChannel: true, IsPrivate: true},
+			{ID: "C3", Name: "mpdm-a--b--c", IsMPIM: true},
+		},
+		IMs:    []boot.IM{{ID: "D1", UserID: "U9", IsIM: true, IsOpen: true}},
+		IsOpen: []string{"D1"},
+	}
+
+	got := bootConversations(res)
+	if len(got) != 4 {
+		t.Fatalf("got %d conversations; want 4 (3 channels + 1 IM)", len(got))
+	}
+	by := map[string]slack.Channel{}
+	for _, c := range got {
+		by[c.ID] = c
+	}
+
+	if c := by["C1"]; c.Name != "general" || c.Topic.Value != "company wide" {
+		t.Errorf("C1 = %+v; want name and topic carried through", c)
+	}
+	// userBoot's channels[] is the user's OWN channel list, so every
+	// entry is one they are in. Losing this bucketed every channel as
+	// unjoined.
+	for _, id := range []string{"C1", "C2", "C3"} {
+		if !by[id].IsMember {
+			t.Errorf("%s IsMember = false; userBoot only returns channels the user is in", id)
+		}
+	}
+	if !by["C2"].IsPrivate {
+		t.Error("C2 lost IsPrivate; it would render as a public channel")
+	}
+	if !by["C3"].IsMpIM {
+		t.Error("C3 lost IsMpIM; group DMs would render as channels")
+	}
+	if d := by["D1"]; !d.IsIM || d.User != "U9" {
+		t.Errorf("D1 = %+v; want IsIM with User U9 — the counterparty id is what names a DM", d)
+	}
+}
+
+func TestBootConversations_SkipsArchivedAndClosed(t *testing.T) {
+	// users.conversations was called with ExcludeArchived: true, so
+	// keeping archived channels here would be a visible regression
+	// dressed up as a fix. A closed DM is not in the sidebar either.
+	res := &bootstrap.Result{
+		Channels: []boot.Channel{
+			{ID: "C1", Name: "live", IsChannel: true},
+			{ID: "C2", Name: "dead", IsChannel: true, IsArchived: true},
+		},
+		IMs: []boot.IM{
+			{ID: "D1", UserID: "U1", IsIM: true, IsOpen: true},
+			{ID: "D2", UserID: "U2", IsIM: true},
+			{ID: "D3", UserID: "U3", IsIM: true, IsArchived: true},
+		},
+		IsOpen: []string{"D1"},
+	}
+	got := bootConversations(res)
+	ids := map[string]bool{}
+	for _, c := range got {
+		ids[c.ID] = true
+	}
+	if ids["C2"] {
+		t.Error("archived channel kept")
+	}
+	if ids["D3"] {
+		t.Error("archived DM kept")
+	}
+	if ids["D2"] {
+		t.Error("closed DM kept; it is not in IsOpen and IsOpen is false on it")
+	}
+	if !ids["C1"] || !ids["D1"] {
+		t.Errorf("dropped something live: %v", ids)
+	}
+}
+
+func TestBootConversations_NilSafe(t *testing.T) {
+	if got := bootConversations(nil); got != nil {
+		t.Errorf("got %v; want nil", got)
 	}
 }

--- a/cmd/slk/bootstrap_adapters_test.go
+++ b/cmd/slk/bootstrap_adapters_test.go
@@ -530,7 +530,7 @@ func TestBootstrapDeps_RevalidatorUsesTheBrowserShapedHTTPClient(t *testing.T) {
 			"telemetry envelope and DefaultCounter; any other sends bare Go requests to edgeapi.")
 	}
 
-	if _, err := deps.Revalidate.ChannelsInfo(context.Background(), map[string]int64{"C1": 0}); err != nil {
+	if _, err := deps.Revalidate.ChannelsInfo(context.Background(), "T1", map[string]int64{"C1": 0}); err != nil {
 		t.Fatalf("ChannelsInfo: %v", err)
 	}
 

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -2261,10 +2261,31 @@ func connectWorkspace(ctx context.Context, token slackclient.Token, db *cache.DB
 	// as its user ID for the moment before resolveUser answers, rather
 	// than for the (much longer) moment before the sweep finished.
 
-	// Fetch channels
+	// The sidebar comes from users.conversations, with client.userBoot
+	// as a fallback -- in that order, and the order was measured.
+	//
+	// userBoot cannot be the primary source. On a real 218-channel
+	// workspace its channels[] carried 67 of them; on another, 60 of
+	// 71. It is evidently not the complete joined-conversation list,
+	// and preferring it silently drops channels from the sidebar,
+	// which is a worse failure than the one this fixes because nobody
+	// notices a channel that is merely absent.
+	//
+	// But users.conversations must not be FATAL either. On the
+	// Enterprise Grid org in gammons/slk#5 it is rejected outright, and
+	// treating that as fatal dropped the entire workspace: no
+	// channels, no threads, no active workspace, and -- until the
+	// commit before this one -- no logged reason. userBoot had already
+	// returned all 217 of that user's conversations, so falling back to
+	// a partial list beats losing the session.
 	channels, err := client.GetChannels(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("fetching channels for %s: %w", token.TeamName, err)
+		log.Printf("workspace %s: users.conversations failed (%v); falling back to the conversations client.userBoot returned, which may be a subset", token.TeamName, err)
+		debuglog.General("workspace %s: users.conversations failed: %v", token.TeamName, err)
+		channels = bootConversations(res)
+	}
+	if len(channels) == 0 {
+		log.Printf("workspace %s: no conversations from either users.conversations or client.userBoot; the sidebar will be empty", token.TeamName)
 	}
 
 	for _, ch := range channels {

--- a/docs/superpowers/plans/2026-08-05-grid-edge-team-scoping.md
+++ b/docs/superpowers/plans/2026-08-05-grid-edge-team-scoping.md
@@ -1,0 +1,697 @@
+# Team-Scoped Edge Revalidation (Grid) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `channels/info` revalidation work on Enterprise Grid by scoping each request to the team that owns the conversations, per `docs/superpowers/specs/2026-08-05-grid-edge-team-scoping-design.md`.
+
+**Architecture:** `edge.Client.call` takes a per-request team id; `ChannelsInfo` gains a mandatory team parameter; `bootstrap.revalidateChannels` partitions `updated_ids` by userBoot's `context_team_id` (empty → the workspace's own team) and processes one call per team. Nothing else changes scope: `users/info`, search, and the members endpoints keep the workspace team.
+
+**Tech Stack:** Go, stdlib only (`maps`, `slices` already in use).
+
+**Key fixture fact that shapes everything below:**
+`cannedBootResult` (internal/bootstrap/bootstrap_test.go:49) already mixes context teams: C_GENERAL + D_ALICE are `T_HOME`; C_PRIVATE + D_BOB are `T_OTHER`. The workspace id is `T_HOME`. So the moment partitioning lands, the existing suite makes TWO channels/info calls and exercises the split for free. The fake must become team-aware (record per-call, filter its canned response to the ids asked), and three existing assertions change: the budget test (1 → 2 calls), the workspace-id test (1 → 2 membership calls), and the membership queried-set test (split across two calls).
+
+---
+
+### Task 1: edge.Client — per-request team id
+
+**Files:**
+- Modify: `internal/slack/edge/client.go:53-56` (call signature + URL)
+- Modify: `internal/slack/edge/cache.go` (fetchInfo + ChannelsInfo signatures, UsersInfo passes `c.teamID`, wrong Grid comment)
+- Modify: `internal/slack/edge/members.go:125,178,235` and `internal/slack/edge/search.go:91,164` (pass `c.teamID`)
+- Test: `internal/slack/edge/cache_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/slack/edge/cache_test.go`, next to the other ChannelsInfo tests:
+
+```go
+func TestChannelsInfo_ScopesThePathToTheGivenTeam(t *testing.T) {
+	// On Enterprise Grid a user's conversations are owned by many
+	// teams within the org, and the edge cache keys them under the
+	// owning team. The team in the request path is therefore a
+	// per-call decision, not a client property: scoping every request
+	// to the auth.test team is what resolved zero of raff's 217
+	// conversations (gammons/slk#5).
+	rec := newRecorder(t, alwaysEmpty)
+	c := rec.client() // constructed with team T04T4TH8W
+
+	if _, err := c.ChannelsInfo(context.Background(), "T_OTHER_TEAM", map[string]int64{"C1": 0}); err != nil {
+		t.Fatalf("ChannelsInfo: %v", err)
+	}
+	reqs := rec.requests()
+	if len(reqs) != 1 {
+		t.Fatalf("requests = %d; want 1", len(reqs))
+	}
+	if want := "/cache/T_OTHER_TEAM/channels/info"; reqs[0].path != want {
+		t.Errorf("path = %q; want %q — the call's team, not the client's construction team", reqs[0].path, want)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/slack/edge/ -run TestChannelsInfo_ScopesThePathToTheGivenTeam 2>&1 | tail -3`
+Expected: build failure — `too many arguments in call to c.ChannelsInfo`.
+
+- [ ] **Step 3: Change call, fetchInfo and ChannelsInfo to carry the team**
+
+`internal/slack/edge/client.go` — `call` gains `teamID` as its second parameter, and the URL uses it:
+
+```go
+// call POSTs payload (with the token merged in) to
+// /cache/<teamID>/<endpoint> and decodes the response into out.
+//
+// teamID is a per-request argument, not read from the client: on
+// Enterprise Grid the conversations one call asks about are owned by
+// different teams within the org, and the edge cache keys records
+// under the owning team. Callers whose scope is the workspace pass
+// the client's team; ChannelsInfo passes the owning team.
+func (c *Client) call(ctx context.Context, teamID, endpoint string, payload map[string]any, out any) error {
+```
+
+and in the body:
+
+```go
+	url := fmt.Sprintf("%s/cache/%s/%s", c.baseURL, teamID, endpoint)
+```
+
+`internal/slack/edge/cache.go` — `fetchInfo` gains the team right after the client:
+
+```go
+func fetchInfo[Resp any](
+	ctx context.Context,
+	c *Client,
+	teamID string,
+	endpoint string,
+	flags map[string]any,
+	updatedIDs map[string]int64,
+	batchSize int,
+	merge func(Resp, []string),
+) error {
+```
+
+and its inner call becomes:
+
+```go
+		if err := c.call(ctx, teamID, endpoint, payload, &resp); err != nil {
+```
+
+`ChannelsInfo` gains the team as its second parameter (doc comment extended):
+
+```go
+// ChannelsInfo revalidates channels against the edge cache, scoped to
+// teamID: the request path is /cache/<teamID>/channels/info.
+//
+// teamID is mandatory and per-call because of Enterprise Grid. A Grid
+// user's conversations are owned by different teams within the org,
+// and the edge cache keys records under the owning team; a request
+// scoped to the auth.test team resolves only the conversations that
+// team owns and fails the rest (gammons/slk#5: 217 of 217 failed).
+// The caller partitions by userBoot's context_team_id; non-Grid
+// callers pass the workspace's own team id, which is every
+// conversation's context team there.
+func (c *Client) ChannelsInfo(ctx context.Context, teamID string, updatedIDs map[string]int64) (ChannelsInfoResult, error) {
+	var out ChannelsInfoResult
+	err := fetchInfo(ctx, c, teamID, "channels/info", map[string]any{
+```
+
+`UsersInfo` keeps its signature and passes the client team — Grid
+scoping for users is deliberately unchanged until a log implicates it:
+
+```go
+	err := fetchInfo(ctx, c, c.teamID, "users/info", map[string]any{
+```
+
+The five other call sites pass `c.teamID`:
+- `internal/slack/edge/members.go:125` → `c.call(ctx, c.teamID, "users/list", payload, &resp)`
+- `internal/slack/edge/members.go:178` → `c.call(ctx, c.teamID, "channels/membership", map[string]any{`
+- `internal/slack/edge/members.go:235` → `c.call(ctx, c.teamID, "users/counts", map[string]any{`
+- `internal/slack/edge/search.go:91` → `c.call(ctx, c.teamID, "channels/search", payload, &resp)`
+- `internal/slack/edge/search.go:164` → `c.call(ctx, c.teamID, "users/search", payload, &resp)`
+
+Fix the wrong provenance comment in `internal/slack/edge/cache.go`
+(the "These are not documented limits" block): the captures are from a
+non-Grid workspace, and claiming otherwise is how "Grid is covered"
+nearly got believed. Change
+
+```
+// under the largest batch the official web client has been observed
+// sending, measured across 8 HAR captures of a live Grid workspace:
+```
+
+to
+
+```
+// under the largest batch the official web client has been observed
+// sending, measured across 8 HAR captures of a live NON-Grid
+// workspace (Rands, T04T4TH8W). No Grid capture of edgeapi exists;
+// behaviour there is inferred from a user's log, not observed:
+```
+
+- [ ] **Step 4: Update the existing edge tests mechanically, with an assertion**
+
+All ~21 `ChannelsInfo` call sites in `internal/slack/edge/cache_test.go`
+and the 2 direct `fetchInfo` calls gain the team. Run:
+
+```bash
+cd ~/local_code/slk
+before=$(grep -c '\.ChannelsInfo(context\.Background(), ' internal/slack/edge/cache_test.go)
+sed -i 's/\.ChannelsInfo(context\.Background(), /.ChannelsInfo(context.Background(), "T04T4TH8W", /g' internal/slack/edge/cache_test.go
+after=$(grep -c '\.ChannelsInfo(context\.Background(), "T04T4TH8W", ' internal/slack/edge/cache_test.go)
+[ "$before" -eq "$after" ] && [ "$before" -gt 20 ] || { echo "sed miscounted: before=$before after=$after"; exit 1; }
+sed -i 's/fetchInfo(context\.Background(), c, "channels\/info",/fetchInfo(context.Background(), c, "T04T4TH8W", "channels\/info",/g' internal/slack/edge/cache_test.go
+grep -c 'fetchInfo(context.Background(), c, "T04T4TH8W"' internal/slack/edge/cache_test.go  # must be 2
+```
+
+(The count guard exists because a scripted edit against a pattern that
+silently matches nothing has already cost this project a debugging
+session. Assert the pattern matched.)
+
+- [ ] **Step 5: Run the edge package tests**
+
+Run: `go test ./internal/slack/edge/ 2>&1 | tail -3`
+Expected: PASS, including the new test.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/slack/edge/
+git commit -m "feat(edge): per-request team scoping, so channels/info can target the owning team"
+```
+
+---
+
+### Task 2: bootstrap — partition revalidation by context team
+
+**Files:**
+- Modify: `internal/bootstrap/bootstrap.go:79-81` (Revalidator interface)
+- Modify: `internal/bootstrap/revalidate.go` (revalidateChannels rewrite; new imports)
+- Test: `internal/bootstrap/revalidate_test.go` (fake becomes team-aware; new tests)
+- Test: `internal/bootstrap/bootstrap_test.go` (budget assertion)
+- Modify: `cmd/slk/bootstrap_adapters_test.go:533` (call-site signature)
+
+- [ ] **Step 1: Update the interface, and keep everything compiling at today's behaviour**
+
+`internal/bootstrap/bootstrap.go:79-81`:
+
+```go
+type Revalidator interface {
+	// ChannelsInfo revalidates conversations against the edge cache,
+	// scoped to teamID — on Enterprise Grid the owning team, which is
+	// not necessarily the workspace's own. See edge.ChannelsInfo.
+	ChannelsInfo(ctx context.Context, teamID string, updatedIDs map[string]int64) (edge.ChannelsInfoResult, error)
+	UsersInfo(ctx context.Context, updatedIDs map[string]int64) ([]edge.User, error)
+}
+```
+
+Immediately adapt the two call sites so the tree still builds, with NO
+behaviour change — one call, scoped to the workspace team, exactly as
+today:
+
+- `internal/bootstrap/revalidate.go`: the existing
+  `res, err := deps.Revalidate.ChannelsInfo(ctx, updated)` becomes
+  `res, err := deps.Revalidate.ChannelsInfo(ctx, deps.WorkspaceID, updated)`.
+- `cmd/slk/bootstrap_adapters_test.go:533` becomes
+  `if _, err := deps.Revalidate.ChannelsInfo(context.Background(), "T1", map[string]int64{"C1": 0}); err != nil {`.
+
+Run: `go build ./... 2>&1 | head -5`
+Expected: one compile error remains — the fake in revalidate_test.go
+no longer satisfies the interface. Fixed in Step 2.
+
+- [ ] **Step 2: Make the fake team-aware (suite still green — behaviour is unchanged)**
+
+In `internal/bootstrap/revalidate_test.go`:
+
+Add the call record type and fields to `revalidateFake` (next to the
+existing `channelsInfoSent` field):
+
+```go
+// channelsInfoCall is one team-scoped channels/info request.
+type channelsInfoCall struct {
+	team string
+	sent map[string]int64
+}
+```
+
+Add to the `revalidateFake` struct:
+
+```go
+	channelsInfoCalls  []channelsInfoCall
+	channelsInfoErrFor map[string]error // per-team error injection
+```
+
+Replace the fake `ChannelsInfo` method. The filtered response is the
+honest part: a real server answers about the ids it was asked, so the
+canned result is intersected with the request. `channelsInfoSent` keeps
+accumulating a merged map so the existing single-map assertions survive
+unchanged:
+
+```go
+func (f *fakeDeps) ChannelsInfo(_ context.Context, teamID string, updatedIDs map[string]int64) (edge.ChannelsInfoResult, error) {
+	f.record(callChannelsInfo)
+	f.mu.Lock()
+	sent := make(map[string]int64, len(updatedIDs))
+	for k, v := range updatedIDs {
+		sent[k] = v
+	}
+	f.channelsInfoCalls = append(f.channelsInfoCalls, channelsInfoCall{team: teamID, sent: sent})
+	if f.channelsInfoSent == nil {
+		f.channelsInfoSent = map[string]int64{}
+	}
+	for k, v := range sent {
+		f.channelsInfoSent[k] = v
+	}
+	err := f.channelsInfoErr
+	if e, ok := f.channelsInfoErrFor[teamID]; ok {
+		err = e
+	}
+	f.mu.Unlock()
+	if err != nil {
+		return poisonedChannelsInfo(), err
+	}
+	return filterChannelsInfo(f.channelsInfoRes, sent), nil
+}
+
+// filterChannelsInfo intersects a canned result with the ids one
+// request actually asked about, the way the server scopes its answer
+// to the request. A canned membership report that names no asked id
+// decays to "this batch said nothing" (empty MembershipQueried), which
+// is what the real absent-member_channels case already models.
+func filterChannelsInfo(res edge.ChannelsInfoResult, sent map[string]int64) edge.ChannelsInfoResult {
+	var out edge.ChannelsInfoResult
+	for _, ch := range res.Channels {
+		if _, ok := sent[ch.ID]; ok {
+			out.Channels = append(out.Channels, ch)
+		}
+	}
+	keep := func(ids []string) []string {
+		var kept []string
+		for _, id := range ids {
+			if _, ok := sent[id]; ok {
+				kept = append(kept, id)
+			}
+		}
+		return kept
+	}
+	out.MemberChannels = keep(res.MemberChannels)
+	out.MembershipQueried = keep(res.MembershipQueried)
+	out.FailedIDs = keep(res.FailedIDs)
+	return out
+}
+```
+
+(`maps`/`slices` are NOT needed in the test file for this; plain loops
+match the file's existing style.)
+
+Run: `go test ./internal/bootstrap/ 2>&1 | tail -3`
+Expected: PASS, unchanged. One channels/info call still happens
+(production passes `deps.WorkspaceID`), the filter is a no-op against
+the full id set, and every existing assertion still holds. If anything
+fails here, the fake change is wrong — fix it before going on.
+
+- [ ] **Step 3: Write the new failing tests, and update the three assertions the partition will change**
+
+Add to `internal/bootstrap/revalidate_test.go`:
+
+```go
+// --- team partitioning ------------------------------------------------
+
+// TestRevalidate_PartitionsChannelsInfoByContextTeam is the Grid fix.
+// The fixture spans two context teams (C_GENERAL/D_ALICE on T_HOME,
+// C_PRIVATE/D_BOB on T_OTHER), so a correct run issues one
+// channels/info per team, each carrying exactly that team's ids.
+func TestRevalidate_PartitionsChannelsInfoByContextTeam(t *testing.T) {
+	f := openedFake()
+
+	if _, err := Run(context.Background(), f.Deps()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(f.channelsInfoCalls) != 2 {
+		t.Fatalf("channels/info calls = %d; want 2, one per context team (calls: %+v)", len(f.channelsInfoCalls), f.channelsInfoCalls)
+	}
+	byTeam := map[string]map[string]int64{}
+	for _, c := range f.channelsInfoCalls {
+		byTeam[c.team] = c.sent
+	}
+	if want := map[string]int64{"C_GENERAL": 1783337533019, "D_ALICE": 0}; !reflect.DeepEqual(byTeam["T_HOME"], want) {
+		t.Errorf("T_HOME was sent %v; want %v", byTeam["T_HOME"], want)
+	}
+	if want := map[string]int64{"C_PRIVATE": 0, "D_BOB": 1783337533022}; !reflect.DeepEqual(byTeam["T_OTHER"], want) {
+		t.Errorf("T_OTHER was sent %v; want %v", byTeam["T_OTHER"], want)
+	}
+}
+
+// TestRevalidate_EmptyContextTeamUsesTheWorkspaceTeam: a conversation
+// userBoot gave no context_team_id for must behave exactly as
+// pre-Grid code behaved — scoped to the workspace's own team.
+//
+// NOTE: this is a characterization test. It passes both before and
+// after the partition lands, because the pre-partition code scopes
+// everything to the workspace team anyway. Its job is to pin the
+// fallback rule so a future refactor can't drop it.
+func TestRevalidate_EmptyContextTeamUsesTheWorkspaceTeam(t *testing.T) {
+	f := openedFake()
+	f.bootRes.Channels = append(f.bootRes.Channels, boot.Channel{ID: "C_NO_TEAM", Name: "no-team"})
+
+	if _, err := Run(context.Background(), f.Deps()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	for _, c := range f.channelsInfoCalls {
+		if _, ok := c.sent["C_NO_TEAM"]; ok {
+			if c.team != "T_HOME" {
+				t.Errorf("C_NO_TEAM was scoped to %q; want the workspace team T_HOME", c.team)
+			}
+			return
+		}
+	}
+	t.Errorf("C_NO_TEAM was never sent (calls: %+v)", f.channelsInfoCalls)
+}
+
+// TestRevalidate_TeamFailureDoesNotSkipOtherTeams mirrors the existing
+// channels/users independence guarantee one level down: one team's
+// failure must not strand the other team's revalidation.
+func TestRevalidate_TeamFailureDoesNotSkipOtherTeams(t *testing.T) {
+	f := openedFake()
+	f.channelsInfoErrFor = map[string]error{"T_OTHER": errors.New("ratelimited")}
+
+	if _, err := Run(context.Background(), f.Deps()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(f.channelsInfoCalls) != 2 {
+		t.Fatalf("channels/info calls = %d; want 2 — a failed team must not suppress the other team's call", len(f.channelsInfoCalls))
+	}
+	// T_HOME's results still land.
+	if !reflect.DeepEqual(f.channelUpdates, wantChannelUpdates()) {
+		t.Errorf("channel updates = %#v; want %#v from the healthy team", f.channelUpdates, wantChannelUpdates())
+	}
+	if !f.loggedMatching("team T_OTHER") {
+		t.Errorf("the failed team was not named in the log; on Grid this line is the only diagnostic (logged: %v)", f.logged())
+	}
+}
+```
+
+Then update the three existing assertions whose expectations the
+partition changes (they encode the old single-call behaviour; updating
+them before the production change keeps this step honestly RED):
+
+In `TestRevalidate_StaysInsideTheBootCallBudget` (revalidate_test.go,
+the `countPrefix(callChannelsInfo)` assertion):
+
+```go
+	if n := f.countPrefix(callChannelsInfo); n != 2 {
+		t.Errorf("channels/info called %d times; want exactly 2 — the fixture spans two context teams (T_HOME, T_OTHER), and each gets one batched conditional request (sequence: %v)", n, f.calls)
+	}
+```
+
+In `TestRevalidate_UsesTheWorkspaceIDForEveryCacheCall`, replace the
+`len(f.membershipCalls) != 1` block with:
+
+```go
+	if len(f.membershipCalls) != 2 {
+		t.Fatalf("ApplyMembership called %d times; want 2, one per context team (%#v)", len(f.membershipCalls), f.membershipCalls)
+	}
+	for _, c := range f.membershipCalls {
+		if c.workspaceID != "T_HOME" {
+			t.Errorf("ApplyMembership workspace = %q; want T_HOME", c.workspaceID)
+		}
+	}
+```
+
+In `TestRevalidate_AppliesMembershipToTheQueriedIDsNotTheReturnedOnes`,
+keep the original comment block (the hazard it names is unchanged) and
+replace the single-call assertions with the per-team split. The
+failed-id half moves to the T_OTHER call because D_BOB is T_OTHER.
+Team order is sorted (T_HOME first), and membership is applied inside
+the same per-team iteration, so `channelsInfoCalls[i]` and
+`membershipCalls[i]` align:
+
+```go
+	if len(f.membershipCalls) != 2 {
+		t.Fatalf("ApplyMembership called %d times; want 2, one per context team (%#v)", len(f.membershipCalls), f.membershipCalls)
+	}
+	byTeam := map[string]membershipCall{}
+	for i, c := range f.channelsInfoCalls {
+		byTeam[c.team] = f.membershipCalls[i]
+	}
+	home := byTeam["T_HOME"]
+	if want := []string{"C_GENERAL", "D_ALICE"}; !reflect.DeepEqual(home.queriedIDs, want) {
+		t.Errorf("T_HOME queried set = %v; want %v (MembershipQueried, never MemberChannels %v)", home.queriedIDs, want, cannedChannelsInfo().MemberChannels)
+	}
+	if want := cache.MembershipReported([]string{"C_GENERAL"}, nil); !reflect.DeepEqual(home.snap, want) {
+		t.Errorf("T_HOME snapshot = %#v; want %#v", home.snap, want)
+	}
+	other := byTeam["T_OTHER"]
+	if want := []string{"C_PRIVATE"}; !reflect.DeepEqual(other.queriedIDs, want) {
+		t.Errorf("T_OTHER queried set = %v; want %v", other.queriedIDs, want)
+	}
+	// The failed id rides in its own team's snapshot: omitting it
+	// would clear is_member for an id the server explicitly could not
+	// answer about.
+	if want := cache.MembershipReported(nil, failedChannelIDs); !reflect.DeepEqual(other.snap, want) {
+		t.Errorf("T_OTHER snapshot = %#v; want %#v", other.snap, want)
+	}
+```
+
+Run: `go test ./internal/bootstrap/ 2>&1 | tail -8`
+Expected: FAIL — the three updated tests plus the three new ones fail,
+because production still makes one workspace-scoped call. The rest of
+the suite passes. If an UNRELATED test fails, the fake's filter is
+wrong — fix it, not the test.
+
+- [ ] **Step 4: Rewrite revalidateChannels with partitioning (GREEN)**
+
+Replace `revalidateChannels` in `internal/bootstrap/revalidate.go`.
+The per-team body is the existing call/write/membership/failed-ids
+logic, moved under the loop and given team-named log lines. New imports
+for the file: `"maps"` and `"slices"`.
+
+```go
+// revalidateChannels conditionally refreshes the conversations the
+// sidebar will render: userBoot's channels plus its ims, and nothing
+// else in the cache.
+//
+// The id set is partitioned by each conversation's context_team_id,
+// and each team gets its own channels/info call. On Enterprise Grid a
+// user's conversations are owned by many teams within the org and the
+// edge cache keys records under the owning team: a single call scoped
+// to the auth.test team resolved zero of one Grid user's 217
+// conversations (gammons/slk#5). On a non-Grid workspace every
+// context team IS the workspace team, so the partition is a single
+// group and the request shape is identical to before. An empty
+// context team groups under the workspace team, preserving the old
+// behaviour for anything the field is missing on.
+//
+// The ims are included on purpose even though channels/info cannot
+// resolve them. Measured across the captures: of 193 ids the official
+// client sent to this endpoint, 22 were IM ids, and **all 22 came back
+// in failed_ids** — none appeared in results, none in member_channels.
+// So the official client sends them and they always fail, and matching
+// that is the point of this package.
+//
+// Two consequences worth knowing before anyone "optimises" ims out of
+// this set, which would be a divergence from the client:
+//
+//   - No IM is ever written by UpdateChannelFromEdge, because IMs never
+//     come back as results. A DM's cached name and type cannot be
+//     corrupted from here.
+//   - Every IM lands in FailedIDs, and ApplyMembership preserves failed
+//     ids rather than clearing them. That is the only reason DMs keep
+//     is_member across a boot. Removing the failed-id exclusion would
+//     mark every DM a non-membership on the next revalidation.
+func revalidateChannels(ctx context.Context, deps Deps, out *Result, logf func(string, ...any)) {
+	teamOf := make(map[string]string, len(out.Channels)+len(out.IMs))
+	ids := make([]string, 0, len(out.Channels)+len(out.IMs))
+	for _, ch := range out.Channels {
+		ids = append(ids, ch.ID)
+		teamOf[ch.ID] = ch.ContextTeamID
+	}
+	for _, im := range out.IMs {
+		ids = append(ids, im.ID)
+		teamOf[im.ID] = im.ContextTeamID
+	}
+
+	cached, err := deps.Store.ChannelVersions(deps.WorkspaceID)
+	if err != nil {
+		// Degrade to sending 0 for everything, which asks for full
+		// records: more bytes back, but correct. The map returned
+		// beside the error is discarded — a version slk cannot vouch
+		// for makes the server withhold a record slk does not have.
+		logf("bootstrap: reading cached channel versions: %v (revalidating everything from scratch)", err)
+		cached = nil
+	}
+
+	updated := conditionalVersions(ids, cached)
+	if len(updated) == 0 {
+		// No request at all. An updated_ids-less revalidation is a
+		// round trip that can only return nothing, and a stream of
+		// them is a shape the official client never produces.
+		return
+	}
+
+	groups := make(map[string]map[string]int64)
+	for id, version := range updated {
+		team := teamOf[id]
+		if team == "" {
+			team = deps.WorkspaceID
+		}
+		if groups[team] == nil {
+			groups[team] = make(map[string]int64)
+		}
+		groups[team][id] = version
+	}
+	// Sorted for determinism: request order must not depend on map
+	// iteration, both for the debug log's readability and so a test
+	// can rely on call order.
+	teams := slices.Collect(maps.Keys(groups))
+	slices.Sort(teams)
+	for _, team := range teams {
+		revalidateChannelTeam(ctx, deps, team, groups[team], logf)
+	}
+}
+
+// revalidateChannelTeam runs the channels/info call and its
+// write-through for one owning team. Team failures are independent:
+// one team's error is logged and its ids are left stale, and the
+// remaining teams still run — the same independence the channels and
+// users passes have from each other, one level down.
+func revalidateChannelTeam(ctx context.Context, deps Deps, team string, updated map[string]int64, logf func(string, ...any)) {
+	res, err := deps.Revalidate.ChannelsInfo(ctx, team, updated)
+	if err != nil {
+		// Everything below is discarded along with it. Slack answers
+		// ok:false with a populated body, so "err != nil and the
+		// value looks fine" is the normal shape of a failure here.
+		logf("bootstrap: channels/info for team %s: %d conversations: %v (leaving them stale)", team, len(updated), err)
+		return
+	}
+
+	for _, ch := range res.Channels {
+		if err := deps.Store.UpdateChannelFromEdge(cache.EdgeChannelUpdate{
+			ID:      ch.ID,
+			Name:    ch.Name,
+			Type:    channelType(ch),
+			Topic:   ch.Topic.Value,
+			Version: ch.Version,
+		}); err != nil {
+			// One bad row must not cost the rest of the batch: the
+			// call is already spent, and abandoning the remaining
+			// updates would leave versions unadvanced for channels the
+			// server did answer about.
+			logf("bootstrap: caching revalidated channel %s: %v", ch.ID, err)
+		}
+	}
+
+	// Membership, and the queried set is res.MembershipQueried — the
+	// ids sent in batches whose response actually carried
+	// member_channels — never res.MemberChannels.
+	//
+	// The difference is silent data loss. member_channels is a
+	// snapshot over the ids ASKED about: one absent from it is a
+	// genuine non-member, so passing the returned members as the
+	// queried set would tell ApplyMembership that every id it was not
+	// handed is a non-member, and clear is_member for the whole rest
+	// of the batch.
+	//
+	// Empty means no batch reported, which is the COMMON case —
+	// member_channels is absent from 13 of 18 observed responses, all
+	// of which requested it — and it means "no information", so
+	// nothing is written and no call is made. Note res.FailedIDs
+	// accumulates across all batches while MembershipQueried covers
+	// only the reporting ones; that is harmless, since ApplyMembership
+	// touches nothing outside the queried set.
+	//
+	// Applying per team is safe because the queried set is exactly
+	// this team's ids: membership answers never cross the partition.
+	if len(res.MembershipQueried) > 0 {
+		if err := deps.Store.ApplyMembership(deps.WorkspaceID, res.MembershipQueried,
+			cache.MembershipReported(res.MemberChannels, res.FailedIDs)); err != nil {
+			logf("bootstrap: applying membership for %d conversations: %v", len(res.MembershipQueried), err)
+		}
+	}
+
+	// Failed ids are left exactly as they were, versions included.
+	//
+	// This is a correctness hazard rather than a lost nicety. Absence
+	// from res.Channels otherwise means "unchanged, still fresh", so
+	// stamping a failed id as current would keep its stale record
+	// forever — its version never advances, so it never comes back.
+	// Leaving the version where it is means the next boot asks again.
+	//
+	// The team is named: on Grid this line is the whole diagnosis.
+	if len(res.FailedIDs) > 0 {
+		logf("bootstrap: channels/info for team %s could not resolve %d ids (%v); leaving them stale to be retried", team, len(res.FailedIDs), res.FailedIDs)
+	}
+}
+```
+
+Note: the old single-call log line `channels/info for %d conversations`
+is replaced by the team-named one. The existing failure-mode test
+asserts `loggedMatching("channels/info for")`, which the new line still
+satisfies.
+
+- [ ] **Step 5: Run the full affected suites**
+
+Run: `go build ./... && go test ./internal/bootstrap/ ./internal/slack/edge/ ./cmd/slk/ 2>&1 | tail -6`
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/bootstrap/ cmd/slk/bootstrap_adapters_test.go
+git commit -m "feat(bootstrap): partition channels/info revalidation by context_team_id
+
+On Enterprise Grid a user's conversations are owned by many teams and
+the edge cache keys records under the owning team, so a single call
+scoped to the auth.test team resolved zero of one Grid user's 217
+conversations (gammons/slk#5). Each context team now gets its own
+batched call; an empty context team groups under the workspace team,
+and on non-Grid workspaces the partition is a single group whose
+request shape is identical to before. Failures are per-team
+independent and the failure logs name the team, since that line is
+the whole diagnosis on Grid."
+```
+
+---
+
+### Task 3: Live verification (non-Grid no-op proof)
+
+**Files:** none modified; produces the evidence the spec's merge gate needs.
+
+- [ ] **Step 1: Build and run a 25-second session**
+
+```bash
+cd ~/local_code/slk
+go build -o /tmp/slk-gridfix ./cmd/slk
+cd /tmp/opencode/slk-repro   # or any scratch dir; the log lands in $PWD
+SLK_DEBUG=1 script -qec 'timeout -s INT 25 /tmp/slk-gridfix' /dev/null >/dev/null 2>&1
+grep -A25 'shutdown API request tally' slk-debug.log
+```
+
+- [ ] **Step 2: Assert the tally is unchanged**
+
+Expected: `edge:channels/info` count is **3** (unchanged from the
+pre-change runs), total still **37 across 18 endpoints**, and no new
+endpoints appear. A different count means some conversation on the
+local workspaces carries a foreign or empty context team — investigate
+with `grep 'channels/info for team' slk-debug.log` before proceeding;
+the per-team log line should name only the workspaces' own teams.
+
+- [ ] **Step 3: Commit nothing; report**
+
+Report the tally diff (expected: none) to the user. The change is then
+ready for the raff-facing PR together with `fix/sidebar-from-userboot`.
+
+---
+
+## Self-review notes
+
+- Spec coverage: items 1–5 of the design map to Tasks 1–2; the local
+  verifiability gate is Task 3; the cache.go comment fix is Task 1
+  Step 3; out-of-scope items (host derivation, users scoping, cache
+  column) are untouched.
+- Type consistency: `ChannelsInfo(ctx, teamID string, updatedIDs)` is
+  the same shape in the interface (Task 2 Step 1), the fake (Step 2),
+  the production call (Step 4), and the cmd/slk test (Step 6).
+- The fake's merged `channelsInfoSent` map keeps every existing
+  single-map assertion valid; only the three assertions named in Task 2
+  Step 5 change.

--- a/docs/superpowers/plans/2026-08-05-next-session-handoff.md
+++ b/docs/superpowers/plans/2026-08-05-next-session-handoff.md
@@ -1,0 +1,169 @@
+# Handoff — 2026-08-05
+
+Read this first. It is the state of play, not a design document. The
+forward-looking documents are listed at the bottom.
+
+## Where things are
+
+| | |
+|---|---|
+| `main` | `0cfdcc7` — grid-parity merged (PR #121), release config updated, connect errors now logged |
+| `fix/sidebar-from-userboot` | `96596e1` — **WIP, DO NOT MERGE OR TAG** |
+| Released | `v0.13.0-beta.1` — GitHub pre-release, tap untouched, `v0.12.0` still "Latest" |
+| Live bug report | [#5](https://github.com/gammons/slk/issues/5), an Enterprise Grid user (`@raff`) |
+
+Phase 2b is done and measured: a 25-second two-workspace session went from
+270 API requests to 37, with `users.list`, `conversations.list`, the
+per-channel history backfill and the boot-time thread-subscription sweep all
+deleted — three of them removed from the interfaces that could reach them, so
+they fail a test rather than a review if reintroduced.
+
+## THE BLOCKER — do this first, it needs nobody else
+
+**A binary built from `fix/sidebar-from-userboot` makes 42
+`conversations.members` calls per session. `main` makes 1-2.**
+
+Fully reproducible locally. No Grid account, no volunteer, no waiting.
+
+```bash
+cd ~/local_code/slk
+git checkout main               && go build -o /tmp/slk-before ./cmd/slk
+git checkout fix/sidebar-from-userboot && go build -o /tmp/slk-after ./cmd/slk
+
+cd .worktrees/grid-parity-phase1        # any dir; the log lands in $PWD
+SLK_DEBUG=1 script -qec 'timeout -s INT 25 /tmp/slk-before' /dev/null >/dev/null 2>&1
+grep -A20 'shutdown API request tally' slk-debug.log | grep conversations.members
+# repeat with /tmp/slk-after
+```
+
+Measured, alternating runs: before **2**, after **42**, after **42**, before **1**.
+So it is the binary, not cache state.
+
+**What is ruled out:** only 3 `ChannelSelectedMsg` events occurred, so the
+`MembershipFetch`-on-channel-switch path cannot account for it. The current
+(inverted) version does not even call `bootConversations` when
+`users.conversations` succeeds — and it succeeds on these workspaces — so the
+mechanism is genuinely not understood.
+
+**Where to look:** `conversations.members` is only issued by
+`membership.Manager.backgroundFetch` (`internal/slack/membership/manager.go`),
+reached via `EnsureFresh`. Callers are the `MembershipFetch` service closure and
+`OnConnect` for the active channel. Add a caller-identifying log line to
+`backgroundFetch` and diff the two binaries' logs. The diff between them is
+small: `bootConversations` in `cmd/slk/bootstrap_adapters.go` plus a rewritten
+error branch in `connectWorkspace`.
+
+**Until this is explained, do not tag a beta.** 42 membership fetches per
+session is the same shape of problem this entire phase exists to remove, and it
+would be shipped to a user who has already been signed out of Slack once.
+
+## What the WIP branch does, and the trap it already fell into
+
+It makes `users.conversations` non-fatal, falling back to the conversations
+`client.userBoot` returned. That fixes the Grid failure below.
+
+**The first version had it the other way round — `userBoot` primary — and it
+was wrong.** Measured on real workspaces:
+
+| workspace | `users.conversations` | `userBoot` |
+|---|---|---|
+| Rands | **218** channels | 67 |
+| Truelist | 71 | 60 |
+
+`userBoot`'s `channels[]` is *not* the complete joined-conversation list.
+Preferring it silently drops channels from the sidebar — worse than the bug it
+fixes, because an absent channel is not noticeable. With the order inverted,
+channel counts and `users.conversations` call counts match `main` exactly.
+
+Do not re-derive this. It cost an A/B run to find and it is not documented
+anywhere else.
+
+## The Grid situation (#5)
+
+`@raff` ran `v0.13.0-beta.1` on a large Grid org. **It no longer signs him out**
+— that is this project's actual success criterion and it now has one data point
+rather than zero. Two failures remain:
+
+1. **No channels, no threads, "no active workspaces."** Diagnosed from his full
+   log: `connectWorkspace` called `users.conversations`, it failed, the function
+   returned an error, and the caller discarded it — so nothing was logged and a
+   hard failure looked identical to an empty workspace. `stars.list` on the same
+   org returns `enterprise_is_restricted`, so `users.conversations` almost
+   certainly does too. **`0cfdcc7` on `main` now logs the reason**; the WIP
+   branch is the actual fix.
+
+2. **`channels/info could not resolve 217 ids`** — every conversation he has.
+   Separate bug, not what breaks him. The workspace client derives its host from
+   `auth.test` and correctly targets `<org>.n.slack.com` on Grid
+   (`internal/slack/client.go:305`); the edge client hardcodes
+   `edgeapi.slack.com` and scopes every request to a single team id
+   (`internal/slack/edge/client.go:73`). slk models a workspace; Grid is an org
+   of many. **Conditional revalidation — the mechanism two phases were built
+   around — is therefore non-functional on Grid.** Fixable, unverifiable without
+   a Grid account.
+
+He has been asked to re-run once the logging fix is out, to confirm the
+restricted-endpoint theory rather than leave it as an inference.
+
+## Work available now, in priority order
+
+Nothing here waits on raff.
+
+1. **Explain the 42 `conversations.members`** (above). Blocks beta 2.
+2. **Make the edge client Grid-aware** — derive its host as the workspace client
+   does, and reckon with `/cache/<teamID>/` assuming one team when a Grid user's
+   conversations span many. Cannot be *verified* without Grid, but can be
+   written and reviewed.
+3. **Task 11b** — mention picker on `edge.UsersSearch`, debounced. The last
+   unfinished task in the Phase 2b plan. The picker's candidate list shrank when
+   the per-member resolution was removed; this restores it. Entirely local.
+4. **`edge.UsersList` for channel members** — one request per channel returning
+   user records inline, which is what the official client does. Would take
+   `conversations.members` to zero and is a strict improvement regardless of
+   what (1) turns out to be.
+5. **Batch resolver misses through `edge.UsersInfo`** — the ~200 `users.info`
+   on a cold boot become ~4.
+6. **QA sections 5-10** (`2026-08-03-grid-parity-qa-checklist.md`) — needs a
+   human at a terminal, not a Grid account. §6, a real 90-second outage, is the
+   most valuable: it is new code that runs on every wifi flap and has never seen
+   one.
+7. **Boot budget** — ~18 requests per workspace against a criterion of 10.
+   `dnd.info` and `users.conversations` are dedupable against data already in
+   hand. `usergroups.list` and `stars.list` are **blocked on capture evidence**:
+   `boot.Result.Subteams` and `.Starred` are `[]json.RawMessage` because both
+   existing captures show empty arrays. Guessing the shape is the mistake this
+   project has made twice. §11 of the QA checklist describes the 10-minute
+   browser capture that would unblock them.
+
+## Traps this session hit — all of them cost real time
+
+- **A stale binary.** `~/local_code/slk/slk` dates from July and predates
+  everything. The first QA attempt ran it and "found" the original bug at full
+  scale. Always build to a distinct name and run by absolute path; §1.1 of the
+  QA checklist is a provenance check keyed on log strings that exist in exactly
+  one of the two binaries. Run it every session.
+- **Warm-cache measurements say nothing about a cold cache.** A 40,000-request
+  fan-out hid behind a warm cache for four tasks. Measure cold first: copy
+  `~/.local/share/slk/tokens` into a temp `XDG_DATA_HOME`, boot, then delete the
+  token copy.
+- **`slackhttp.Counter` records at `RoundTrip` entry** (`transport.go`), so its
+  numbers are requests *started*, not delivered. With an unbounded fan-out most
+  never reach Slack. Say "started", never quote it as delivered traffic.
+- **A test can encode the bug.** `TestBackgroundFetchTriggersResolverForEachID`
+  pinned one `users.info` per channel member — the exact behaviour that had to
+  be deleted. Replaced by its inverse. If a test blocks a fix, question the test.
+- **Assert before scripted edits.** A `python .replace()` against text copied
+  from a *plan document* rather than the file silently did nothing, and the test
+  kept failing for a reason that looked unrelated. Assert the pattern matched.
+- **A mutation that fails to compile has proved nothing.** Re-adding a method to
+  an interface broke the mock before the assertion could run; it had to be
+  re-run with the mock restored.
+
+## The documents that matter
+
+| | |
+|---|---|
+| `2026-08-01-grid-parity-STATE.md` | State of the three phases; symbol table; standing risks |
+| `2026-07-31-grid-parity-phase2b-outcomes.md` | Measured before/after, criteria scored honestly, first Grid evidence |
+| `2026-08-03-grid-parity-qa-checklist.md` | The manual QA gate, with what to suspect when each check fails |
+| `2026-07-31-grid-parity-phase2b-bootstrap-rewrite.md` | The 12-task plan; task 11b is the only one unfinished |

--- a/docs/superpowers/specs/2026-08-05-grid-edge-team-scoping-design.md
+++ b/docs/superpowers/specs/2026-08-05-grid-edge-team-scoping-design.md
@@ -75,12 +75,13 @@ evidence-gathering step for all of them.
    (`channels/info for team T… could not resolve N ids`), so the next
    Grid log says which scoping failed, not just that one did.
 
-5. Result merging across teams: each team's `ChannelsInfoResult` is
-   merged field-by-field into one aggregate before the store updates
-   run. `MemberChannels`/`MembershipQueried` stay paired per batch by
-   the existing pointer-guard machinery; concatenating the per-team
-   slices preserves that invariant because the pairing is positional
-   within each call already.
+5. Result handling across teams: each team is processed fully inside
+   its own iteration — call, write-through, membership, failed-ids —
+   rather than merging per-team results into one aggregate first.
+   (Amended during implementation: the aggregate design below was
+   superseded. Per-team processing gives failure independence for
+   free, and the MemberChannels/MembershipQueried pairing invariant
+   holds trivially because a queried set never crosses the partition.)
 
 ## Why this is safe to ship unverifiable-on-Grid
 

--- a/docs/superpowers/specs/2026-08-05-grid-edge-team-scoping-design.md
+++ b/docs/superpowers/specs/2026-08-05-grid-edge-team-scoping-design.md
@@ -1,0 +1,116 @@
+# Grid-aware edge revalidation — team-scoped channels/info
+
+Date: 2026-08-05
+Status: approved (design), unverifiable on Grid until raff runs it
+
+## Problem
+
+On Enterprise Grid, slk's edge revalidation resolves nothing. Raff's
+log (gammons/slk#5): `channels/info could not resolve 217 ids` — every
+conversation he has. That message is the `FailedIDs` branch of
+`revalidateChannels` (internal/bootstrap/revalidate.go), which only
+prints after an HTTP 200 + `ok:true` response. So
+`edgeapi.slack.com` accepts a Grid user's request; what fails is the
+`/cache/<teamID>/` path scoping. The edge client
+(internal/slack/edge/client.go:73) builds that path from the single
+team id `auth.test` returned, but on Grid a user's conversations are
+owned by many teams within the org, and the edge cache keys them under
+their owning team.
+
+Conditional revalidation — the mechanism Phase 2 was built around — is
+therefore non-functional on Grid, and every boot leaves the whole
+cache stale there.
+
+## Evidence and non-evidence
+
+- The 8 HAR captures behind the edge package are all from Rands
+  (T04T4TH8W), a non-Grid workspace. There is **no capture evidence**
+  of what the official client does for edgeapi on Grid. (The comment
+  at internal/slack/edge/cache.go claiming "a live Grid workspace" is
+  wrong and is corrected as part of this work.)
+- userBoot already decodes `context_team_id` for every channel
+  (internal/slack/boot/boot.go:117) and IM (boot.go:143), and
+  conversations.view users carry `team_id`
+  (internal/slack/boot/view.go:67). None of it is consumed today.
+- Failure here is already non-fatal: unresolved ids are left stale and
+  logged. A wrong guess degrades to today's behavior, not worse.
+
+## Decision
+
+**Team-scoping only.** The host is not changed: raff's log shows
+edgeapi.slack.com serving his requests, and switching hosts would risk
+breaking a path that currently degrades gracefully. (The handoff's
+"derive its host as the workspace client does" framing predates this
+reading of his log.)
+
+**channels/info only.** users/info may fail the same way on Grid, but
+there is no evidence it does, and regrouping users could break a path
+that works for him today. Search, UsersList, UsersCounts and
+ChannelsMembership are likewise unchanged. Raff's next log is the
+evidence-gathering step for all of them.
+
+## Design
+
+1. `edge.Client.call` takes the team id per request instead of reading
+   `c.teamID`; the URL becomes `/cache/<team>/<endpoint>` with the
+   team chosen by the caller. The struct field stays as the default
+   for the endpoints that keep their current scoping (search,
+   members, users/info).
+
+2. `ChannelsInfo` gains an explicit team parameter:
+   `ChannelsInfo(ctx, teamID string, updatedIDs map[string]int64)`.
+   A signature change, not a new `ChannelsInfoForTeam` method: one
+   production caller plus mocks, and a mandatory parameter forces every
+   future caller to decide the scoping instead of inheriting a default
+   that is wrong on Grid.
+
+3. `bootstrap.revalidateChannels` partitions `updated_ids` by each
+   conversation's `context_team_id` from userBoot, then calls
+   `ChannelsInfo` once per team, batching within each group at 60 as
+   today. **An empty or absent `context_team_id` groups under the
+   workspace's own team id**, so any entry lacking the field behaves
+   exactly as it does now.
+
+4. Failure logging names the team
+   (`channels/info for team T… could not resolve N ids`), so the next
+   Grid log says which scoping failed, not just that one did.
+
+5. Result merging across teams: each team's `ChannelsInfoResult` is
+   merged field-by-field into one aggregate before the store updates
+   run. `MemberChannels`/`MembershipQueried` stay paired per batch by
+   the existing pointer-guard machinery; concatenating the per-team
+   slices preserves that invariant because the pairing is positional
+   within each call already.
+
+## Why this is safe to ship unverifiable-on-Grid
+
+On a non-Grid workspace every `context_team_id` is expected to equal
+the auth.test team id, which makes the partition a single group and
+the request shape byte-identical to today. Verified locally before
+merge: run a 25-second session and confirm the `edge:channels/info`
+tally and count are unchanged, and that the debug log shows exactly
+one team group. If any shared channel on a non-Grid workspace carries
+a foreign context team, the change produces additional, correctly
+scoped requests — more traffic, but semantically right, and bounded by
+the same batching.
+
+## Explicitly out of scope
+
+- Deriving the edge host from auth.test's URL (rejected: no evidence
+  the host is wrong; adds risk to the working degradation path).
+- users/info, users/search, users/list, channels/membership,
+  users/counts team scoping (no evidence of breakage).
+- Persisting `context_team_id` into the cache (nothing downstream
+  needs it yet; adding a column for a hypothetical reader is the
+  shape-guessing failure mode).
+
+## Testing
+
+- Partition logic: unit tests over `revalidateChannels`' grouping —
+  mixed teams produce one call per team with the right ids; empty
+  context team lands in the default group; non-Grid fixtures produce
+  exactly one call identical to today's.
+- edge client: `ChannelsInfo` hits `/cache/<given team>/`, and the
+  existing contract tests keep passing with the default team.
+- Regression: the 25-second local session tally for
+  `edge:channels/info` must be unchanged.

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -77,7 +77,10 @@ type Historian interface {
 // Revalidator is the edgeapi conditional-revalidation pair. This is
 // what replaces enumeration.
 type Revalidator interface {
-	ChannelsInfo(ctx context.Context, updatedIDs map[string]int64) (edge.ChannelsInfoResult, error)
+	// ChannelsInfo revalidates conversations against the edge cache,
+	// scoped to teamID — on Enterprise Grid the owning team, which is
+	// not necessarily the workspace's own. See edge.ChannelsInfo.
+	ChannelsInfo(ctx context.Context, teamID string, updatedIDs map[string]int64) (edge.ChannelsInfoResult, error)
 	UsersInfo(ctx context.Context, updatedIDs map[string]int64) ([]edge.User, error)
 }
 

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"reflect"
 	"sync"
 	"testing"
@@ -411,8 +412,7 @@ func (f *fakeDeps) record(name string) {
 func (f *fakeDeps) log(format string, args ...any) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	_ = args
-	f.logs = append(f.logs, format)
+	f.logs = append(f.logs, fmt.Sprintf(format, args...))
 }
 
 func (f *fakeDeps) logged() []string {
@@ -1218,8 +1218,8 @@ func TestRun_OpensTheChannelAfterCounts(t *testing.T) {
 		prepare func(*fakeDeps)
 		want    []string
 	}{
-		{"view honoured", func(f *fakeDeps) { f.viewChannelID = "C_WANT" }, []string{callUserBoot, callCounts, callView, callChannelsInfo, callUsersInfo}},
-		{"fallback", func(f *fakeDeps) { f.viewChannelID = "C_LASTVIEWED" }, []string{callUserBoot, callCounts, callView, callHistory, callChannelsInfo, callUsersInfo}},
+		{"view honoured", func(f *fakeDeps) { f.viewChannelID = "C_WANT" }, []string{callUserBoot, callCounts, callView, callChannelsInfo, callChannelsInfo, callUsersInfo}},
+		{"fallback", func(f *fakeDeps) { f.viewChannelID = "C_LASTVIEWED" }, []string{callUserBoot, callCounts, callView, callHistory, callChannelsInfo, callChannelsInfo, callUsersInfo}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f := newFakeDeps()

--- a/internal/bootstrap/revalidate.go
+++ b/internal/bootstrap/revalidate.go
@@ -2,6 +2,8 @@ package bootstrap
 
 import (
 	"context"
+	"maps"
+	"slices"
 
 	"github.com/gammons/slk/internal/cache"
 	"github.com/gammons/slk/internal/slack/edge"
@@ -67,6 +69,17 @@ func revalidate(ctx context.Context, deps Deps, out *Result, logf func(string, .
 // sidebar will render: userBoot's channels plus its ims, and nothing
 // else in the cache.
 //
+// The id set is partitioned by each conversation's context_team_id,
+// and each team gets its own channels/info call. On Enterprise Grid a
+// user's conversations are owned by many teams within the org and the
+// edge cache keys records under the owning team: a single call scoped
+// to the auth.test team resolved zero of one Grid user's 217
+// conversations (gammons/slk#5). On a non-Grid workspace every
+// context team IS the workspace team, so the partition is a single
+// group and the request shape is identical to before. An empty
+// context team groups under the workspace team, preserving the old
+// behaviour for anything the field is missing on.
+//
 // The ims are included on purpose even though channels/info cannot
 // resolve them. Measured across the captures: of 193 ids the official
 // client sent to this endpoint, 22 were IM ids, and **all 22 came back
@@ -85,12 +98,15 @@ func revalidate(ctx context.Context, deps Deps, out *Result, logf func(string, .
 //     is_member across a boot. Removing the failed-id exclusion would
 //     mark every DM a non-membership on the next revalidation.
 func revalidateChannels(ctx context.Context, deps Deps, out *Result, logf func(string, ...any)) {
+	teamOf := make(map[string]string, len(out.Channels)+len(out.IMs))
 	ids := make([]string, 0, len(out.Channels)+len(out.IMs))
 	for _, ch := range out.Channels {
 		ids = append(ids, ch.ID)
+		teamOf[ch.ID] = ch.ContextTeamID
 	}
 	for _, im := range out.IMs {
 		ids = append(ids, im.ID)
+		teamOf[im.ID] = im.ContextTeamID
 	}
 
 	cached, err := deps.Store.ChannelVersions(deps.WorkspaceID)
@@ -111,12 +127,39 @@ func revalidateChannels(ctx context.Context, deps Deps, out *Result, logf func(s
 		return
 	}
 
-	res, err := deps.Revalidate.ChannelsInfo(ctx, updated)
+	groups := make(map[string]map[string]int64)
+	for id, version := range updated {
+		team := teamOf[id]
+		if team == "" {
+			team = deps.WorkspaceID
+		}
+		if groups[team] == nil {
+			groups[team] = make(map[string]int64)
+		}
+		groups[team][id] = version
+	}
+	// Sorted for determinism: request order must not depend on map
+	// iteration, both for the debug log's readability and so a test
+	// can rely on call order.
+	teams := slices.Collect(maps.Keys(groups))
+	slices.Sort(teams)
+	for _, team := range teams {
+		revalidateChannelTeam(ctx, deps, team, groups[team], logf)
+	}
+}
+
+// revalidateChannelTeam runs the channels/info call and its
+// write-through for one owning team. Team failures are independent:
+// one team's error is logged and its ids are left stale, and the
+// remaining teams still run — the same independence the channels and
+// users passes have from each other, one level down.
+func revalidateChannelTeam(ctx context.Context, deps Deps, team string, updated map[string]int64, logf func(string, ...any)) {
+	res, err := deps.Revalidate.ChannelsInfo(ctx, team, updated)
 	if err != nil {
 		// Everything below is discarded along with it. Slack answers
 		// ok:false with a populated body, so "err != nil and the
 		// value looks fine" is the normal shape of a failure here.
-		logf("bootstrap: channels/info for %d conversations: %v (leaving them stale)", len(updated), err)
+		logf("bootstrap: channels/info for team %s: %d conversations: %v (leaving them stale)", team, len(updated), err)
 		return
 	}
 
@@ -148,12 +191,15 @@ func revalidateChannels(ctx context.Context, deps Deps, out *Result, logf func(s
 	// of the batch.
 	//
 	// Empty means no batch reported, which is the COMMON case —
-	// member_channels is absent from 13 of 18 observed responses, all
+	// member_channels is absent from 13 of the 18 observed responses, all
 	// of which requested it — and it means "no information", so
 	// nothing is written and no call is made. Note res.FailedIDs
 	// accumulates across all batches while MembershipQueried covers
 	// only the reporting ones; that is harmless, since ApplyMembership
 	// touches nothing outside the queried set.
+	//
+	// Applying per team is safe because the queried set is exactly
+	// this team's ids: membership answers never cross the partition.
 	if len(res.MembershipQueried) > 0 {
 		if err := deps.Store.ApplyMembership(deps.WorkspaceID, res.MembershipQueried,
 			cache.MembershipReported(res.MemberChannels, res.FailedIDs)); err != nil {
@@ -168,8 +214,10 @@ func revalidateChannels(ctx context.Context, deps Deps, out *Result, logf func(s
 	// stamping a failed id as current would keep its stale record
 	// forever — its version never advances, so it never comes back.
 	// Leaving the version where it is means the next boot asks again.
+	//
+	// The team is named: on Grid this line is the whole diagnosis.
 	if len(res.FailedIDs) > 0 {
-		logf("bootstrap: channels/info could not resolve %d ids (%v); leaving them stale to be retried", len(res.FailedIDs), res.FailedIDs)
+		logf("bootstrap: channels/info for team %s could not resolve %d ids (%v); leaving them stale to be retried", team, len(res.FailedIDs), res.FailedIDs)
 	}
 }
 

--- a/internal/bootstrap/revalidate.go
+++ b/internal/bootstrap/revalidate.go
@@ -75,8 +75,9 @@ func revalidate(ctx context.Context, deps Deps, out *Result, logf func(string, .
 // edge cache keys records under the owning team: a single call scoped
 // to the auth.test team resolved zero of one Grid user's 217
 // conversations (gammons/slk#5). On a non-Grid workspace every
-// context team IS the workspace team, so the partition is a single
-// group and the request shape is identical to before. An empty
+// context team is expected to be the workspace team, so the partition
+// is a single group and the request shape is identical to before. An
+// empty
 // context team groups under the workspace team, preserving the old
 // behaviour for anything the field is missing on.
 //

--- a/internal/bootstrap/revalidate.go
+++ b/internal/bootstrap/revalidate.go
@@ -77,9 +77,8 @@ func revalidate(ctx context.Context, deps Deps, out *Result, logf func(string, .
 // conversations (gammons/slk#5). On a non-Grid workspace every
 // context team is expected to be the workspace team, so the partition
 // is a single group and the request shape is identical to before. An
-// empty
-// context team groups under the workspace team, preserving the old
-// behaviour for anything the field is missing on.
+// empty context team groups under the workspace team, preserving the
+// old behaviour for anything the field is missing on.
 //
 // The ims are included on purpose even though channels/info cannot
 // resolve them. Measured across the captures: of 193 ids the official

--- a/internal/bootstrap/revalidate_test.go
+++ b/internal/bootstrap/revalidate_test.go
@@ -225,6 +225,12 @@ type membershipCall struct {
 	snap        cache.MembershipSnapshot
 }
 
+// channelsInfoCall is one team-scoped channels/info request.
+type channelsInfoCall struct {
+	team string
+	sent map[string]int64
+}
+
 // The revalidation half of fakeDeps. Declared here rather than in
 // bootstrap_test.go so the recording sits next to the assertions.
 type revalidateFake struct {
@@ -238,9 +244,11 @@ type revalidateFake struct {
 	userVersionsFor   []string
 	userVersionsCalls int
 
-	channelsInfoRes  edge.ChannelsInfoResult
-	channelsInfoErr  error
-	channelsInfoSent map[string]int64
+	channelsInfoRes    edge.ChannelsInfoResult
+	channelsInfoErr    error
+	channelsInfoSent   map[string]int64
+	channelsInfoCalls  []channelsInfoCall
+	channelsInfoErrFor map[string]error // per-team error injection
 
 	usersInfoRes  []edge.User
 	usersInfoErr  error
@@ -284,20 +292,56 @@ func (f *fakeDeps) UserVersions(workspaceID string) (map[string]int64, error) {
 	return f.userVersions, nil
 }
 
-func (f *fakeDeps) ChannelsInfo(_ context.Context, updatedIDs map[string]int64) (edge.ChannelsInfoResult, error) {
+func (f *fakeDeps) ChannelsInfo(_ context.Context, teamID string, updatedIDs map[string]int64) (edge.ChannelsInfoResult, error) {
 	f.record(callChannelsInfo)
 	f.mu.Lock()
-	// Copied: the caller may reuse or clear its map, and an assertion
-	// that reads it later would then be reading the future.
-	f.channelsInfoSent = make(map[string]int64, len(updatedIDs))
+	sent := make(map[string]int64, len(updatedIDs))
 	for k, v := range updatedIDs {
+		sent[k] = v
+	}
+	f.channelsInfoCalls = append(f.channelsInfoCalls, channelsInfoCall{team: teamID, sent: sent})
+	if f.channelsInfoSent == nil {
+		f.channelsInfoSent = map[string]int64{}
+	}
+	for k, v := range sent {
 		f.channelsInfoSent[k] = v
 	}
-	f.mu.Unlock()
-	if f.channelsInfoErr != nil {
-		return poisonedChannelsInfo(), f.channelsInfoErr
+	err := f.channelsInfoErr
+	if e, ok := f.channelsInfoErrFor[teamID]; ok {
+		err = e
 	}
-	return f.channelsInfoRes, nil
+	f.mu.Unlock()
+	if err != nil {
+		return poisonedChannelsInfo(), err
+	}
+	return filterChannelsInfo(f.channelsInfoRes, sent), nil
+}
+
+// filterChannelsInfo intersects a canned result with the ids one
+// request actually asked about, the way the server scopes its answer
+// to the request. A canned membership report that names no asked id
+// decays to "this batch said nothing" (empty MembershipQueried), which
+// is what the real absent-member_channels case already models.
+func filterChannelsInfo(res edge.ChannelsInfoResult, sent map[string]int64) edge.ChannelsInfoResult {
+	var out edge.ChannelsInfoResult
+	for _, ch := range res.Channels {
+		if _, ok := sent[ch.ID]; ok {
+			out.Channels = append(out.Channels, ch)
+		}
+	}
+	keep := func(ids []string) []string {
+		var kept []string
+		for _, id := range ids {
+			if _, ok := sent[id]; ok {
+				kept = append(kept, id)
+			}
+		}
+		return kept
+	}
+	out.MemberChannels = keep(res.MemberChannels)
+	out.MembershipQueried = keep(res.MembershipQueried)
+	out.FailedIDs = keep(res.FailedIDs)
+	return out
 }
 
 func (f *fakeDeps) UsersInfo(_ context.Context, updatedIDs map[string]int64) ([]edge.User, error) {
@@ -566,11 +610,13 @@ func TestRevalidate_UsesTheWorkspaceIDForEveryCacheCall(t *testing.T) {
 	if want := []string{"T_HOME"}; !reflect.DeepEqual(f.userVersionsFor, want) {
 		t.Errorf("UserVersions called for %v; want %v", f.userVersionsFor, want)
 	}
-	if len(f.membershipCalls) != 1 {
-		t.Fatalf("ApplyMembership called %d times; want 1", len(f.membershipCalls))
+	if len(f.membershipCalls) != 2 {
+		t.Fatalf("ApplyMembership called %d times; want 2, one per context team (%#v)", len(f.membershipCalls), f.membershipCalls)
 	}
-	if f.membershipCalls[0].workspaceID != "T_HOME" {
-		t.Errorf("ApplyMembership workspace = %q; want T_HOME", f.membershipCalls[0].workspaceID)
+	for _, c := range f.membershipCalls {
+		if c.workspaceID != "T_HOME" {
+			t.Errorf("ApplyMembership workspace = %q; want T_HOME", c.workspaceID)
+		}
 	}
 }
 
@@ -752,19 +798,29 @@ func TestRevalidate_AppliesMembershipToTheQueriedIDsNotTheReturnedOnes(t *testin
 	if _, err := Run(context.Background(), f.Deps()); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if len(f.membershipCalls) != 1 {
-		t.Fatalf("ApplyMembership called %d times; want 1 (%#v)", len(f.membershipCalls), f.membershipCalls)
+	if len(f.membershipCalls) != 2 {
+		t.Fatalf("ApplyMembership called %d times; want 2, one per context team (%#v)", len(f.membershipCalls), f.membershipCalls)
 	}
-	got := f.membershipCalls[0]
-	wantQueried := cannedChannelsInfo().MembershipQueried
-	if !reflect.DeepEqual(got.queriedIDs, wantQueried) {
-		t.Errorf("ApplyMembership queried set = %v; want %v (MembershipQueried — the ids whose batch actually answered). MemberChannels is %v and must never be used here",
-			got.queriedIDs, wantQueried, cannedChannelsInfo().MemberChannels)
+	byTeam := map[string]membershipCall{}
+	for i, c := range f.channelsInfoCalls {
+		byTeam[c.team] = f.membershipCalls[i]
 	}
-	wantSnap := cache.MembershipReported(cannedChannelsInfo().MemberChannels, failedChannelIDs)
-	if !reflect.DeepEqual(got.snap, wantSnap) {
-		t.Errorf("ApplyMembership snapshot = %#v; want %#v — failed ids are part of it, and omitting them clears is_member for ids the server explicitly could not answer about",
-			got.snap, wantSnap)
+	home := byTeam["T_HOME"]
+	if want := []string{"C_GENERAL", "D_ALICE"}; !reflect.DeepEqual(home.queriedIDs, want) {
+		t.Errorf("T_HOME queried set = %v; want %v (MembershipQueried, never MemberChannels %v)", home.queriedIDs, want, cannedChannelsInfo().MemberChannels)
+	}
+	if want := cache.MembershipReported([]string{"C_GENERAL"}, nil); !reflect.DeepEqual(home.snap, want) {
+		t.Errorf("T_HOME snapshot = %#v; want %#v", home.snap, want)
+	}
+	other := byTeam["T_OTHER"]
+	if want := []string{"C_PRIVATE"}; !reflect.DeepEqual(other.queriedIDs, want) {
+		t.Errorf("T_OTHER queried set = %v; want %v", other.queriedIDs, want)
+	}
+	// The failed id rides in its own team's snapshot: omitting it
+	// would clear is_member for an id the server explicitly could not
+	// answer about.
+	if want := cache.MembershipReported(nil, failedChannelIDs); !reflect.DeepEqual(other.snap, want) {
+		t.Errorf("T_OTHER snapshot = %#v; want %#v", other.snap, want)
 	}
 }
 
@@ -1049,6 +1105,81 @@ func TestRevalidate_MissingDependenciesAreLoggedNotFatal(t *testing.T) {
 	}
 }
 
+// --- team partitioning ------------------------------------------------
+
+// TestRevalidate_PartitionsChannelsInfoByContextTeam is the Grid fix.
+// The fixture spans two context teams (C_GENERAL/D_ALICE on T_HOME,
+// C_PRIVATE/D_BOB on T_OTHER), so a correct run issues one
+// channels/info per team, each carrying exactly that team's ids.
+func TestRevalidate_PartitionsChannelsInfoByContextTeam(t *testing.T) {
+	f := openedFake()
+
+	if _, err := Run(context.Background(), f.Deps()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(f.channelsInfoCalls) != 2 {
+		t.Fatalf("channels/info calls = %d; want 2, one per context team (calls: %+v)", len(f.channelsInfoCalls), f.channelsInfoCalls)
+	}
+	byTeam := map[string]map[string]int64{}
+	for _, c := range f.channelsInfoCalls {
+		byTeam[c.team] = c.sent
+	}
+	if want := map[string]int64{"C_GENERAL": 1783337533019, "D_ALICE": 0}; !reflect.DeepEqual(byTeam["T_HOME"], want) {
+		t.Errorf("T_HOME was sent %v; want %v", byTeam["T_HOME"], want)
+	}
+	if want := map[string]int64{"C_PRIVATE": 0, "D_BOB": 1783337533022}; !reflect.DeepEqual(byTeam["T_OTHER"], want) {
+		t.Errorf("T_OTHER was sent %v; want %v", byTeam["T_OTHER"], want)
+	}
+}
+
+// TestRevalidate_EmptyContextTeamUsesTheWorkspaceTeam: a conversation
+// userBoot gave no context_team_id for must behave exactly as
+// pre-Grid code behaved — scoped to the workspace's own team.
+//
+// NOTE: this is a characterization test. It passes both before and
+// after the partition lands, because the pre-partition code scopes
+// everything to the workspace team anyway. Its job is to pin the
+// fallback rule so a future refactor can't drop it.
+func TestRevalidate_EmptyContextTeamUsesTheWorkspaceTeam(t *testing.T) {
+	f := openedFake()
+	f.bootRes.Channels = append(f.bootRes.Channels, boot.Channel{ID: "C_NO_TEAM", Name: "no-team"})
+
+	if _, err := Run(context.Background(), f.Deps()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	for _, c := range f.channelsInfoCalls {
+		if _, ok := c.sent["C_NO_TEAM"]; ok {
+			if c.team != "T_HOME" {
+				t.Errorf("C_NO_TEAM was scoped to %q; want the workspace team T_HOME", c.team)
+			}
+			return
+		}
+	}
+	t.Errorf("C_NO_TEAM was never sent (calls: %+v)", f.channelsInfoCalls)
+}
+
+// TestRevalidate_TeamFailureDoesNotSkipOtherTeams mirrors the existing
+// channels/users independence guarantee one level down: one team's
+// failure must not strand the other team's revalidation.
+func TestRevalidate_TeamFailureDoesNotSkipOtherTeams(t *testing.T) {
+	f := openedFake()
+	f.channelsInfoErrFor = map[string]error{"T_OTHER": errors.New("ratelimited")}
+
+	if _, err := Run(context.Background(), f.Deps()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(f.channelsInfoCalls) != 2 {
+		t.Fatalf("channels/info calls = %d; want 2 — a failed team must not suppress the other team's call", len(f.channelsInfoCalls))
+	}
+	// T_HOME's results still land.
+	if !reflect.DeepEqual(f.channelUpdates, wantChannelUpdates()) {
+		t.Errorf("channel updates = %#v; want %#v from the healthy team", f.channelUpdates, wantChannelUpdates())
+	}
+	if !f.loggedMatching("team T_OTHER") {
+		t.Errorf("the failed team was not named in the log; on Grid this line is the only diagnostic (logged: %v)", f.logged())
+	}
+}
+
 // --- budget -----------------------------------------------------------
 
 func TestRevalidate_StaysInsideTheBootCallBudget(t *testing.T) {
@@ -1063,8 +1194,8 @@ func TestRevalidate_StaysInsideTheBootCallBudget(t *testing.T) {
 	if len(f.calls) > 10 {
 		t.Errorf("boot issued %d calls; budget is 10 (sequence: %v)", len(f.calls), f.calls)
 	}
-	if n := f.countPrefix(callChannelsInfo); n != 1 {
-		t.Errorf("channels/info called %d times; want exactly 1 — one batched conditional request, not a per-channel loop (sequence: %v)", n, f.calls)
+	if n := f.countPrefix(callChannelsInfo); n != 2 {
+		t.Errorf("channels/info called %d times; want exactly 2 — the fixture spans two context teams (T_HOME, T_OTHER), and each gets one batched conditional request (sequence: %v)", n, f.calls)
 	}
 	if n := f.countPrefix(callUsersInfo); n != 1 {
 		t.Errorf("users/info called %d times; want exactly 1 (sequence: %v)", n, f.calls)

--- a/internal/bootstrap/revalidate_test.go
+++ b/internal/bootstrap/revalidate_test.go
@@ -801,6 +801,11 @@ func TestRevalidate_AppliesMembershipToTheQueriedIDsNotTheReturnedOnes(t *testin
 	if len(f.membershipCalls) != 2 {
 		t.Fatalf("ApplyMembership called %d times; want 2, one per context team (%#v)", len(f.membershipCalls), f.membershipCalls)
 	}
+	// Index alignment is the invariant: one membership call per
+	// channels/info call, in the same order. It holds only because
+	// every team's filtered MembershipQueried is non-empty — a team
+	// whose batch reported nothing produces no membership call and
+	// would shift the alignment.
 	byTeam := map[string]membershipCall{}
 	for i, c := range f.channelsInfoCalls {
 		byTeam[c.team] = f.membershipCalls[i]
@@ -1184,8 +1189,9 @@ func TestRevalidate_TeamFailureDoesNotSkipOtherTeams(t *testing.T) {
 
 func TestRevalidate_StaysInsideTheBootCallBudget(t *testing.T) {
 	// Success criterion 1, on the full sequence: userBoot, counts,
-	// conversations.view, channels/info, users/info — five, against a
-	// budget of ten, replacing roughly four hundred.
+	// conversations.view, channels/info per context team (two here),
+	// users/info — six, against a budget of ten, replacing roughly
+	// four hundred.
 	f := openedFake()
 
 	if _, err := Run(context.Background(), f.Deps()); err != nil {

--- a/internal/slack/edge/cache.go
+++ b/internal/slack/edge/cache.go
@@ -10,7 +10,9 @@ import (
 //
 // These are not documented limits. They are caps chosen at or just
 // under the largest batch the official web client has been observed
-// sending, measured across 8 HAR captures of a live Grid workspace:
+// sending, measured across 8 HAR captures of a live NON-Grid
+// workspace (Rands, T04T4TH8W). No Grid capture of edgeapi exists;
+// behaviour there is inferred from a user's log, not observed:
 //
 //	channels/info   18 requests, 1–63 ids per request
 //	users/info      30 requests, 1–80 ids per request
@@ -232,7 +234,17 @@ type channelsInfoResponse struct {
 	FailedIDs      []string  `json:"failed_ids"`
 }
 
-// ChannelsInfo revalidates channels against the edge cache.
+// ChannelsInfo revalidates channels against the edge cache, scoped to
+// teamID: the request path is /cache/<teamID>/channels/info.
+//
+// teamID is mandatory and per-call because of Enterprise Grid. A Grid
+// user's conversations are owned by different teams within the org,
+// and the edge cache keys records under the owning team; a request
+// scoped to the auth.test team resolves only the conversations that
+// team owns and fails the rest (gammons/slk#5: 217 of 217 failed).
+// The caller partitions by userBoot's context_team_id; non-Grid
+// callers pass the workspace's own team id, which is every
+// conversation's context team there.
 //
 // updatedIDs maps channel id to the version last seen (0 for a channel
 // we have never seen). Only the entries whose version moved, plus the
@@ -244,9 +256,9 @@ type channelsInfoResponse struct {
 // the top-level member_channels array, returned for every id in the
 // batch whether or not that channel changed — see
 // ChannelsInfoResult.MemberChannels.
-func (c *Client) ChannelsInfo(ctx context.Context, updatedIDs map[string]int64) (ChannelsInfoResult, error) {
+func (c *Client) ChannelsInfo(ctx context.Context, teamID string, updatedIDs map[string]int64) (ChannelsInfoResult, error) {
 	var out ChannelsInfoResult
-	err := fetchInfo(ctx, c, "channels/info", map[string]any{
+	err := fetchInfo(ctx, c, teamID, "channels/info", map[string]any{
 		"check_membership": true,
 	}, updatedIDs, channelsInfoBatchSize, func(batch channelsInfoResponse, queried []string) {
 		out.Channels = append(out.Channels, batch.Results...)
@@ -293,7 +305,7 @@ type usersInfoResponse struct {
 // caller wants. Adding it later is a two-line change plus a merge.
 func (c *Client) UsersInfo(ctx context.Context, updatedIDs map[string]int64) ([]User, error) {
 	var out []User
-	err := fetchInfo(ctx, c, "users/info", map[string]any{
+	err := fetchInfo(ctx, c, c.teamID, "users/info", map[string]any{
 		"check_interaction":          true,
 		"include_profile_only_users": true,
 	}, updatedIDs, usersInfoBatchSize, func(batch usersInfoResponse, _ []string) {
@@ -368,6 +380,7 @@ func (c *Client) UsersInfo(ctx context.Context, updatedIDs map[string]int64) ([]
 func fetchInfo[Resp any](
 	ctx context.Context,
 	c *Client,
+	teamID string,
 	endpoint string,
 	flags map[string]any,
 	updatedIDs map[string]int64,
@@ -396,7 +409,7 @@ func fetchInfo[Resp any](
 		queried := slices.Collect(maps.Keys(batch))
 
 		var resp Resp
-		if err := c.call(ctx, endpoint, payload, &resp); err != nil {
+		if err := c.call(ctx, teamID, endpoint, payload, &resp); err != nil {
 			return err
 		}
 		merge(resp, queried)

--- a/internal/slack/edge/cache_test.go
+++ b/internal/slack/edge/cache_test.go
@@ -177,7 +177,7 @@ func TestChannelsInfo_SendsUpdatedIDsAndDecodesResults(t *testing.T) {
 	})
 	c := rec.client()
 
-	got, err := c.ChannelsInfo(context.Background(), map[string]int64{
+	got, err := c.ChannelsInfo(context.Background(), "T04T4TH8W", map[string]int64{
 		"C2QPK1V44":   1783337533019,
 		"C092E63RUUC": 0,
 	})
@@ -268,6 +268,28 @@ func TestChannelsInfo_SendsUpdatedIDsAndDecodesResults(t *testing.T) {
 	}
 }
 
+func TestChannelsInfo_ScopesThePathToTheGivenTeam(t *testing.T) {
+	// On Enterprise Grid a user's conversations are owned by many
+	// teams within the org, and the edge cache keys them under the
+	// owning team. The team in the request path is therefore a
+	// per-call decision, not a client property: scoping every request
+	// to the auth.test team is what resolved zero of raff's 217
+	// conversations (gammons/slk#5).
+	rec := newRecorder(t, alwaysEmpty)
+	c := rec.client() // constructed with team T04T4TH8W
+
+	if _, err := c.ChannelsInfo(context.Background(), "T_OTHER_TEAM", map[string]int64{"C1": 0}); err != nil {
+		t.Fatalf("ChannelsInfo: %v", err)
+	}
+	reqs := rec.requests()
+	if len(reqs) != 1 {
+		t.Fatalf("requests = %d; want 1", len(reqs))
+	}
+	if want := "/cache/T_OTHER_TEAM/channels/info"; reqs[0].path != want {
+		t.Errorf("path = %q; want %q — the call's team, not the client's construction team", reqs[0].path, want)
+	}
+}
+
 // channelBooleanFlags is every boolean modelled on Channel, paired
 // with the wire key it must decode from.
 var channelBooleanFlags = []struct {
@@ -318,7 +340,7 @@ func TestChannel_DecodesEachBooleanFlagIndependently(t *testing.T) {
 					strings.Join(fields, ","))
 			})
 
-			got, err := rec.client().ChannelsInfo(context.Background(), map[string]int64{"C2QPK1V44": 1})
+			got, err := rec.client().ChannelsInfo(context.Background(), "T04T4TH8W", map[string]int64{"C2QPK1V44": 1})
 			if err != nil {
 				t.Fatalf("ChannelsInfo: %v", err)
 			}
@@ -429,7 +451,7 @@ func TestChannelsInfo_MembershipArrivesWithNoResults(t *testing.T) {
 	})
 	c := rec.client()
 
-	got, err := c.ChannelsInfo(context.Background(), map[string]int64{
+	got, err := c.ChannelsInfo(context.Background(), "T04T4TH8W", map[string]int64{
 		"C2QPK1V44":   1,
 		"CL0AET1L0":   2,
 		"C092E63RUUC": 3,
@@ -470,7 +492,7 @@ func TestChannelsInfo_SurfacesFailedIDs(t *testing.T) {
 	})
 	c := rec.client()
 
-	got, err := c.ChannelsInfo(context.Background(), map[string]int64{
+	got, err := c.ChannelsInfo(context.Background(), "T04T4TH8W", map[string]int64{
 		"C2QPK1V44":    1,
 		"C092E63RUUCX": 2,
 		"C0B0QD6BH1N":  3,
@@ -504,7 +526,7 @@ func TestChannelsInfo_AbsentMembershipAndFailuresDecodeEmpty(t *testing.T) {
 	rec := newRecorder(t, alwaysEmpty) // {"results":[],"ok":true}
 	c := rec.client()
 
-	got, err := c.ChannelsInfo(context.Background(), map[string]int64{"C2QPK1V44": 1})
+	got, err := c.ChannelsInfo(context.Background(), "T04T4TH8W", map[string]int64{"C2QPK1V44": 1})
 	if err != nil {
 		t.Fatalf("ChannelsInfo on a response with neither key: %v", err)
 	}
@@ -530,7 +552,7 @@ func TestChannelsInfo_AccumulatesMembershipAcrossBatches(t *testing.T) {
 	})
 	c := rec.client()
 
-	got, err := c.ChannelsInfo(context.Background(), ids("C", channelsInfoBatchSize*2+10))
+	got, err := c.ChannelsInfo(context.Background(), "T04T4TH8W", ids("C", channelsInfoBatchSize*2+10))
 	if err != nil {
 		t.Fatalf("ChannelsInfo: %v", err)
 	}
@@ -590,7 +612,7 @@ func TestChannelsInfo_MembershipQueriedCoversOnlyBatchesThatReported(t *testing.
 	})
 	c := rec.client()
 
-	got, err := c.ChannelsInfo(context.Background(), ids("C", channelsInfoBatchSize*2+10))
+	got, err := c.ChannelsInfo(context.Background(), "T04T4TH8W", ids("C", channelsInfoBatchSize*2+10))
 	if err != nil {
 		t.Fatalf("ChannelsInfo: %v", err)
 	}
@@ -643,7 +665,7 @@ func TestChannelsInfo_SurfacesFailedIDsWithoutMemberChannels(t *testing.T) {
 	})
 	c := rec.client()
 
-	got, err := c.ChannelsInfo(context.Background(), map[string]int64{
+	got, err := c.ChannelsInfo(context.Background(), "T04T4TH8W", map[string]int64{
 		"C092E63RUUCX": 44,
 		"C0B0QD6BH1N":  55,
 	})
@@ -671,7 +693,7 @@ func TestChannelsInfo_AbsentMemberChannelsCoversNoIDs(t *testing.T) {
 	rec := newRecorder(t, alwaysEmpty) // {"results":[],"ok":true}
 	c := rec.client()
 
-	got, err := c.ChannelsInfo(context.Background(), map[string]int64{
+	got, err := c.ChannelsInfo(context.Background(), "T04T4TH8W", map[string]int64{
 		"C2QPK1V44":   11,
 		"CL0AET1L0":   22,
 		"C092E63RUUC": 33,
@@ -706,7 +728,7 @@ func TestChannelsInfo_ExplicitlyEmptyMemberChannelsCoversTheWholeBatch(t *testin
 		"CL0AET1L0":   22,
 		"C092E63RUUC": 33,
 	}
-	got, err := c.ChannelsInfo(context.Background(), queried)
+	got, err := c.ChannelsInfo(context.Background(), "T04T4TH8W", queried)
 	if err != nil {
 		t.Fatalf("ChannelsInfo: %v", err)
 	}
@@ -740,7 +762,7 @@ func TestChannelsInfo_MembershipQueriedHoldsIDsSentNotIDsReturned(t *testing.T) 
 	})
 	c := rec.client()
 
-	got, err := c.ChannelsInfo(context.Background(), map[string]int64{
+	got, err := c.ChannelsInfo(context.Background(), "T04T4TH8W", map[string]int64{
 		"C2QPK1V44":   11, // reported on, named nowhere: a non-member
 		"CL0AET1L0":   22, // a member
 		"C092E63RUUC": 33, // a failure
@@ -782,7 +804,7 @@ func TestChannelsInfo_AllAccumulatorsPreserveRequestOrder(t *testing.T) {
 	})
 	c := rec.client()
 
-	got, err := c.ChannelsInfo(context.Background(), ids("C", channelsInfoBatchSize*2+10))
+	got, err := c.ChannelsInfo(context.Background(), "T04T4TH8W", ids("C", channelsInfoBatchSize*2+10))
 	if err != nil {
 		t.Fatalf("ChannelsInfo: %v", err)
 	}
@@ -829,7 +851,7 @@ func TestChannelsInfo_EmptyResultsMeansNothingChanged(t *testing.T) {
 	rec := newRecorder(t, alwaysEmpty)
 	c := rec.client()
 
-	got, err := c.ChannelsInfo(context.Background(), map[string]int64{"CL0AET1L0": 1783337533019})
+	got, err := c.ChannelsInfo(context.Background(), "T04T4TH8W", map[string]int64{"CL0AET1L0": 1783337533019})
 	if err != nil {
 		t.Fatalf("ChannelsInfo: %v", err)
 	}
@@ -847,7 +869,7 @@ func TestChannelsInfo_NoIDsMakesNoRequest(t *testing.T) {
 	c := rec.client()
 
 	for _, in := range []map[string]int64{nil, {}} {
-		got, err := c.ChannelsInfo(context.Background(), in)
+		got, err := c.ChannelsInfo(context.Background(), "T04T4TH8W", in)
 		if err != nil {
 			t.Fatalf("ChannelsInfo(%v): %v", in, err)
 		}
@@ -867,7 +889,7 @@ func TestChannelsInfo_SplitsLargeIDSets(t *testing.T) {
 
 	const total = channelsInfoBatchSize*2 + 10
 	want := ids("C", total)
-	if _, err := c.ChannelsInfo(context.Background(), want); err != nil {
+	if _, err := c.ChannelsInfo(context.Background(), "T04T4TH8W", want); err != nil {
 		t.Fatalf("ChannelsInfo: %v", err)
 	}
 
@@ -916,7 +938,7 @@ func TestChannelsInfo_ExactMultipleOfBatchSizeSendsNoEmptyBatch(t *testing.T) {
 	rec := newRecorder(t, alwaysEmpty)
 	c := rec.client()
 
-	if _, err := c.ChannelsInfo(context.Background(), ids("C", channelsInfoBatchSize)); err != nil {
+	if _, err := c.ChannelsInfo(context.Background(), "T04T4TH8W", ids("C", channelsInfoBatchSize)); err != nil {
 		t.Fatalf("ChannelsInfo: %v", err)
 	}
 	if n := len(rec.requests()); n != 1 {
@@ -934,7 +956,7 @@ func TestChannelsInfo_ReturnsResultsFromEveryBatch(t *testing.T) {
 	})
 	c := rec.client()
 
-	got, err := c.ChannelsInfo(context.Background(), ids("C", channelsInfoBatchSize*2+10))
+	got, err := c.ChannelsInfo(context.Background(), "T04T4TH8W", ids("C", channelsInfoBatchSize*2+10))
 	if err != nil {
 		t.Fatalf("ChannelsInfo: %v", err)
 	}
@@ -979,7 +1001,7 @@ func TestChannelsInfo_IgnoresUnknownResponseFields(t *testing.T) {
 	})
 	c := rec.client()
 
-	got, err := c.ChannelsInfo(context.Background(), map[string]int64{"C2QPK1V44": 1})
+	got, err := c.ChannelsInfo(context.Background(), "T04T4TH8W", map[string]int64{"C2QPK1V44": 1})
 	if err != nil {
 		t.Fatalf("ChannelsInfo on a full real-shaped response: %v", err)
 	}
@@ -998,7 +1020,7 @@ func TestChannelsInfo_PropagatesAPIError(t *testing.T) {
 	})
 	c := rec.client()
 
-	got, err := c.ChannelsInfo(context.Background(), map[string]int64{"C1": 1})
+	got, err := c.ChannelsInfo(context.Background(), "T04T4TH8W", map[string]int64{"C1": 1})
 	if err == nil {
 		t.Fatal("ChannelsInfo returned nil error on ok:false")
 	}
@@ -1027,7 +1049,7 @@ func TestChannelsInfo_MidBatchErrorAbortsAndDiscardsPartialResults(t *testing.T)
 	})
 	c := rec.client()
 
-	got, err := c.ChannelsInfo(context.Background(), ids("C", channelsInfoBatchSize*2+10))
+	got, err := c.ChannelsInfo(context.Background(), "T04T4TH8W", ids("C", channelsInfoBatchSize*2+10))
 	if err == nil {
 		t.Fatal("ChannelsInfo returned nil error when the second batch failed")
 	}
@@ -1435,7 +1457,7 @@ func TestFetchInfo_DoesNotMergeAnErroredBatch(t *testing.T) {
 	c := rec.client()
 
 	var merged []channelsInfoResponse
-	err := fetchInfo(context.Background(), c, "channels/info",
+	err := fetchInfo(context.Background(), c, "T04T4TH8W", "channels/info",
 		map[string]any{"check_membership": true},
 		ids("C", channelsInfoBatchSize*2+10), channelsInfoBatchSize,
 		func(batch channelsInfoResponse, _ []string) { merged = append(merged, batch) })
@@ -1484,7 +1506,7 @@ func TestFetchInfo_HandsMergeTheIDsThatBatchSent(t *testing.T) {
 	c := rec.client()
 
 	var seen [][]string
-	err := fetchInfo(context.Background(), c, "channels/info",
+	err := fetchInfo(context.Background(), c, "T04T4TH8W", "channels/info",
 		map[string]any{"check_membership": true},
 		ids("C", channelsInfoBatchSize*2+10), channelsInfoBatchSize,
 		func(_ channelsInfoResponse, queried []string) {

--- a/internal/slack/edge/client.go
+++ b/internal/slack/edge/client.go
@@ -38,6 +38,11 @@ type Client struct {
 // New returns a Client. httpClient must be one built with
 // slackhttp.BrowserTransport so requests carry the browser headers and
 // edgeapi envelope; pass the same client slack.Client uses.
+//
+// teamID is the workspace-scope default: most endpoints are keyed
+// under it, and their callers pass it through to call. It is not the
+// team on every request path — ChannelsInfo takes the owning team
+// per call, because on Grid one user's conversations span teams.
 func New(token, teamID string, httpClient *http.Client) *Client {
 	if httpClient == nil {
 		httpClient = http.DefaultClient

--- a/internal/slack/edge/client.go
+++ b/internal/slack/edge/client.go
@@ -52,7 +52,13 @@ func New(token, teamID string, httpClient *http.Client) *Client {
 
 // call POSTs payload (with the token merged in) to
 // /cache/<teamID>/<endpoint> and decodes the response into out.
-func (c *Client) call(ctx context.Context, endpoint string, payload map[string]any, out any) error {
+//
+// teamID is a per-request argument, not read from the client: on
+// Enterprise Grid the conversations one call asks about are owned by
+// different teams within the org, and the edge cache keys records
+// under the owning team. Callers whose scope is the workspace pass
+// the client's team; ChannelsInfo passes the owning team.
+func (c *Client) call(ctx context.Context, teamID, endpoint string, payload map[string]any, out any) error {
 	body := make(map[string]any, len(payload)+1)
 	for k, v := range payload {
 		body[k] = v
@@ -70,7 +76,7 @@ func (c *Client) call(ctx context.Context, endpoint string, payload map[string]a
 		return fmt.Errorf("edge %s: encoding request: %w", endpoint, err)
 	}
 
-	url := fmt.Sprintf("%s/cache/%s/%s", c.baseURL, c.teamID, endpoint)
+	url := fmt.Sprintf("%s/cache/%s/%s", c.baseURL, teamID, endpoint)
 	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(encoded))
 	if err != nil {
 		return fmt.Errorf("edge %s: building request: %w", endpoint, err)

--- a/internal/slack/edge/client_test.go
+++ b/internal/slack/edge/client_test.go
@@ -31,7 +31,7 @@ func TestClient_PostsJSONAsTextPlain(t *testing.T) {
 	var out struct {
 		OK bool `json:"ok"`
 	}
-	err := c.call(context.Background(), "users/info",
+	err := c.call(context.Background(), "T04T4TH8W", "users/info",
 		map[string]any{"check_interaction": true}, &out)
 	if err != nil {
 		t.Fatalf("call: %v", err)
@@ -79,7 +79,7 @@ func TestClient_PropagatesHTTPError(t *testing.T) {
 	c := New("xoxc-test", "T1", srv.Client())
 	c.baseURL = srv.URL
 	var out struct{}
-	err := c.call(context.Background(), "users/info", map[string]any{}, &out)
+	err := c.call(context.Background(), "T1", "users/info", map[string]any{}, &out)
 	if err == nil {
 		t.Fatal("call returned nil error on HTTP 500")
 	}
@@ -102,7 +102,7 @@ func TestClient_PropagatesAPIError(t *testing.T) {
 	c := New("xoxc-test", "T1", srv.Client())
 	c.baseURL = srv.URL
 	var out struct{}
-	err := c.call(context.Background(), "users/info", map[string]any{}, &out)
+	err := c.call(context.Background(), "T1", "users/info", map[string]any{}, &out)
 	if err == nil {
 		t.Fatal("call returned nil error on ok:false")
 	}
@@ -129,7 +129,7 @@ func TestClient_RespectsContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	var out struct{}
-	err := c.call(ctx, "users/info", map[string]any{}, &out)
+	err := c.call(ctx, "T1", "users/info", map[string]any{}, &out)
 	if err == nil {
 		t.Fatal("call ignored a cancelled context")
 	}
@@ -175,7 +175,7 @@ func TestClient_SendsThroughTheCallerSuppliedHTTPClient(t *testing.T) {
 	c := New("xoxc-test", "T1", &http.Client{Transport: marker})
 	c.baseURL = srv.URL
 
-	if err := c.call(context.Background(), "users/info", map[string]any{}, nil); err != nil {
+	if err := c.call(context.Background(), "T1", "users/info", map[string]any{}, nil); err != nil {
 		t.Fatalf("call: %v", err)
 	}
 	if !marker.used.Load() {
@@ -196,7 +196,7 @@ func TestClient_AcceptsNilOutToDiscardTheBody(t *testing.T) {
 
 	c := New("xoxc-test", "T1", srv.Client())
 	c.baseURL = srv.URL
-	if err := c.call(context.Background(), "users/info", map[string]any{}, nil); err != nil {
+	if err := c.call(context.Background(), "T1", "users/info", map[string]any{}, nil); err != nil {
 		t.Fatalf("call with out=nil: %v", err)
 	}
 }
@@ -212,7 +212,7 @@ func TestClient_ReportsAPIErrorWithNoErrorField(t *testing.T) {
 
 	c := New("xoxc-test", "T1", srv.Client())
 	c.baseURL = srv.URL
-	err := c.call(context.Background(), "users/info", map[string]any{}, nil)
+	err := c.call(context.Background(), "T1", "users/info", map[string]any{}, nil)
 	if err == nil {
 		t.Fatal("call returned nil error on ok:false")
 	}

--- a/internal/slack/edge/members.go
+++ b/internal/slack/edge/members.go
@@ -122,7 +122,7 @@ func (c *Client) UsersList(ctx context.Context, channelID string, count int) (us
 		// for why the value itself does not leave this function.
 		NextMarker string `json:"next_marker"`
 	}
-	if err := c.call(ctx, "users/list", payload, &resp); err != nil {
+	if err := c.call(ctx, c.teamID, "users/list", payload, &resp); err != nil {
 		return nil, false, err
 	}
 	return resp.Results, resp.NextMarker != "", nil
@@ -175,7 +175,7 @@ func (c *Client) ChannelsMembership(ctx context.Context, channelID string, userI
 		Members    []string `json:"members"`
 		NonMembers []string `json:"non_members"`
 	}
-	if err := c.call(ctx, "channels/membership", map[string]any{
+	if err := c.call(ctx, c.teamID, "channels/membership", map[string]any{
 		"channel": channelID,
 		"users":   userIDs,
 		// Sent explicitly as false in 10 of 10 observations, not
@@ -232,7 +232,7 @@ func (c *Client) UsersCounts(ctx context.Context, channelID string) (Counts, err
 	var resp struct {
 		Counts Counts `json:"counts"`
 	}
-	if err := c.call(ctx, "users/counts", map[string]any{
+	if err := c.call(ctx, c.teamID, "users/counts", map[string]any{
 		"channel": channelID,
 		// false explicitly, 7 of 7 — see ChannelsMembership.
 		"as_admin": false,

--- a/internal/slack/edge/search.go
+++ b/internal/slack/edge/search.go
@@ -88,7 +88,7 @@ func (c *Client) ChannelsSearch(ctx context.Context, query string, topChannels [
 		Results        []Channel `json:"results"`
 		MemberChannels []string  `json:"member_channels"`
 	}
-	if err := c.call(ctx, "channels/search", payload, &resp); err != nil {
+	if err := c.call(ctx, c.teamID, "channels/search", payload, &resp); err != nil {
 		return nil, nil, err
 	}
 	return resp.Results, resp.MemberChannels, nil
@@ -161,7 +161,7 @@ func (c *Client) UsersSearch(ctx context.Context, query, currentChannel string, 
 	var resp struct {
 		Results []User `json:"results"`
 	}
-	if err := c.call(ctx, "users/search", payload, &resp); err != nil {
+	if err := c.call(ctx, c.teamID, "users/search", payload, &resp); err != nil {
 		return nil, err
 	}
 	return resp.Results, nil


### PR DESCRIPTION
Fixes the two remaining failures from #5 (Enterprise Grid, @raff). The base commit's message says DO NOT MERGE — that was true while the 42-`conversations.members` regression was unexplained; that turned out to be a pre-existing `main` bug, fixed separately in #124.

## 1. Sidebar survives `users.conversations` being rejected

On raff's Grid org, `users.conversations` fails (`stars.list` on the same org returns `enterprise_is_restricted`), and `connectWorkspace` treated the failure as fatal — the whole workspace was dropped: no channels, no threads, no active workspace. Now it falls back to the conversations `client.userBoot` already returned (217/217 for raff).

The order is `users.conversations` primary, `userBoot` fallback — **measured, not guessed**: on real workspaces userBoot's `channels[]` carried 67 of 218 and 60 of 71 joined conversations, so preferring it silently drops channels from the sidebar. With this order, channel counts and `users.conversations` call counts match `main` exactly on non-Grid.

## 2. Team-scoped edge revalidation

Raff's log: `channels/info could not resolve 217 ids` — every conversation he has. That message prints only after HTTP 200 + `ok:true`, so `edgeapi.slack.com` accepts Grid requests; what fails is the `/cache/<teamID>/` path scoping — on Grid an org's conversations are owned by many teams and the edge cache keys records under the owning team.

- `edge.Client` takes the team per request; `ChannelsInfo(ctx, teamID, updatedIDs)`.
- `bootstrap.revalidateChannels` partitions by userBoot's `context_team_id` (already decoded, previously unused); empty → workspace team.
- Per-team failure independence; failure logs name the team, so the next Grid log says *which* scoping failed.
- Deliberately out of scope (no evidence of breakage): host derivation, users/info, search, members endpoints.

Spec: `docs/superpowers/specs/2026-08-05-grid-edge-team-scoping-design.md`. Plan: `docs/superpowers/plans/2026-08-05-grid-edge-team-scoping.md`.

## Verification

- Full suite + vet green; executed via subagent-driven TDD with spec + quality review per task and a final whole-change review (READY TO MERGE).
- Live non-Grid 25s session: `edge:channels/info` tally unchanged (3), exactly one team group per workspace — the change is a no-op where context teams equal the workspace team.
- Grid behaviour is unverifiable locally by construction; raff's re-run is the test.

## After merge

Tag `v0.13.0-beta.2` (also ships the connect-error logging from `0cfdcc7`) and ask raff to re-run: his log answers whether the sidebar populates and whether per-team `channels/info` resolves.
