### PR TITLE
feat(slk): edge health + batched user resolution (23 wasted edge calls, 282 users.info → ~4)

### DIFF
--- a/cmd/slk/bootstrap_adapters.go
+++ b/cmd/slk/bootstrap_adapters.go
@@ -47,7 +47,7 @@ import (
 // accessToken is the xoxc credential; it is passed separately because
 // edge.New takes the token directly rather than going through
 // *slackclient.Client, which does not expose it.
-func newBootstrapDeps(c *slackclient.Client, db *cache.DB, accessToken, openChannelID string) bootstrap.Deps {
+func newBootstrapDeps(c *slackclient.Client, db *cache.DB, accessToken, openChannelID string, health *edge.Health) bootstrap.Deps {
 	return bootstrap.Deps{
 		WorkspaceID: c.TeamID(),
 		Boot:        bootAdapter{c},
@@ -59,6 +59,7 @@ func newBootstrapDeps(c *slackclient.Client, db *cache.DB, accessToken, openChan
 		// one differs only in what goes on the wire. See
 		// (*slackclient.Client).HTTPClient.
 		Revalidate:    edge.New(accessToken, c.TeamID(), c.HTTPClient()),
+		Health:        health,
 		Store:         storeAdapter{db},
 		OpenChannelID: openChannelID,
 		Log:           debuglog.General,

--- a/cmd/slk/bootstrap_adapters_test.go
+++ b/cmd/slk/bootstrap_adapters_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gammons/slk/internal/cache"
 	slackclient "github.com/gammons/slk/internal/slack"
 	"github.com/gammons/slk/internal/slack/boot"
+	"github.com/gammons/slk/internal/slack/edge"
 	"github.com/gammons/slk/internal/slackhttp"
 )
 
@@ -462,7 +463,7 @@ func TestBootstrapDeps_PopulatesEveryDependency(t *testing.T) {
 	}
 	defer db.Close()
 
-	deps := newBootstrapDeps(slackclient.NewClient("xoxc-test", "d-cookie"), db, "xoxc-test", "C1")
+	deps := newBootstrapDeps(slackclient.NewClient("xoxc-test", "d-cookie"), db, "xoxc-test", "C1", edge.NewHealth())
 
 	v := reflect.ValueOf(deps)
 	for i := 0; i < v.NumField(); i++ {
@@ -474,6 +475,9 @@ func TestBootstrapDeps_PopulatesEveryDependency(t *testing.T) {
 				t.Errorf("Deps.%s is nil; bootstrap.Run cannot use a dependency that was never wired", name)
 			}
 		}
+	}
+	if deps.Health == nil {
+		t.Errorf("Deps.Health is nil; bootstrap cannot mark wholesale edge failures degraded without it")
 	}
 	if deps.OpenChannelID != "C1" {
 		t.Errorf("OpenChannelID = %q; want the channel it was given", deps.OpenChannelID)
@@ -505,7 +509,7 @@ func TestBootstrapDeps_RevalidatorUsesTheBrowserShapedHTTPClient(t *testing.T) {
 	}
 	defer db.Close()
 
-	deps := newBootstrapDeps(c, db, "xoxc-test", "")
+	deps := newBootstrapDeps(c, db, "xoxc-test", "", edge.NewHealth())
 
 	// Structural check FIRST, and it is deliberately not redundant
 	// with the wire assertions below. edge.Client's base URL is

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -274,6 +274,20 @@ func (r *workspaceRouter) ByID(teamID string) *WorkspaceContext {
 // browser opens to one host and far more than a person generates.
 const userResolverConcurrency = 8
 
+// userResolverBatchWindow is how long Request waits for more misses
+// to coalesce before flushing them as one edge users/info call. The
+// render path resolves a channel's unknown authors in a single
+// burst, so a short window turns a channel open from N requests into
+// one; 200 ms is below what a person perceives as resolution lag.
+const userResolverBatchWindow = 200 * time.Millisecond
+
+// userBatcher is the edge.UsersInfo subset the resolver batches
+// misses through. *edge.Client satisfies it structurally; nil means
+// no batching and every miss takes the per-user users.info path.
+type userBatcher interface {
+	UsersInfo(ctx context.Context, updatedIDs map[string]int64) ([]edge.User, error)
+}
+
 // userResolver dispatches users.info lookups for unknown message
 // authors in the background. Deduplicates concurrent requests for
 // the same userID; failures are silent (the row stays rendered as
@@ -291,6 +305,13 @@ type userResolver struct {
 	// blocks -- it is called from the render path and from WS event
 	// handlers, neither of which may wait on the network.
 	sem chan struct{}
+
+	batcher  userBatcher
+	degraded func() bool // nil: never degraded
+
+	pendingMu  sync.Mutex
+	pending    map[string]struct{}
+	flushTimer *time.Timer
 }
 
 func newUserResolver(
@@ -299,14 +320,19 @@ func newUserResolver(
 	db *cache.DB,
 	avatars *avatar.Cache,
 	send func(tea.Msg),
+	batcher userBatcher,
+	degraded func() bool,
 ) *userResolver {
 	return &userResolver{
-		teamID:  teamID,
-		client:  client,
-		db:      db,
-		avatars: avatars,
-		send:    send,
-		sem:     make(chan struct{}, userResolverConcurrency),
+		teamID:   teamID,
+		client:   client,
+		db:       db,
+		avatars:  avatars,
+		send:     send,
+		sem:      make(chan struct{}, userResolverConcurrency),
+		batcher:  batcher,
+		degraded: degraded,
+		pending:  map[string]struct{}{},
 	}
 }
 
@@ -339,68 +365,170 @@ func (r *userResolver) Request(userID string) {
 		r.inflight.Delete(userID)
 		return
 	}
-	go func() {
-		defer r.inflight.Delete(userID)
-		if r.sem != nil {
-			r.sem <- struct{}{}
-			defer func() { <-r.sem }()
-		}
-		u, err := r.client.GetUserProfile(userID)
-		if err != nil {
-			debuglog.Cache("userResolver: GetUserProfile team=%s user=%s err=%v",
-				r.teamID, userID, err)
-			return
-		}
-		name := u.Profile.DisplayName
-		if name == "" {
-			name = u.RealName
-		}
-		if name == "" {
-			name = u.Name
-		}
-		isBot := u.IsBot || u.IsAppUser
-		// r.teamID is the workspace's home TeamID; u.TeamID is the
-		// user's home TeamID. If they differ (and u.TeamID is set),
-		// the user is a Slack Connect / shared-channel guest. Treat
-		// an empty u.TeamID as internal — better to under-detect than
-		// to falsely flag.
-		isExternal := u.TeamID != "" && u.TeamID != r.teamID
-		// Persist to the cache DB (its own goroutine-safe SQLite
-		// connection) and the avatar cache (internal RWMutex), but
-		// do NOT write r.userNames[userID] from this goroutine —
-		// userNames is a plain map shared with the UI goroutine and
-		// other code paths, and a direct write here trips Go's
-		// "concurrent map writes" detector under load (two parallel
-		// Request goroutines for different userIDs is enough). The
-		// UserResolvedMsg below is delivered to the bubbletea Update
-		// loop, which calls Model.PatchUserName on the UI goroutine
-		// — that is the single safe writer for in-history rows.
-		// Subsequent resolveUserCached misses fall back to the DB
-		// row we just upserted, so we don't re-fetch on every miss
-		// in the small window before UserResolvedMsg lands.
-		r.avatars.Preload(userID, u.Profile.Image32)
-		_ = r.db.UpsertUser(cache.User{
-			ID:          userID,
-			WorkspaceID: r.teamID,
-			Name:        u.Name,
+	if r.batcher == nil || (r.degraded != nil && r.degraded()) {
+		go r.resolveOne(userID)
+		return
+	}
+	r.pendingMu.Lock()
+	r.pending[userID] = struct{}{}
+	if r.flushTimer == nil {
+		r.flushTimer = time.AfterFunc(userResolverBatchWindow, r.flush)
+	}
+	r.pendingMu.Unlock()
+}
+
+// resolveOne resolves a single user through the Web API users.info
+// path: the pre-batch behaviour, now the fallback for ids edge did
+// not return, for a failed edge call, and for workspaces whose edge
+// is degraded. Callers run it on its own goroutine.
+func (r *userResolver) resolveOne(userID string) {
+	defer r.inflight.Delete(userID)
+	if r.sem != nil {
+		r.sem <- struct{}{}
+		defer func() { <-r.sem }()
+	}
+	u, err := r.client.GetUserProfile(userID)
+	if err != nil {
+		debuglog.Cache("userResolver: GetUserProfile team=%s user=%s err=%v",
+			r.teamID, userID, err)
+		return
+	}
+	name := u.Profile.DisplayName
+	if name == "" {
+		name = u.RealName
+	}
+	if name == "" {
+		name = u.Name
+	}
+	isBot := u.IsBot || u.IsAppUser
+	// r.teamID is the workspace's home TeamID; u.TeamID is the
+	// user's home TeamID. If they differ (and u.TeamID is set),
+	// the user is a Slack Connect / shared-channel guest. Treat
+	// an empty u.TeamID as internal — better to under-detect than
+	// to falsely flag.
+	isExternal := u.TeamID != "" && u.TeamID != r.teamID
+	// Persist to the cache DB (its own goroutine-safe SQLite
+	// connection) and the avatar cache (internal RWMutex), but
+	// do NOT write r.userNames[userID] from this goroutine —
+	// userNames is a plain map shared with the UI goroutine and
+	// other code paths, and a direct write here trips Go's
+	// "concurrent map writes" detector under load (two parallel
+	// Request goroutines for different userIDs is enough). The
+	// UserResolvedMsg below is delivered to the bubbletea Update
+	// loop, which calls Model.PatchUserName on the UI goroutine
+	// — that is the single safe writer for in-history rows.
+	// Subsequent resolveUserCached misses fall back to the DB
+	// row we just upserted, so we don't re-fetch on every miss
+	// in the small window before UserResolvedMsg lands.
+	r.avatars.Preload(userID, u.Profile.Image32)
+	_ = r.db.UpsertUser(cache.User{
+		ID:          userID,
+		WorkspaceID: r.teamID,
+		Name:        u.Name,
+		DisplayName: name,
+		AvatarURL:   u.Profile.Image32,
+		Presence:    "away",
+		IsBot:       isBot,
+		IsExternal:  isExternal,
+	})
+	if r.send != nil {
+		r.send(ui.UserResolvedMsg{
+			TeamID:      r.teamID,
+			UserID:      userID,
 			DisplayName: name,
-			AvatarURL:   u.Profile.Image32,
-			Presence:    "away",
 			IsBot:       isBot,
-			IsExternal:  isExternal,
 		})
-		if r.send != nil {
-			r.send(ui.UserResolvedMsg{
-				TeamID:      r.teamID,
-				UserID:      userID,
-				DisplayName: name,
-				IsBot:       isBot,
-			})
+	}
+	if isExternal && r.send != nil {
+		r.send(ui.UserExternalMsg{UserID: userID, IsExternal: true})
+	}
+}
+
+// flush resolves everything queued since the window opened, as one
+// edge users/info batch. Anything the batch does not return falls
+// back to the per-user path: absence from the batch means "could not
+// resolve", and an errored batch resolves nothing at all.
+func (r *userResolver) flush() {
+	r.pendingMu.Lock()
+	ids := make([]string, 0, len(r.pending))
+	for id := range r.pending {
+		ids = append(ids, id)
+	}
+	clear(r.pending)
+	r.flushTimer = nil
+	r.pendingMu.Unlock()
+	if len(ids) == 0 {
+		return
+	}
+	// Re-check at flush time: boot may have marked the workspace
+	// degraded while the window was open.
+	if r.degraded != nil && r.degraded() {
+		for _, id := range ids {
+			go r.resolveOne(id)
 		}
-		if isExternal && r.send != nil {
-			r.send(ui.UserExternalMsg{UserID: userID, IsExternal: true})
+		return
+	}
+	updated := make(map[string]int64, len(ids))
+	for _, id := range ids {
+		// 0 is the conditional protocol's "never seen, send the full
+		// record" — the resolver only ever queues cache misses.
+		updated[id] = 0
+	}
+	users, err := r.batcher.UsersInfo(context.Background(), updated)
+	if err != nil {
+		debuglog.Cache("userResolver: edge users/info for %d users team=%s: %v (falling back to per-user users.info)", len(ids), r.teamID, err)
+		for _, id := range ids {
+			go r.resolveOne(id)
 		}
-	}()
+		return
+	}
+	returned := make(map[string]struct{}, len(users))
+	for _, u := range users {
+		returned[u.ID] = struct{}{}
+		r.applyEdgeUser(u)
+	}
+	for _, id := range ids {
+		if _, ok := returned[id]; !ok {
+			go r.resolveOne(id)
+		}
+	}
+}
+
+// applyEdgeUser records one user the edge batch returned: cache row
+// (created — these are misses), avatar preload, and the same
+// UserResolvedMsg/UserExternalMsg pair the per-user path emits, so
+// the UI cannot tell the two paths apart.
+func (r *userResolver) applyEdgeUser(u edge.User) {
+	defer r.inflight.Delete(u.ID)
+	name := u.Profile.DisplayName
+	if name == "" {
+		name = u.Profile.RealName
+	}
+	if name == "" {
+		name = u.Name
+	}
+	isExternal := u.TeamID != "" && u.TeamID != r.teamID
+	r.avatars.Preload(u.ID, u.Profile.ImageOriginal)
+	_ = r.db.UpsertUserFromEdge(r.teamID, cache.EdgeUserUpdate{
+		ID:          u.ID,
+		Name:        u.Name,
+		DisplayName: name,
+		AvatarURL:   u.Profile.ImageOriginal,
+		IsBot:       u.IsBot,
+		IsExternal:  isExternal,
+		Version:     u.Version,
+	})
+	if r.send != nil {
+		r.send(ui.UserResolvedMsg{
+			TeamID:      r.teamID,
+			UserID:      u.ID,
+			DisplayName: name,
+			IsBot:       u.IsBot,
+		})
+	}
+	if isExternal && r.send != nil {
+		r.send(ui.UserExternalMsg{UserID: u.ID, IsExternal: true})
+	}
 }
 
 // RequestBot enqueues a bots.info fetch for a bot author (bot_message has
@@ -2108,6 +2236,7 @@ func connectWorkspace(ctx context.Context, token slackclient.Token, db *cache.DB
 				p.Send(msg)
 			}
 		},
+		nil, nil, // batcher and degraded wired in Task 4
 	)
 
 	// Per-workspace channel-membership manager. *slackclient.Client

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -514,10 +514,16 @@ func (r *userResolver) flush() {
 // Nil means "resolve everything per-user": no edge client, a degraded
 // workspace, a failed call, or nothing worth sending.
 //
-// Note applyEdgeUser's inflight.Delete is a no-op for these ids —
-// they were never queued. A Request racing a ResolveNow for the same
-// id can produce one duplicate users.info; the upserts are idempotent
-// and the window is a cache miss wide, so no guard is taken.
+// Note applyEdgeUser's deferred inflight.Delete is NOT always a
+// no-op here: a Request(id) racing a ResolveNow for the same id can
+// claim the inflight slot after ResolveNow's batch returned but
+// before its applyEdgeUser runs, and the deferred Delete then drops
+// that claim. The duplicate work this enables is bounded: the Delete
+// runs after the cache upsert, so any Request arriving later bails
+// on the cache check; the realistic duplicate is a Request that
+// already queued a pending entry before the upsert landed, which
+// flush then re-fetches once. The upserts are idempotent, so no
+// guard is taken.
 func (r *userResolver) ResolveNow(ids []string) []edge.User {
 	if r == nil || r.batcher == nil || len(ids) == 0 {
 		return nil
@@ -2779,22 +2785,29 @@ func resolveDMNames(wctx *WorkspaceContext, db *cache.DB, avatarCache *avatar.Ca
 			if name == "" {
 				name = u.Name
 			}
-			// edge users/info carries no is_app_user: a Slack app's DM
-			// resolved here may bucket as "dm" rather than "app" until
-			// something else classifies it. No capture shows that
-			// field on this endpoint, so none is invented; the
-			// per-user fallback below classifies the ids edge missed.
-			if u.IsBot {
-				wctx.BotUserIDs[dm.UserID] = true
+			if name != "" {
+				// edge users/info carries no is_app_user: a Slack app's DM
+				// resolved here may bucket as "dm" rather than "app" until
+				// something else classifies it. No capture shows that
+				// field on this endpoint, so none is invented; the
+				// per-user fallback below classifies the ids edge missed.
+				if u.IsBot {
+					wctx.BotUserIDs[dm.UserID] = true
+				}
+				if send != nil {
+					send(ui.DMNameResolvedMsg{
+						ChannelID:   dm.ChannelID,
+						DisplayName: name,
+						IsBot:       u.IsBot,
+					})
+				}
+				continue
 			}
-			if name != "" && send != nil {
-				send(ui.DMNameResolvedMsg{
-					ChannelID:   dm.ChannelID,
-					DisplayName: name,
-					IsBot:       u.IsBot,
-				})
-			}
-			continue
+			// An edge record with all three name fields empty is no
+			// resolution at all — and applyEdgeUser has already
+			// upserted its empty-DisplayName row, which satisfies
+			// Request's cache-skip gate. Fall through to the per-user
+			// path, which re-fetches and repairs the row.
 		}
 		resolved, isBot := resolveUser(wctx.Client, dm.UserID, wctx.UserNames, db, avatarCache)
 		if isBot {

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -505,6 +505,46 @@ func (r *userResolver) flush() {
 	}
 }
 
+// ResolveNow resolves ids immediately through one edge users/info
+// batch and returns the records edge resolved. Unlike Request it
+// blocks the caller, so it is for background goroutines that need the
+// results — the unresolved-DM sweep maps them to channel ids and
+// cannot use the fire-and-forget queue. Ids edge does not resolve are
+// simply absent from the result; the caller falls back per-user.
+// Nil means "resolve everything per-user": no edge client, a degraded
+// workspace, a failed call, or nothing worth sending.
+//
+// Note applyEdgeUser's inflight.Delete is a no-op for these ids —
+// they were never queued. A Request racing a ResolveNow for the same
+// id can produce one duplicate users.info; the upserts are idempotent
+// and the window is a cache miss wide, so no guard is taken.
+func (r *userResolver) ResolveNow(ids []string) []edge.User {
+	if r == nil || r.batcher == nil || len(ids) == 0 {
+		return nil
+	}
+	if r.degraded != nil && r.degraded() {
+		return nil
+	}
+	updated := make(map[string]int64, len(ids))
+	for _, id := range ids {
+		if id != "" {
+			updated[id] = 0
+		}
+	}
+	if len(updated) == 0 {
+		return nil
+	}
+	users, err := r.batcher.UsersInfo(context.Background(), updated)
+	if err != nil {
+		debuglog.Cache("userResolver: ResolveNow edge users/info for %d users team=%s: %v (caller falls back per-user)", len(updated), r.teamID, err)
+		return nil
+	}
+	for _, u := range users {
+		r.applyEdgeUser(u)
+	}
+	return users
+}
+
 // applyEdgeUser records one user the edge batch returned: cache row
 // (created — these are misses), avatar preload, and the same
 // UserResolvedMsg/UserExternalMsg pair the per-user path emits, so
@@ -2023,21 +2063,11 @@ func run() error {
 
 			// Resolve unknown DM user names in background
 			if len(wctx.UnresolvedDMs) > 0 {
-				go func() {
-					for _, dm := range wctx.UnresolvedDMs {
-						resolved, isBot := resolveUser(wctx.Client, dm.UserID, wctx.UserNames, db, avatarCache)
-						if isBot {
-							wctx.BotUserIDs[dm.UserID] = true
-						}
-						if resolved != dm.UserID {
-							p.Send(ui.DMNameResolvedMsg{
-								ChannelID:   dm.ChannelID,
-								DisplayName: resolved,
-								IsBot:       isBot,
-							})
-						}
+				go resolveDMNames(wctx, db, avatarCache, func(msg tea.Msg) {
+					if p != nil {
+						p.Send(msg)
 					}
-				}()
+				})
 			}
 		}(ot.Token)
 	}
@@ -2719,6 +2749,65 @@ func resolveUser(client *slackclient.Client, userID string, userNames map[string
 		return name, isBot
 	}
 	return userID, false
+}
+
+// resolveDMNames resolves the display names of unresolved DM
+// counterparties, one edge users/info batch for the whole sweep, with
+// the per-user resolveUser loop as the fallback for ids edge did not
+// return. Batched because the sweep is the dominant cold-boot
+// users.info source: one synchronous GetUserProfile per unresolved DM,
+// measured at ~100 calls on a two-workspace cold boot and 282 in a
+// full Grid session. The mapping to channel ids is why this cannot go
+// through UserResolver.Request: DMNameResolvedMsg renames the sidebar
+// row and re-buckets app DMs, while UserResolvedMsg only patches
+// in-history names.
+func resolveDMNames(wctx *WorkspaceContext, db *cache.DB, avatarCache *avatar.Cache, send func(tea.Msg)) {
+	dmIDs := make([]string, 0, len(wctx.UnresolvedDMs))
+	for _, dm := range wctx.UnresolvedDMs {
+		dmIDs = append(dmIDs, dm.UserID)
+	}
+	byEdge := make(map[string]edge.User)
+	for _, u := range wctx.UserResolver.ResolveNow(dmIDs) {
+		byEdge[u.ID] = u
+	}
+	for _, dm := range wctx.UnresolvedDMs {
+		if u, ok := byEdge[dm.UserID]; ok {
+			name := u.Profile.DisplayName
+			if name == "" {
+				name = u.Profile.RealName
+			}
+			if name == "" {
+				name = u.Name
+			}
+			// edge users/info carries no is_app_user: a Slack app's DM
+			// resolved here may bucket as "dm" rather than "app" until
+			// something else classifies it. No capture shows that
+			// field on this endpoint, so none is invented; the
+			// per-user fallback below classifies the ids edge missed.
+			if u.IsBot {
+				wctx.BotUserIDs[dm.UserID] = true
+			}
+			if name != "" && send != nil {
+				send(ui.DMNameResolvedMsg{
+					ChannelID:   dm.ChannelID,
+					DisplayName: name,
+					IsBot:       u.IsBot,
+				})
+			}
+			continue
+		}
+		resolved, isBot := resolveUser(wctx.Client, dm.UserID, wctx.UserNames, db, avatarCache)
+		if isBot {
+			wctx.BotUserIDs[dm.UserID] = true
+		}
+		if resolved != dm.UserID && send != nil {
+			send(ui.DMNameResolvedMsg{
+				ChannelID:   dm.ChannelID,
+				DisplayName: resolved,
+				IsBot:       isBot,
+			})
+		}
+	}
 }
 
 // messageAuthor resolves the display identity for a fetched message.

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -108,6 +108,11 @@ type WorkspaceContext struct {
 	// conditional-revalidation and server-side-search endpoints. Nil
 	// only if construction failed, and every caller nil-checks.
 	Edge       *edge.Client
+	// EdgeHealth records whether edge resolution is working for this
+	// workspace this session. bootstrap marks it degraded on a
+	// wholesale failure; the user resolver reads it to skip batch
+	// attempts that would resolve nothing.
+	EdgeHealth *edge.Health
 	ConnMgr    *slackclient.ConnectionManager
 	RTMHandler *rtmEventHandler
 	UserNames  map[string]string
@@ -2178,6 +2183,7 @@ func connectWorkspace(ctx context.Context, token slackclient.Token, db *cache.DB
 		// BrowserTransport-carrying client, and a plain one differs
 		// only in what goes on the wire.
 		Edge:                 edge.New(token.AccessToken, client.TeamID(), client.HTTPClient()),
+		EdgeHealth:           edge.NewHealth(),
 		TeamID:               client.TeamID(),
 		TeamName:             token.TeamName,
 		UserID:               client.UserID(),
@@ -2242,7 +2248,7 @@ func connectWorkspace(ctx context.Context, token slackclient.Token, db *cache.DB
 				p.Send(msg)
 			}
 		},
-		nil, nil, // batcher and degraded wired in Task 4
+		wctx.Edge, wctx.EdgeHealth.Degraded,
 	)
 
 	// Per-workspace channel-membership manager. *slackclient.Client
@@ -2292,7 +2298,7 @@ func connectWorkspace(ctx context.Context, token slackclient.Token, db *cache.DB
 	// so no intermediate commit leaves slk unable to boot. Until then
 	// slk does both, and the request tally goes UP.
 	res, err := bootstrap.Run(ctx, newBootstrapDeps(client, db, token.AccessToken,
-		mostRecentlyVisitedChannel(wctx.LastVisitedByChannel)))
+		mostRecentlyVisitedChannel(wctx.LastVisitedByChannel), wctx.EdgeHealth))
 	if err != nil {
 		return nil, fmt.Errorf("bootstrapping %s: %w", token.TeamName, err)
 	}

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -495,6 +495,18 @@ func (r *userResolver) flush() {
 	}
 	returned := make(map[string]struct{}, len(users))
 	for _, u := range users {
+		name := u.Profile.DisplayName
+		if name == "" {
+			name = u.Profile.RealName
+		}
+		if name == "" {
+			name = u.Name
+		}
+		if name == "" {
+			// Unobserved, but an empty record would otherwise cache
+			// an empty name and blank a rendered one.
+			continue
+		}
 		returned[u.ID] = struct{}{}
 		r.applyEdgeUser(u)
 	}

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -288,11 +288,13 @@ type userBatcher interface {
 	UsersInfo(ctx context.Context, updatedIDs map[string]int64) ([]edge.User, error)
 }
 
-// userResolver dispatches users.info lookups for unknown message
-// authors in the background. Deduplicates concurrent requests for
-// the same userID; failures are silent (the row stays rendered as
-// its user ID). Bound to a single workspace because user IDs are
-// workspace-scoped.
+// userResolver resolves unknown message authors in the background.
+// Misses coalesce into batched edge users/info calls (see flush); ids
+// edge cannot resolve, a failed batch, and degraded workspaces fall
+// back to the per-user Web API users.info path (see resolveOne).
+// Deduplicates concurrent requests for the same userID; failures are
+// silent (the row stays rendered as its user ID). Bound to a single
+// workspace because user IDs are workspace-scoped.
 type userResolver struct {
 	teamID   string
 	client   *slackclient.Client
@@ -300,10 +302,14 @@ type userResolver struct {
 	avatars  *avatar.Cache
 	send     func(tea.Msg)
 	inflight sync.Map // userID -> struct{}
-	// sem bounds concurrent round trips. Buffered, so acquiring it
-	// happens inside the request goroutine and Request itself never
-	// blocks -- it is called from the render path and from WS event
-	// handlers, neither of which may wait on the network.
+	// sem bounds concurrent round trips on the per-user users.info
+	// path (resolveOne). Buffered, so acquiring it happens inside the
+	// request goroutine and Request itself never blocks -- it is
+	// called from the render path and from WS event handlers, neither
+	// of which may wait on the network. The batch path needs no
+	// semaphore: it is bounded by the window itself, at one edge
+	// users/info call per userResolverBatchWindow (plus that call's
+	// internal 80-id splitting, sequential within the call).
 	sem chan struct{}
 
 	batcher  userBatcher

--- a/cmd/slk/user_resolver_test.go
+++ b/cmd/slk/user_resolver_test.go
@@ -1,12 +1,20 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/gammons/slk/internal/slack/edge"
+	"github.com/gammons/slk/internal/ui"
 )
 
 // TestUserResolver_BoundsConcurrentRequests is the second half of the
@@ -45,7 +53,7 @@ func TestUserResolver_BoundsConcurrentRequests(t *testing.T) {
 	defer srv.Close()
 
 	db := newTestDB(t)
-	r := newUserResolver("T1", newTestClient(t, srv), db, nil, nil)
+	r := newUserResolver("T1", newTestClient(t, srv), db, nil, nil, nil, nil)
 
 	const requests = 60
 	for i := 0; i < requests; i++ {
@@ -77,7 +85,7 @@ func TestUserResolver_RequestDoesNotBlockTheCaller(t *testing.T) {
 	defer close(release)
 
 	db := newTestDB(t)
-	r := newUserResolver("T1", newTestClient(t, srv), db, nil, nil)
+	r := newUserResolver("T1", newTestClient(t, srv), db, nil, nil, nil, nil)
 
 	// Enough to fill the pool several times over. Every one of these
 	// must return immediately even though nothing can complete.
@@ -93,5 +101,201 @@ func TestUserResolver_RequestDoesNotBlockTheCaller(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("Request blocked its caller; it is called from the render path and from WS event handlers, neither of which may wait on a users.info round trip")
+	}
+}
+
+// fakeBatcher implements userBatcher and records each batch it was
+// asked for.
+type fakeBatcher struct {
+	mu   sync.Mutex
+	sent []map[string]int64
+	res  []edge.User
+	err  error
+}
+
+func (f *fakeBatcher) UsersInfo(_ context.Context, updatedIDs map[string]int64) ([]edge.User, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	cp := make(map[string]int64, len(updatedIDs))
+	for k, v := range updatedIDs {
+		cp[k] = v
+	}
+	f.sent = append(f.sent, cp)
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.res, nil
+}
+
+func (f *fakeBatcher) calls() []map[string]int64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]map[string]int64(nil), f.sent...)
+}
+
+// edgeUserRecord builds an edge.User, whose Profile is an anonymous
+// struct with no spellable type at a call site.
+func edgeUserRecord(id, name, display, real, teamID string, version int64, isBot bool) edge.User {
+	u := edge.User{ID: id, Name: name, Version: version, IsBot: isBot, TeamID: teamID}
+	u.Profile.DisplayName = display
+	u.Profile.RealName = real
+	return u
+}
+
+func TestUserResolver_BatchesMissesThroughEdge(t *testing.T) {
+	// Measured on the first working Grid session: 282 users.info
+	// calls, one per miss, with no coalescing. edge users/info takes
+	// 80 ids a request and returns full records inline — the same
+	// misses are ~4 requests.
+	db := newTestDB(t)
+	batcher := &fakeBatcher{res: []edge.User{
+		edgeUserRecord("U001", "alice", "Alice", "", "T1", 1783337599010, false),
+		edgeUserRecord("U002", "bob", "", "Bob Real", "T1", 1783337599011, false),
+	}}
+	var sentMu sync.Mutex
+	var sent []tea.Msg
+	r := newUserResolver("T1", nil, db, nil, func(m tea.Msg) {
+		sentMu.Lock()
+		sent = append(sent, m)
+		sentMu.Unlock()
+	}, batcher, nil)
+
+	r.Request("U001")
+	r.Request("U002")
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) && len(batcher.calls()) == 0 {
+		time.Sleep(10 * time.Millisecond)
+	}
+	calls := batcher.calls()
+	if len(calls) != 1 {
+		t.Fatalf("edge batches = %d; want 1 — misses inside the window coalesce (sent: %v)", len(calls), calls)
+	}
+	want := map[string]int64{"U001": 0, "U002": 0}
+	if !reflect.DeepEqual(calls[0], want) {
+		t.Errorf("batch = %v; want %v — 0 is the protocol's 'never seen, send the full record'", calls[0], want)
+	}
+
+	// Cached, so a second Request is a no-op.
+	vers, err := db.UserVersions("T1")
+	if err != nil {
+		t.Fatalf("UserVersions: %v", err)
+	}
+	for _, id := range []string{"U001", "U002"} {
+		if _, err := db.GetUser(id); err != nil {
+			t.Fatalf("%s was not cached from the edge batch: %v", id, err)
+		}
+		if vers[id] == 0 {
+			t.Errorf("%s cached with version 0; the batch returned one and conditional revalidation reads it", id)
+		}
+	}
+	// Display-name chain: display when set, real otherwise.
+	u1, _ := db.GetUser("U001")
+	if u1.DisplayName != "Alice" {
+		t.Errorf("U001 display = %q; want Alice", u1.DisplayName)
+	}
+	u2, _ := db.GetUser("U002")
+	if u2.DisplayName != "Bob Real" {
+		t.Errorf("U002 display = %q; want the real-name fallback", u2.DisplayName)
+	}
+	// One UserResolvedMsg per resolved user, same as the per-user path.
+	sentMu.Lock()
+	resolved := 0
+	for _, m := range sent {
+		if _, ok := m.(ui.UserResolvedMsg); ok {
+			resolved++
+		}
+	}
+	sentMu.Unlock()
+	if resolved != 2 {
+		t.Errorf("UserResolvedMsg count = %d; want 2 — the UI patches display names live from these", resolved)
+	}
+	// Dedup end-to-end: a repeat Request resolves nothing further.
+	r.Request("U001")
+	time.Sleep(userResolverBatchWindow + 300*time.Millisecond)
+	if n := len(batcher.calls()); n != 1 {
+		t.Errorf("a repeat Request produced batch %d; the cache check must make it a no-op", n)
+	}
+}
+
+func TestUserResolver_EdgeMissFallsBackToPerUser(t *testing.T) {
+	// ids edge does not return are resolved the old way — absence
+	// from the batch means "could not resolve", and a raw user id on
+	// screen is the failure this whole path exists to avoid.
+	db := newTestDB(t)
+	batcher := &fakeBatcher{res: []edge.User{
+		edgeUserRecord("U001", "alice", "Alice", "", "T1", 1, false),
+	}}
+	var profiles atomic.Int32
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		profiles.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"user":{"id":"U002","name":"bob","team_id":"T1","profile":{"display_name":"Bob"}}}`))
+	}))
+	defer srv.Close()
+
+	r := newUserResolver("T1", newTestClient(t, srv), db, nil, nil, batcher, nil)
+	r.Request("U001")
+	r.Request("U002")
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := db.GetUser("U002"); err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if _, err := db.GetUser("U002"); err != nil {
+		t.Fatal("U002 was absent from the edge batch and was never resolved per-user")
+	}
+	if got := profiles.Load(); got != 1 {
+		t.Errorf("per-user users.info calls = %d; want 1 — only the id edge missed", got)
+	}
+}
+
+func TestUserResolver_EdgeErrorFallsBackToPerUser(t *testing.T) {
+	db := newTestDB(t)
+	batcher := &fakeBatcher{err: errors.New("ratelimited")}
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"user":{"id":"U001","name":"alice","team_id":"T1","profile":{"display_name":"Alice"}}}`))
+	}))
+	defer srv.Close()
+
+	r := newUserResolver("T1", newTestClient(t, srv), db, nil, nil, batcher, nil)
+	r.Request("U001")
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := db.GetUser("U001"); err == nil {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("the edge call failed and the per-user fallback never ran")
+}
+
+func TestUserResolver_DegradedWorkspaceSkipsEdge(t *testing.T) {
+	// Once boot has marked a workspace's edge broken, the resolver
+	// must not spend even one call discovering it again.
+	db := newTestDB(t)
+	batcher := &fakeBatcher{res: []edge.User{
+		edgeUserRecord("U001", "alice", "Alice", "", "T1", 1, false),
+	}}
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"user":{"id":"U001","name":"alice","team_id":"T1","profile":{"display_name":"Alice"}}}`))
+	}))
+	defer srv.Close()
+
+	r := newUserResolver("T1", newTestClient(t, srv), db, nil, nil, batcher, func() bool { return true })
+	r.Request("U001")
+	time.Sleep(userResolverBatchWindow + 300*time.Millisecond)
+
+	if n := len(batcher.calls()); n != 0 {
+		t.Errorf("a degraded workspace made %d edge calls; want 0", n)
+	}
+	if _, err := db.GetUser("U001"); err != nil {
+		t.Error("U001 was not resolved per-user on the degraded path")
 	}
 }

--- a/cmd/slk/user_resolver_test.go
+++ b/cmd/slk/user_resolver_test.go
@@ -299,3 +299,137 @@ func TestUserResolver_DegradedWorkspaceSkipsEdge(t *testing.T) {
 		t.Error("U001 was not resolved per-user on the degraded path")
 	}
 }
+
+func TestUserResolver_ResolveNowBatchesAndApplies(t *testing.T) {
+	db := newTestDB(t)
+	batcher := &fakeBatcher{res: []edge.User{
+		edgeUserRecord("U001", "alice", "Alice", "", "T1", 1783337599010, false),
+		edgeUserRecord("U002", "bob", "", "Bob Real", "T1", 1783337599011, false),
+	}}
+	r := newUserResolver("T1", nil, db, nil, nil, batcher, nil)
+
+	got := r.ResolveNow([]string{"U001", "U002"})
+
+	if len(got) != 2 {
+		t.Fatalf("ResolveNow returned %d records; want 2", len(got))
+	}
+	calls := batcher.calls()
+	if len(calls) != 1 {
+		t.Fatalf("edge batches = %d; want 1", len(calls))
+	}
+	if want := map[string]int64{"U001": 0, "U002": 0}; !reflect.DeepEqual(calls[0], want) {
+		t.Errorf("batch = %v; want %v", calls[0], want)
+	}
+	// Applied: cache rows exist and carry versions, so the sweep's
+	// callers and conditional revalidation both read them.
+	for _, id := range []string{"U001", "U002"} {
+		if _, err := db.GetUser(id); err != nil {
+			t.Errorf("%s was not cached by ResolveNow: %v", id, err)
+		}
+	}
+	versions, err := db.UserVersions("T1")
+	if err != nil {
+		t.Fatalf("UserVersions: %v", err)
+	}
+	if versions["U001"] != 1783337599010 {
+		t.Errorf("U001 version = %d; want 1783337599010", versions["U001"])
+	}
+}
+
+func TestUserResolver_ResolveNowReturnsNilWhenDegraded(t *testing.T) {
+	db := newTestDB(t)
+	batcher := &fakeBatcher{}
+	r := newUserResolver("T1", nil, db, nil, nil, batcher, func() bool { return true })
+
+	if got := r.ResolveNow([]string{"U001"}); got != nil {
+		t.Errorf("a degraded workspace resolved %v through edge; want nil so the caller falls back per-user", got)
+	}
+	if n := len(batcher.calls()); n != 0 {
+		t.Errorf("a degraded workspace made %d edge calls; want 0", n)
+	}
+}
+
+func TestUserResolver_ResolveNowReturnsNilOnError(t *testing.T) {
+	db := newTestDB(t)
+	batcher := &fakeBatcher{err: errors.New("ratelimited")}
+	r := newUserResolver("T1", nil, db, nil, nil, batcher, nil)
+
+	if got := r.ResolveNow([]string{"U001"}); got != nil {
+		t.Errorf("a failed edge call returned %v; want nil", got)
+	}
+	if _, err := db.GetUser("U001"); err == nil {
+		t.Error("U001 was cached from a response the resolver rejected")
+	}
+}
+
+func TestUserResolver_ResolveNowSkipsEmptyInput(t *testing.T) {
+	db := newTestDB(t)
+	batcher := &fakeBatcher{}
+	r := newUserResolver("T1", nil, db, nil, nil, batcher, nil)
+
+	if got := r.ResolveNow(nil); got != nil {
+		t.Errorf("ResolveNow(nil) = %v; want nil", got)
+	}
+	if got := r.ResolveNow([]string{""}); got != nil {
+		t.Errorf("ResolveNow([\"\"]) = %v; want nil — an updated_ids map containing \"\" is a request shape nothing observed produces", got)
+	}
+	if n := len(batcher.calls()); n != 0 {
+		t.Errorf("empty input produced %d edge calls; want 0", n)
+	}
+}
+
+func TestResolveDMNames(t *testing.T) {
+	// The sweep maps resolutions to CHANNEL ids: DMNameResolvedMsg
+	// renames the sidebar row and re-buckets app DMs, which
+	// UserResolvedMsg (history patching) cannot do.
+	db := newTestDB(t)
+	batcher := &fakeBatcher{res: []edge.User{
+		edgeUserRecord("U_ALICE", "alice", "Alice A", "", "T1", 1, false),
+		edgeUserRecord("U_APP", "someapp", "Some App", "", "T1", 1, true),
+	}}
+	wctx := &WorkspaceContext{
+		TeamID:       "T1",
+		UserNames:    map[string]string{},
+		BotUserIDs:   map[string]bool{},
+		UserResolver: newUserResolver("T1", nil, db, nil, nil, batcher, nil),
+		UnresolvedDMs: []UnresolvedDM{
+			{ChannelID: "D_ALICE", UserID: "U_ALICE"},
+			{ChannelID: "D_APP", UserID: "U_APP"},
+		},
+	}
+	var mu sync.Mutex
+	var sent []tea.Msg
+	resolveDMNames(wctx, db, nil, func(m tea.Msg) {
+		mu.Lock()
+		sent = append(sent, m)
+		mu.Unlock()
+	})
+
+	mu.Lock()
+	defer mu.Unlock()
+	var alice, app *ui.DMNameResolvedMsg
+	for _, m := range sent {
+		if dm, ok := m.(ui.DMNameResolvedMsg); ok {
+			switch dm.ChannelID {
+			case "D_ALICE":
+				d := dm
+				alice = &d
+			case "D_APP":
+				d := dm
+				app = &d
+			}
+		}
+	}
+	if alice == nil || alice.DisplayName != "Alice A" {
+		t.Errorf("D_ALICE got %+v; want a DMNameResolvedMsg naming Alice A", alice)
+	}
+	if app == nil || app.DisplayName != "Some App" || !app.IsBot {
+		t.Errorf("D_APP got %+v; want a DMNameResolvedMsg naming Some App with IsBot true — that flag re-buckets the row into the Apps section", app)
+	}
+	if !wctx.BotUserIDs["U_APP"] {
+		t.Error("U_APP was not recorded in BotUserIDs")
+	}
+	if n := len(batcher.calls()); n != 1 {
+		t.Errorf("the sweep made %d edge calls; want 1 for any number of DMs", n)
+	}
+}

--- a/cmd/slk/user_resolver_test.go
+++ b/cmd/slk/user_resolver_test.go
@@ -144,9 +144,12 @@ func edgeUserRecord(id, name, display, real, teamID string, version int64, isBot
 
 func TestUserResolver_BatchesMissesThroughEdge(t *testing.T) {
 	// Measured on the first working Grid session: 282 users.info
-	// calls, one per miss, with no coalescing. edge users/info takes
-	// 80 ids a request and returns full records inline — the same
-	// misses are ~4 requests.
+	// calls on a cold boot. Task 5's A/B later refined the
+	// attribution: the Request queue coalesces the render/WS-path
+	// misses this test pins, while the unresolved-DM sweep was the
+	// dominant cold-boot source (batched separately, through
+	// ResolveNow). edge users/info takes 80 ids a request and
+	// returns full records inline — the same misses are ~4 requests.
 	db := newTestDB(t)
 	batcher := &fakeBatcher{res: []edge.User{
 		edgeUserRecord("U001", "alice", "Alice", "", "T1", 1783337599010, false),
@@ -250,6 +253,61 @@ func TestUserResolver_EdgeMissFallsBackToPerUser(t *testing.T) {
 	}
 	if got := profiles.Load(); got != 1 {
 		t.Errorf("per-user users.info calls = %d; want 1 — only the id edge missed", got)
+	}
+}
+
+func TestUserResolver_EmptyNameEdgeRecordFallsBackToPerUser(t *testing.T) {
+	// Unobserved in captures, but symmetric to the sweep's guard: an
+	// edge record with all three name fields empty must not be
+	// cached (its empty DisplayName would satisfy Request's
+	// cache-skip gate permanently) nor emitted (an empty
+	// UserResolvedMsg would blank a rendered in-history name).
+	db := newTestDB(t)
+	batcher := &fakeBatcher{res: []edge.User{
+		edgeUserRecord("U001", "", "", "", "T1", 1, false),
+		edgeUserRecord("U002", "bob", "Bob", "", "T1", 1, false),
+	}}
+	var profiles atomic.Int32
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		profiles.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"user":{"id":"U001","name":"alice","team_id":"T1","profile":{"display_name":"Alice"}}}`))
+	}))
+	defer srv.Close()
+
+	var sentMu sync.Mutex
+	var sent []tea.Msg
+	r := newUserResolver("T1", newTestClient(t, srv), db, nil, func(m tea.Msg) {
+		sentMu.Lock()
+		sent = append(sent, m)
+		sentMu.Unlock()
+	}, batcher, nil)
+	r.Request("U001")
+	r.Request("U002")
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if u, err := db.GetUser("U001"); err == nil && u.DisplayName == "Alice" {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	u1, err := db.GetUser("U001")
+	if err != nil || u1.DisplayName != "Alice" {
+		t.Fatalf("U001 cached as %+v (err=%v); want the per-user fallback's Alice — the empty edge record must be treated as a miss", u1, err)
+	}
+	if got := profiles.Load(); got != 1 {
+		t.Errorf("per-user users.info calls = %d; want 1 — only the empty-name id", got)
+	}
+	if u2, err := db.GetUser("U002"); err != nil || u2.DisplayName != "Bob" {
+		t.Errorf("U002 cached as %+v (err=%v); the good record in the same batch must still apply", u2, err)
+	}
+	sentMu.Lock()
+	defer sentMu.Unlock()
+	for _, m := range sent {
+		if msg, ok := m.(ui.UserResolvedMsg); ok && msg.DisplayName == "" {
+			t.Errorf("an empty-name UserResolvedMsg was sent for %s; that blanks a rendered in-history name", msg.UserID)
+		}
 	}
 }
 

--- a/docs/superpowers/plans/2026-08-05-edge-health-and-batched-resolver.md
+++ b/docs/superpowers/plans/2026-08-05-edge-health-and-batched-resolver.md
@@ -965,7 +965,322 @@ git commit -m "feat(slk): wire edge health from bootstrap through to the user re
 
 ---
 
-### Task 5: live verification (cold-cache A/B)
+### Task 6: batch the unresolved-DM sweep (added after Task 5's measurement)
+
+**Files:**
+- Modify: `cmd/slk/main.go` (userResolver.ResolveNow; extract the DM sweep into a testable resolveDMNames)
+- Test: `cmd/slk/user_resolver_test.go`
+
+**Why this task exists (the measurement that falsified Task 3's
+assumption):** Task 5's cold-boot A/B showed the batcher absorbing
+almost nothing — 116 users.info with it vs 99 without. Reading the
+code showed why: the dominant cold-boot users.info source is not
+`UserResolver.Request` at all. The unresolved-DM sweep
+(cmd/slk/main.go, the `if len(wctx.UnresolvedDMs) > 0` block in
+connectWorkspace) loops every DM whose counterparty the cache does not
+know and calls `resolveUser`, which issues one synchronous
+`GetUserProfile` per DM. The sweep also cannot simply call `Request`:
+it needs results mapped to channel ids — `DMNameResolvedMsg` renames
+sidebar DM rows and re-buckets app DMs (internal/ui/reducer_workspace.go:92),
+while `UserResolvedMsg` only patches in-history names
+(reducer_workspace.go:107).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `cmd/slk/user_resolver_test.go` (the fakeBatcher and
+edgeUserRecord helpers from Task 3 are reused):
+
+```go
+func TestUserResolver_ResolveNowBatchesAndApplies(t *testing.T) {
+	db := newTestDB(t)
+	batcher := &fakeBatcher{res: []edge.User{
+		edgeUserRecord("U001", "alice", "Alice", "", "T1", 1783337599010, false),
+		edgeUserRecord("U002", "bob", "", "Bob Real", "T1", 1783337599011, false),
+	}}
+	r := newUserResolver("T1", nil, db, nil, nil, batcher, nil)
+
+	got := r.ResolveNow([]string{"U001", "U002"})
+
+	if len(got) != 2 {
+		t.Fatalf("ResolveNow returned %d records; want 2", len(got))
+	}
+	calls := batcher.calls()
+	if len(calls) != 1 {
+		t.Fatalf("edge batches = %d; want 1", len(calls))
+	}
+	if want := map[string]int64{"U001": 0, "U002": 0}; !reflect.DeepEqual(calls[0], want) {
+		t.Errorf("batch = %v; want %v", calls[0], want)
+	}
+	// Applied: cache rows exist and carry versions, so the sweep's
+	// callers and conditional revalidation both read them.
+	for _, id := range []string{"U001", "U002"} {
+		if _, err := db.GetUser(id); err != nil {
+			t.Errorf("%s was not cached by ResolveNow: %v", id, err)
+		}
+	}
+	versions, err := db.UserVersions("T1")
+	if err != nil {
+		t.Fatalf("UserVersions: %v", err)
+	}
+	if versions["U001"] != 1783337599010 {
+		t.Errorf("U001 version = %d; want 1783337599010", versions["U001"])
+	}
+}
+
+func TestUserResolver_ResolveNowReturnsNilWhenDegraded(t *testing.T) {
+	db := newTestDB(t)
+	batcher := &fakeBatcher{}
+	r := newUserResolver("T1", nil, db, nil, nil, batcher, func() bool { return true })
+
+	if got := r.ResolveNow([]string{"U001"}); got != nil {
+		t.Errorf("a degraded workspace resolved %v through edge; want nil so the caller falls back per-user", got)
+	}
+	if n := len(batcher.calls()); n != 0 {
+		t.Errorf("a degraded workspace made %d edge calls; want 0", n)
+	}
+}
+
+func TestUserResolver_ResolveNowReturnsNilOnError(t *testing.T) {
+	db := newTestDB(t)
+	batcher := &fakeBatcher{err: errors.New("ratelimited")}
+	r := newUserResolver("T1", nil, db, nil, nil, batcher, nil)
+
+	if got := r.ResolveNow([]string{"U001"}); got != nil {
+		t.Errorf("a failed edge call returned %v; want nil", got)
+	}
+	if _, err := db.GetUser("U001"); err == nil {
+		t.Error("U001 was cached from a response the resolver rejected")
+	}
+}
+
+func TestUserResolver_ResolveNowSkipsEmptyInput(t *testing.T) {
+	db := newTestDB(t)
+	batcher := &fakeBatcher{}
+	r := newUserResolver("T1", nil, db, nil, nil, batcher, nil)
+
+	if got := r.ResolveNow(nil); got != nil {
+		t.Errorf("ResolveNow(nil) = %v; want nil", got)
+	}
+	if got := r.ResolveNow([]string{""}); got != nil {
+		t.Errorf("ResolveNow([\"\"]) = %v; want nil — an updated_ids map containing \"\" is a request shape nothing observed produces", got)
+	}
+	if n := len(batcher.calls()); n != 0 {
+		t.Errorf("empty input produced %d edge calls; want 0", n)
+	}
+}
+
+func TestResolveDMNames(t *testing.T) {
+	// The sweep maps resolutions to CHANNEL ids: DMNameResolvedMsg
+	// renames the sidebar row and re-buckets app DMs, which
+	// UserResolvedMsg (history patching) cannot do.
+	db := newTestDB(t)
+	batcher := &fakeBatcher{res: []edge.User{
+		edgeUserRecord("U_ALICE", "alice", "Alice A", "", "T1", 1, false),
+		edgeUserRecord("U_APP", "someapp", "Some App", "", "T1", 1, true),
+	}}
+	wctx := &WorkspaceContext{
+		TeamID:        "T1",
+		UserNames:     map[string]string{},
+		BotUserIDs:    map[string]bool{},
+		UserResolver:  newUserResolver("T1", nil, db, nil, nil, batcher, nil),
+		UnresolvedDMs: []UnresolvedDM{
+			{ChannelID: "D_ALICE", UserID: "U_ALICE"},
+			{ChannelID: "D_APP", UserID: "U_APP"},
+		},
+	}
+	var mu sync.Mutex
+	var sent []tea.Msg
+	resolveDMNames(wctx, db, nil, func(m tea.Msg) {
+		mu.Lock()
+		sent = append(sent, m)
+		mu.Unlock()
+	})
+
+	mu.Lock()
+	defer mu.Unlock()
+	var alice, app *ui.DMNameResolvedMsg
+	for _, m := range sent {
+		if dm, ok := m.(ui.DMNameResolvedMsg); ok {
+			switch dm.ChannelID {
+			case "D_ALICE":
+				d := dm
+				alice = &d
+			case "D_APP":
+				d := dm
+				app = &d
+			}
+		}
+	}
+	if alice == nil || alice.DisplayName != "Alice A" {
+		t.Errorf("D_ALICE got %+v; want a DMNameResolvedMsg naming Alice A", alice)
+	}
+	if app == nil || app.DisplayName != "Some App" || !app.IsBot {
+		t.Errorf("D_APP got %+v; want a DMNameResolvedMsg naming Some App with IsBot true — that flag re-buckets the row into the Apps section", app)
+	}
+	if !wctx.BotUserIDs["U_APP"] {
+		t.Error("U_APP was not recorded in BotUserIDs")
+	}
+	if n := len(batcher.calls()); n != 1 {
+		t.Errorf("the sweep made %d edge calls; want 1 for any number of DMs", n)
+	}
+}
+```
+
+Check the `UnresolvedDM` struct's field names before writing the test
+(`rg -n 'type UnresolvedDM' cmd/slk/main.go`) — adjust the literal if
+they differ.
+
+Run: `go test ./cmd/slk/ -run 'TestUserResolver_ResolveNow|TestResolveDMNames' 2>&1 | tail -3`
+Expected: build failure — ResolveNow/resolveDMNames undefined.
+
+- [ ] **Step 2: Implement ResolveNow**
+
+In `cmd/slk/main.go`, after `flush`:
+
+```go
+// ResolveNow resolves ids immediately through one edge users/info
+// batch and returns the records edge resolved. Unlike Request it
+// blocks the caller, so it is for background goroutines that need the
+// results — the unresolved-DM sweep maps them to channel ids and
+// cannot use the fire-and-forget queue. Ids edge does not resolve are
+// simply absent from the result; the caller falls back per-user.
+// Nil means "resolve everything per-user": no edge client, a degraded
+// workspace, a failed call, or nothing worth sending.
+//
+// Note applyEdgeUser's inflight.Delete is a no-op for these ids —
+// they were never queued. A Request racing a ResolveNow for the same
+// id can produce one duplicate users.info; the upserts are idempotent
+// and the window is a cache miss wide, so no guard is taken.
+func (r *userResolver) ResolveNow(ids []string) []edge.User {
+	if r == nil || r.batcher == nil || len(ids) == 0 {
+		return nil
+	}
+	if r.degraded != nil && r.degraded() {
+		return nil
+	}
+	updated := make(map[string]int64, len(ids))
+	for _, id := range ids {
+		if id != "" {
+			updated[id] = 0
+		}
+	}
+	if len(updated) == 0 {
+		return nil
+	}
+	users, err := r.batcher.UsersInfo(context.Background(), updated)
+	if err != nil {
+		debuglog.Cache("userResolver: ResolveNow edge users/info for %d users team=%s: %v (caller falls back per-user)", len(updated), r.teamID, err)
+		return nil
+	}
+	for _, u := range users {
+		r.applyEdgeUser(u)
+	}
+	return users
+}
+```
+
+- [ ] **Step 3: Extract resolveDMNames and batch the sweep**
+
+Replace the `// Resolve unknown DM user names in background` block in
+connectWorkspace (the `if len(wctx.UnresolvedDMs) > 0 { go func() {...}() }`
+statement) with:
+
+```go
+		// Resolve unknown DM user names in background
+		if len(wctx.UnresolvedDMs) > 0 {
+			go resolveDMNames(wctx, db, avatarCache, func(msg tea.Msg) {
+				if p != nil {
+					p.Send(msg)
+				}
+			})
+		}
+```
+
+and add the function (near resolveUser):
+
+```go
+// resolveDMNames resolves the display names of unresolved DM
+// counterparties, one edge users/info batch for the whole sweep, with
+// the per-user resolveUser loop as the fallback for ids edge did not
+// return. Batched because the sweep is the dominant cold-boot
+// users.info source: one synchronous GetUserProfile per unresolved DM,
+// measured at ~100 calls on a two-workspace cold boot and 282 in a
+// full Grid session. The mapping to channel ids is why this cannot go
+// through UserResolver.Request: DMNameResolvedMsg renames the sidebar
+// row and re-buckets app DMs, while UserResolvedMsg only patches
+// in-history names.
+func resolveDMNames(wctx *WorkspaceContext, db *cache.DB, avatarCache *avatar.Cache, send func(tea.Msg)) {
+	dmIDs := make([]string, 0, len(wctx.UnresolvedDMs))
+	for _, dm := range wctx.UnresolvedDMs {
+		dmIDs = append(dmIDs, dm.UserID)
+	}
+	byEdge := make(map[string]edge.User)
+	for _, u := range wctx.UserResolver.ResolveNow(dmIDs) {
+		byEdge[u.ID] = u
+	}
+	for _, dm := range wctx.UnresolvedDMs {
+		if u, ok := byEdge[dm.UserID]; ok {
+			name := u.Profile.DisplayName
+			if name == "" {
+				name = u.Profile.RealName
+			}
+			if name == "" {
+				name = u.Name
+			}
+			// edge users/info carries no is_app_user: a Slack app's DM
+			// resolved here may bucket as "dm" rather than "app" until
+			// something else classifies it. No capture shows that
+			// field on this endpoint, so none is invented; the
+			// per-user fallback below classifies the ids edge missed.
+			if u.IsBot {
+				wctx.BotUserIDs[dm.UserID] = true
+			}
+			if name != "" && send != nil {
+				send(ui.DMNameResolvedMsg{
+					ChannelID:   dm.ChannelID,
+					DisplayName: name,
+					IsBot:       u.IsBot,
+				})
+			}
+			continue
+		}
+		resolved, isBot := resolveUser(wctx.Client, dm.UserID, wctx.UserNames, db, avatarCache)
+		if isBot {
+			wctx.BotUserIDs[dm.UserID] = true
+		}
+		if resolved != dm.UserID && send != nil {
+			send(ui.DMNameResolvedMsg{
+				ChannelID:   dm.ChannelID,
+				DisplayName: resolved,
+				IsBot:       isBot,
+			})
+		}
+	}
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `go test -count=1 ./cmd/slk/ -run 'TestUserResolver|TestResolveDMNames' 2>&1 | tail -3`
+Expected: PASS. Then `go build ./... && go vet ./... && go test -count=1 ./... 2>&1 | grep -v '^ok\|no test files' | head -5` — no output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/slk/
+git commit -m "feat(slk): batch the unresolved-DM sweep through edge users/info
+
+The sweep — one synchronous GetUserProfile per unresolved DM — is the
+dominant cold-boot users.info source, measured at ~100 calls on a
+two-workspace boot and 282 in a full Grid session. Task 5's A/B
+showed the Request queue absorbing almost none of it. The sweep now
+resolves its whole counterparty list in one edge users/info call via
+ResolveNow and falls back per-user only for ids edge did not return."
+```
+
+---
+
+### Task 7: live verification (cold-cache A/B)
 
 **Files:** none modified; produces the merge-gate evidence.
 
@@ -981,15 +1296,24 @@ mkdir -p $COLDXDG/slk
 cp -r ~/.local/share/slk/tokens $COLDXDG/slk/
 ```
 
-- [ ] **Step 2: Cold boot with the new binary**
+- [ ] **Step 2: Cold boot with the new binary (and a main-built baseline)**
+
+Build the baseline from `main` first (`git archive main | tar -x -C <dir>`, build there) so the comparison is exact. Run both cold, in either order:
 
 ```bash
 cd /tmp/opencode/slk-repro
-XDG_DATA_HOME=$COLDXDG SLK_DEBUG=1 script -qec 'timeout -s INT 25 /tmp/slk-batched' /dev/null >/dev/null 2>&1
-grep -A25 'shutdown API request tally' slk-debug.log
+XDG_DATA_HOME=$COLDXDG SLK_DEBUG=1 script -qec 'timeout -s INT 25 /tmp/slk-mainline' /dev/null >/dev/null 2>&1
+mv slk-debug.log cold-main.log
+# fresh temp XDG with the same tokens for the new binary
+XDG_DATA_HOME=$COLDXDG2 SLK_DEBUG=1 script -qec 'timeout -s INT 25 /tmp/slk-batched' /dev/null >/dev/null 2>&1
+mv slk-debug.log cold-batched.log
 ```
 
-Expected: `edge:users/info` appears (a small number — 1-2 per workspace needing resolution), and `users.info` is dramatically lower than a cold boot used to produce (the handoff measured ~200; healthy warm-ish caches may show few misses at all — in that case note it and rely on Step 3).
+Expected after Task 6: the batched binary's `users.info` count is near
+zero (only ids edge genuinely cannot resolve), `edge:users/info` is a
+small number (boot revalidation plus one batch per workspace needing
+resolution), and the total drops correspondingly against the main
+baseline.
 
 - [ ] **Step 3: Warm boot regression check**
 

--- a/docs/superpowers/plans/2026-08-05-edge-health-and-batched-resolver.md
+++ b/docs/superpowers/plans/2026-08-05-edge-health-and-batched-resolver.md
@@ -1,0 +1,1014 @@
+# Edge Health + Batched User Resolution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop paying full price for broken edge resolution on Grid (23 wasted `edge:channels/info` per boot) and coalesce per-miss `users.info` fan-out (measured 282 in one Grid session) into batched `edge.UsersInfo` calls — per `docs/superpowers/specs/2026-08-05-edge-health-and-batched-resolver-design.md`.
+
+**Architecture:** A session-scoped `edge.Health` tracker per workspace; bootstrap marks it degraded when the largest context-team group fails wholesale (≥50% of ids) and aborts the remaining groups. `userResolver` queues misses for 200ms and flushes them as one `edge.UsersInfo` batch, falling back to today's per-user path for anything edge doesn't return, on edge error, or when the workspace is degraded.
+
+**Tech Stack:** Go, stdlib. New cache upsert method (SQLite).
+
+**Landmine the plan is designed around (verified by reading the code):**
+`cache.UpdateUserFromEdge` (internal/cache/edge_sync.go:207) is UPDATE-only — it writes nothing for a row that does not exist. Bootstrap gets away with it because `hydrateFirstSight` inserts placeholder rows first. The resolver's misses are by definition rows that do NOT exist, so the resolver's edge path must use a NEW upsert method (`UpsertUserFromEdge`, Task 3), never `UpdateUserFromEdge`.
+
+**Fixture facts:**
+- `cannedBootResult` teams: C_GENERAL+D_ALICE are T_HOME, C_PRIVATE+D_BOB are T_OTHER, 2 ids each — equal sizes, so the new size-descending/alpha-tiebreak order keeps T_HOME first and existing tests are unaffected.
+- The bootstrap fake already supports per-team error injection (`channelsInfoErrFor`) and filters canned `FailedIDs` to the asked ids.
+- Existing resolver tests (cmd/slk/user_resolver_test.go) construct with `newUserResolver("T1", newTestClient(t, srv), db, nil, nil)` — they get two new nil params and must behave identically (nil batcher → per-user path).
+- `avatar.Cache.Preload(userID, "")` is safe on a nil cache; a non-empty URL with a nil cache is not. Tests pass empty avatar URLs or a real cache, matching the existing convention.
+
+---
+
+### Task 1: edge.Health
+
+**Files:**
+- Create: `internal/slack/edge/health.go`
+- Test: `internal/slack/edge/health_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package edge
+
+import "testing"
+
+func TestHealth(t *testing.T) {
+	h := NewHealth()
+	if h.Degraded() {
+		t.Error("a new Health is degraded; degradation must be earned by an observed wholesale failure")
+	}
+	h.MarkDegraded()
+	h.MarkDegraded() // idempotent
+	if !h.Degraded() {
+		t.Error("MarkDegraded did not stick")
+	}
+}
+```
+
+- [ ] **Step 2: Run it, watch it fail to build**
+
+Run: `go test ./internal/slack/edge/ -run TestHealth 2>&1 | tail -2`
+Expected: undefined NewHealth.
+
+- [ ] **Step 3: Implement**
+
+```go
+package edge
+
+import "sync/atomic"
+
+// Health records whether edge resolution is working for one workspace
+// this session. Two states — unknown and degraded — and deliberately
+// nothing else: it exists so that a workspace where edge resolution
+// fails wholesale (Enterprise Grid today: the enterprise-id group
+// resolves nothing, the foreign teams are Unauthenticated) pays for
+// that discovery once per boot instead of once per call site.
+//
+// Session-scoped by construction. Persisting pessimism would risk
+// suppressing the real Grid-scoping fix when it lands, and a cold
+// boot re-discovers degradation for the cost of a handful of calls.
+type Health struct {
+	degraded atomic.Bool
+}
+
+// NewHealth returns a Health in the unknown (not degraded) state.
+func NewHealth() *Health { return &Health{} }
+
+// MarkDegraded latches the degraded state. Idempotent; there is no
+// path back within a session.
+func (h *Health) MarkDegraded() { h.degraded.Store(true) }
+
+// Degraded reports whether edge resolution has failed wholesale this
+// session. Nil-safe: a nil *Health reads as not degraded, so callers
+// wired optionally need no guard.
+func (h *Health) Degraded() bool { return h != nil && h.degraded.Load() }
+```
+
+- [ ] **Step 4: Run the package tests**
+
+Run: `go test -count=1 ./internal/slack/edge/ 2>&1 | tail -2`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/slack/edge/health.go internal/slack/edge/health_test.go
+git commit -m "feat(edge): session-scoped per-workspace health signal"
+```
+
+---
+
+### Task 2: bootstrap — mark degraded on wholesale failure, abort remaining groups
+
+**Files:**
+- Modify: `internal/bootstrap/bootstrap.go` (Deps gains Health)
+- Modify: `internal/bootstrap/revalidate.go` (ordering + wholesale check + abort; revalidateChannelTeam returns an outcome)
+- Test: `internal/bootstrap/revalidate_test.go`
+
+- [ ] **Step 1: Deps.Health**
+
+In `internal/bootstrap/bootstrap.go`, add to the Deps struct after `Revalidate Revalidator`:
+
+```go
+	// Health, when non-nil, is marked degraded when the largest
+	// context-team group fails wholesale (every non-IM id unresolved)
+	// and holds at least half of all revalidated ids; the remaining
+	// groups are then aborted. Nil disables the check. See
+	// revalidateChannels for the reasoning.
+	Health *edge.Health
+```
+
+Run: `go build ./internal/bootstrap/`
+Expected: builds (the field is inert until Step 4).
+
+- [ ] **Step 2: Write the failing tests**
+
+Add to `internal/bootstrap/revalidate_test.go`:
+
+```go
+// --- edge health ------------------------------------------------------
+
+// bigTeamFixture builds a boot whose conversations partition into one
+// 6-id T_BIG group and one 2-id T_SMALL group, all channels (no IMs
+// unless added by the test). 6 of 8 ids is over the majority
+// threshold; T_BIG sorts first by size.
+func bigTeamFixture(f *fakeDeps) {
+	f.bootRes.Channels = []boot.Channel{
+		{ID: "C_BIG1", Name: "big1", ContextTeamID: "T_BIG"},
+		{ID: "C_BIG2", Name: "big2", ContextTeamID: "T_BIG"},
+		{ID: "C_BIG3", Name: "big3", ContextTeamID: "T_BIG"},
+		{ID: "C_BIG4", Name: "big4", ContextTeamID: "T_BIG"},
+		{ID: "C_BIG5", Name: "big5", ContextTeamID: "T_BIG"},
+		{ID: "C_BIG6", Name: "big6", ContextTeamID: "T_BIG"},
+		{ID: "C_SMALL1", Name: "small1", ContextTeamID: "T_SMALL"},
+		{ID: "C_SMALL2", Name: "small2", ContextTeamID: "T_SMALL"},
+	}
+	f.bootRes.IMs = nil
+}
+
+func TestRevalidate_WholesaleFailureMarksDegradedAndAborts(t *testing.T) {
+	// Measured on the first working Grid session (2026-08-05): one
+	// enterprise-id group holding 79% of the user's conversations
+	// resolved none of them, and the 16 foreign-team groups behind it
+	// were all Unauthenticated — 23 wasted edge calls per boot. The
+	// largest group failing wholesale IS the diagnosis; the rest of
+	// the partition is not worth spending requests on.
+	f := openedFake()
+	bigTeamFixture(f)
+	f.deps.Health = edge.NewHealth()
+	f.channelsInfoRes.FailedIDs = []string{"C_BIG1", "C_BIG2", "C_BIG3", "C_BIG4", "C_BIG5", "C_BIG6"}
+	// The canned response's Channels/queried sets name fixture ids
+	// this boot does not have, so filterChannelsInfo reduces them to
+	// nothing for these ids — only the failed ids apply.
+
+	if _, err := Run(context.Background(), f.Deps()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !f.deps.Health.Degraded() {
+		t.Error("the majority group failed wholesale and edge was not marked degraded; the resolver will keep spending edge calls on a workspace where they resolve nothing")
+	}
+	if len(f.channelsInfoCalls) != 1 {
+		t.Errorf("channels/info calls = %d; want 1 — after a wholesale failure of the majority group the remaining teams are aborted (calls: %+v)", len(f.channelsInfoCalls), f.channelsInfoCalls)
+	}
+	if f.channelsInfoCalls[0].team != "T_BIG" {
+		t.Errorf("first call went to %q; want T_BIG — groups are processed largest-first so the diagnosis comes before the spend", f.channelsInfoCalls[0].team)
+	}
+	if !f.loggedMatching("degraded") {
+		t.Errorf("a wholesale edge failure must say what it decided (logged: %v)", f.logged())
+	}
+}
+
+func TestRevalidate_CallErrorOfTheMajorityGroupAlsoMarksDegraded(t *testing.T) {
+	// The other wholesale shape: not failed_ids but an error —
+	// ratelimited, or Grid's Unauthenticated.
+	f := openedFake()
+	bigTeamFixture(f)
+	f.deps.Health = edge.NewHealth()
+	f.channelsInfoErrFor = map[string]error{"T_BIG": errors.New("Unauthenticated")}
+
+	if _, err := Run(context.Background(), f.Deps()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !f.deps.Health.Degraded() {
+		t.Error("an errored majority group did not mark edge degraded")
+	}
+	if len(f.channelsInfoCalls) != 1 {
+		t.Errorf("channels/info calls = %d; want 1", len(f.channelsInfoCalls))
+	}
+}
+
+func TestRevalidate_IMOnlyFailureDoesNotMarkDegraded(t *testing.T) {
+	// IMs ALWAYS land in failed_ids — 22 of 22 across the captures,
+	// on healthy workspaces. A group whose only failures are IMs is
+	// the normal case, and marking it degraded would disable edge
+	// batching everywhere.
+	f := openedFake()
+	f.bootRes.Channels = nil
+	f.bootRes.IMs = []boot.IM{
+		{ID: "D_A", UserID: "U_ALICE", IsIM: true, IsOpen: true, ContextTeamID: "T_HOME"},
+		{ID: "D_B", UserID: "U_BOB", IsIM: true, IsOpen: true, ContextTeamID: "T_HOME"},
+	}
+	f.deps.Health = edge.NewHealth()
+	f.channelsInfoRes.FailedIDs = []string{"D_A", "D_B"}
+
+	if _, err := Run(context.Background(), f.Deps()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if f.deps.Health.Degraded() {
+		t.Error("IM-only failures marked edge degraded; IMs land in failed_ids on every healthy workspace")
+	}
+}
+
+func TestRevalidate_HealthyRunDoesNotMarkDegraded(t *testing.T) {
+	f := openedFake()
+	f.deps.Health = edge.NewHealth()
+
+	if _, err := Run(context.Background(), f.Deps()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if f.deps.Health.Degraded() {
+		t.Error("a healthy revalidation marked edge degraded")
+	}
+}
+
+func TestRevalidate_MinorityWholesaleFailureDoesNotAbort(t *testing.T) {
+	// The threshold is the majority: a failing group that holds less
+	// than half the ids is one team's problem, not a broken edge.
+	// Here T_BIG holds 3 of 7 — wholesale-failed, but a minority —
+	// so all three teams are still called and nothing is marked.
+	f := openedFake()
+	f.bootRes.Channels = []boot.Channel{
+		{ID: "C_BIG1", Name: "big1", ContextTeamID: "T_BIG"},
+		{ID: "C_BIG2", Name: "big2", ContextTeamID: "T_BIG"},
+		{ID: "C_BIG3", Name: "big3", ContextTeamID: "T_BIG"},
+		{ID: "C_MID1", Name: "mid1", ContextTeamID: "T_MID"},
+		{ID: "C_MID2", Name: "mid2", ContextTeamID: "T_MID"},
+		{ID: "C_SMALL1", Name: "small1", ContextTeamID: "T_SMALL"},
+		{ID: "C_SMALL2", Name: "small2", ContextTeamID: "T_SMALL"},
+	}
+	f.bootRes.IMs = nil
+	f.deps.Health = edge.NewHealth()
+	f.channelsInfoErrFor = map[string]error{"T_BIG": errors.New("ratelimited")}
+
+	if _, err := Run(context.Background(), f.Deps()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if f.deps.Health.Degraded() {
+		t.Error("a minority group's failure marked edge degraded; the threshold is the majority of ids")
+	}
+	if len(f.channelsInfoCalls) != 3 {
+		t.Errorf("channels/info calls = %d; want 3 — a minority failure aborts nothing", len(f.channelsInfoCalls))
+	}
+}
+```
+
+Run: `go test ./internal/bootstrap/ -run 'TestRevalidate_Wholesale|TestRevalidate_CallError|TestRevalidate_IMOnly|TestRevalidate_HealthyRun|TestRevalidate_Minority' 2>&1 | tail -6`
+Expected: FAIL — Degraded is never set, calls are never aborted (4 of 5 fail); `TestRevalidate_HealthyRunDoesNotMarkDegraded` and possibly `TestRevalidate_IMOnlyFailureDoesNotMarkDegraded` may pass already (nothing marks anything yet). If a PRE-EXISTING test fails, the fixture helpers are wrong — fix them, not the old tests.
+
+- [ ] **Step 3: Implement the wholesale check and abort**
+
+In `internal/bootstrap/revalidate.go`:
+
+Add `"strings"` to imports (for the tiebreak).
+
+In `revalidateChannels`, replace the group-building-and-iteration tail (from `groups := make(...)` through the `for _, team := range teams` loop) with:
+
+```go
+	// noteIM tracks which ids are IMs: they ALWAYS land in failed_ids
+	// (22 of 22 across the captures, healthy workspaces included), so
+	// the wholesale-failure check below must not count them, or every
+	// healthy workspace would trip it.
+	noteIM := make(map[string]bool, len(out.IMs))
+	for _, im := range out.IMs {
+		noteIM[im.ID] = true
+	}
+
+	groups := make(map[string]map[string]int64)
+	for id, version := range updated {
+		team := teamOf[id]
+		if team == "" {
+			team = deps.WorkspaceID
+		}
+		if groups[team] == nil {
+			groups[team] = make(map[string]int64)
+		}
+		groups[team][id] = version
+	}
+	// Largest group first, alphabetical on ties. On a Grid org the
+	// enterprise-id group holds the overwhelming majority of a user's
+	// conversations (measured: 218 of 277), and judging it first means
+	// a wholesale edge failure is diagnosed before the remaining
+	// groups spend their requests. Deterministic order also keeps the
+	// debug log readable and tests able to rely on call order.
+	teams := slices.Collect(maps.Keys(groups))
+	slices.SortFunc(teams, func(a, b string) int {
+		if d := len(groups[b]) - len(groups[a]); d != 0 {
+			return d
+		}
+		return strings.Compare(a, b)
+	})
+	for i, team := range teams {
+		outcome := revalidateChannelTeam(ctx, deps, team, groups[team], logf)
+		// Only the first (largest) group can trip the wholesale
+		// check: later groups are smaller, so if the largest holds
+		// under half the ids no group reaches the majority threshold.
+		if i == 0 && deps.Health != nil && len(groups[team])*2 >= len(updated) && wholesaleFailure(outcome, groups[team], noteIM) {
+			deps.Health.MarkDegraded()
+			logf("bootstrap: channels/info for team %s failed wholesale (%d of %d ids); marking edge degraded for this session and skipping the remaining %d team group(s)",
+				team, len(groups[team]), len(updated), len(teams)-1)
+			return
+		}
+	}
+```
+
+Change `revalidateChannelTeam` to RETURN an outcome. Add above it:
+
+```go
+// teamOutcome is what one team's revalidation learned, for the
+// wholesale-failure check in revalidateChannels. callErr covers both
+// transport and ok:false failures (the body's ids are all
+// unresolved either way); failed is the failed_ids set.
+type teamOutcome struct {
+	callErr bool
+	failed  map[string]struct{}
+}
+
+// wholesaleFailure reports whether a team's call resolved NOTHING it
+// was asked about: an errored call, or every non-IM id in failed_ids.
+// IMs are excluded — they always fail (see revalidateChannels), so
+// counting them would trip the check on healthy workspaces. A group
+// whose response is empty because everything was already current is
+// NOT a wholesale failure: nothing in failed_ids means nothing
+// failed. A group with no non-IM ids can never fail wholesale.
+func wholesaleFailure(oc teamOutcome, group map[string]int64, noteIM map[string]bool) bool {
+	if oc.callErr {
+		return true
+	}
+	nonIM := 0
+	for id := range group {
+		if noteIM[id] {
+			continue
+		}
+		nonIM++
+		if _, failed := oc.failed[id]; !failed {
+			return false
+		}
+	}
+	return nonIM > 0
+}
+```
+
+And in `revalidateChannelTeam` itself: signature becomes `func revalidateChannelTeam(ctx context.Context, deps Deps, team string, updated map[string]int64, logf func(string, ...any)) teamOutcome`. The error branch:
+
+```go
+	res, err := deps.Revalidate.ChannelsInfo(ctx, team, updated)
+	if err != nil {
+		// Everything below is discarded along with it. Slack answers
+		// ok:false with a populated body, so "err != nil and the
+		// value looks fine" is the normal shape of a failure here.
+		logf("bootstrap: channels/info for team %s: %d conversations: %v (leaving them stale)", team, len(updated), err)
+		return teamOutcome{callErr: true}
+	}
+```
+
+and the end of the function:
+
+```go
+	failed := make(map[string]struct{}, len(res.FailedIDs))
+	for _, id := range res.FailedIDs {
+		failed[id] = struct{}{}
+	}
+	return teamOutcome{failed: failed}
+}
+```
+
+(The failed-ids log line and membership logic stay exactly as they are, above this new tail.)
+
+- [ ] **Step 4: Run the bootstrap suite**
+
+Run: `go test -count=1 ./internal/bootstrap/ 2>&1 | tail -3`
+Expected: PASS, all of it — the five new tests and every pre-existing one (the fixture's groups are equal-sized, so the tiebreak keeps T_HOME first and old order-dependent tests are unaffected).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/bootstrap/
+git commit -m "feat(bootstrap): mark edge degraded and abort remaining teams on wholesale failure
+
+Measured on the first working Grid session: one enterprise-id group
+holding 79% of the user's conversations resolved none of them, and
+the 16 foreign-team groups behind it were all Unauthenticated — 23
+wasted edge calls per boot. The largest group is now processed
+first; if it fails wholesale (every non-IM id unresolved) and holds
+at least half the ids, edge is marked degraded for the session and
+the rest of the partition is skipped. IMs are excluded from the
+check because they always land in failed_ids, healthy workspaces
+included."
+```
+
+---
+
+### Task 3: cache upsert + batched userResolver
+
+**Files:**
+- Modify: `internal/cache/edge_sync.go` (new UpsertUserFromEdge)
+- Test: `internal/cache/edge_sync_test.go`
+- Modify: `cmd/slk/main.go` (userResolver batching; newUserResolver signature)
+- Test: `cmd/slk/user_resolver_test.go`
+
+- [ ] **Step 1: Write the failing cache test**
+
+Add to `internal/cache/edge_sync_test.go`:
+
+```go
+func TestUpsertUserFromEdge(t *testing.T) {
+	db, err := cache.New(":memory:") // adjust to this file's construction convention
+	...
+}
+```
+
+Write it to match the file's existing construction style (read the file first; several tests there build a db and seed users). It must assert ALL of:
+
+1. A user that does not exist is INSERTED with name, display name, version, is_bot, is_external set.
+2. For an existing row with an avatar, an update with EMPTY AvatarURL preserves the stored avatar (the UpdateUserFromEdge contract, kept for the upsert).
+3. An update with a non-empty AvatarURL replaces it.
+4. `version` is written (assert via `db.UserVersions`).
+
+- [ ] **Step 2: Run it, watch it fail**
+
+Run: `go test ./internal/cache/ -run TestUpsertUserFromEdge 2>&1 | tail -2`
+Expected: undefined UpsertUserFromEdge.
+
+- [ ] **Step 3: Implement UpsertUserFromEdge**
+
+In `internal/cache/edge_sync.go`, after `UpdateUserFromEdge`:
+
+```go
+// UpsertUserFromEdge is UpdateUserFromEdge with row-creating
+// semantics, for callers whose whole case is that the row does not
+// exist yet — the batched user resolver's cache misses. (Bootstrap
+// uses UpdateUserFromEdge because hydrateFirstSight has already
+// inserted placeholder rows; UPDATE-only there is a feature: it
+// cannot invent rows.) workspaceID is taken explicitly because
+// EdgeUserUpdate does not carry it.
+//
+// The preserve-on-empty avatar contract is identical to
+// UpdateUserFromEdge, and for the same reason. presence and
+// updated_at are never touched: on insert they take the column
+// defaults, on conflict they keep what they had.
+func (db *DB) UpsertUserFromEdge(workspaceID string, u EdgeUserUpdate) error {
+	var err error
+	if u.AvatarURL != "" {
+		_, err = db.conn.Exec(`
+			INSERT INTO users (id, workspace_id, name, display_name, avatar_url, is_bot, is_external, version)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT(id) DO UPDATE SET
+				name=excluded.name,
+				display_name=excluded.display_name,
+				avatar_url=excluded.avatar_url,
+				is_bot=excluded.is_bot,
+				is_external=excluded.is_external,
+				version=excluded.version
+		`, u.ID, workspaceID, u.Name, u.DisplayName, u.AvatarURL, boolToInt(u.IsBot), boolToInt(u.IsExternal), u.Version)
+	} else {
+		_, err = db.conn.Exec(`
+			INSERT INTO users (id, workspace_id, name, display_name, is_bot, is_external, version)
+			VALUES (?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT(id) DO UPDATE SET
+				name=excluded.name,
+				display_name=excluded.display_name,
+				is_bot=excluded.is_bot,
+				is_external=excluded.is_external,
+				version=excluded.version
+		`, u.ID, workspaceID, u.Name, u.DisplayName, boolToInt(u.IsBot), boolToInt(u.IsExternal), u.Version)
+	}
+	if err != nil {
+		return fmt.Errorf("upserting user %s from edge: %w", u.ID, err)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run cache tests**
+
+Run: `go test -count=1 ./internal/cache/ 2>&1 | tail -2`
+Expected: PASS.
+
+- [ ] **Step 5: Commit the cache half**
+
+```bash
+git add internal/cache/
+git commit -m "feat(cache): UpsertUserFromEdge — row-creating edge user write for the resolver"
+```
+
+- [ ] **Step 6: Write the failing resolver tests**
+
+Add to `cmd/slk/user_resolver_test.go`. First the helpers:
+
+```go
+// fakeBatcher implements userBatcher and records each batch it was
+// asked for.
+type fakeBatcher struct {
+	mu   sync.Mutex
+	sent []map[string]int64
+	res  []edge.User
+	err  error
+}
+
+func (f *fakeBatcher) UsersInfo(_ context.Context, updatedIDs map[string]int64) ([]edge.User, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	cp := make(map[string]int64, len(updatedIDs))
+	for k, v := range updatedIDs {
+		cp[k] = v
+	}
+	f.sent = append(f.sent, cp)
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.res, nil
+}
+
+func (f *fakeBatcher) calls() []map[string]int64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]map[string]int64(nil), f.sent...)
+}
+
+// edgeUserRecord builds an edge.User, whose Profile is an anonymous
+// struct with no spellable type at a call site.
+func edgeUserRecord(id, name, display, real, teamID string, version int64, isBot bool) edge.User {
+	u := edge.User{ID: id, Name: name, Version: version, IsBot: isBot, TeamID: teamID}
+	u.Profile.DisplayName = display
+	u.Profile.RealName = real
+	return u
+}
+```
+
+Then the tests:
+
+```go
+func TestUserResolver_BatchesMissesThroughEdge(t *testing.T) {
+	// Measured on the first working Grid session: 282 users.info
+	// calls, one per miss, with no coalescing. edge users/info takes
+	// 80 ids a request and returns full records inline — the same
+	// misses are ~4 requests.
+	db := newTestDB(t)
+	batcher := &fakeBatcher{res: []edge.User{
+		edgeUserRecord("U001", "alice", "Alice", "", "T1", 1783337599010, false),
+		edgeUserRecord("U002", "bob", "", "Bob Real", "T1", 1783337599011, false),
+	}}
+	var sentMu sync.Mutex
+	var sent []tea.Msg
+	r := newUserResolver("T1", nil, db, nil, func(m tea.Msg) {
+		sentMu.Lock()
+		sent = append(sent, m)
+		sentMu.Unlock()
+	}, batcher, nil)
+
+	r.Request("U001")
+	r.Request("U002")
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) && len(batcher.calls()) == 0 {
+		time.Sleep(10 * time.Millisecond)
+	}
+	calls := batcher.calls()
+	if len(calls) != 1 {
+		t.Fatalf("edge batches = %d; want 1 — misses inside the window coalesce (sent: %v)", len(calls), calls)
+	}
+	want := map[string]int64{"U001": 0, "U002": 0}
+	if !reflect.DeepEqual(calls[0], want) {
+		t.Errorf("batch = %v; want %v — 0 is the protocol's 'never seen, send the full record'", calls[0], want)
+	}
+
+	// Cached, so a second Request is a no-op.
+	for _, id := range []string{"U001", "U002"} {
+		u, err := db.GetUser(id)
+		if err != nil {
+			t.Fatalf("%s was not cached from the edge batch: %v", id, err)
+		}
+		if u.Version == 0 {
+			t.Errorf("%s cached with version 0; the batch returned one and conditional revalidation reads it", id)
+		}
+	}
+	// Display-name chain: display when set, real otherwise.
+	u1, _ := db.GetUser("U001")
+	if u1.DisplayName != "Alice" {
+		t.Errorf("U001 display = %q; want Alice", u1.DisplayName)
+	}
+	u2, _ := db.GetUser("U002")
+	if u2.DisplayName != "Bob Real" {
+		t.Errorf("U002 display = %q; want the real-name fallback", u2.DisplayName)
+	}
+	// One UserResolvedMsg per resolved user, same as the per-user path.
+	sentMu.Lock()
+	resolved := 0
+	for _, m := range sent {
+		if _, ok := m.(ui.UserResolvedMsg); ok {
+			resolved++
+		}
+	}
+	sentMu.Unlock()
+	if resolved != 2 {
+		t.Errorf("UserResolvedMsg count = %d; want 2 — the UI patches display names live from these", resolved)
+	}
+	// Dedup end-to-end: a repeat Request resolves nothing further.
+	r.Request("U001")
+	time.Sleep(userResolverBatchWindow + 300*time.Millisecond)
+	if n := len(batcher.calls()); n != 1 {
+		t.Errorf("a repeat Request produced batch %d; the cache check must make it a no-op", n)
+	}
+}
+
+func TestUserResolver_EdgeMissFallsBackToPerUser(t *testing.T) {
+	// ids edge does not return are resolved the old way — absence
+	// from the batch means "could not resolve", and a raw user id on
+	// screen is the failure this whole path exists to avoid.
+	db := newTestDB(t)
+	batcher := &fakeBatcher{res: []edge.User{
+		edgeUserRecord("U001", "alice", "Alice", "", "T1", 1, false),
+	}}
+	var profiles atomic.Int32
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		profiles.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"user":{"id":"U002","name":"bob","team_id":"T1","profile":{"display_name":"Bob"}}}`))
+	}))
+	defer srv.Close()
+
+	r := newUserResolver("T1", newTestClient(t, srv), db, nil, nil, batcher, nil)
+	r.Request("U001")
+	r.Request("U002")
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := db.GetUser("U002"); err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if _, err := db.GetUser("U002"); err != nil {
+		t.Fatal("U002 was absent from the edge batch and was never resolved per-user")
+	}
+	if got := profiles.Load(); got != 1 {
+		t.Errorf("per-user users.info calls = %d; want 1 — only the id edge missed", got)
+	}
+}
+
+func TestUserResolver_EdgeErrorFallsBackToPerUser(t *testing.T) {
+	db := newTestDB(t)
+	batcher := &fakeBatcher{err: errors.New("ratelimited")}
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"user":{"id":"U001","name":"alice","team_id":"T1","profile":{"display_name":"Alice"}}}`))
+	}))
+	defer srv.Close()
+
+	r := newUserResolver("T1", newTestClient(t, srv), db, nil, nil, batcher, nil)
+	r.Request("U001")
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := db.GetUser("U001"); err == nil {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("the edge call failed and the per-user fallback never ran")
+}
+
+func TestUserResolver_DegradedWorkspaceSkipsEdge(t *testing.T) {
+	// Once boot has marked a workspace's edge broken, the resolver
+	// must not spend even one call discovering it again.
+	db := newTestDB(t)
+	batcher := &fakeBatcher{res: []edge.User{
+		edgeUserRecord("U001", "alice", "Alice", "", "T1", 1, false),
+	}}
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"user":{"id":"U001","name":"alice","team_id":"T1","profile":{"display_name":"Alice"}}}`))
+	}))
+	defer srv.Close()
+
+	r := newUserResolver("T1", newTestClient(t, srv), db, nil, nil, batcher, func() bool { return true })
+	r.Request("U001")
+	time.Sleep(userResolverBatchWindow + 300*time.Millisecond)
+
+	if n := len(batcher.calls()); n != 0 {
+		t.Errorf("a degraded workspace made %d edge calls; want 0", n)
+	}
+	if _, err := db.GetUser("U001"); err != nil {
+		t.Error("U001 was not resolved per-user on the degraded path")
+	}
+}
+```
+
+Add imports as needed: `context`, `errors`, `reflect`, `sync`, `tea "charm.land/bubbletea/v2"`, `"github.com/gammons/slk/internal/slack/edge"`, `"github.com/gammons/slk/internal/ui"`.
+
+- [ ] **Step 7: Run them, watch them fail**
+
+Run: `go test ./cmd/slk/ -run 'TestUserResolver_' 2>&1 | tail -4`
+Expected: build failure — newUserResolver takes 5 args today.
+
+- [ ] **Step 8: Implement the batching**
+
+In `cmd/slk/main.go`:
+
+Add near `userResolverConcurrency`:
+
+```go
+// userResolverBatchWindow is how long Request waits for more misses
+// to coalesce before flushing them as one edge users/info call. The
+// render path resolves a channel's unknown authors in a single
+// burst, so a short window turns a channel open from N requests into
+// one; 200 ms is below what a person perceives as resolution lag.
+const userResolverBatchWindow = 200 * time.Millisecond
+```
+
+Add the interface (above the userResolver struct):
+
+```go
+// userBatcher is the edge.UsersInfo subset the resolver batches
+// misses through. *edge.Client satisfies it structurally; nil means
+// no batching and every miss takes the per-user users.info path.
+type userBatcher interface {
+	UsersInfo(ctx context.Context, updatedIDs map[string]int64) ([]edge.User, error)
+}
+```
+
+Extend the struct:
+
+```go
+	batcher  userBatcher
+	degraded func() bool // nil: never degraded
+
+	pendingMu  sync.Mutex
+	pending    map[string]struct{}
+	flushTimer *time.Timer
+```
+
+Extend newUserResolver's signature with `batcher userBatcher, degraded func() bool` (append them) and initialise `pending: map[string]struct{}{}` in the literal.
+
+Rewrite Request's tail — replace the `go func() {...}()` block and everything after the cache check with:
+
+```go
+	if r.batcher == nil || (r.degraded != nil && r.degraded()) {
+		go r.resolveOne(userID)
+		return
+	}
+	r.pendingMu.Lock()
+	r.pending[userID] = struct{}{}
+	if r.flushTimer == nil {
+		r.flushTimer = time.AfterFunc(userResolverBatchWindow, r.flush)
+	}
+	r.pendingMu.Unlock()
+}
+```
+
+Turn the old goroutine body into a method (its content unchanged):
+
+```go
+// resolveOne resolves a single user through the Web API users.info
+// path: the pre-batch behaviour, now the fallback for ids edge did
+// not return, for a failed edge call, and for workspaces whose edge
+// is degraded. Callers run it on its own goroutine.
+func (r *userResolver) resolveOne(userID string) {
+	defer r.inflight.Delete(userID)
+	if r.sem != nil {
+		r.sem <- struct{}{}
+		defer func() { <-r.sem }()
+	}
+	u, err := r.client.GetUserProfile(userID)
+	... // the rest of the old body, verbatim
+}
+```
+
+Add the flush and the edge-record application:
+
+```go
+// flush resolves everything queued since the window opened, as one
+// edge users/info batch. Anything the batch does not return falls
+// back to the per-user path: absence from the batch means "could not
+// resolve", and an errored batch resolves nothing at all.
+func (r *userResolver) flush() {
+	r.pendingMu.Lock()
+	ids := make([]string, 0, len(r.pending))
+	for id := range r.pending {
+		ids = append(ids, id)
+	}
+	clear(r.pending)
+	r.flushTimer = nil
+	r.pendingMu.Unlock()
+	if len(ids) == 0 {
+		return
+	}
+	// Re-check at flush time: boot may have marked the workspace
+	// degraded while the window was open.
+	if r.degraded != nil && r.degraded() {
+		for _, id := range ids {
+			go r.resolveOne(id)
+		}
+		return
+	}
+	updated := make(map[string]int64, len(ids))
+	for _, id := range ids {
+		// 0 is the conditional protocol's "never seen, send the full
+		// record" — the resolver only ever queues cache misses.
+		updated[id] = 0
+	}
+	users, err := r.batcher.UsersInfo(context.Background(), updated)
+	if err != nil {
+		debuglog.Cache("userResolver: edge users/info for %d users team=%s: %v (falling back to per-user users.info)", len(ids), r.teamID, err)
+		for _, id := range ids {
+			go r.resolveOne(id)
+		}
+		return
+	}
+	returned := make(map[string]struct{}, len(users))
+	for _, u := range users {
+		returned[u.ID] = struct{}{}
+		r.applyEdgeUser(u)
+	}
+	for _, id := range ids {
+		if _, ok := returned[id]; !ok {
+			go r.resolveOne(id)
+		}
+	}
+}
+
+// applyEdgeUser records one user the edge batch returned: cache row
+// (created — these are misses), avatar preload, and the same
+// UserResolvedMsg/UserExternalMsg pair the per-user path emits, so
+// the UI cannot tell the two paths apart.
+func (r *userResolver) applyEdgeUser(u edge.User) {
+	defer r.inflight.Delete(u.ID)
+	name := u.Profile.DisplayName
+	if name == "" {
+		name = u.Profile.RealName
+	}
+	if name == "" {
+		name = u.Name
+	}
+	isExternal := u.TeamID != "" && u.TeamID != r.teamID
+	r.avatars.Preload(u.ID, u.Profile.ImageOriginal)
+	_ = r.db.UpsertUserFromEdge(r.teamID, cache.EdgeUserUpdate{
+		ID:          u.ID,
+		Name:        u.Name,
+		DisplayName: name,
+		AvatarURL:   u.Profile.ImageOriginal,
+		IsBot:       u.IsBot,
+		IsExternal:  isExternal,
+		Version:     u.Version,
+	})
+	if r.send != nil {
+		r.send(ui.UserResolvedMsg{
+			TeamID:      r.teamID,
+			UserID:      u.ID,
+			DisplayName: name,
+			IsBot:       u.IsBot,
+		})
+	}
+	if isExternal && r.send != nil {
+		r.send(ui.UserExternalMsg{UserID: u.ID, IsExternal: true})
+	}
+}
+```
+
+Note: `avatars.Preload(u.ID, u.Profile.ImageOriginal)` — edge returns `image_original` (absolute URL), not the sized `image_32` the per-user path uses. Preload takes any URL. If the receiver is nil and the URL is non-empty it panics, same as the existing path's contract; production always wires a real avatar cache.
+
+- [ ] **Step 9: Update the existing resolver tests' constructor calls**
+
+The two pre-existing tests pass `newUserResolver("T1", newTestClient(t, srv), db, nil, nil)` — append `, nil, nil` (nil batcher, nil degraded → per-user path, behaviour unchanged). Any other newUserResolver call sites in tests get the same treatment EXCEPT the production call, which is Task 4.
+
+Run: `go test -count=1 ./cmd/slk/ -run 'TestUserResolver' -v 2>&1 | tail -12`
+Expected: all PASS, old and new.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add cmd/slk/main.go cmd/slk/user_resolver_test.go
+git commit -m "feat(slk): batch resolver misses through edge users/info
+
+Measured on the first working Grid session: 282 users.info calls in
+one session, one per cache miss. Misses now queue for a 200ms window
+and flush as one edge users/info call ({id: 0} — 'never seen, send
+the full record'). Ids edge does not return, a failed edge call, and
+workspaces marked degraded all fall back to the per-user users.info
+path, which is unchanged."
+```
+
+---
+
+### Task 4: wiring
+
+**Files:**
+- Modify: `cmd/slk/main.go` (WorkspaceContext.EdgeHealth field; construction; newUserResolver call)
+- Modify: `cmd/slk/bootstrap_adapters.go` (newBootstrapDeps gains health)
+- Test: `cmd/slk/bootstrap_adapters_test.go` (TestBootstrapDeps_PopulatesEveryDependency)
+
+- [ ] **Step 1: WorkspaceContext field**
+
+In `cmd/slk/main.go`, add to the WorkspaceContext struct next to `Edge`:
+
+```go
+	// EdgeHealth records whether edge resolution is working for this
+	// workspace this session. bootstrap marks it degraded on a
+	// wholesale failure; the user resolver reads it to skip batch
+	// attempts that would resolve nothing.
+	EdgeHealth *edge.Health
+```
+
+and to the wctx literal (next to the `Edge:` line, ~main.go:2046):
+
+```go
+		EdgeHealth:           edge.NewHealth(),
+```
+
+- [ ] **Step 2: newBootstrapDeps**
+
+In `cmd/slk/bootstrap_adapters.go`, change the signature and add the field:
+
+```go
+func newBootstrapDeps(c *slackclient.Client, db *cache.DB, accessToken, openChannelID string, health *edge.Health) bootstrap.Deps {
+	return bootstrap.Deps{
+		...
+		Revalidate:    edge.New(accessToken, c.TeamID(), c.HTTPClient()),
+		Health:        health,
+		Store:         storeAdapter{db},
+		...
+	}
+}
+```
+
+Update the production call in `cmd/slk/main.go` to pass `wctx.EdgeHealth` (find it with `rg -n 'newBootstrapDeps(' cmd/slk/main.go`; it runs after the wctx literal exists).
+
+- [ ] **Step 3: newUserResolver call**
+
+At `cmd/slk/main.go:2101` (the `wctx.UserResolver = newUserResolver(` call), append the two arguments: `wctx.Edge, wctx.EdgeHealth.Degraded`. Note the method value: `wctx.EdgeHealth.Degraded` is nil-safe because Health.Degraded has a nil receiver guard, and EdgeHealth is always constructed. If `wctx.Edge` is nil (construction failure), the batcher is nil and the resolver takes the per-user path — which is the pre-existing behaviour for that case.
+
+- [ ] **Step 4: Fix the dependency-population test**
+
+`cmd/slk/bootstrap_adapters_test.go` — `TestBootstrapDeps_PopulatesEveryDependency` asserts every Deps field is populated. Update its `newBootstrapDeps(...)` call to pass `edge.NewHealth()` and, if the assertion enumerates fields, add Health. That test exists precisely to catch a forgotten wiring; make it enforce Health too.
+
+- [ ] **Step 5: Full suite**
+
+Run: `go build ./... && go vet ./... && go test -count=1 ./... 2>&1 | grep -v '^ok\|no test files' | head -10`
+Expected: no output after the build.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/slk/
+git commit -m "feat(slk): wire edge health from bootstrap through to the user resolver"
+```
+
+---
+
+### Task 5: live verification (cold-cache A/B)
+
+**Files:** none modified; produces the merge-gate evidence.
+
+- [ ] **Step 1: Cold-cache protocol (from the handoff's trap list)**
+
+A warm cache hides the resolver fan-out. Measure cold: point XDG_DATA_HOME at a temp dir containing ONLY a copy of the tokens:
+
+```bash
+cd ~/local_code/slk
+go build -o /tmp/slk-batched ./cmd/slk
+export COLDXDG=$(mktemp -d)
+mkdir -p $COLDXDG/slk
+cp -r ~/.local/share/slk/tokens $COLDXDG/slk/
+```
+
+- [ ] **Step 2: Cold boot with the new binary**
+
+```bash
+cd /tmp/opencode/slk-repro
+XDG_DATA_HOME=$COLDXDG SLK_DEBUG=1 script -qec 'timeout -s INT 25 /tmp/slk-batched' /dev/null >/dev/null 2>&1
+grep -A25 'shutdown API request tally' slk-debug.log
+```
+
+Expected: `edge:users/info` appears (a small number — 1-2 per workspace needing resolution), and `users.info` is dramatically lower than a cold boot used to produce (the handoff measured ~200; healthy warm-ish caches may show few misses at all — in that case note it and rely on Step 3).
+
+- [ ] **Step 3: Warm boot regression check**
+
+```bash
+SLK_DEBUG=1 script -qec 'timeout -s INT 25 /tmp/slk-batched' /dev/null >/dev/null 2>&1
+grep -A25 'shutdown API request tally' slk-debug.log
+```
+
+Expected: the tally matches the pre-change warm-boot baseline (37-38 total, same endpoints). No new endpoints, no extra edge calls — a fully resolved cache produces no misses, hence no batches.
+
+- [ ] **Step 4: Report, clean up**
+
+`rm -rf $COLDXDG`. Report both tallies to the user.
+
+---
+
+## Self-review notes
+
+- Spec coverage: health signal (Tasks 1+2), batching (Task 3), foreign-team noise via abort (Task 2), no persistence (guard: Task 3's new method is the only cache change, no columns), wiring (Task 4), verification (Task 5).
+- The UPDATE-only landmine is handled by the new `UpsertUserFromEdge` in Task 3; bootstrap's `UpdateUserFromEdge` is untouched.
+- Type consistency: `userBatcher` matches `(*edge.Client).UsersInfo` exactly; `Deps.Health` is `*edge.Health` in bootstrap.go, revalidate.go, the adapter, and the test.
+- Existing-behaviour preservation: nil batcher/degraded → byte-identical resolver path; equal-size fixture groups keep T_HOME first under the new ordering; Health nil in old bootstrap tests disables the check entirely.

--- a/docs/superpowers/plans/2026-08-05-edge-health-and-batched-resolver.md
+++ b/docs/superpowers/plans/2026-08-05-edge-health-and-batched-resolver.md
@@ -17,6 +17,8 @@
 - Existing resolver tests (cmd/slk/user_resolver_test.go) construct with `newUserResolver("T1", newTestClient(t, srv), db, nil, nil)` — they get two new nil params and must behave identically (nil batcher → per-user path).
 - `avatar.Cache.Preload(userID, "")` is safe on a nil cache; a non-empty URL with a nil cache is not. Tests pass empty avatar URLs or a real cache, matching the existing convention.
 
+> **Amendment record (post-implementation):** two code-review rounds changed Task 2's exact code after this plan was written: the majority base is NON-IM ids on both sides (not `len(groups[team])*2 >= len(updated)`), the wholesale comment reads "can only fail wholesale via callErr", and a 50/50 tie is documented as intentionally not-a-majority (commit 9a69d04). Task 6's ResolveNow race comment and the empty-name fall-through in both `resolveDMNames` and `flush` were added in commits 26a6ac6 and 6a584d7. The snippets below are the plan of record at write time; the code and its comments are authoritative.
+
 ---
 
 ### Task 1: edge.Health

--- a/docs/superpowers/specs/2026-08-05-edge-health-and-batched-resolver-design.md
+++ b/docs/superpowers/specs/2026-08-05-edge-health-and-batched-resolver-design.md
@@ -1,0 +1,115 @@
+# Edge health + batched user resolution
+
+Date: 2026-08-05
+Status: approved (direction), pending spec review
+
+## Problem
+
+Two request-amplification measurements from the first working
+Enterprise Grid session (raff, gammons/slk#5, 2026-08-05):
+
+1. **23 `edge:channels/info` calls at boot, every one wasted.** His
+   conversations partition into 17 context-team groups: one enterprise
+   id group (218 ids) that edgeapi accepts but resolves none of, and
+   16 foreign-team groups (1–42 ids) whose calls all fail
+   `Unauthenticated`. The groups are processed independently and to
+   completion, so a workspace where edge resolution is wholesale
+   broken pays the full cost of discovering that on every boot.
+
+2. **282 `users.info` calls in one session.** `userResolver.Request`
+   fires one goroutine and one Web API call per cache miss, with no
+   coalescing. `edge.UsersInfo` accepts 80 ids per request and returns
+   full user records inline; the same misses batched through it are
+   ~4 requests.
+
+Both are the same underlying question — *is edge working for this
+workspace right now?* — asked in two places, so both are answered by
+one mechanism.
+
+## Design
+
+### 1. Per-workspace edge-health signal (session-scoped)
+
+A tiny thread-safe tracker (`internal/slack/edge`, one field on
+`WorkspaceContext`) with two states: **unknown** and **degraded**.
+Session-scoped only — nothing is persisted. Each cold boot
+re-discovers degradation at a cost of a handful of calls; persisting
+pessimism in SQLite risks suppressing the real Grid-scoping fix when
+it lands, and is out of scope.
+
+`bootstrap.revalidateChannels` evaluates the partition outcome:
+
+- Groups are processed in **descending size order** (largest first),
+  replacing the current alphabetical sort. On raff's org the
+  enterprise-id group (79% of ids) is therefore judged first; on a
+  non-Grid workspace the single workspace-team group is.
+- **Wholesale failure** of a group means: the call errored, OR every
+  non-IM id in the group came back in `failed_ids`. IMs are excluded
+  because they ALWAYS land in `failed_ids` — 22 of 22 across the
+  captures, on healthy workspaces — so including them would trip the
+  rule everywhere. (revalidate.go already knows which ids are IMs.)
+- If the largest group fails wholesale **and holds at least half of
+  all ids being revalidated**, edge is marked degraded for the
+  workspace, the remaining groups are aborted, and one log line says
+  so. Raff's boot: 23 edge calls become ~4 (the largest group's own
+  batches). A healthy workspace never trips: its largest group
+  resolves. A workspace whose largest group is merely ratelimited
+  degrades for the session — consequence is falling back to behaviour
+  identical to today's (per-user resolution, foreign teams left
+  stale), and it self-heals next boot.
+
+### 2. Batched resolver misses
+
+`userResolver.Request` keeps its contract (non-blocking, deduped,
+cache-checked) but queues misses instead of firing immediately:
+
+- A pending set (mutex-guarded) collects ids; the first enqueue arms
+  a **200 ms timer**. This coalesces the render-path burst — a
+  channel open resolves its unknown authors as one batch.
+- On flush, if the workspace's edge health is NOT degraded and an
+  edge client is wired: one `UsersInfo` call with `{id: 0}` for every
+  pending id (0 is the protocol's "never seen, send full record";
+  `fetchInfo` batches at 80 internally). Returned users are written
+  via the existing `cache.UpdateUserFromEdge` path and each emits the
+  same `UserResolvedMsg` the per-user path emits today (display-name
+  fallback chain: display → real → handle, mirroring bootstrap's
+  `userDisplayName`).
+- **Fallback preserves correctness everywhere:** ids the edge call
+  did not return, and ALL pending ids when the edge call errors or
+  the workspace is degraded or no edge client is wired, go through
+  today's per-user `users.info` goroutine path unchanged. On Grid
+  today that means the batch attempt costs one failed edge call and
+  then behaves exactly as slk does now; once boot marks the workspace
+  degraded it costs nothing.
+
+### 3. Foreign-team noise
+
+The abort in (1) skips the foreign-team groups whose calls fail
+`Unauthenticated` on Grid. Teams that were processed before the abort
+keeps their current per-team log lines; no new mechanism.
+
+## Explicitly out of scope
+
+- Persisting edge health across sessions (SQLite + TTL). Session
+  rediscovery costs ≤4 calls; revisit only if the Grid capture never
+  arrives.
+- The correct Grid edge scoping itself (enterprise-id groups,
+  `Unauthenticated` teams). Blocked on raff's browser capture; this
+  change deliberately makes no guess at it.
+- Batching `RequestBot` (bots.info has no edge analogue).
+- users/info revalidation at boot (`revalidateUsers`) — already one
+  batched conditional call; unchanged.
+
+## Testing
+
+- Health: largest-group wholesale failure marks degraded and aborts
+  remaining groups (bootstrap fake, per-team error injection
+  exists); a healthy run stays unknown; IM-only failure does not
+  trip; majority threshold respected (largest group < 50% of ids →
+  no abort).
+- Resolver: N requests → 1 edge call with all ids at version 0;
+  returned users cached + one UserResolvedMsg each; unreturned ids
+  fall back to per-user; edge error → all fall back; degraded or
+  nil edge → zero edge calls; duplicate Request dedupes end-to-end.
+- No-persistence guard: no new cache columns, no new files under
+  XDG paths.

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -321,6 +321,13 @@ type Deps struct {
 	Revalidate Revalidator
 	Store      Store
 
+	// Health, when non-nil, is marked degraded when the largest
+	// context-team group fails wholesale (every non-IM id unresolved)
+	// and holds at least half of all revalidated ids; the remaining
+	// groups are then aborted. Nil disables the check. See
+	// revalidateChannels for the reasoning.
+	Health *edge.Health
+
 	// OpenChannelID is the conversation to open — the restored last
 	// channel, or the configured default. Empty means "whatever Slack
 	// considers last-viewed", which is what the capture did.

--- a/internal/bootstrap/revalidate.go
+++ b/internal/bootstrap/revalidate.go
@@ -148,6 +148,11 @@ func revalidateChannels(ctx context.Context, deps Deps, out *Result, logf func(s
 		}
 		groups[team][id] = version
 	}
+	// The majority base is NON-IM ids, on both sides. IMs always fail
+	// (above), so wholesaleFailure excludes them — and counting them
+	// here would let a group that is mostly IMs claim the majority
+	// and get edge marked degraded over a single channel's failure.
+	nonIMTotal := nonIMCount(updated, noteIM)
 	// Largest group first, alphabetical on ties. On a Grid org the
 	// enterprise-id group holds the overwhelming majority of a user's
 	// conversations (measured: 218 of 277), and judging it first means
@@ -165,8 +170,12 @@ func revalidateChannels(ctx context.Context, deps Deps, out *Result, logf func(s
 		outcome := revalidateChannelTeam(ctx, deps, team, groups[team], logf)
 		// Only the first (largest) group can trip the wholesale
 		// check: later groups are smaller, so if the largest holds
-		// under half the ids no group reaches the majority threshold.
-		if i == 0 && deps.Health != nil && len(groups[team])*2 >= len(updated) && wholesaleFailure(outcome, groups[team], noteIM) {
+		// under half the non-IM ids no group reaches the majority
+		// threshold. On an exact 50/50 tie the second group is never
+		// evaluated — half is not a majority — and the alpha-first
+		// tiebreak makes which half goes first arbitrary but
+		// deterministic.
+		if i == 0 && deps.Health != nil && nonIMTotal > 0 && nonIMCount(groups[team], noteIM)*2 >= nonIMTotal && wholesaleFailure(outcome, groups[team], noteIM) {
 			deps.Health.MarkDegraded()
 			logf("bootstrap: channels/info for team %s failed wholesale (%d of %d ids); marking edge degraded for this session and skipping the remaining %d team group(s)",
 				team, len(groups[team]), len(updated), len(teams)-1)
@@ -190,7 +199,8 @@ type teamOutcome struct {
 // counting them would trip the check on healthy workspaces. A group
 // whose response is empty because everything was already current is
 // NOT a wholesale failure: nothing in failed_ids means nothing
-// failed. A group with no non-IM ids can never fail wholesale.
+// failed. A group with no non-IM ids can only fail wholesale via
+// callErr.
 func wholesaleFailure(oc teamOutcome, group map[string]int64, noteIM map[string]bool) bool {
 	if oc.callErr {
 		return true
@@ -206,6 +216,20 @@ func wholesaleFailure(oc teamOutcome, group map[string]int64, noteIM map[string]
 		}
 	}
 	return nonIM > 0
+}
+
+// nonIMCount is the number of ids in group that are not IMs — the
+// base the majority check and wholesaleFailure both reason over,
+// since IMs always land in failed_ids and would otherwise inflate
+// both.
+func nonIMCount(group map[string]int64, noteIM map[string]bool) int {
+	n := 0
+	for id := range group {
+		if !noteIM[id] {
+			n++
+		}
+	}
+	return n
 }
 
 // revalidateChannelTeam runs the channels/info call and its

--- a/internal/bootstrap/revalidate.go
+++ b/internal/bootstrap/revalidate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"maps"
 	"slices"
+	"strings"
 
 	"github.com/gammons/slk/internal/cache"
 	"github.com/gammons/slk/internal/slack/edge"
@@ -127,6 +128,15 @@ func revalidateChannels(ctx context.Context, deps Deps, out *Result, logf func(s
 		return
 	}
 
+	// noteIM tracks which ids are IMs: they ALWAYS land in failed_ids
+	// (22 of 22 across the captures, healthy workspaces included), so
+	// the wholesale-failure check below must not count them, or every
+	// healthy workspace would trip it.
+	noteIM := make(map[string]bool, len(out.IMs))
+	for _, im := range out.IMs {
+		noteIM[im.ID] = true
+	}
+
 	groups := make(map[string]map[string]int64)
 	for id, version := range updated {
 		team := teamOf[id]
@@ -138,14 +148,64 @@ func revalidateChannels(ctx context.Context, deps Deps, out *Result, logf func(s
 		}
 		groups[team][id] = version
 	}
-	// Sorted for determinism: request order must not depend on map
-	// iteration, both for the debug log's readability and so a test
-	// can rely on call order.
+	// Largest group first, alphabetical on ties. On a Grid org the
+	// enterprise-id group holds the overwhelming majority of a user's
+	// conversations (measured: 218 of 277), and judging it first means
+	// a wholesale edge failure is diagnosed before the remaining
+	// groups spend their requests. Deterministic order also keeps the
+	// debug log readable and tests able to rely on call order.
 	teams := slices.Collect(maps.Keys(groups))
-	slices.Sort(teams)
-	for _, team := range teams {
-		revalidateChannelTeam(ctx, deps, team, groups[team], logf)
+	slices.SortFunc(teams, func(a, b string) int {
+		if d := len(groups[b]) - len(groups[a]); d != 0 {
+			return d
+		}
+		return strings.Compare(a, b)
+	})
+	for i, team := range teams {
+		outcome := revalidateChannelTeam(ctx, deps, team, groups[team], logf)
+		// Only the first (largest) group can trip the wholesale
+		// check: later groups are smaller, so if the largest holds
+		// under half the ids no group reaches the majority threshold.
+		if i == 0 && deps.Health != nil && len(groups[team])*2 >= len(updated) && wholesaleFailure(outcome, groups[team], noteIM) {
+			deps.Health.MarkDegraded()
+			logf("bootstrap: channels/info for team %s failed wholesale (%d of %d ids); marking edge degraded for this session and skipping the remaining %d team group(s)",
+				team, len(groups[team]), len(updated), len(teams)-1)
+			return
+		}
 	}
+}
+
+// teamOutcome is what one team's revalidation learned, for the
+// wholesale-failure check in revalidateChannels. callErr covers both
+// transport and ok:false failures (the body's ids are all
+// unresolved either way); failed is the failed_ids set.
+type teamOutcome struct {
+	callErr bool
+	failed  map[string]struct{}
+}
+
+// wholesaleFailure reports whether a team's call resolved NOTHING it
+// was asked about: an errored call, or every non-IM id in failed_ids.
+// IMs are excluded — they always fail (see revalidateChannels), so
+// counting them would trip the check on healthy workspaces. A group
+// whose response is empty because everything was already current is
+// NOT a wholesale failure: nothing in failed_ids means nothing
+// failed. A group with no non-IM ids can never fail wholesale.
+func wholesaleFailure(oc teamOutcome, group map[string]int64, noteIM map[string]bool) bool {
+	if oc.callErr {
+		return true
+	}
+	nonIM := 0
+	for id := range group {
+		if noteIM[id] {
+			continue
+		}
+		nonIM++
+		if _, failed := oc.failed[id]; !failed {
+			return false
+		}
+	}
+	return nonIM > 0
 }
 
 // revalidateChannelTeam runs the channels/info call and its
@@ -153,14 +213,14 @@ func revalidateChannels(ctx context.Context, deps Deps, out *Result, logf func(s
 // one team's error is logged and its ids are left stale, and the
 // remaining teams still run — the same independence the channels and
 // users passes have from each other, one level down.
-func revalidateChannelTeam(ctx context.Context, deps Deps, team string, updated map[string]int64, logf func(string, ...any)) {
+func revalidateChannelTeam(ctx context.Context, deps Deps, team string, updated map[string]int64, logf func(string, ...any)) teamOutcome {
 	res, err := deps.Revalidate.ChannelsInfo(ctx, team, updated)
 	if err != nil {
 		// Everything below is discarded along with it. Slack answers
 		// ok:false with a populated body, so "err != nil and the
 		// value looks fine" is the normal shape of a failure here.
 		logf("bootstrap: channels/info for team %s: %d conversations: %v (leaving them stale)", team, len(updated), err)
-		return
+		return teamOutcome{callErr: true}
 	}
 
 	for _, ch := range res.Channels {
@@ -219,6 +279,12 @@ func revalidateChannelTeam(ctx context.Context, deps Deps, team string, updated 
 	if len(res.FailedIDs) > 0 {
 		logf("bootstrap: channels/info for team %s could not resolve %d ids (%v); leaving them stale to be retried", team, len(res.FailedIDs), res.FailedIDs)
 	}
+
+	failed := make(map[string]struct{}, len(res.FailedIDs))
+	for _, id := range res.FailedIDs {
+		failed[id] = struct{}{}
+	}
+	return teamOutcome{failed: failed}
 }
 
 // revalidateUsers conditionally refreshes the people the opened

--- a/internal/bootstrap/revalidate_test.go
+++ b/internal/bootstrap/revalidate_test.go
@@ -1185,6 +1185,141 @@ func TestRevalidate_TeamFailureDoesNotSkipOtherTeams(t *testing.T) {
 	}
 }
 
+// --- edge health ------------------------------------------------------
+
+// bigTeamFixture builds a boot whose conversations partition into one
+// 6-id T_BIG group and one 2-id T_SMALL group, all channels (no IMs
+// unless added by the test). 6 of 8 ids is over the majority
+// threshold; T_BIG sorts first by size.
+func bigTeamFixture(f *fakeDeps) {
+	f.bootRes.Channels = []boot.Channel{
+		{ID: "C_BIG1", Name: "big1", ContextTeamID: "T_BIG"},
+		{ID: "C_BIG2", Name: "big2", ContextTeamID: "T_BIG"},
+		{ID: "C_BIG3", Name: "big3", ContextTeamID: "T_BIG"},
+		{ID: "C_BIG4", Name: "big4", ContextTeamID: "T_BIG"},
+		{ID: "C_BIG5", Name: "big5", ContextTeamID: "T_BIG"},
+		{ID: "C_BIG6", Name: "big6", ContextTeamID: "T_BIG"},
+		{ID: "C_SMALL1", Name: "small1", ContextTeamID: "T_SMALL"},
+		{ID: "C_SMALL2", Name: "small2", ContextTeamID: "T_SMALL"},
+	}
+	f.bootRes.IMs = nil
+}
+
+func TestRevalidate_WholesaleFailureMarksDegradedAndAborts(t *testing.T) {
+	// Measured on the first working Grid session (2026-08-05): one
+	// enterprise-id group holding 79% of the user's conversations
+	// resolved none of them, and the 16 foreign-team groups behind it
+	// were all Unauthenticated — 23 wasted edge calls per boot. The
+	// largest group failing wholesale IS the diagnosis; the rest of
+	// the partition is not worth spending requests on.
+	f := openedFake()
+	bigTeamFixture(f)
+	f.deps.Health = edge.NewHealth()
+	f.channelsInfoRes.FailedIDs = []string{"C_BIG1", "C_BIG2", "C_BIG3", "C_BIG4", "C_BIG5", "C_BIG6"}
+	// The canned response's Channels/queried sets name fixture ids
+	// this boot does not have, so filterChannelsInfo reduces them to
+	// nothing for these ids — only the failed ids apply.
+
+	if _, err := Run(context.Background(), f.Deps()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !f.deps.Health.Degraded() {
+		t.Error("the majority group failed wholesale and edge was not marked degraded; the resolver will keep spending edge calls on a workspace where they resolve nothing")
+	}
+	if len(f.channelsInfoCalls) != 1 {
+		t.Errorf("channels/info calls = %d; want 1 — after a wholesale failure of the majority group the remaining teams are aborted (calls: %+v)", len(f.channelsInfoCalls), f.channelsInfoCalls)
+	}
+	if f.channelsInfoCalls[0].team != "T_BIG" {
+		t.Errorf("first call went to %q; want T_BIG — groups are processed largest-first so the diagnosis comes before the spend", f.channelsInfoCalls[0].team)
+	}
+	if !f.loggedMatching("degraded") {
+		t.Errorf("a wholesale edge failure must say what it decided (logged: %v)", f.logged())
+	}
+}
+
+func TestRevalidate_CallErrorOfTheMajorityGroupAlsoMarksDegraded(t *testing.T) {
+	// The other wholesale shape: not failed_ids but an error —
+	// ratelimited, or Grid's Unauthenticated.
+	f := openedFake()
+	bigTeamFixture(f)
+	f.deps.Health = edge.NewHealth()
+	f.channelsInfoErrFor = map[string]error{"T_BIG": errors.New("Unauthenticated")}
+
+	if _, err := Run(context.Background(), f.Deps()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !f.deps.Health.Degraded() {
+		t.Error("an errored majority group did not mark edge degraded")
+	}
+	if len(f.channelsInfoCalls) != 1 {
+		t.Errorf("channels/info calls = %d; want 1", len(f.channelsInfoCalls))
+	}
+}
+
+func TestRevalidate_IMOnlyFailureDoesNotMarkDegraded(t *testing.T) {
+	// IMs ALWAYS land in failed_ids — 22 of 22 across the captures,
+	// on healthy workspaces. A group whose only failures are IMs is
+	// the normal case, and marking it degraded would disable edge
+	// batching everywhere.
+	f := openedFake()
+	f.bootRes.Channels = nil
+	f.bootRes.IMs = []boot.IM{
+		{ID: "D_A", UserID: "U_ALICE", IsIM: true, IsOpen: true, ContextTeamID: "T_HOME"},
+		{ID: "D_B", UserID: "U_BOB", IsIM: true, IsOpen: true, ContextTeamID: "T_HOME"},
+	}
+	f.deps.Health = edge.NewHealth()
+	f.channelsInfoRes.FailedIDs = []string{"D_A", "D_B"}
+
+	if _, err := Run(context.Background(), f.Deps()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if f.deps.Health.Degraded() {
+		t.Error("IM-only failures marked edge degraded; IMs land in failed_ids on every healthy workspace")
+	}
+}
+
+func TestRevalidate_HealthyRunDoesNotMarkDegraded(t *testing.T) {
+	f := openedFake()
+	f.deps.Health = edge.NewHealth()
+
+	if _, err := Run(context.Background(), f.Deps()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if f.deps.Health.Degraded() {
+		t.Error("a healthy revalidation marked edge degraded")
+	}
+}
+
+func TestRevalidate_MinorityWholesaleFailureDoesNotAbort(t *testing.T) {
+	// The threshold is the majority: a failing group that holds less
+	// than half the ids is one team's problem, not a broken edge.
+	// Here T_BIG holds 3 of 7 — wholesale-failed, but a minority —
+	// so all three teams are still called and nothing is marked.
+	f := openedFake()
+	f.bootRes.Channels = []boot.Channel{
+		{ID: "C_BIG1", Name: "big1", ContextTeamID: "T_BIG"},
+		{ID: "C_BIG2", Name: "big2", ContextTeamID: "T_BIG"},
+		{ID: "C_BIG3", Name: "big3", ContextTeamID: "T_BIG"},
+		{ID: "C_MID1", Name: "mid1", ContextTeamID: "T_MID"},
+		{ID: "C_MID2", Name: "mid2", ContextTeamID: "T_MID"},
+		{ID: "C_SMALL1", Name: "small1", ContextTeamID: "T_SMALL"},
+		{ID: "C_SMALL2", Name: "small2", ContextTeamID: "T_SMALL"},
+	}
+	f.bootRes.IMs = nil
+	f.deps.Health = edge.NewHealth()
+	f.channelsInfoErrFor = map[string]error{"T_BIG": errors.New("ratelimited")}
+
+	if _, err := Run(context.Background(), f.Deps()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if f.deps.Health.Degraded() {
+		t.Error("a minority group's failure marked edge degraded; the threshold is the majority of ids")
+	}
+	if len(f.channelsInfoCalls) != 3 {
+		t.Errorf("channels/info calls = %d; want 3 — a minority failure aborts nothing", len(f.channelsInfoCalls))
+	}
+}
+
 // --- budget -----------------------------------------------------------
 
 func TestRevalidate_StaysInsideTheBootCallBudget(t *testing.T) {

--- a/internal/cache/edge_sync.go
+++ b/internal/cache/edge_sync.go
@@ -224,3 +224,47 @@ func (db *DB) UpdateUserFromEdge(u EdgeUserUpdate) error {
 	}
 	return nil
 }
+
+// UpsertUserFromEdge is UpdateUserFromEdge with row-creating
+// semantics, for callers whose whole case is that the row does not
+// exist yet — the batched user resolver's cache misses. (Bootstrap
+// uses UpdateUserFromEdge because hydrateFirstSight has already
+// inserted placeholder rows; UPDATE-only there is a feature: it
+// cannot invent rows.) workspaceID is taken explicitly because
+// EdgeUserUpdate does not carry it.
+//
+// The preserve-on-empty avatar contract is identical to
+// UpdateUserFromEdge, and for the same reason. presence and
+// updated_at are never touched: on insert they take the column
+// defaults, on conflict they keep what they had.
+func (db *DB) UpsertUserFromEdge(workspaceID string, u EdgeUserUpdate) error {
+	var err error
+	if u.AvatarURL != "" {
+		_, err = db.conn.Exec(`
+			INSERT INTO users (id, workspace_id, name, display_name, avatar_url, is_bot, is_external, version)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT(id) DO UPDATE SET
+				name=excluded.name,
+				display_name=excluded.display_name,
+				avatar_url=excluded.avatar_url,
+				is_bot=excluded.is_bot,
+				is_external=excluded.is_external,
+				version=excluded.version
+		`, u.ID, workspaceID, u.Name, u.DisplayName, u.AvatarURL, boolToInt(u.IsBot), boolToInt(u.IsExternal), u.Version)
+	} else {
+		_, err = db.conn.Exec(`
+			INSERT INTO users (id, workspace_id, name, display_name, is_bot, is_external, version)
+			VALUES (?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT(id) DO UPDATE SET
+				name=excluded.name,
+				display_name=excluded.display_name,
+				is_bot=excluded.is_bot,
+				is_external=excluded.is_external,
+				version=excluded.version
+		`, u.ID, workspaceID, u.Name, u.DisplayName, boolToInt(u.IsBot), boolToInt(u.IsExternal), u.Version)
+	}
+	if err != nil {
+		return fmt.Errorf("upserting user %s from edge: %w", u.ID, err)
+	}
+	return nil
+}

--- a/internal/cache/edge_sync_test.go
+++ b/internal/cache/edge_sync_test.go
@@ -234,6 +234,69 @@ func TestUpdateUserFromEdge_WritesAvatarWhenSupplied(t *testing.T) {
 	}
 }
 
+// UpsertUserFromEdge is the row-creating counterpart of
+// UpdateUserFromEdge, for the batched user resolver whose misses are
+// by definition rows that do not exist. It must keep every contract of
+// the UPDATE — above all the empty-avatar preserve — while inserting
+// when the row is missing.
+func TestUpsertUserFromEdge(t *testing.T) {
+	db := openEdgeSyncTestDB(t)
+	seedWorkspace(t, db, "T1")
+
+	// 1. A user that does not exist is INSERTED, with every column the
+	// update carries.
+	if err := db.UpsertUserFromEdge("T1", EdgeUserUpdate{
+		ID: "U1", Name: "alice", DisplayName: "Alice",
+		AvatarURL: "https://example.invalid/a.png",
+		IsBot:     true, IsExternal: true, Version: sampleUserVersion,
+	}); err != nil {
+		t.Fatalf("UpsertUserFromEdge: %v", err)
+	}
+	u := getUserRow(t, db, "U1")
+	if u.Name != "alice" || u.DisplayName != "Alice" || !u.IsBot || !u.IsExternal {
+		t.Errorf("inserted row missing columns: %+v", u)
+	}
+	if u.AvatarURL != "https://example.invalid/a.png" {
+		t.Errorf("avatar_url = %q; want the supplied one", u.AvatarURL)
+	}
+	// 4. version is written and readable through UserVersions — the
+	// resolver's inserts are what conditional revalidation later reads.
+	vers, err := db.UserVersions("T1")
+	if err != nil {
+		t.Fatalf("UserVersions: %v", err)
+	}
+	if vers["U1"] != sampleUserVersion {
+		t.Errorf("version = %d; want %d — an unstamped row is sent as 0 in updated_ids and refetched in full on every boot, forever", vers["U1"], sampleUserVersion)
+	}
+
+	// 2. Empty AvatarURL on an existing row preserves the stored avatar,
+	// the same contract UpdateUserFromEdge holds.
+	if err := db.UpsertUserFromEdge("T1", EdgeUserUpdate{
+		ID: "U1", Name: "alice2", DisplayName: "Alice Two",
+		Version: sampleUserVersion + 1,
+	}); err != nil {
+		t.Fatalf("UpsertUserFromEdge (empty avatar): %v", err)
+	}
+	u = getUserRow(t, db, "U1")
+	if u.AvatarURL != "https://example.invalid/a.png" {
+		t.Errorf("avatar_url = %q; want the original preserved — an empty AvatarURL means 'this source has none', not 'this user has none'", u.AvatarURL)
+	}
+	if u.Name != "alice2" || u.DisplayName != "Alice Two" {
+		t.Errorf("conflict path did not write edge-owned columns: %+v", u)
+	}
+
+	// 3. A non-empty AvatarURL replaces the stored one.
+	if err := db.UpsertUserFromEdge("T1", EdgeUserUpdate{
+		ID: "U1", Name: "alice2", DisplayName: "Alice Two",
+		AvatarURL: "https://example.invalid/new.png", Version: sampleUserVersion + 2,
+	}); err != nil {
+		t.Fatalf("UpsertUserFromEdge (avatar): %v", err)
+	}
+	if got := getUserRow(t, db, "U1").AvatarURL; got != "https://example.invalid/new.png" {
+		t.Errorf("avatar_url = %q; want the new one — preserve must not mean ignore", got)
+	}
+}
+
 func TestUpdateFromEdge_UnknownRowIsANoOpNotAnInsert(t *testing.T) {
 	// These are revalidation writers. A row we have never seen is
 	// hydrated through the normal Upsert path, which knows every

--- a/internal/slack/edge/health.go
+++ b/internal/slack/edge/health.go
@@ -1,0 +1,29 @@
+package edge
+
+import "sync/atomic"
+
+// Health records whether edge resolution is working for one workspace
+// this session. Two states — unknown and degraded — and deliberately
+// nothing else: it exists so that a workspace where edge resolution
+// fails wholesale (Enterprise Grid today: the enterprise-id group
+// resolves nothing, the foreign teams are Unauthenticated) pays for
+// that discovery once per boot instead of once per call site.
+//
+// Session-scoped by construction. Persisting pessimism would risk
+// suppressing the real Grid-scoping fix when it lands, and a cold
+// boot re-discovers degradation for the cost of a handful of calls.
+type Health struct {
+	degraded atomic.Bool
+}
+
+// NewHealth returns a Health in the unknown (not degraded) state.
+func NewHealth() *Health { return &Health{} }
+
+// MarkDegraded latches the degraded state. Idempotent; there is no
+// path back within a session.
+func (h *Health) MarkDegraded() { h.degraded.Store(true) }
+
+// Degraded reports whether edge resolution has failed wholesale this
+// session. Nil-safe: a nil *Health reads as not degraded, so callers
+// wired optionally need no guard.
+func (h *Health) Degraded() bool { return h != nil && h.degraded.Load() }

--- a/internal/slack/edge/health_test.go
+++ b/internal/slack/edge/health_test.go
@@ -1,0 +1,15 @@
+package edge
+
+import "testing"
+
+func TestHealth(t *testing.T) {
+	h := NewHealth()
+	if h.Degraded() {
+		t.Error("a new Health is degraded; degradation must be earned by an observed wholesale failure")
+	}
+	h.MarkDegraded()
+	h.MarkDegraded() // idempotent
+	if !h.Degraded() {
+		t.Error("MarkDegraded did not stick")
+	}
+}


### PR DESCRIPTION
Two request-amplification fixes from the first working Enterprise Grid session's measurements (#5, raff's log, 2026-08-05), unified by one mechanism: a per-workspace, session-scoped answer to *"is edge resolution working here right now?"*

## 1. Edge health: stop paying for wholesale-broken revalidation

Raff's boot spent **23 `edge:channels/info` calls, every one wasted**: the enterprise-id group (218 of his 277 conversations) resolved zero ids, and 16 foreign-team groups all failed `Unauthenticated`. Now:

- Context-team groups are processed **largest-first** (alpha tiebreak).
- If the largest group **fails wholesale** (call errored, or every non-IM id in `failed_ids` — IMs excluded because they *always* fail, 22/22 in the captures) **and holds ≥ half the non-IM ids**, edge is marked **degraded** for the workspace-session, the remaining groups are aborted, and one log line says so. Raff's boot: 23 calls → ~4.
- Healthy workspaces never trip (their largest group resolves); a fully-current cache returns empty results, which is *not* failure by this definition. Session-scoped only — nothing persisted, so this can't suppress the real Grid-scoping fix when raff's capture arrives.

## 2. Batched user resolution: 282 `users.info` → ~4

Two paths, one fallback everywhere:

- **`UserResolver.Request`** (render/WS/membership path) queues misses for a 200 ms window and flushes them as one `edge.UsersInfo` call with `{id: 0}` ("never seen, send full record"; batches internally at 80). Returned users are upserted (new `cache.UpsertUserFromEdge` — row-creating; `UpdateUserFromEdge` is UPDATE-only and would have silently written nothing for misses) and emit the same `UserResolvedMsg` as the per-user path.
- **The unresolved-DM sweep** — the actual cold-boot dominant source, found when the first A/B falsified the assumption that `Request` was (116 vs 99 `users.info`) — resolves its whole counterparty list in one synchronous `ResolveNow` batch, mapping results to `DMNameResolvedMsg`/`BotUserIDs` as before.
- **Fallback is the unchanged per-user `users.info` path** for: ids edge doesn't return, failed edge calls, degraded workspaces, and empty-name edge records. On Grid today that means behaviour identical to current slk at worst one extra call, and zero extra once boot marks the workspace degraded.

## Measured verification

- **Cold boot A/B** (fresh XDG, tokens only): `main` 134 requests / **99 `users.info`** → branch **39 requests / 0 `users.info`** (`edge:users/info` 7).
- **Warm boot regression**: 36 requests, same endpoint set as the pre-change baseline.
- Full suite + `go vet` + `-race` on the new concurrency, green. Executed via subagent-driven TDD with spec + quality review per task and a final whole-change review (READY TO MERGE).

## Honestly flagged

- On Grid, `edge:users/info` resolution is still a guess at the same scoping that fails `channels/info`; the degraded signal is what keeps it free there until raff's capture tells us the right shape.
- `edge.User` does not decode `is_app_user` (present on 1/1 committed users/info result — thin evidence, so not acted on): an app DM resolved via edge may bucket as "dm" until something else classifies it.
- The ResolveNow/Request inflight race is documented in code and bounded to one duplicate call.

Spec: `docs/superpowers/specs/2026-08-05-edge-health-and-batched-resolver-design.md`. Plan (with amendment record): `docs/superpowers/plans/2026-08-05-edge-health-and-batched-resolver.md`.
