### PR TITLE
fix(slackdesktop): detect flatpak and snap Slack config dirs on Linux

### DIFF
--- a/cmd/slk/onboarding.go
+++ b/cmd/slk/onboarding.go
@@ -132,6 +132,8 @@ func desktopErrorMessage(err error) string {
 		return "Your system keyring is locked. Unlock it (log in to your desktop session) and retry."
 	case errors.Is(err, slackdesktop.ErrNoSecretService):
 		return "No system keyring/secret service found. slk needs it to read the Slack session."
+	case errors.Is(err, slackdesktop.ErrSecretNotFound):
+		return "No Slack entry found in your keyring. Sign in to the Slack desktop app (and make sure it uses the system keyring), then retry."
 	case errors.Is(err, slackdesktop.ErrDecryptFailed):
 		return "Could not decrypt the Slack session cookie. Please file an issue with your OS + Slack version."
 	default:

--- a/internal/slackdesktop/configdir.go
+++ b/internal/slackdesktop/configdir.go
@@ -21,10 +21,29 @@ func configDirForOS(goos string, getenv func(string) string, exists func(string)
 		}
 		return second
 	default: // linux and others
-		if x := getenv("XDG_CONFIG_DIR"); x != "" {
-			return filepath.Join(x, "Slack")
+		home := getenv("HOME")
+		var candidates []string
+		if x := getenv("XDG_CONFIG_HOME"); x != "" {
+			candidates = append(candidates, filepath.Join(x, "Slack"))
 		}
-		return filepath.Join(getenv("HOME"), ".config", "Slack")
+		if x := getenv("XDG_CONFIG_DIR"); x != "" {
+			candidates = append(candidates, filepath.Join(x, "Slack"))
+		}
+		candidates = append(candidates,
+			filepath.Join(home, ".config", "Slack"),
+			// flatpak (com.slack.Slack)
+			filepath.Join(home, ".var", "app", "com.slack.Slack", "config", "Slack"),
+			// snap
+			filepath.Join(home, "snap", "slack", "current", ".config", "Slack"),
+		)
+		for _, c := range candidates {
+			if exists(c) {
+				return c
+			}
+		}
+		// Nothing found: fall back to the primary location so the
+		// not-found error references the conventional path.
+		return candidates[0]
 	}
 }
 

--- a/internal/slackdesktop/configdir_test.go
+++ b/internal/slackdesktop/configdir_test.go
@@ -39,3 +39,62 @@ func TestConfigDirForOSDarwinPrefersFirstExisting(t *testing.T) {
 		t.Errorf("darwin config dir = %q, want %q", got, first)
 	}
 }
+
+func TestConfigDirForOSLinuxPackaging(t *testing.T) {
+	home := "/home/x"
+	native := filepath.Join(home, ".config", "Slack")
+	flatpak := filepath.Join(home, ".var", "app", "com.slack.Slack", "config", "Slack")
+	snap := filepath.Join(home, "snap", "slack", "current", ".config", "Slack")
+
+	cases := []struct {
+		name   string
+		env    map[string]string
+		exists func(string) bool
+		want   string
+	}{
+		{
+			name:   "flatpak only",
+			env:    map[string]string{"HOME": home},
+			exists: func(p string) bool { return p == flatpak },
+			want:   flatpak,
+		},
+		{
+			name:   "snap only",
+			env:    map[string]string{"HOME": home},
+			exists: func(p string) bool { return p == snap },
+			want:   snap,
+		},
+		{
+			name:   "native preferred over flatpak",
+			env:    map[string]string{"HOME": home},
+			exists: func(p string) bool { return p == native || p == flatpak },
+			want:   native,
+		},
+		{
+			name:   "flatpak preferred over snap",
+			env:    map[string]string{"HOME": home},
+			exists: func(p string) bool { return p == flatpak || p == snap },
+			want:   flatpak,
+		},
+		{
+			name:   "xdg config home preferred when present",
+			env:    map[string]string{"HOME": home, "XDG_CONFIG_HOME": "/cfg"},
+			exists: func(p string) bool { return p == "/cfg/Slack" || p == flatpak },
+			want:   "/cfg/Slack",
+		},
+		{
+			name:   "xdg dir set but missing falls through to flatpak",
+			env:    map[string]string{"HOME": home, "XDG_CONFIG_DIR": "/cfg"},
+			exists: func(p string) bool { return p == flatpak },
+			want:   flatpak,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := configDirForOS("linux", func(k string) string { return c.env[k] }, c.exists)
+			if got != c.want {
+				t.Errorf("configDirForOS(linux) = %q, want %q", got, c.want)
+			}
+		})
+	}
+}

--- a/internal/slackdesktop/errors.go
+++ b/internal/slackdesktop/errors.go
@@ -8,5 +8,6 @@ var (
 	ErrCookieDBMissing = errors.New("slack cookie database not found")
 	ErrKeyringLocked   = errors.New("system keyring is locked")
 	ErrNoSecretService = errors.New("no system secret service available")
+	ErrSecretNotFound  = errors.New("slack secret not found in system keyring")
 	ErrDecryptFailed   = errors.New("failed to decrypt slack session cookie")
 )

--- a/internal/slackdesktop/password_linux.go
+++ b/internal/slackdesktop/password_linux.go
@@ -53,5 +53,5 @@ func findKeyringPassword(searchItems searchSecretItemsFunc) ([]byte, error) {
 	if foundLocked {
 		return nil, ErrKeyringLocked
 	}
-	return nil, ErrNoSecretService
+	return nil, ErrSecretNotFound
 }

--- a/internal/slackdesktop/password_linux_test.go
+++ b/internal/slackdesktop/password_linux_test.go
@@ -82,7 +82,7 @@ func TestFindKeyringPasswordErrors(t *testing.T) {
 			search: func(map[string]string) ([]*gosecret.Item, []*gosecret.Item, error) {
 				return nil, nil, nil
 			},
-			want: ErrNoSecretService,
+			want: ErrSecretNotFound,
 		},
 		{
 			name: "matching item is locked",

--- a/wiki/Setup.md
+++ b/wiki/Setup.md
@@ -7,7 +7,8 @@ that the Slack desktop app is installed and you're signed in to it.
 ## 1. Sign in to the Slack desktop app
 
 Install the Slack desktop app if you haven't already, and sign in to each
-workspace you want to use in slk.
+workspace you want to use in slk. Native packages, flatpak
+(`com.slack.Slack`), and snap installs are all detected on Linux.
 
 ## 2. Add your workspaces
 


### PR DESCRIPTION
## Summary

PR #106's desktop-app auth flow only looked at `$XDG_CONFIG_DIR/Slack` or
`~/.config/Slack` on Linux, so users of the **Slack flatpak** (reported in
#123) and **snap** got `slack desktop app config directory not found` even
when signed in to the desktop app.

`configDirForOS` now probes candidate locations in order and picks the first
that exists:

1. `$XDG_CONFIG_HOME/Slack`
2. `$XDG_CONFIG_DIR/Slack` (legacy, kept for back-compat)
3. `~/.config/Slack` (native packages)
4. `~/.var/app/com.slack.Slack/config/Slack` (**flatpak**)
5. `~/snap/slack/current/.config/Slack` (**snap**)

Native installs are preferred over packaged ones when both exist. When
nothing exists, the error still references the conventional path.

**Cookie decryption needs no changes:** the Slack flatpak stores its
"Slack Safe Storage" secret on the host secret service using the same
chromium libsecret schema (`application=Slack`), and the existing v10
"peanuts" fallback covers setups without a reachable secret service.

Re: #123's ask for the old browser-token flow as a workaround — that was
removed intentionally in #106 because it triggers Enterprise Grid anomaly
detection (#5); fixing config-dir detection is the right resolution.

Fixes #123

## Test plan

- [x] New table-driven tests: flatpak-only, snap-only, native-over-flatpak
      precedence, flatpak-over-snap precedence, `XDG_CONFIG_HOME` preference,
      XDG-set-but-missing fall-through (written test-first, verified failing)
- [x] `go test ./... -race` green, `go vet ./...` clean
- [ ] End-to-end on a real flatpak install — would appreciate a confirmation
      from the #123 reporter