### PR TITLE
fix(slack): restore typing indicators — send the official client's full start_args

### DIFF
--- a/internal/slack/client.go
+++ b/internal/slack/client.go
@@ -385,10 +385,29 @@ func wsUpgradeHeaders() http.Header {
 // Events are dispatched to the provided handler in a goroutine.
 // Call this after Connect.
 func (c *Client) StartWebSocket(handler EventHandler) error {
+	// start_args matches the official client's, key for key, from the
+	// 2026-08-02 coldboot capture. slk used to send only
+	// agent/connect_only/ms_latest, and at some point user_typing
+	// frames stopped arriving — typing indicators silently disappeared
+	// while everything else on the socket kept working. Which key
+	// gates typing delivery is undocumented; the capture is the
+	// contract, so all of them go out. agent_version is the same
+	// version_ts the envelope carries (_x_version_ts); without an
+	// envelope it is simply empty, matching the no-envelope clients
+	// the envelope doc describes.
+	agentVersion := ""
+	if c.envelope != nil {
+		agentVersion = c.envelope.VersionTS()
+	}
+	startArgs := fmt.Sprintf(
+		"?agent=client&org_wide_aware=true&agent_version=%s&eac_cache_ts=true&cache_ts=0&name_tagging=true&only_self_subteams=true&connect_only=true&ms_latest=true",
+		agentVersion,
+	)
 	wsURL := fmt.Sprintf(
-		"%s/?token=%s&sync_desync=1&slack_client=desktop&start_args=%%3Fagent%%3Dclient%%26connect_only%%3Dtrue%%26ms_latest%%3Dtrue&no_query_on_subscribe=1&flannel=3&lazy_channels=1&gateway_server=%s-1&batch_presence_aware=1",
+		"%s/?token=%s&sync_desync=1&slack_client=desktop&start_args=%s&no_query_on_subscribe=1&flannel=3&lazy_channels=1&gateway_server=%s-1&batch_presence_aware=1",
 		c.wsBaseURL,
 		url.QueryEscape(c.token),
+		url.QueryEscape(startArgs),
 		c.teamID,
 	)
 

--- a/internal/slack/client_test.go
+++ b/internal/slack/client_test.go
@@ -2144,6 +2144,88 @@ func TestStartWebSocket_SendsChromeUpgradeHeaders(t *testing.T) {
 	}
 }
 
+// TestStartWebSocket_StartArgsMatchTheCapture pins the start_args
+// query param against the official client's, from the 2026-08-02
+// coldboot capture:
+//
+//	start_args = ?agent=client&org_wide_aware=true&agent_version=1785403654
+//	             &eac_cache_ts=true&cache_ts=0&name_tagging=true
+//	             &only_self_subteams=true&connect_only=true&ms_latest=true
+//
+// slk sent only agent/connect_only/ms_latest, and at some point
+// user_typing frames stopped arriving — the visible symptom was typing
+// indicators silently disappearing while everything else on the socket
+// kept working. Which of the missing keys gates typing delivery is not
+// documented anywhere; the fix is the project's standing rule — match
+// the capture, don't invent — applied in full.
+func TestStartWebSocket_StartArgsMatchTheCapture(t *testing.T) {
+	gotCh := make(chan url.Values, 1)
+	upgrader := websocket.Upgrader{
+		CheckOrigin: func(r *http.Request) bool {
+			select {
+			case gotCh <- r.URL.Query():
+			default:
+			}
+			return true
+		},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Logf("upgrade failed: %v", err)
+			return
+		}
+		conn.Close()
+	}))
+	defer srv.Close()
+
+	env := slackhttp.NewEnvelope()
+	env.SetVersionTS("1785403654")
+	c := &Client{
+		token:     "xoxc-test",
+		cookie:    "d-cookie",
+		teamID:    "T12345",
+		wsBaseURL: "ws://" + srv.Listener.Addr().String(),
+		envelope:  env,
+	}
+	if err := c.StartWebSocket(&mockEventHandler{}); err != nil {
+		t.Fatalf("StartWebSocket: %v", err)
+	}
+	defer func() { <-c.WsDone() }()
+
+	var q url.Values
+	select {
+	case q = <-gotCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("server never received an upgrade request")
+	}
+
+	raw := q.Get("start_args")
+	if raw == "" {
+		t.Fatalf("no start_args in dialed URL: %v", q)
+	}
+	args, err := url.ParseQuery(strings.TrimPrefix(raw, "?"))
+	if err != nil {
+		t.Fatalf("start_args is not a query string: %q (%v)", raw, err)
+	}
+	want := map[string]string{
+		"agent":              "client",
+		"org_wide_aware":     "true",
+		"agent_version":      "1785403654", // the envelope's version_ts
+		"eac_cache_ts":       "true",
+		"cache_ts":           "0",
+		"name_tagging":       "true",
+		"only_self_subteams": "true",
+		"connect_only":       "true",
+		"ms_latest":          "true",
+	}
+	for k, v := range want {
+		if got := args.Get(k); got != v {
+			t.Errorf("start_args[%s] = %q; want %q (from the capture)", k, got, v)
+		}
+	}
+}
+
 func TestGetUsersInConversationPaginates(t *testing.T) {
 	type page struct {
 		users []string

--- a/internal/slack/events.go
+++ b/internal/slack/events.go
@@ -412,6 +412,7 @@ func dispatchWebSocketEvent(data []byte, handler EventHandler) {
 		if err := json.Unmarshal(data, &evt); err != nil {
 			return
 		}
+		debuglog.WS("user_typing: channel=%s user=%s", evt.Channel, evt.User)
 		handler.OnUserTyping(evt.Channel, evt.User)
 
 	case "member_joined_channel":


### PR DESCRIPTION
## Symptom

Typing indicators silently stopped rendering. Everything else on the socket (messages, presence) kept working.

## Root cause

Slack gates `user_typing` frame delivery behind `start_args` keys slk never sent. The official client sends nine keys (2026-08-02 coldboot capture); slk sent three (`agent`, `connect_only`, `ms_latest`). Which key gates typing is undocumented; per the project's standing rule, the capture is the contract and all nine now go out:

`org_wide_aware`, `agent_version` (wired to the envelope's `_x_version_ts`), `eac_cache_ts`, `cache_ts=0`, `name_tagging`, `only_self_subteams` — plus the original three.

Eliminated along the way: the UI pipeline (verified intact with a throwaway end-to-end test) and code changes to the typing path (none since long before the regression).

## Verification

- New end-to-end test pins the dialed URL's `start_args` against the capture; full suite + vet green.
- **Live**: 9 `user_typing` frames received across channels and DMs, indicator rendered on screen; session request tally normal.
- Also adds a `[ws] user_typing` debug log line — that arm was the only known-event arm without one, and it's what made this diagnosable from a debug log.

## Enterprise Grid impact

Assessed key by key in the PR discussion on the branch: the only Grid-relevant key, `org_wide_aware`, is *enabling* (asks the gateway for org-wide events, which the official client sends everywhere including non-Grid); unknown event types are already ignored gracefully by `events.go`. The change's direction is strictly "look more like the official client" — divergence goes down, not up. Whether Grid clients send byte-identical `start_args` is the same open question as the rest of the Grid work, answerable by the capture requested in #5.