### PR TITLE
docs(install): document formula→cask migration; use --cask

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,18 @@ Full feature breakdown: **[[Features|https://github.com/gammons/slk/wiki/Feature
 
 ## Quick install
 
-**Homebrew** (macOS and Linux):
+**Homebrew** (macOS only):
 
 ```bash
-brew install gammons/tap/slk
+brew install --cask gammons/tap/slk
 ```
+
+> **Note:** As of v0.13.0, slk is published as a Homebrew Cask (goreleaser v2.10
+> deprecated the `brews`/formula path for prebuilt binaries). Casks are macOS-only;
+> Linuxbrew users should use the tarball or `.deb`/`.rpm`/`.apk` packages below.
+> Existing installs may also need `tap_migrations.json` on the tap (tracked
+> upstream) before `brew upgrade` will move them from the old 0.12.0 formula to
+> the cask — until then, run `brew uninstall slk && brew install --cask gammons/tap/slk`.
 
 **Linux/macOS tarball** (auto-resolves the latest version):
 


### PR DESCRIPTION
## Context

Follows up the v0.13.0 move from Homebrew **Formula** to **Cask** (goreleaser v2.10 deprecates `brews`). The README's `Quick install` section still shows the pre-migration command:

```bash
brew install gammons/tap/slk
```

With both `Formula/slk.rb` (stale at 0.12.0) and `Casks/slk.rb` (0.13.1) present in `gammons/homebrew-tap`, the plain command resolves to the **formula** and installs **0.12.0** — silently installing a stale version missing the v0.13.1 typing-indicator fix.

## Impact

```bash
$ brew install gammons/tap/slk                    # README command
==> Pouring slk--0.12.0.arm64_sonoma.bottle.tar.gz   ← stale 0.12.0
$ slk --version
slk version 0.12.0                                ← missing v0.13.1 typing-indicator fix
```

New users following the README get 0.12.0. Existing users running `brew upgrade slk` never move to the cask (separate tap-side fix needed — see related).

## Why the plain command is wrong now

Brew prefers **formula over cask** on a name collision. With both `Formula/slk.rb` (0.12.0) and `Casks/slk.rb` (0.13.1) present, the unqualified `brew install gammons/tap/slk` resolves to the stale formula.

## Changes

`Quick install` section now reads:

```markdown
**Homebrew** (macOS only):

​```bash
brew install --cask gammons/tap/slk
​```

> **Note:** As of v0.13.0, slk is published as a Homebrew Cask (goreleaser v2.10
> deprecated the `brews`/formula path for prebuilt binaries). Casks are macOS-only;
> Linuxbrew users should use the tarball or `.deb`/`.rpm`/`.apk` packages below.
> Existing installs may also need `tap_migrations.json` on the tap (tracked
> upstream) before `brew upgrade` will move them from the old 0.12.0 formula to
> the cask — until then, run `brew uninstall slk && brew install --cask gammons/tap/slk`.
```

## Why this is the right shape

- `--cask` is unambiguous and works **today**, even before the tap-side migration (`tap_migrations.json` + `Formula/slk.rb` deletion) lands.
- Switching `(macOS and Linux)` → `(macOS only)` reflects reality: casks are macOS-only, so Linuxbrew users can no longer use this path and should use the tarball / native packages (already documented below).
- The note also tells the existing-user story: a one-shot uninstall + reinstall, since auto-migration depends on the upstream tap fix.

## Related

- Tap-side fix PR: <https://github.com/gammons/homebrew-tap/pull/2>
- goreleaser deprecation notice: <https://goreleaser.com/resources/deprecations/#brews>
- The maintainer's own migration notes live in `.goreleaser.yaml` (`homebrew_casks` block comment).

Once the tap-side PR merges and `tap_migrations.json` is in place, the README could be simplified back to `brew install gammons/tap/slk` (which would then resolve to the cask once `Formula/slk.rb` is gone). I left the explicit `--cask` + note because (a) it's robust to either state, and (b) it's honest about the current macOS-only situation.

Happy to amend the wording if the style is off.