### PR TITLE
Inline images on sixel terminals (WezTerm, iTerm2, foot, mlterm)

### DIFF
--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -899,6 +899,16 @@ func run() error {
 
 	// Create app
 	app := ui.NewApp()
+	// Frame-correlated sixel output: the App publishes immutable
+	// placement snapshots into sixelFrames; terminalOutput strips the
+	// internal frame marker from Bubble Tea's window title, takes the
+	// exact flushed frame, and paints its sixel operations after the
+	// text diff. Kitty uploads share the same serialized writer so
+	// byte streams from different goroutines can't interleave.
+	sixelFrames := imgpkg.NewSixelFrameStore()
+	terminalOutput := imgpkg.NewFrameOutput(os.Stdout, sixelFrames)
+	imgpkg.KittyOutput = terminalOutput.SideChannel()
+	app.SetSixelFrameStore(sixelFrames)
 	app.SetHelpFooter(versionpkg.ModalFooter(version))
 	app.SetClipboardAvailable(clipboardOK)
 	if sr := notify.NewStatusReporter(cfg.Notifications.StatusCommand); sr != nil {
@@ -1015,6 +1025,12 @@ func run() error {
 	// Cell pixel metrics for sizing decisions.
 	pxW, pxH := imgpkg.CellPixels(int(os.Stdout.Fd()))
 	debuglog.ImgRender("cell pixels: %dx%d", pxW, pxH)
+	// Sixel encodes at absolute pixel dimensions — the terminal paints
+	// one sixel pixel per device pixel rather than scaling into a cell
+	// box the way kitty does. Hand it the measured metrics so an image
+	// occupying N rows of layout is encoded N*cellHeight pixels tall and
+	// actually lands on those rows.
+	imgpkg.SetCellPixels(pxW, pxH)
 
 	// Wire the inline-image pipeline into the messages pane. SendMsg
 	// stays nil here because tea.NewProgram has not run yet; we re-call
@@ -1884,8 +1900,11 @@ func run() error {
 	// activeTeamID == "" and both set InitialActive=true.
 	var firstReady sync.Once
 
-	// Start the TUI immediately (shows loading overlay)
-	p = tea.NewProgram(app)
+	// Start the TUI immediately (shows loading overlay). All output —
+	// every protocol — flows through the frame-correlated writer: it is
+	// a serialized pass-through for non-sixel frames (no marker present)
+	// and the sixel paint site for marked frames.
+	p = tea.NewProgram(app, tea.WithOutput(terminalOutput))
 
 	// Now that `p` exists, re-install the ImageContext with a real
 	// SendMsg callback so the prefetcher can dispatch ImageReadyMsg

--- a/internal/image/capability.go
+++ b/internal/image/capability.go
@@ -85,8 +85,7 @@ func Detect(env Env, cfg string) Protocol {
 	if env.KittyWindowID != "" || env.Term == "xterm-kitty" {
 		return ProtoKitty
 	}
-	switch env.TermProgram {
-	case "ghostty", "WezTerm":
+	if env.TermProgram == "ghostty" {
 		return ProtoKitty
 	}
 	if env.TMUX != "" {
@@ -105,6 +104,19 @@ func Detect(env Env, cfg string) Protocol {
 		return ProtoHalfBlock
 	}
 	if env.Term == "foot" || env.Term == "mlterm" {
+		return ProtoSixel
+	}
+	// iTerm2 and WezTerm both support kitty *graphics*, but not the
+	// unicode-placeholder extension slk's kitty renderer depends on for
+	// placement (see the U=1 note on writeKittySequence / kitty.go) —
+	// iTerm2 because its kitty implementation is partial and fails the
+	// startup probe, WezTerm because it answers the probe but then
+	// prints the placeholder codepoints as literal glyphs. Both have
+	// solid sixel support, so auto picks sixel for real pixels instead
+	// of the halfblock mosaic the failed kitty probe would otherwise
+	// fall back to.
+	switch env.TermProgram {
+	case "iTerm.app", "WezTerm":
 		return ProtoSixel
 	}
 	return ProtoHalfBlock

--- a/internal/image/capability_test.go
+++ b/internal/image/capability_test.go
@@ -30,18 +30,36 @@ func TestDetect_ConfigOverrides(t *testing.T) {
 
 // Pre-tmux env signals still work if they happened to propagate (e.g.
 // user launched tmux from inside kitty, KITTY_WINDOW_ID survived).
+// WezTerm is deliberately not in this set: unlike ghostty it has no
+// U=1 placeholder support (see the sixel-detect comment on Detect),
+// and sixel-under-tmux is intentionally conservative, so an inherited
+// TermProgram=WezTerm under tmux with an unresolved client term falls
+// through to the same halfblock fallback as any other unrecognized
+// outer terminal — see TestDetect_TmuxWezTermInheritedFallsBackToHalfBlock.
 func TestDetect_TmuxKittyHostFromInheritedEnv(t *testing.T) {
 	withTmuxClientTerm(t, "")
 	cases := []Env{
 		{TMUX: "/tmp/tmux", KittyWindowID: "1"},
 		{TMUX: "/tmp/tmux", Term: "xterm-kitty"},
 		{TMUX: "/tmp/tmux", TermProgram: "ghostty"},
-		{TMUX: "/tmp/tmux", TermProgram: "WezTerm"},
 	}
 	for i, env := range cases {
 		if got := Detect(env, "auto"); got != ProtoKitty {
 			t.Errorf("case %d (%+v): want kitty, got %v", i, env, got)
 		}
+	}
+}
+
+// Under tmux, sixel is never auto-selected regardless of the outer
+// terminal (bandwidth-hostile with tmux passthrough, no probe-verify —
+// see Detect's doc comment), so an inherited TermProgram=WezTerm with
+// no resolvable client term must land on the same conservative
+// halfblock fallback as any other unrecognized tmux client, not sixel.
+func TestDetect_TmuxWezTermInheritedFallsBackToHalfBlock(t *testing.T) {
+	withTmuxClientTerm(t, "")
+	env := Env{TMUX: "/tmp/tmux", TermProgram: "WezTerm"}
+	if got := Detect(env, "auto"); got != ProtoHalfBlock {
+		t.Errorf("want halfblock, got %v", got)
 	}
 }
 
@@ -92,7 +110,6 @@ func TestDetect_KittyByEnvVar(t *testing.T) {
 		{KittyWindowID: "1"},
 		{Term: "xterm-kitty"},
 		{TermProgram: "ghostty"},
-		{TermProgram: "WezTerm"},
 	}
 	for i, env := range cases {
 		if got := Detect(env, "auto"); got != ProtoKitty {
@@ -105,6 +122,18 @@ func TestDetect_Sixel(t *testing.T) {
 	cases := []Env{
 		{Term: "foot"},
 		{Term: "mlterm"},
+		// iTerm2 has no working kitty graphics implementation (the
+		// startup probe would time out and downgrade to halfblock),
+		// but it does support sixel — real pixels instead of the
+		// halfblock mosaic.
+		{TermProgram: "iTerm.app"},
+		// WezTerm answers the kitty capability probe (it does support
+		// kitty *graphics*) but has no U=1 placeholder support, so the
+		// placeholder codepoints render as literal glyphs. Routing it
+		// to kitty and letting the probe downgrade it was the old
+		// behavior; that downgrade path lands on halfblock, which is
+		// what motivates going straight to sixel here instead.
+		{TermProgram: "WezTerm"},
 	}
 	for _, env := range cases {
 		if got := Detect(env, "auto"); got != ProtoSixel {

--- a/internal/image/preview.go
+++ b/internal/image/preview.go
@@ -1,6 +1,7 @@
 package image
 
 import (
+	"bytes"
 	"fmt"
 	"image"
 	"strings"
@@ -42,6 +43,56 @@ type Preview struct {
 	sibIndex     int
 	loading      bool
 	loadingFrame int
+
+	// sixelPaint is the most recent frame's sixel placement, in
+	// coordinates relative to this panel's own content area (the panel
+	// has no border of its own — row/col 0 is the panel's top-left
+	// cell). nil except right after a View() call with proto ==
+	// ProtoSixel that produced a paintable image. See SixelPaint.
+	sixelPaint *SixelPaint
+
+	// Encoded-image memo. View() runs on every App.View(), which
+	// bubbletea calls after EVERY message — every keystroke, key repeat
+	// and mouse motion — and the compositor deliberately never memoizes
+	// overlay frames (see internal/ui/app.go: overlay content can change
+	// without a Version bump). Re-encoding is not cheap: a full-pane
+	// sixel encode measures ~1.4s at typical preview dimensions, so
+	// without this memo the overlay re-encodes on every message and the
+	// terminal visibly lags both opening and closing the preview.
+	//
+	// The key is everything RenderImage's result depends on: image
+	// identity, cell target, and protocol. SwapImage invalidates
+	// explicitly, because cycling siblings can land on an equal target
+	// and the loading→loaded swap can reuse a file ID.
+	memo      Render
+	memoValid bool
+	memoFID   string
+	memoProto Protocol
+	memoTgt   image.Point
+}
+
+// SixelPaint is one sixel image a rendering surface (the messages pane
+// or the preview overlay) wants painted, in that surface's LOCAL
+// coordinate frame: Row is the 0-based row of the image's first line
+// below the surface's content origin, Col the 0-based column where the
+// image's placeholder sits (the message content column, not 0 — images
+// sit next to the avatar). Rows/Cols are the cell footprint, which the
+// painter needs in order to erase the region.
+//
+// Key changes whenever the pixel content changes (a different image, or
+// the same image resized by a terminal resize) so the painter knows to
+// repaint rather than treat it as the same placement.
+//
+// Deliberately NOT written into the string View() returns: sixel bytes
+// in the frame string can't be erased or cheaply skipped when unchanged
+// (see internal/ui/sixelpaint.go, which has the same constraint for the
+// messages pane and the full rationale). The caller converts these to
+// absolute imgpkg.SixelPlacement values and paints them out-of-band.
+type SixelPaint struct {
+	Key        string
+	Row, Col   int
+	Rows, Cols int
+	Bytes      []byte
 }
 
 // NewPreview returns an open preview displaying the given image.
@@ -84,6 +135,12 @@ func normalizeSiblings(count, idx int) (int, int) {
 	}
 	return count, idx
 }
+
+// SixelPaint returns the sixel placement produced by the most recent
+// View() call, or nil when that call didn't render a paintable sixel
+// image (wrong protocol, loading state, no image, or no room). Valid
+// until the next View call.
+func (p *Preview) SixelPaint() *SixelPaint { return p.sixelPaint }
 
 // IsLoading reports whether the preview is currently waiting for image
 // bytes to land.
@@ -131,6 +188,20 @@ func (p *Preview) SwapImage(in PreviewInput) {
 		p.sibIndex = in.SiblingIndex
 	}
 	p.loading = false
+	p.memoValid = false
+}
+
+// renderImage returns the encoded render for target, reusing the memo
+// when the image, target and protocol are all unchanged. See the memo
+// fields on Preview for why this matters.
+func (p *Preview) renderImage(proto Protocol, target image.Point) Render {
+	if p.memoValid && p.memoFID == p.fid && p.memoProto == proto && p.memoTgt == target {
+		return p.memo
+	}
+	r := RenderImage(proto, p.img, target)
+	p.memo, p.memoValid = r, true
+	p.memoFID, p.memoProto, p.memoTgt = p.fid, proto, target
+	return r
 }
 
 // previewSpinnerFrames is the small set of braille glyphs used to
@@ -145,6 +216,7 @@ var previewSpinnerFrames = []rune{'⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦
 // While loading, the image area shows a centered spinner + filename
 // instead of an image. Caption and hint render the same way.
 func (p *Preview) View(width, height int, proto Protocol) string {
+	p.sixelPaint = nil
 	if !p.open || width <= 0 || height <= 0 {
 		return ""
 	}
@@ -167,15 +239,45 @@ func (p *Preview) View(width, height int, proto Protocol) string {
 	srcW, srcH := p.img.Bounds().Dx(), p.img.Bounds().Dy()
 	target := fitInto(srcW, srcH, imgCols, imgRows)
 
-	render := RenderImage(proto, p.img, target)
+	render := p.renderImage(proto, target)
 
-	// For kitty: write the upload APC escape directly to the terminal
-	// side channel before the placeholder cells go into the View string.
-	// Embedding the upload in the returned string would have it mangled
-	// by lipgloss/bubbletea (same reason the messages-pane goes around
-	// the frame buffer).
-	if render.OnFlush != nil {
-		_ = render.OnFlush(KittyOutput)
+	// Kitty and sixel both need their bytes to reach the terminal
+	// outside the View() return string — lipgloss/bubbletea's renderer
+	// is known to mangle escape sequences embedded in line content —
+	// but they need it delivered differently:
+	//
+	//   - kitty's upload (APC) must reach the terminal BEFORE the
+	//     unicode placeholder cells that reference it, and re-uploading
+	//     the same image ID is a harmless no-op, so writing it directly
+	//     here on every View() is correct.
+	//   - sixel has no re-render/erase of its own (see
+	//     internal/ui/sixelpaint.go for the full rationale): writing it
+	//     here, every View(), with no erase, is exactly what produced
+	//     the tiled/duplicated overlay images this replaces. Instead we
+	//     hand the bytes + position to the caller, which owns a
+	//     SixelPainter that paints once, erases on change, and stays
+	//     out of View() entirely.
+	leftPad := (width - target.X) / 2
+	topGap := (imgRows - target.Y) / 2
+	switch proto {
+	case ProtoKitty:
+		if render.OnFlush != nil {
+			_ = render.OnFlush(KittyOutput)
+		}
+	case ProtoSixel:
+		if render.OnFlush != nil {
+			var buf bytes.Buffer
+			if err := render.OnFlush(&buf); err == nil && buf.Len() > 0 {
+				p.sixelPaint = &SixelPaint{
+					Key:   PlacementKey(p.fid, buf.Bytes(), target.X, target.Y),
+					Row:   1 + topGap, // caption row + vertical centering gap
+					Col:   leftPad,
+					Rows:  target.Y,
+					Cols:  target.X,
+					Bytes: buf.Bytes(),
+				}
+			}
+		}
 	}
 
 	caption := fmt.Sprintf("%s  •  %dx%d", p.name, srcW, srcH)
@@ -188,12 +290,10 @@ func (p *Preview) View(width, height int, proto Protocol) string {
 	b.WriteString(captionStyle.Render(caption))
 	b.WriteByte('\n')
 
-	leftPad := (width - target.X) / 2
 	rightPad := width - target.X - leftPad
 	pad := strings.Repeat(" ", leftPad)
 	rpad := strings.Repeat(" ", rightPad)
 
-	topGap := (imgRows - target.Y) / 2
 	for i := 0; i < topGap; i++ {
 		b.WriteString(strings.Repeat(" ", width))
 		b.WriteByte('\n')

--- a/internal/image/preview_test.go
+++ b/internal/image/preview_test.go
@@ -1,6 +1,7 @@
 package image
 
 import (
+	"bytes"
 	"image/color"
 	"strings"
 	"testing"
@@ -85,5 +86,177 @@ func TestPreview_SwapImageUpdatesIndex(t *testing.T) {
 	}
 	if p.SiblingCount() != 3 {
 		t.Errorf("count should remain 3, got %d", p.SiblingCount())
+	}
+}
+
+// TestPreview_SixelPaint_RoutedOutOfBand pins the fix for the tiled/
+// duplicated preview images: for ProtoSixel, View() must NOT write the
+// image bytes anywhere the caller can see (they'd get re-emitted every
+// frame with no way to erase them — see internal/ui/sixelpaint.go for
+// why that's a bug, not just a style choice) and must instead expose
+// them via SixelPaint() for the caller's out-of-band painter.
+func TestPreview_SixelPaint_RoutedOutOfBand(t *testing.T) {
+	p := NewPreview(PreviewInput{
+		Name: "screenshot.png",
+		Img:  makeSolid(200, 100, color.RGBA{10, 20, 30, 255}),
+	})
+	out := p.View(60, 30, ProtoSixel)
+
+	sp := p.SixelPaint()
+	if sp == nil {
+		t.Fatal("SixelPaint() is nil after a ProtoSixel render with a real image")
+	}
+	if len(sp.Bytes) == 0 {
+		t.Error("SixelPaint().Bytes is empty")
+	}
+	if sp.Rows <= 0 || sp.Cols <= 0 {
+		t.Errorf("SixelPaint() footprint = %dx%d, want positive", sp.Cols, sp.Rows)
+	}
+	if sp.Key == "" {
+		t.Error("SixelPaint().Key is empty; painter needs it to detect content changes")
+	}
+	// The DCS payload itself must not appear in the returned string —
+	// only the sentinel placeholder line does.
+	if strings.Contains(out, string(sp.Bytes)) {
+		t.Error("sixel bytes leaked into the View() string; must be out-of-band only")
+	}
+}
+
+// TestPreview_SixelPaint_NilForOtherProtocols asserts SixelPaint() is
+// only ever populated for ProtoSixel — kitty keeps its existing eager
+// OnFlush-to-KittyOutput path, and halfblock has nothing to paint
+// out-of-band.
+func TestPreview_SixelPaint_NilForOtherProtocols(t *testing.T) {
+	for _, proto := range []Protocol{ProtoHalfBlock, ProtoKitty} {
+		p := NewPreview(PreviewInput{
+			Name: "screenshot.png",
+			Img:  makeSolid(200, 100, color.RGBA{10, 20, 30, 255}),
+		})
+		p.View(60, 30, proto)
+		if sp := p.SixelPaint(); sp != nil {
+			t.Errorf("proto=%v: SixelPaint() = %+v, want nil", proto, sp)
+		}
+	}
+}
+
+// TestPreview_SixelPaint_NilWhileLoadingOrClosed guards the reset at the
+// top of View(): a stale placement from a previous displaying frame
+// must not survive into a loading or closed frame, since the caller
+// would otherwise keep painting an image that's no longer being shown.
+func TestPreview_SixelPaint_NilWhileLoadingOrClosed(t *testing.T) {
+	p := NewPreview(PreviewInput{
+		Name: "screenshot.png",
+		Img:  makeSolid(200, 100, color.RGBA{10, 20, 30, 255}),
+	})
+	p.View(60, 30, ProtoSixel)
+	if p.SixelPaint() == nil {
+		t.Fatal("precondition: expected a populated SixelPaint after a displaying sixel render")
+	}
+
+	loading := NewLoadingPreview("screenshot.png", 1, 0)
+	loading.View(60, 30, ProtoSixel)
+	if sp := loading.SixelPaint(); sp != nil {
+		t.Errorf("loading preview: SixelPaint() = %+v, want nil", sp)
+	}
+
+	p.Close()
+	p.View(60, 30, ProtoSixel)
+	if sp := p.SixelPaint(); sp != nil {
+		t.Errorf("closed preview: SixelPaint() = %+v, want nil", sp)
+	}
+}
+
+// TestPreview_SixelPaint_Key_DifferentFileIDsDiffer pins the preview
+// side of the collision regression: two same-size solid images with
+// different non-empty file IDs must produce different placement keys
+// regardless of encoded byte length.
+func TestPreview_SixelPaint_Key_DifferentFileIDsDiffer(t *testing.T) {
+	red := NewPreview(PreviewInput{Name: "red.png", FileID: "FRED-720", Img: makeSolid(200, 100, color.RGBA{200, 0, 0, 255})})
+	blue := NewPreview(PreviewInput{Name: "blue.png", FileID: "FBLUE-720", Img: makeSolid(200, 100, color.RGBA{0, 0, 200, 255})})
+	red.View(60, 30, ProtoSixel)
+	blue.View(60, 30, ProtoSixel)
+	kr, kb := red.SixelPaint().Key, blue.SixelPaint().Key
+	if kr == "" || kb == "" {
+		t.Fatal("empty placement keys")
+	}
+	if kr == kb {
+		t.Fatalf("different file IDs collided: %q", kr)
+	}
+}
+
+// TestPreview_SixelPaint_Key_DifferentPayloadsDiffer is the digest
+// fallback: with no file ID, two same-size different-color images encode
+// to the same byte length but must still differ.
+func TestPreview_SixelPaint_Key_DifferentPayloadsDiffer(t *testing.T) {
+	red := NewPreview(PreviewInput{Name: "red.png", Img: makeSolid(200, 100, color.RGBA{200, 0, 0, 255})})
+	blue := NewPreview(PreviewInput{Name: "blue.png", Img: makeSolid(200, 100, color.RGBA{0, 0, 200, 255})})
+	red.View(60, 30, ProtoSixel)
+	blue.View(60, 30, ProtoSixel)
+	if len(red.SixelPaint().Bytes) != len(blue.SixelPaint().Bytes) {
+		t.Fatal("precondition: encoded payload lengths must match for this regression")
+	}
+	kr, kb := red.SixelPaint().Key, blue.SixelPaint().Key
+	if kr == "" || kb == "" {
+		t.Fatal("empty placement keys")
+	}
+	if kr == kb {
+		t.Fatalf("equal-length different payloads collided: %q", kr)
+	}
+}
+
+// TestPreview_ReusesEncodedRenderAcrossViews pins the memo that keeps
+// the overlay usable. App.View() runs after every bubbletea message and
+// never memoizes overlay frames, so without this the preview re-encodes
+// its image on every keystroke and mouse motion — ~1.4s per encode at
+// full-pane size, which showed up as a multi-second lag opening and
+// closing the preview.
+//
+// The image is swapped behind the memo's back (a direct field write, no
+// SwapImage) so a re-encode would be visible as different payload bytes.
+func TestPreview_ReusesEncodedRenderAcrossViews(t *testing.T) {
+	p := NewPreview(PreviewInput{
+		Name:   "screenshot.png",
+		FileID: "F01",
+		Img:    makeSolid(200, 100, color.RGBA{10, 20, 30, 255}),
+	})
+	p.View(60, 30, ProtoSixel)
+	first := append([]byte(nil), p.SixelPaint().Bytes...)
+
+	// Same file, same target, same protocol: the memo must win even
+	// though the underlying pixels now differ.
+	p.img = makeSolid(200, 100, color.RGBA{200, 40, 90, 255})
+	p.View(60, 30, ProtoSixel)
+	if !bytes.Equal(first, p.SixelPaint().Bytes) {
+		t.Error("preview re-encoded an unchanged image; the render memo is not being hit")
+	}
+
+	// A different cell target is a different encode and must miss.
+	p.View(40, 20, ProtoSixel)
+	if bytes.Equal(first, p.SixelPaint().Bytes) {
+		t.Error("memo served a stale render for a different target size")
+	}
+}
+
+// TestPreview_SwapImageInvalidatesRenderMemo covers the case the memo
+// key alone cannot: the loading→loaded swap and sibling cycling can
+// reuse a file ID, so SwapImage has to invalidate explicitly or the
+// overlay would keep showing the previous image.
+func TestPreview_SwapImageInvalidatesRenderMemo(t *testing.T) {
+	p := NewPreview(PreviewInput{
+		Name:   "a.png",
+		FileID: "F01",
+		Img:    makeSolid(200, 100, color.RGBA{10, 20, 30, 255}),
+	})
+	p.View(60, 30, ProtoSixel)
+	first := append([]byte(nil), p.SixelPaint().Bytes...)
+
+	p.SwapImage(PreviewInput{
+		Name:   "a.png",
+		FileID: "F01", // deliberately the same ID
+		Img:    makeSolid(200, 100, color.RGBA{200, 40, 90, 255}),
+	})
+	p.View(60, 30, ProtoSixel)
+	if bytes.Equal(first, p.SixelPaint().Bytes) {
+		t.Error("SwapImage did not invalidate the render memo; preview would show the old image")
 	}
 }

--- a/internal/image/renderer.go
+++ b/internal/image/renderer.go
@@ -141,10 +141,3 @@ func (s *serializedWriter) Write(p []byte) (int, error) {
 	defer s.mu.Unlock()
 	return s.w.Write(p)
 }
-
-// SixelSentinel is a private-use codepoint reserved for slk to mark a row
-// in viewEntry.Lines that should trigger a sixel byte stream emission
-// during messages-pane rendering. The character is U+E0001 (LANGUAGE TAG),
-// chosen because no terminal renders it with a glyph; it is effectively
-// zero-width and ignored by selection/copy.
-const SixelSentinel = '\U000E0001'

--- a/internal/image/sixel.go
+++ b/internal/image/sixel.go
@@ -5,11 +5,58 @@ import (
 	"image"
 	"io"
 	"strings"
+	"sync/atomic"
 
 	"github.com/gammons/slk/internal/debuglog"
 	gosixel "github.com/mattn/go-sixel"
 	"golang.org/x/image/draw"
 )
+
+// Default cell geometry, used until SetCellPixels reports the real
+// values. Matches the CellPixels fallback so behaviour is unchanged on
+// terminals that don't answer TIOCGWINSZ.
+const (
+	defaultCellPxW = 8
+	defaultCellPxH = 16
+)
+
+// cellPxW / cellPxH hold the terminal's measured cell size in pixels.
+//
+// Unlike kitty — which transmits c=<cols>,r=<rows> and lets the terminal
+// scale the image into that cell box — sixel has no cell-aware placement:
+// the terminal paints one sixel pixel per device pixel and advances the
+// cursor by the image's own height. So the encoded pixel dimensions ARE
+// the on-screen size, and they must be derived from the real cell metrics
+// or the image won't line up with the rows the layout reserved for it.
+//
+// Set once at startup from CellPixels() before any rendering goroutine
+// runs; atomics keep that safe against the prerender worker pool.
+var (
+	cellPxW atomic.Int32
+	cellPxH atomic.Int32
+)
+
+// SetCellPixels records the terminal's cell size for sixel encoding.
+// Non-positive values are ignored, so a terminal that reports nothing
+// keeps the 8x16 default. Call once during startup.
+func SetCellPixels(w, h int) {
+	if w <= 0 || h <= 0 {
+		debuglog.ImgRender("sixel.SetCellPixels: ignoring non-positive cell size %dx%d", w, h)
+		return
+	}
+	cellPxW.Store(int32(w))
+	cellPxH.Store(int32(h))
+	debuglog.ImgRender("sixel.SetCellPixels: cell_w=%d cell_h=%d", w, h)
+}
+
+// sixelCellPixels returns the cell size to encode against.
+func sixelCellPixels() (int, int) {
+	w, h := int(cellPxW.Load()), int(cellPxH.Load())
+	if w <= 0 || h <= 0 {
+		return defaultCellPxW, defaultCellPxH
+	}
+	return w, h
+}
 
 // SixelRenderer encodes images as DEC sixel byte streams.
 type SixelRenderer struct{}
@@ -19,18 +66,22 @@ func NewSixelRenderer() *SixelRenderer {
 	return &SixelRenderer{}
 }
 
-// Render emits a Render whose Lines contain a sentinel marker on row 0;
-// the messages-pane line writer recognizes the sentinel and emits the
-// sixel byte stream via OnFlush only when the image fits fully on screen.
-// Otherwise, the Fallback (half-block) Lines are emitted instead.
+// Render emits a Render whose Lines reserve the image's cell footprint
+// with plain spaces, exactly like a text block of the same size — the
+// messages pane treats them as ordinary content, reserves the rows, and
+// drives the sixel byte stream from the placement pipeline (see
+// internal/ui/messages and imgpkg.SixelPaint) rather than from the line
+// content. Fallback carries the half-block equivalent used when the
+// image is only partially visible.
 func (s *SixelRenderer) Render(img image.Image, target image.Point) Render {
 	if target.X <= 0 || target.Y <= 0 {
 		debuglog.ImgRender("sixel.Render: target=(%d,%d) abort=zero_target", target.X, target.Y)
 		return Render{Cells: target}
 	}
 
-	pxW := target.X * 8
-	pxH := target.Y * 16
+	cw, ch := sixelCellPixels()
+	pxW := target.X * cw
+	pxH := target.Y * ch
 	resized := image.NewRGBA(image.Rect(0, 0, pxW, pxH))
 	draw.BiLinear.Scale(resized, resized.Bounds(), img, img.Bounds(), draw.Over, nil)
 
@@ -42,19 +93,14 @@ func (s *SixelRenderer) Render(img image.Image, target image.Point) Render {
 		return HalfBlockRenderer{}.Render(img, target)
 	}
 	sixelBytes := sx.Bytes()
-	debuglog.ImgRender("sixel.Render: target=(%d,%d) sixel_bytes=%d", target.X, target.Y, len(sixelBytes))
+	debuglog.ImgRender("sixel.Render: target=(%d,%d) cell=(%d,%d) px=(%d,%d) sixel_bytes=%d",
+		target.X, target.Y, cw, ch, pxW, pxH, len(sixelBytes))
 
 	hb := HalfBlockRenderer{}.Render(img, target)
 
 	lines := make([]string, target.Y)
-	rowSpaces := strings.Repeat(" ", target.X)
-	if target.X >= 1 {
-		lines[0] = string(SixelSentinel) + strings.Repeat(" ", target.X-1)
-	} else {
-		lines[0] = string(SixelSentinel)
-	}
-	for i := 1; i < target.Y; i++ {
-		lines[i] = rowSpaces
+	for i := range lines {
+		lines[i] = strings.Repeat(" ", target.X)
 	}
 
 	bs := sixelBytes

--- a/internal/image/sixel_cellpx_test.go
+++ b/internal/image/sixel_cellpx_test.go
@@ -1,0 +1,79 @@
+package image
+
+import (
+	"image"
+	"strings"
+	"testing"
+)
+
+// Sixel has no cell-aware placement: the encoded pixel size is the
+// on-screen size. An image the layout gave N rows must therefore be
+// encoded N*cellHeight pixels tall, or it won't cover those rows and
+// the cursor advance won't match the reserved space.
+
+func resetCellPixels(t *testing.T) {
+	t.Helper()
+	cellPxW.Store(0)
+	cellPxH.Store(0)
+}
+
+func TestSixelCellPixels_DefaultsTo8x16(t *testing.T) {
+	resetCellPixels(t)
+	w, h := sixelCellPixels()
+	if w != 8 || h != 16 {
+		t.Errorf("sixelCellPixels() = %dx%d, want 8x16 default", w, h)
+	}
+}
+
+func TestSetCellPixels_UsesMeasuredMetrics(t *testing.T) {
+	resetCellPixels(t)
+	SetCellPixels(14, 33)
+	t.Cleanup(func() { resetCellPixels(t) })
+
+	if w, h := sixelCellPixels(); w != 14 || h != 33 {
+		t.Errorf("sixelCellPixels() = %dx%d, want 14x33", w, h)
+	}
+}
+
+func TestSetCellPixels_IgnoresNonPositive(t *testing.T) {
+	resetCellPixels(t)
+	SetCellPixels(0, 33)
+	SetCellPixels(14, -1)
+	if w, h := sixelCellPixels(); w != 8 || h != 16 {
+		t.Errorf("sixelCellPixels() = %dx%d, want the 8x16 default to survive bad input", w, h)
+	}
+}
+
+// The encoded raster must scale with the reported cell height: a taller
+// cell means more pixels for the same row count.
+func TestSixelRender_ScalesWithCellHeight(t *testing.T) {
+	resetCellPixels(t)
+	t.Cleanup(func() { resetCellPixels(t) })
+
+	src := image.NewRGBA(image.Rect(0, 0, 64, 64))
+	target := image.Pt(10, 5)
+
+	SetCellPixels(8, 16)
+	small := renderSixelBytes(t, src, target)
+
+	SetCellPixels(16, 32)
+	large := renderSixelBytes(t, src, target)
+
+	if len(large) <= len(small) {
+		t.Errorf("doubling the cell size did not grow the sixel raster: small=%d large=%d bytes",
+			len(small), len(large))
+	}
+}
+
+func renderSixelBytes(t *testing.T, img image.Image, target image.Point) []byte {
+	t.Helper()
+	out := (&SixelRenderer{}).Render(img, target)
+	if out.OnFlush == nil {
+		t.Fatal("Render returned no OnFlush; expected sixel bytes")
+	}
+	var sb strings.Builder
+	if err := out.OnFlush(&sb); err != nil {
+		t.Fatalf("OnFlush: %v", err)
+	}
+	return []byte(sb.String())
+}

--- a/internal/image/sixel_test.go
+++ b/internal/image/sixel_test.go
@@ -19,12 +19,12 @@ func TestSixel_RenderShape(t *testing.T) {
 	if len(out.Lines) != 5 {
 		t.Fatalf("expected 5 lines, got %d", len(out.Lines))
 	}
-	if !strings.ContainsRune(out.Lines[0], SixelSentinel) {
-		t.Errorf("row 0 missing sentinel: %q", out.Lines[0])
-	}
-	for i := 1; i < len(out.Lines); i++ {
-		if strings.ContainsRune(out.Lines[i], SixelSentinel) {
-			t.Errorf("row %d has unexpected sentinel", i)
+	// The placeholder rows are plain spaces reserving the footprint; the
+	// messages pane drives emission from the placement pipeline, not from
+	// any marker in the line content.
+	for i, l := range out.Lines {
+		if w := strings.Count(l, " "); w != 20 {
+			t.Errorf("row %d width = %d, want 20 cells of space", i, w)
 		}
 	}
 	if len(out.Fallback) != 5 {

--- a/internal/image/sixelframe.go
+++ b/internal/image/sixelframe.go
@@ -1,0 +1,338 @@
+package image
+
+import (
+	"bytes"
+	"io"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/gammons/slk/internal/debuglog"
+)
+
+// frameTitleMarker is the private suffix slk appends to Bubble Tea's
+// window title to carry the exact frame ID through the renderer. The US
+// byte (0x1f) is chosen because no terminal displays it and the real
+// window title never contains it; FrameOutput strips the suffix before
+// any byte reaches the terminal.
+const frameTitleMarker = "\x1fslk-sixel-frame="
+
+// SixelFrame is one published snapshot of the placements the App's
+// View() produced for a single screen. The frame store correlates it
+// with the Bubble Tea frame that actually flushes by embedding its ID
+// in the view's window title.
+type SixelFrame struct {
+	// Placements is the immutable set of absolute placements the frame
+	// wants displayed. The store clones the slice header, never the
+	// payload bytes.
+	Placements []SixelPlacement
+	// EraseSGR is the background sequence to set before each ECH so
+	// vacated cells take the pane's theme background.
+	EraseSGR string
+	// Force repaints every valid wanted placement even when unchanged
+	// (renderer full redraws such as terminal resize).
+	Force bool
+}
+
+// SixelFrameStore publishes View-time placement snapshots and hands
+// them back to FrameOutput in monotonic flush order. Publish clones
+// only the placement slice; the large payload bytes stay shared by
+// reference.
+type SixelFrameStore struct {
+	mu     sync.Mutex
+	nextID uint64
+	frames map[uint64]SixelFrame
+}
+
+// NewSixelFrameStore returns an empty store with IDs starting at 1.
+func NewSixelFrameStore() *SixelFrameStore {
+	return &SixelFrameStore{frames: make(map[uint64]SixelFrame)}
+}
+
+// Publish stores frame and returns its monotonic ID. The placement
+// slice is cloned so the caller can reuse its buffer; payload bytes are
+// not copied.
+func (s *SixelFrameStore) Publish(frame SixelFrame) uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.nextID++
+	frame.Placements = slices.Clone(frame.Placements)
+	s.frames[s.nextID] = frame
+	return s.nextID
+}
+
+// Take returns the exact frame with id and prunes every pending frame
+// with an ID <= id. Bubble Tea flushes views in monotonic order, so a
+// skipped intermediate view will never flush later and its frame can be
+// discarded. There is no latest-fallback: a missing id yields ok=false.
+func (s *SixelFrameStore) Take(id uint64) (SixelFrame, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	frame, ok := s.frames[id]
+	for k := range s.frames {
+		if k <= id {
+			delete(s.frames, k)
+		}
+	}
+	return frame, ok
+}
+
+// FrameTitle encodes id into the Bubble Tea window title so the flushed
+// bytes identify the exact frame, using a private marker that the real
+// title never contains.
+func FrameTitle(realTitle string, id uint64) string {
+	return realTitle + frameTitleMarker + strconv.FormatUint(id, 10)
+}
+
+// parseFrameTitle splits a FrameTitle back into the real title and the
+// frame ID. Returns ok=false when the title carries no marker.
+func parseFrameTitle(title string) (real string, id uint64, ok bool) {
+	idx := strings.Index(title, frameTitleMarker)
+	if idx < 0 {
+		return "", 0, false
+	}
+	real = title[:idx]
+	n, err := strconv.ParseUint(title[idx+len(frameTitleMarker):], 10, 64)
+	if err != nil {
+		return "", 0, false
+	}
+	return real, n, true
+}
+
+// FrameOutput is the serialized writer that sits between Bubble Tea's
+// renderer and the terminal. One mutex serializes every renderer frame
+// and every side-channel write (kitty uploads), so byte streams never
+// interleave.
+//
+// For a marked frame it:
+//   - extracts the frame ID from the internal title suffix and removes
+//     the suffix before any byte reaches the terminal;
+//   - forwards the real OSC 2 title only when it actually changed;
+//   - takes the exact frame from the store and asks the painter for a
+//     non-mutating reconciliation plan;
+//   - appends the plan after the text diff (or immediately before a
+//     final synchronized-output reset CSI ?2026l);
+//   - writes sanitized text + plan in one serialized call;
+//   - treats a short write as io.ErrShortWrite and commits painter and
+//     title state only after a full successful write.
+//
+// Writes without a valid slk frame marker pass through unchanged and
+// do not mutate painter state.
+type FrameOutput struct {
+	mu        sync.Mutex
+	out       io.Writer
+	frames    *SixelFrameStore
+	painter   *SixelPainter
+	lastTitle string
+	haveTitle bool
+}
+
+// sideChannelWriter is the SideChannel's writer: it shares FrameOutput's
+// mutex so out-of-band writes (kitty APC uploads) cannot interleave with
+// renderer frames.
+type sideChannelWriter struct{ parent *FrameOutput }
+
+// NewFrameOutput wraps w. frames feeds the exact-frame lookups; the
+// painter is owned here and only commits after a full successful write.
+func NewFrameOutput(w io.Writer, frames *SixelFrameStore) *FrameOutput {
+	return &FrameOutput{out: w, frames: frames, painter: NewSixelPainter()}
+}
+
+// SideChannel returns the serialized side-channel writer for
+// out-of-band protocol writes (kitty uploads). It shares the same mutex
+// as renderer frames.
+func (w *FrameOutput) SideChannel() io.Writer {
+	return sideChannelWriter{parent: w}
+}
+
+// Fd, Read, and Close delegate to the wrapped writer so FrameOutput
+// satisfies term.File. Bubble Tea and colorprofile type-assert the
+// program output to term.File to detect the TTY and query the terminal
+// size; without these methods the renderer initializes at 0x0 and draws
+// a blank screen. The terminal never reads from or closes the output
+// during normal operation, so the delegates are only exercised through
+// that interface check.
+func (w *FrameOutput) Fd() uintptr {
+	if f, ok := w.out.(interface{ Fd() uintptr }); ok {
+		return f.Fd()
+	}
+	return ^uintptr(0)
+}
+
+func (w *FrameOutput) Read(p []byte) (int, error) {
+	if r, ok := w.out.(io.Reader); ok {
+		return r.Read(p)
+	}
+	return 0, io.EOF
+}
+
+func (w *FrameOutput) Close() error {
+	if c, ok := w.out.(io.Closer); ok {
+		return c.Close()
+	}
+	return nil
+}
+
+func (s sideChannelWriter) Write(p []byte) (int, error) {
+	s.parent.mu.Lock()
+	defer s.parent.mu.Unlock()
+	return s.parent.out.Write(p)
+}
+
+// Write implements io.Writer for a renderer flush. It returns len(p) on
+// success (the input length, not the expanded output length).
+func (w *FrameOutput) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	sanitized, realTitle, id, marked := sanitizeFrameTitle(p)
+	var plan SixelPlan
+	if marked {
+		if frame, ok := w.frames.Take(id); ok {
+			plan = w.painter.Plan(frame.Placements, frame.EraseSGR, frame.Force)
+		} else {
+			debuglog.ImgRender("sixel frame: missing id=%d", id)
+		}
+	}
+
+	// Forward the real title only when it changed; otherwise the marked
+	// OSC 2 was already dropped by the sanitizer and stays dropped.
+	var title []byte
+	if marked && (!w.haveTitle || realTitle != w.lastTitle) {
+		title = osc2(realTitle)
+	}
+
+	// Erase bytes land BEFORE the text diff and paint bytes AFTER it:
+	// ECH also blanks the cells it clears, so erases must run before
+	// the diff rewrites a vacated image region with scrolled-in text,
+	// while paints must overlay the text that was just written.
+	withPaint := insertBeforeSyncReset(sanitized, plan.Bytes)
+	withErase := insertEraseAfterSyncStart(withPaint, plan.Erase)
+	combined := append(title, withErase...)
+	n, err := w.out.Write(combined)
+	if err != nil {
+		return 0, err
+	}
+	if n != len(combined) {
+		return 0, io.ErrShortWrite
+	}
+	if marked && plan.next != nil {
+		w.painter.Commit(plan)
+	}
+	if marked {
+		w.lastTitle = realTitle
+		w.haveTitle = true
+	}
+	return len(p), nil
+}
+
+// osc2 renders an OSC 2 window-title sequence terminated by BEL,
+// matching Bubble Tea's own title emission.
+func osc2(title string) []byte {
+	return []byte("\x1b]2;" + title + "\a")
+}
+
+// sanitizeFrameTitle scans a renderer flush for OSC 2 sequences.
+//
+//   - A marked OSC 2 (title carrying the internal frame suffix) is
+//     extracted and dropped from the output; the real title and frame
+//     ID are returned. FrameOutput re-emits the real title only when it
+//     changed.
+//   - A plain OSC 2 is preserved byte-for-byte.
+//   - All other bytes (including unrelated OSC sequences) are preserved
+//     byte-for-byte.
+func sanitizeFrameTitle(p []byte) (sanitized []byte, realTitle string, id uint64, marked bool) {
+	sanitized = make([]byte, 0, len(p))
+	i := 0
+	for i < len(p) {
+		if p[i] != 0x1b || i+1 >= len(p) || p[i+1] != ']' {
+			sanitized = append(sanitized, p[i])
+			i++
+			continue
+		}
+		// OSC sequence: ESC ] ... terminated by BEL (0x07) or ST (ESC \).
+		j := i + 2
+		end := -1
+		for j < len(p) {
+			if p[j] == 0x07 {
+				end = j + 1
+				break
+			}
+			if p[j] == 0x1b && j+1 < len(p) && p[j+1] == '\\' {
+				end = j + 2
+				break
+			}
+			j++
+		}
+		if end < 0 {
+			// Unterminated OSC; preserve the remainder verbatim.
+			sanitized = append(sanitized, p[i:]...)
+			break
+		}
+		body := p[i+2 : j]
+		if len(body) >= 2 && body[0] == '2' && body[1] == ';' {
+			if real, idv, ok := parseFrameTitle(string(body[2:])); ok {
+				// Marked frame: drop the OSC entirely; the caller
+				// re-emits the real title on change.
+				marked = true
+				realTitle = real
+				id = idv
+			} else {
+				// Plain title: preserve unchanged.
+				sanitized = append(sanitized, p[i:end]...)
+			}
+		} else {
+			// Unrelated OSC sequence: preserve byte-for-byte.
+			sanitized = append(sanitized, p[i:end]...)
+		}
+		i = end
+	}
+	return sanitized, realTitle, id, marked
+}
+
+// insertBeforeSyncReset appends plan to the text diff. When the diff
+// ends with the synchronized-output reset (CSI ?2026l), the plan is
+// inserted immediately before that reset so sixel operations run inside
+// the synchronized output window, not after it.
+func insertBeforeSyncReset(sanitized, plan []byte) []byte {
+	if len(plan) == 0 {
+		return sanitized
+	}
+	idx := bytes.LastIndex(sanitized, []byte("\x1b[?2026l"))
+	if idx < 0 {
+		out := make([]byte, 0, len(sanitized)+len(plan))
+		out = append(out, sanitized...)
+		out = append(out, plan...)
+		return out
+	}
+	out := make([]byte, 0, len(sanitized)+len(plan))
+	out = append(out, sanitized[:idx]...)
+	out = append(out, plan...)
+	out = append(out, sanitized[idx:]...)
+	return out
+}
+
+// insertEraseAfterSyncStart inserts the erase operations immediately
+// after the synchronized-output start (CSI ?2026h), so they run before
+// the text diff that follows and stay inside the sync window. Without
+// a sync start (a cursor-only flush), the erases are prepended.
+func insertEraseAfterSyncStart(sanitized, erase []byte) []byte {
+	if len(erase) == 0 {
+		return sanitized
+	}
+	const syncStart = "\x1b[?2026h"
+	idx := bytes.Index(sanitized, []byte(syncStart))
+	if idx < 0 {
+		out := make([]byte, 0, len(sanitized)+len(erase))
+		out = append(out, erase...)
+		out = append(out, sanitized...)
+		return out
+	}
+	after := idx + len(syncStart)
+	out := make([]byte, 0, len(sanitized)+len(erase))
+	out = append(out, sanitized[:after]...)
+	out = append(out, erase...)
+	out = append(out, sanitized[after:]...)
+	return out
+}

--- a/internal/image/sixelframe_integration_test.go
+++ b/internal/image/sixelframe_integration_test.go
@@ -1,0 +1,76 @@
+package image
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// frameTestDone triggers a single Update cycle so the program renders
+// exactly one meaningful frame before quitting.
+type frameTestDone struct{}
+
+type frameTestModel struct {
+	frames *SixelFrameStore
+}
+
+func (m frameTestModel) Init() tea.Cmd {
+	return func() tea.Msg { return frameTestDone{} }
+}
+
+func (m frameTestModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if _, ok := msg.(frameTestDone); ok {
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+func (m frameTestModel) View() tea.View {
+	id := m.frames.Publish(SixelFrame{Placements: []SixelPlacement{{
+		Key: "integration", Row: 2, Col: 1, Rows: 1, Cols: 1,
+		Bytes: []byte("\x1bPqintegration\x1b\\"),
+	}}})
+	v := tea.NewView("visible-text")
+	v.AltScreen = true
+	v.WindowTitle = FrameTitle("slk-test", id)
+	return v
+}
+
+// TestSixelFrameOutput_BubbleTeaFlushContract is the end-to-end
+// regression for the frame-correlation design: a real Bubble Tea
+// v2.0.6 program flushes a marked frame through FrameOutput, and the
+// captured stream must show the text frame before the exact frame's
+// sixel DCS, with the internal marker stripped and only the real title
+// forwarded.
+func TestSixelFrameOutput_BubbleTeaFlushContract(t *testing.T) {
+	raw := new(bytes.Buffer)
+	frames := NewSixelFrameStore()
+	out := NewFrameOutput(raw, frames)
+	p := tea.NewProgram(frameTestModel{frames: frames},
+		tea.WithInput(nil),
+		tea.WithOutput(out),
+		tea.WithFPS(120),
+		tea.WithWindowSize(80, 24),
+	)
+	if _, err := p.Run(); err != nil {
+		t.Fatalf("program run: %v", err)
+	}
+
+	got := raw.String()
+	textAt := strings.Index(got, "visible-text")
+	paintAt := strings.Index(got, "\x1bPqintegration\x1b\\")
+	if textAt < 0 || paintAt < 0 {
+		t.Fatalf("output missing text or sixel DCS; got %q", got)
+	}
+	if textAt > paintAt {
+		t.Fatalf("text must precede the sixel DCS for the exact flushed frame; got %q", got)
+	}
+	if strings.Contains(got, "slk-sixel-frame=") {
+		t.Fatalf("internal marker leaked to the terminal writer: %q", got)
+	}
+	if !strings.Contains(got, "\x1b]2;slk-test\a") {
+		t.Fatalf("real window title was not forwarded unchanged: %q", got)
+	}
+}

--- a/internal/image/sixelframe_test.go
+++ b/internal/image/sixelframe_test.go
@@ -1,0 +1,418 @@
+package image
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/term"
+)
+
+func oscTitle(title string) []byte {
+	return []byte("\x1b]2;" + title + "\a")
+}
+
+func markedFlush(real string, id uint64, body string) []byte {
+	return append(oscTitle(FrameTitle(real, id)), []byte(body)...)
+}
+
+// TestSixelFrameStore_TakeExactFrameAndPruneSkipped pins the monotonic
+// flush contract: flushing a later frame must prune every earlier frame,
+// because skipped intermediate views will never flush later.
+func TestSixelFrameStore_TakeExactFrameAndPruneSkipped(t *testing.T) {
+	s := NewSixelFrameStore()
+	id1 := s.Publish(SixelFrame{Placements: []SixelPlacement{pl("a", 1, 1, 1, 1)}})
+	id2 := s.Publish(SixelFrame{Placements: []SixelPlacement{pl("b", 2, 2, 1, 1)}})
+
+	got, ok := s.Take(id2)
+	if !ok || len(got.Placements) != 1 || got.Placements[0].Key != "b" {
+		t.Fatalf("Take(%d) = %+v, %v", id2, got, ok)
+	}
+	if _, ok := s.Take(id1); ok {
+		t.Fatal("skipped older frame survived pruning")
+	}
+}
+
+// Publish must clone the placement slice so the caller can reuse its
+// buffer, while the large payload byte slices stay shared by reference.
+func TestSixelFrameStore_PublishClonesPlacementSlice(t *testing.T) {
+	s := NewSixelFrameStore()
+	placements := []SixelPlacement{pl("a", 1, 1, 1, 1)}
+	id := s.Publish(SixelFrame{Placements: placements})
+	placements[0].Key = "mutated"
+	got, _ := s.Take(id)
+	if got.Placements[0].Key != "a" {
+		t.Fatalf("published frame aliased caller slice: %+v", got.Placements[0])
+	}
+	// Payload backing data must remain shared (no deep copy of Bytes).
+	if &got.Placements[0].Bytes[0] != &placements[0].Bytes[0] {
+		t.Fatal("publish deep-copied the payload bytes; must keep them by reference")
+	}
+}
+
+// TestFrameOutput_WritesTextBeforeExactFrameSixel proves the ordering
+// contract: the text diff for the exact flushed frame precedes the sixel
+// DCS payload, and a frame that was never flushed contributes nothing.
+func TestFrameOutput_WritesTextBeforeExactFrameSixel(t *testing.T) {
+	var raw bytes.Buffer
+	frames := NewSixelFrameStore()
+	out := NewFrameOutput(&raw, frames)
+
+	// Publish frame A and frame B, then flush only the marker for B —
+	// as if the renderer skipped A.
+	frames.Publish(SixelFrame{Placements: []SixelPlacement{pl("A", 2, 3, 1, 1)}})
+	idB := frames.Publish(SixelFrame{Placements: []SixelPlacement{pl("B", 4, 5, 1, 1)}})
+
+	n, err := out.Write(markedFlush("real-title", idB, "body-text"))
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	got := raw.String()
+	if n != len(markedFlush("real-title", idB, "body-text")) {
+		t.Fatalf("Write returned %d, want input length %d", n, len(markedFlush("real-title", idB, "body-text")))
+	}
+	textAt := strings.Index(got, "body-text")
+	paintAt := strings.Index(got, "\x1bPqB\x1b\\")
+	if textAt < 0 || paintAt < 0 {
+		t.Fatalf("output missing text or DCS; got %q", got)
+	}
+	if textAt > paintAt {
+		t.Fatalf("text must precede the sixel DCS for the same frame: %q", got)
+	}
+	if strings.Contains(got, "\x1bPqA\x1b\\") {
+		t.Fatalf("skipped frame A leaked into output: %q", got)
+	}
+}
+
+// The internal marker must never reach the terminal or a captured
+// underlying writer.
+func TestFrameOutput_StripsInternalMarker(t *testing.T) {
+	var raw bytes.Buffer
+	frames := NewSixelFrameStore()
+	out := NewFrameOutput(&raw, frames)
+	id := frames.Publish(SixelFrame{Placements: []SixelPlacement{pl("a", 2, 2, 1, 1)}})
+
+	if _, err := out.Write(markedFlush("slk", id, "text")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if strings.Contains(raw.String(), "slk-sixel-frame=") {
+		t.Fatalf("internal marker leaked to the underlying writer: %q", raw.String())
+	}
+	if strings.Contains(raw.String(), "\x1f") {
+		t.Fatalf("US separator leaked to the underlying writer: %q", raw.String())
+	}
+}
+
+// A real title that does not change must not be re-emitted; only the
+// first flush forwards it, and it is never suffixed.
+func TestFrameOutput_SuppressesDuplicateRealTitle(t *testing.T) {
+	var raw bytes.Buffer
+	frames := NewSixelFrameStore()
+	out := NewFrameOutput(&raw, frames)
+
+	id1 := frames.Publish(SixelFrame{})
+	if _, err := out.Write(markedFlush("slk", id1, "text-1")); err != nil {
+		t.Fatalf("Write 1: %v", err)
+	}
+	id2 := frames.Publish(SixelFrame{})
+	if _, err := out.Write(markedFlush("slk", id2, "text-2")); err != nil {
+		t.Fatalf("Write 2: %v", err)
+	}
+
+	if got := strings.Count(raw.String(), "\x1b]2;slk\a"); got != 1 {
+		t.Fatalf("title forwarded %d times, want 1; raw %q", got, raw.String())
+	}
+	if strings.Contains(raw.String(), "slk-sixel-frame=") {
+		t.Fatalf("suffix leaked: %q", raw.String())
+	}
+}
+
+// A changed real title is forwarded once.
+func TestFrameOutput_ForwardsChangedRealTitle(t *testing.T) {
+	var raw bytes.Buffer
+	frames := NewSixelFrameStore()
+	out := NewFrameOutput(&raw, frames)
+
+	id1 := frames.Publish(SixelFrame{})
+	if _, err := out.Write(markedFlush("first", id1, "text-1")); err != nil {
+		t.Fatalf("Write 1: %v", err)
+	}
+	id2 := frames.Publish(SixelFrame{})
+	if _, err := out.Write(markedFlush("second", id2, "text-2")); err != nil {
+		t.Fatalf("Write 2: %v", err)
+	}
+	for _, want := range []string{"\x1b]2;first\a", "\x1b]2;second\a"} {
+		if !strings.Contains(raw.String(), want) {
+			t.Fatalf("missing forwarded title %q; raw %q", want, raw.String())
+		}
+	}
+	if strings.Contains(raw.String(), "slk-sixel-frame=") {
+		t.Fatalf("suffix leaked: %q", raw.String())
+	}
+}
+
+// A missing frame ID passes the text through untouched and must not
+// mutate painter state (the previously painted image stays live).
+func TestFrameOutput_MissingFramePassesTextWithoutPainterMutation(t *testing.T) {
+	var raw bytes.Buffer
+	frames := NewSixelFrameStore()
+	out := NewFrameOutput(&raw, frames)
+
+	// Paint frame 1.
+	id1 := frames.Publish(SixelFrame{Placements: []SixelPlacement{pl("a", 2, 2, 1, 1)}})
+	if _, err := out.Write(markedFlush("slk", id1, "text-1")); err != nil {
+		t.Fatalf("Write 1: %v", err)
+	}
+	if out.painter.Live() != 1 {
+		t.Fatalf("Live = %d after paint, want 1", out.painter.Live())
+	}
+
+	// Flush a marker for a frame that was never published.
+	if _, err := out.Write(markedFlush("slk", 999, "text-2")); err != nil {
+		t.Fatalf("Write 2: %v", err)
+	}
+	if out.painter.Live() != 1 {
+		t.Fatalf("missing frame must not mutate painter state; Live = %d, want 1", out.painter.Live())
+	}
+	if !strings.Contains(raw.String(), "text-2") {
+		t.Fatalf("text for the missing frame did not pass through: %q", raw.String())
+	}
+
+	// Re-publish the same placement: still live, so no re-emit.
+	raw.Reset()
+	id3 := frames.Publish(SixelFrame{Placements: []SixelPlacement{pl("a", 2, 2, 1, 1)}})
+	if _, err := out.Write(markedFlush("slk", id3, "text-3")); err != nil {
+		t.Fatalf("Write 3: %v", err)
+	}
+	if strings.Contains(raw.String(), "\x1bPqa\x1b\\") {
+		t.Fatalf("painter state lost; repainted a placement that should still be live: %q", raw.String())
+	}
+}
+
+// The sixel plan belongs inside synchronized output: immediately before
+// the final CSI ?2026l reset, never after it.
+func TestFrameOutput_InsertsSixelBeforeSynchronizedOutputReset(t *testing.T) {
+	var raw bytes.Buffer
+	frames := NewSixelFrameStore()
+	out := NewFrameOutput(&raw, frames)
+	id := frames.Publish(SixelFrame{Placements: []SixelPlacement{pl("a", 2, 2, 1, 1)}})
+
+	flush := append(markedFlush("slk", id, "diff-text"), []byte("\x1b[?2026l")...)
+	if _, err := out.Write(flush); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	got := raw.String()
+	diffAt := strings.Index(got, "diff-text")
+	paintAt := strings.Index(got, "\x1bPqa\x1b\\")
+	resetAt := strings.Index(got, "\x1b[?2026l")
+	if diffAt < 0 || paintAt < 0 || resetAt < 0 {
+		t.Fatalf("output missing components; got %q", got)
+	}
+	if !(diffAt < paintAt && paintAt < resetAt) {
+		t.Fatalf("expected diff < DCS < ?2026l; got %q", got)
+	}
+}
+
+// When a placement moves on scroll, its erase must land BEFORE the text
+// diff (ECH blanks the cells it clears — after the diff it would wipe
+// the text that scrolled into the vacated region) while the paint lands
+// after the diff. Both stay inside the synchronized-output window.
+func TestFrameOutput_ErasePrecedesTextDiffPaintFollows(t *testing.T) {
+	var raw bytes.Buffer
+	frames := NewSixelFrameStore()
+	out := NewFrameOutput(&raw, frames)
+
+	id1 := frames.Publish(SixelFrame{Placements: []SixelPlacement{pl("a", 10, 5, 2, 20)}})
+	if _, err := out.Write(markedFlush("slk", id1, "first")); err != nil {
+		t.Fatalf("Write 1: %v", err)
+	}
+	raw.Reset()
+
+	id2 := frames.Publish(SixelFrame{Placements: []SixelPlacement{pl("a", 8, 5, 2, 20)}})
+	flush := append(markedFlush("slk", id2, "diff-text"), []byte("\x1b[?2026l")...)
+	if _, err := out.Write(flush); err != nil {
+		t.Fatalf("Write 2: %v", err)
+	}
+	got := raw.String()
+	eraseAt := strings.Index(got, "\x1b[10;5H")
+	paintAt := strings.Index(got, "\x1bPqa\x1b\\")
+	textAt := strings.Index(got, "diff-text")
+	resetAt := strings.Index(got, "\x1b[?2026l")
+	if eraseAt < 0 || paintAt < 0 || textAt < 0 || resetAt < 0 {
+		t.Fatalf("output missing components; got %q", got)
+	}
+	if !(eraseAt < textAt && textAt < paintAt && paintAt < resetAt) {
+		t.Fatalf("expected erase < diff-text < DCS < ?2026l; got %q", got)
+	}
+}
+
+// A failed underlying write must not commit painter state, and the next
+// successful write of the same frame must emit the paint again.
+func TestFrameOutput_WriteFailureDoesNotCommitPainter(t *testing.T) {
+	frames := NewSixelFrameStore()
+	out := NewFrameOutput(&failWriter{err: errors.New("boom")}, frames)
+	id := frames.Publish(SixelFrame{Placements: []SixelPlacement{pl("a", 5, 12, 4, 20)}})
+
+	if _, err := out.Write(markedFlush("real", id, "body")); err == nil {
+		t.Fatal("expected the underlying write error")
+	}
+	if out.painter.Live() != 0 {
+		t.Fatalf("painter Live = %d after failed write, want 0", out.painter.Live())
+	}
+
+	// Recover: successful buffer, same frame content published again.
+	buf := new(bytes.Buffer)
+	out.out = buf
+	id2 := frames.Publish(SixelFrame{Placements: []SixelPlacement{pl("a", 5, 12, 4, 20)}})
+	if _, err := out.Write(markedFlush("real", id2, "body")); err != nil {
+		t.Fatalf("Write after recovery: %v", err)
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("\x1bPqa\x1b\\")) {
+		t.Fatalf("paint not emitted after failure recovery; got %q", buf.String())
+	}
+}
+
+// A short write (n < len, nil error) is an io.ErrShortWrite and must not
+// commit painter state or record the title as forwarded.
+func TestFrameOutput_ShortWriteDoesNotCommitPainterOrTitle(t *testing.T) {
+	frames := NewSixelFrameStore()
+	out := NewFrameOutput(&shortWriter{}, frames)
+	id := frames.Publish(SixelFrame{Placements: []SixelPlacement{pl("a", 5, 12, 4, 20)}})
+
+	_, err := out.Write(markedFlush("real", id, "body"))
+	if err != io.ErrShortWrite {
+		t.Fatalf("err = %v, want io.ErrShortWrite", err)
+	}
+	if out.painter.Live() != 0 {
+		t.Fatalf("painter Live = %d after short write, want 0", out.painter.Live())
+	}
+
+	// The title was not recorded as forwarded: a same-title flush on a
+	// good writer still emits the OSC 2, and the paint lands.
+	buf := new(bytes.Buffer)
+	out.out = buf
+	id2 := frames.Publish(SixelFrame{Placements: []SixelPlacement{pl("a", 5, 12, 4, 20)}})
+	if _, err := out.Write(markedFlush("real", id2, "body")); err != nil {
+		t.Fatalf("Write after recovery: %v", err)
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("\x1b]2;real\a")) {
+		t.Fatalf("title not forwarded after short write; got %q", buf.String())
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("\x1bPqa\x1b\\")) {
+		t.Fatalf("paint not emitted after short write; got %q", buf.String())
+	}
+}
+
+// io.Writer contract: Write returns the length of its input on success,
+// not the length of the expanded output.
+func TestFrameOutput_ReturnsInputLengthOnSuccess(t *testing.T) {
+	var raw bytes.Buffer
+	frames := NewSixelFrameStore()
+	out := NewFrameOutput(&raw, frames)
+	id := frames.Publish(SixelFrame{Placements: []SixelPlacement{pl("a", 2, 2, 1, 1)}})
+
+	input := markedFlush("slk", id, "text")
+	n, err := out.Write(input)
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if n != len(input) {
+		t.Fatalf("Write returned %d, want %d", n, len(input))
+	}
+}
+
+// Both OSC 2 terminators — BEL and ST — must be sanitized and framed.
+func TestFrameOutput_SupportsBELAndSTTerminatedOSC2(t *testing.T) {
+	for name, flush := range map[string][]byte{
+		"BEL": append([]byte("\x1b]2;"+FrameTitle("slk", 1)+"\a"), []byte("body-bel")...),
+		"ST":  append([]byte("\x1b]2;"+FrameTitle("slk", 1)+"\x1b\\"), []byte("body-st")...),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var raw bytes.Buffer
+			frames := NewSixelFrameStore()
+			out := NewFrameOutput(&raw, frames)
+			frames.Publish(SixelFrame{Placements: []SixelPlacement{pl("a", 2, 2, 1, 1)}})
+			if _, err := out.Write(flush); err != nil {
+				t.Fatalf("Write: %v", err)
+			}
+			got := raw.String()
+			if strings.Contains(got, "slk-sixel-frame=") {
+				t.Fatalf("marker leaked: %q", got)
+			}
+			if !strings.Contains(got, "body-"+strings.ToLower(name)) {
+				t.Fatalf("text missing: %q", got)
+			}
+		})
+	}
+}
+
+// A frame whose OSC 2 is marked must still forward the real title once,
+// regardless of which terminator Bubble Tea used.
+func TestFrameOutput_ForwardsRealTitleWithBothTerminators(t *testing.T) {
+	for name, term := range map[string][]byte{"BEL": {'\a'}, "ST": {'\x1b', '\\'}} {
+		t.Run(name, func(t *testing.T) {
+			var raw bytes.Buffer
+			frames := NewSixelFrameStore()
+			out := NewFrameOutput(&raw, frames)
+			id := frames.Publish(SixelFrame{})
+			osc := append([]byte("\x1b]2;"+FrameTitle("my-title", id)), term...)
+			if _, err := out.Write(append(osc, []byte("text")...)); err != nil {
+				t.Fatalf("Write: %v", err)
+			}
+			if !strings.Contains(raw.String(), "\x1b]2;my-title\a") {
+				t.Fatalf("real title not forwarded; got %q", raw.String())
+			}
+		})
+	}
+}
+
+// Writes without a marker pass through unchanged and mutate nothing.
+func TestFrameOutput_UnmarkedFlushPassesThrough(t *testing.T) {
+	var raw bytes.Buffer
+	frames := NewSixelFrameStore()
+	out := NewFrameOutput(&raw, frames)
+	input := []byte("plain \x1b]2;my-title\a renderer bytes")
+	if _, err := out.Write(input); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if !bytes.Equal(raw.Bytes(), input) {
+		t.Fatalf("unmarked flush mutated; got %q want %q", raw.Bytes(), input)
+	}
+	if out.painter.Live() != 0 {
+		t.Fatalf("unmarked flush mutated painter; Live = %d", out.painter.Live())
+	}
+}
+
+type failWriter struct{ err error }
+
+func (w failWriter) Write([]byte) (int, error) { return 0, w.err }
+
+type shortWriter struct{}
+
+func (w shortWriter) Write(p []byte) (int, error) { return len(p) - 1, nil }
+
+// FrameOutput must satisfy term.File so Bubble Tea and colorprofile can
+// type-assert the program output and detect the terminal: when the
+// wrapper hides the underlying fd, the renderer initializes at 0x0 and
+// draws nothing. The delegated fd must be the real terminal's.
+var _ term.File = (*FrameOutput)(nil)
+
+func TestFrameOutput_ExposesUnderlyingFileDescriptor(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "fd")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+
+	out := NewFrameOutput(f, NewSixelFrameStore())
+	if out.Fd() != f.Fd() {
+		t.Fatalf("Fd() = %d, want %d", out.Fd(), f.Fd())
+	}
+	var asFile term.File = out
+	if asFile.Fd() != f.Fd() {
+		t.Fatalf("term.File Fd() = %d, want %d", asFile.Fd(), f.Fd())
+	}
+}

--- a/internal/image/sixelpaint.go
+++ b/internal/image/sixelpaint.go
@@ -1,0 +1,245 @@
+package image
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/gammons/slk/internal/debuglog"
+)
+
+// SixelPlacement is one image painted at an absolute screen position.
+//
+// Row and Col are 1-based absolute terminal coordinates (the coordinate
+// system of CUP, ESC[row;colH). Rows and Cols are the cell footprint,
+// used to erase the region when the placement goes away.
+//
+// Key identifies the image content at this position. Two placements with
+// equal Key, Row, Col, Rows and Cols are considered identical and the
+// painter will not re-emit — that is what stops the per-frame flood.
+type SixelPlacement struct {
+	Key        string
+	Row, Col   int
+	Rows, Cols int
+	Bytes      []byte
+
+	// Guard fingerprints the frame text underneath this placement.
+	//
+	// Painting out-of-band assumes the cells beneath an image stay
+	// untouched, which holds only while their content is identical frame
+	// to frame. Anything that restyles those rows — moving focus recolors
+	// the pane border, selection tints a row — changes the line, so
+	// bubbletea rewrites it and the rewrite paints over the pixels. The
+	// placement itself has not changed, so without this the painter would
+	// consider the image current and never repaint it: the image
+	// disappears permanently.
+	Guard string
+}
+
+// PlacementKey derives the content identity for a placement. identity is
+// the stable cache key (file ID + thumb suffix) when one exists; without
+// one the freshly encoded payload is hashed once here, at construction
+// time — never during painter comparison. The cell footprint is always
+// appended, so a key collision is still broken by a geometry change.
+//
+// The encoded byte LENGTH is deliberately not part of the identity: two
+// different images of the same size and palette depth encode to the same
+// length, so a length-based key would treat a slot swap as unchanged and
+// never repaint. Shared by the messages pane and the preview overlay.
+func PlacementKey(identity string, payload []byte, cols, rows int) string {
+	if identity == "" {
+		sum := sha256.Sum256(payload)
+		identity = hex.EncodeToString(sum[:16])
+	}
+	return fmt.Sprintf("%s/%dx%d", identity, cols, rows)
+}
+
+// sameSlot reports whether p occupies the same screen slot with the same
+// content as q. Bytes are deliberately not compared: Key is the content
+// identity (a cache key), and the byte slices are large.
+func (p SixelPlacement) sameSlot(q SixelPlacement) bool {
+	return p.Key == q.Key && p.Row == q.Row && p.Col == q.Col &&
+		p.Rows == q.Rows && p.Cols == q.Cols && p.Guard == q.Guard
+}
+
+// sixelSlot is the screen position that keys the painted set. A plain
+// struct is used instead of a "row,col" string so frame reconciliation
+// never allocates a formatted key per placement.
+type sixelSlot struct {
+	row int
+	col int
+}
+
+// SixelPainter tracks which sixel images are currently painted on the
+// terminal and reconciles that against what each frame wants.
+//
+// Sixel has no cell-aware placement and no addressable image identity:
+// the terminal paints pixels at the cursor and forgets about them. Unlike
+// kitty — where a unicode placeholder in the text stream lets the terminal
+// re-render the image itself — nothing repaints or removes a sixel image
+// for us. So slk must own the screen region: paint when it appears, erase
+// when it leaves, and otherwise leave it alone.
+//
+// The painter is transactional: Plan computes the operation bytes and the
+// resulting state without touching the painter; Commit installs that
+// state. A caller that fails to write the plan's bytes to the terminal
+// simply skips Commit, so a failed write never leaves the painter
+// believing an image is on screen that is not.
+//
+// Not safe for concurrent use; call from the serialized output path only.
+type SixelPainter struct {
+	painted map[sixelSlot]SixelPlacement
+}
+
+// SixelPlan is the output of Plan: the exact bytes to append to the
+// terminal write for the reconciliation, the change counters, and the
+// state to install when the write succeeds. next is nil when nothing
+// changed, which makes Commit a no-op.
+//
+// Erase and Bytes are separate because they land on opposite sides of
+// the text diff: an erase clears old sixel pixels, and ECH also blanks
+// the cells it touches. If erases ran AFTER the text diff (like paints
+// must), they would wipe the freshly written text inside a vacated
+// image region when the image moves on scroll. FrameOutput therefore
+// emits Erase before the text diff and Bytes after it.
+type SixelPlan struct {
+	Erase   []byte
+	Bytes   []byte
+	Painted int
+	Erased  int
+	next    map[sixelSlot]SixelPlacement
+}
+
+// NewSixelPainter returns an empty painter. The terminal write side is
+// owned by the caller (FrameOutput), not the painter.
+func NewSixelPainter() *SixelPainter {
+	return &SixelPainter{painted: make(map[sixelSlot]SixelPlacement)}
+}
+
+// Plan computes the erase/paint operations needed to display want,
+// without mutating p. eraseSGR is the SGR sequence emitted before each
+// ECH so vacated cells take the pane's background rather than the
+// terminal default; empty disables it. force=true erases and repaints
+// every valid wanted placement even when key, geometry, and guard are
+// unchanged — used for renderer full redraws such as terminal resize.
+//
+// Returned plan bytes are owned by the plan and safe to append to a
+// write; Commit installs the planned state.
+func (p *SixelPainter) Plan(want []SixelPlacement, eraseSGR string, force bool) SixelPlan {
+	wanted := make(map[sixelSlot]SixelPlacement, len(want))
+	for _, pl := range want {
+		if pl.Rows <= 0 || pl.Cols <= 0 || pl.Row < 1 || pl.Col < 1 {
+			continue // nonsensical placement; never touch the screen for it
+		}
+		wanted[sixelSlot{row: pl.Row, col: pl.Col}] = pl
+	}
+
+	next := make(map[sixelSlot]SixelPlacement, len(wanted))
+	var eraseBuf bytes.Buffer
+	var buf bytes.Buffer
+	painted, erased := 0, 0
+
+	// Erase slots that are gone or whose content/footprint changed (or
+	// all of them under force). Sorted for deterministic output (maps
+	// randomize iteration order, which would make tests flaky and diffs
+	// unreadable).
+	//
+	// Erase bytes are collected separately from paint bytes: FrameOutput
+	// emits them BEFORE the text diff so they never blank freshly
+	// written text, while paints must stay after the text diff.
+	for _, k := range sortedSlots(p.painted) {
+		old := p.painted[k]
+		if cur, ok := wanted[k]; ok && cur.sameSlot(old) && !force {
+			next[k] = old
+			continue
+		}
+		writeErase(&eraseBuf, old, eraseSGR)
+		erased++
+	}
+
+	// Paint anything not already on screen.
+	for _, k := range sortedSlots(wanted) {
+		pl := wanted[k]
+		if cur, ok := p.painted[k]; ok && cur.sameSlot(pl) && !force {
+			next[k] = cur
+			continue
+		}
+		if len(pl.Bytes) == 0 {
+			continue
+		}
+		writeSixelAt(&buf, pl)
+		next[k] = pl
+		painted++
+	}
+
+	if painted > 0 || erased > 0 {
+		debuglog.ImgRender("sixel painter: painted=%d erased=%d live=%d bytes=%d",
+			painted, erased, len(next), buf.Len())
+	}
+	return SixelPlan{Erase: eraseBuf.Bytes(), Bytes: buf.Bytes(), Painted: painted, Erased: erased, next: next}
+}
+
+// Commit installs the state produced by Plan. Call it only after the
+// plan's bytes were written to the terminal in full; a short or failed
+// write must leave the painter untouched.
+func (p *SixelPainter) Commit(plan SixelPlan) {
+	if plan.next != nil {
+		p.painted = plan.next
+	}
+}
+
+// Live returns the number of placements currently painted. For tests and
+// diagnostics.
+func (p *SixelPainter) Live() int { return len(p.painted) }
+
+// writeSixelAt emits one image at its absolute position, leaving the
+// cursor where it found it. DECSC/DECRC (ESC 7 / ESC 8) rather than
+// CSI s/u: the DEC pair is what terminals with sixel support implement.
+func writeSixelAt(w io.Writer, pl SixelPlacement) {
+	fmt.Fprint(w, "\x1b7")                        // save cursor
+	fmt.Fprintf(w, "\x1b[%d;%dH", pl.Row, pl.Col) // absolute position
+	w.Write(pl.Bytes)
+	fmt.Fprint(w, "\x1b8") // restore cursor
+}
+
+// writeErase clears the cells a placement occupied, one row at a time
+// with ECH (CSI n X). Erasing by cell is what removes sixel pixels;
+// simply not re-emitting leaves them on screen forever, which is the bug
+// this whole type exists to fix.
+//
+// eraseSGR is applied first and reset afterwards: ECH clears to the
+// current background, so without it the cleared region shows the
+// terminal default instead of the pane colour.
+func writeErase(w io.Writer, pl SixelPlacement, eraseSGR string) {
+	fmt.Fprint(w, "\x1b7")
+	if eraseSGR != "" {
+		fmt.Fprint(w, eraseSGR)
+	}
+	for r := 0; r < pl.Rows; r++ {
+		fmt.Fprintf(w, "\x1b[%d;%dH", pl.Row+r, pl.Col)
+		fmt.Fprintf(w, "\x1b[%dX", pl.Cols)
+	}
+	if eraseSGR != "" {
+		fmt.Fprint(w, "\x1b[0m")
+	}
+	fmt.Fprint(w, "\x1b8")
+}
+
+// sortedSlots returns the painter's slot keys in deterministic (row,
+// col) order.
+func sortedSlots(m map[sixelSlot]SixelPlacement) []sixelSlot {
+	out := make([]sixelSlot, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].row != out[j].row {
+			return out[i].row < out[j].row
+		}
+		return out[i].col < out[j].col
+	})
+	return out
+}

--- a/internal/image/sixelpaint_test.go
+++ b/internal/image/sixelpaint_test.go
@@ -1,0 +1,264 @@
+package image
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func pl(key string, row, col, rows, cols int) SixelPlacement {
+	return SixelPlacement{
+		Key: key, Row: row, Col: col, Rows: rows, Cols: cols,
+		Bytes: []byte("\x1bPq" + key + "\x1b\\"),
+	}
+}
+
+// applyPlan plans a reconciliation and commits it, mirroring what
+// FrameOutput does after a successful terminal write. Tests use it to
+// build painter state and inspect the plan that would be emitted.
+func applyPlan(t *testing.T, p *SixelPainter, want []SixelPlacement, eraseSGR string, force bool) SixelPlan {
+	t.Helper()
+	plan := p.Plan(want, eraseSGR, force)
+	p.Commit(plan)
+	return plan
+}
+
+// A new placement is painted at its absolute position, with the cursor
+// saved and restored around it.
+func TestSixelPainter_PaintsNewPlacement(t *testing.T) {
+	p := NewSixelPainter()
+
+	plan := applyPlan(t, p, []SixelPlacement{pl("a", 5, 12, 4, 20)}, "", false)
+	if plan.Painted != 1 || plan.Erased != 0 {
+		t.Fatalf("painted=%d erased=%d, want 1/0", plan.Painted, plan.Erased)
+	}
+	out := string(plan.Bytes)
+	for _, want := range []string{"\x1b7", "\x1b[5;12H", "\x1bPq", "\x1b8"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q", want)
+		}
+	}
+	if len(plan.Erase) != 0 {
+		t.Errorf("new placement must not emit erases; got %q", plan.Erase)
+	}
+}
+
+// The whole point: an unchanged placement must not be re-emitted. This is
+// what stopped the per-frame 283KB flood.
+func TestSixelPainter_UnchangedPlacementNotRepainted(t *testing.T) {
+	p := NewSixelPainter()
+	want := []SixelPlacement{pl("a", 5, 12, 4, 20)}
+
+	applyPlan(t, p, want, "", false)
+	plan := p.Plan(want, "", false)
+
+	if plan.Painted != 0 || plan.Erased != 0 || len(plan.Bytes) != 0 || len(plan.Erase) != 0 {
+		t.Fatalf("painted=%d erased=%d bytes=%d erase=%d, want all zero", plan.Painted, plan.Erased, len(plan.Bytes), len(plan.Erase))
+	}
+}
+
+// A placement that disappears must be erased, not merely forgotten.
+func TestSixelPainter_ErasesVanishedPlacement(t *testing.T) {
+	p := NewSixelPainter()
+	applyPlan(t, p, []SixelPlacement{pl("a", 5, 12, 3, 20)}, "", false)
+
+	plan := p.Plan(nil, "", false)
+	if plan.Painted != 0 || plan.Erased != 1 {
+		t.Fatalf("painted=%d erased=%d, want 0/1", plan.Painted, plan.Erased)
+	}
+	out := string(plan.Erase)
+	// One ECH per occupied row, positioned at the region's columns.
+	for _, want := range []string{"\x1b[5;12H", "\x1b[6;12H", "\x1b[7;12H", "\x1b[20X"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("erase output missing %q; got %q", want, out)
+		}
+	}
+	p.Commit(plan)
+	if p.Live() != 0 {
+		t.Errorf("Live()=%d after erase, want 0", p.Live())
+	}
+}
+
+// Scrolling moves an image: the old region's erase lands in plan.Erase
+// (emitted BEFORE the text diff) and the new paint in plan.Bytes
+// (emitted AFTER the text diff). If the erase ever followed the diff it
+// would wipe the text that scrolled into the vacated region.
+func TestSixelPainter_MovedPlacementErasesThenPaints(t *testing.T) {
+	p := NewSixelPainter()
+	applyPlan(t, p, []SixelPlacement{pl("a", 10, 5, 3, 20)}, "", false)
+
+	plan := p.Plan([]SixelPlacement{pl("a", 8, 5, 3, 20)}, "", false)
+	if plan.Painted != 1 || plan.Erased != 1 {
+		t.Fatalf("painted=%d erased=%d on move, want 1/1", plan.Painted, plan.Erased)
+	}
+	if !strings.Contains(string(plan.Erase), "\x1b[10;5H") {
+		t.Errorf("erase of the old row missing from plan.Erase; got %q", plan.Erase)
+	}
+	if !strings.Contains(string(plan.Bytes), "\x1b[8;5H") {
+		t.Errorf("paint of the new row missing from plan.Bytes; got %q", plan.Bytes)
+	}
+}
+
+// Same slot, different image (cache key changes) must repaint.
+func TestSixelPainter_ContentChangeRepaints(t *testing.T) {
+	p := NewSixelPainter()
+	applyPlan(t, p, []SixelPlacement{pl("a", 5, 12, 4, 20)}, "", false)
+
+	plan := p.Plan([]SixelPlacement{pl("b", 5, 12, 4, 20)}, "", false)
+	if plan.Painted != 1 || plan.Erased != 1 {
+		t.Errorf("painted=%d erased=%d on content change, want 1/1", plan.Painted, plan.Erased)
+	}
+}
+
+// An empty desired frame erases everything previously live — the same
+// contract the old Clear() provided (closing the preview, hiding the
+// pane, quitting must not leave pixels behind).
+func TestSixelPainter_ClearToEmptyErasesEverything(t *testing.T) {
+	p := NewSixelPainter()
+	applyPlan(t, p, []SixelPlacement{pl("a", 5, 12, 2, 10), pl("b", 20, 4, 2, 10)}, "", false)
+
+	plan := p.Plan(nil, "", false)
+	if plan.Erased != 2 {
+		t.Fatalf("Erased=%d, want 2", plan.Erased)
+	}
+	out := string(plan.Erase)
+	if !strings.Contains(out, "\x1b[5;12H") || !strings.Contains(out, "\x1b[20;4H") {
+		t.Errorf("erase did not clear both regions; got %q", out)
+	}
+	p.Commit(plan)
+	if p.Live() != 0 {
+		t.Errorf("Live()=%d after clear-to-empty, want 0", p.Live())
+	}
+}
+
+// Garbage in must not touch the screen.
+func TestSixelPainter_IgnoresInvalidPlacements(t *testing.T) {
+	p := NewSixelPainter()
+	plan := p.Plan([]SixelPlacement{
+		pl("zero-rows", 5, 5, 0, 10),
+		pl("zero-cols", 5, 5, 3, 0),
+		pl("row-zero", 0, 5, 3, 10),
+		pl("col-zero", 5, 0, 3, 10),
+	}, "", false)
+	if plan.Painted != 0 || plan.Erased != 0 || len(plan.Bytes) != 0 || len(plan.Erase) != 0 {
+		t.Errorf("painted=%d erased=%d bytes=%d erase=%d; invalid placements must be ignored",
+			plan.Painted, plan.Erased, len(plan.Bytes), len(plan.Erase))
+	}
+}
+
+// A restyled region (focus change, selection tint) rewrites the frame
+// lines under an image and paints over the pixels. The placement is
+// otherwise identical, so only the guard can catch it — without this the
+// image disappears for good.
+func TestSixelPainter_GuardChangeForcesRepaint(t *testing.T) {
+	p := NewSixelPainter()
+
+	before := pl("a", 5, 12, 4, 20)
+	before.Guard = "frame-1"
+	applyPlan(t, p, []SixelPlacement{before}, "", false)
+
+	after := pl("a", 5, 12, 4, 20)
+	after.Guard = "frame-2" // same image, same slot, rewritten underneath
+	plan := p.Plan([]SixelPlacement{after}, "", false)
+	if plan.Painted != 1 || plan.Erased != 1 {
+		t.Errorf("painted=%d erased=%d after an underlying rewrite, want 1/1", plan.Painted, plan.Erased)
+	}
+}
+
+// The guard must not defeat the change detection it sits beside: a stable
+// frame still means zero bytes.
+func TestSixelPainter_StableGuardStaysQuiet(t *testing.T) {
+	p := NewSixelPainter()
+	want := pl("a", 5, 12, 4, 20)
+	want.Guard = "frame-1"
+
+	applyPlan(t, p, []SixelPlacement{want}, "", false)
+	plan := p.Plan([]SixelPlacement{want}, "", false)
+
+	if plan.Painted != 0 || plan.Erased != 0 || len(plan.Bytes) != 0 || len(plan.Erase) != 0 {
+		t.Errorf("painted=%d erased=%d bytes=%d erase=%d with an unchanged guard, want all zero",
+			plan.Painted, plan.Erased, len(plan.Bytes), len(plan.Erase))
+	}
+}
+
+// ECH clears to the CURRENT background, so an erase with no SGR leaves a
+// bright rectangle where the image was. The pane background must be set
+// before the ECH run and reset after.
+func TestSixelPainter_ErasesWithPaneBackground(t *testing.T) {
+	p := NewSixelPainter()
+	const bg = "\x1b[48;2;30;30;46m"
+
+	applyPlan(t, p, []SixelPlacement{pl("a", 5, 12, 2, 20)}, "", false)
+	plan := p.Plan(nil, bg, false)
+
+	out := string(plan.Erase)
+	bgAt := strings.Index(out, bg)
+	echAt := strings.Index(out, "\x1b[20X")
+	if bgAt < 0 {
+		t.Fatalf("erase did not set the pane background; got %q", out)
+	}
+	if echAt < 0 || bgAt > echAt {
+		t.Error("background must be set BEFORE the ECH run, or cells clear to the terminal default")
+	}
+	if !strings.Contains(out, "\x1b[0m") {
+		t.Error("erase must reset SGR afterwards so it does not leak into later output")
+	}
+}
+
+// Without a style configured the erase stays byte-for-byte as before.
+func TestSixelPainter_EraseWithoutStyleUnchanged(t *testing.T) {
+	p := NewSixelPainter()
+	applyPlan(t, p, []SixelPlacement{pl("a", 5, 12, 2, 20)}, "", false)
+
+	plan := p.Plan(nil, "", false)
+	if strings.Contains(string(plan.Erase), "\x1b[0m") {
+		t.Error("no erase style configured, so no SGR should be emitted")
+	}
+}
+
+// Plan must not mutate the painter: state changes only on Commit, so a
+// failed underlying write never leaves the reconciler out of sync.
+func TestSixelPainter_PlanDoesNotMutateUntilCommit(t *testing.T) {
+	p := NewSixelPainter()
+	plan := p.Plan([]SixelPlacement{pl("a", 5, 12, 4, 20)}, "", false)
+	if p.Live() != 0 {
+		t.Fatalf("Live before Commit = %d, want 0", p.Live())
+	}
+	p.Commit(plan)
+	if p.Live() != 1 {
+		t.Fatalf("Live after Commit = %d, want 1", p.Live())
+	}
+}
+
+// A resize-force frame must erase and repaint an otherwise unchanged
+// placement exactly once. The erase and paint are separate buffers with
+// separate placements in the write: erase before the text diff, paint
+// after it (see FrameOutput).
+func TestSixelPainter_ForceRepaintsStablePlacement(t *testing.T) {
+	p := NewSixelPainter()
+	want := []SixelPlacement{pl("a", 5, 12, 4, 20)}
+	p.Commit(p.Plan(want, "", false))
+
+	plan := p.Plan(want, "", true)
+	if plan.Painted != 1 || plan.Erased != 1 {
+		t.Fatalf("force painted=%d erased=%d, want 1/1", plan.Painted, plan.Erased)
+	}
+	if !bytes.Contains(plan.Erase, []byte("\x1b[20X")) {
+		t.Fatalf("force erase missing from plan.Erase: %q", plan.Erase)
+	}
+	if !bytes.Contains(plan.Bytes, want[0].Bytes) {
+		t.Fatalf("force paint missing from plan.Bytes: %q", plan.Bytes)
+	}
+}
+
+// A force frame must not touch placements that are gone: only wanted
+// placements are repainted; vanished ones are merely erased once.
+func TestSixelPainter_ForceDoesNotResurrectVanishedPlacement(t *testing.T) {
+	p := NewSixelPainter()
+	p.Commit(p.Plan([]SixelPlacement{pl("a", 5, 12, 2, 4)}, "", false))
+
+	plan := p.Plan(nil, "", true)
+	if plan.Painted != 0 || plan.Erased != 1 {
+		t.Fatalf("force with empty want: painted=%d erased=%d, want 0/1", plan.Painted, plan.Erased)
+	}
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -415,6 +415,19 @@ type App struct {
 	// cycling locate sibling attachments). See internal/ui/imagepreview.go.
 	preview *imagePreviewController
 
+	// sixelFrames is the shared frame store correlating every sixel
+	// App.View with the Bubble Tea frame that actually flushes. The App
+	// publishes immutable placement snapshots here; FrameOutput (wired
+	// in main) takes the exact flushed frame and paints it after the
+	// text diff. nil until SetSixelFrameStore runs.
+	sixelFrames *imgpkg.SixelFrameStore
+
+	// forceSixelRepaint marks the next published frame for a full
+	// erase/repaint. Set on a real terminal resize (width or height
+	// actually changed), consumed by finalizeSixelView after the next
+	// publication.
+	forceSixelRepaint bool
+
 	// Compositor memo (Stage A perf). bubbletea v2 calls View() after
 	// EVERY message -- every keystroke, key-repeat, mouse-motion, and
 	// tick -- synchronously in the event loop (tea.go render-on-update).
@@ -642,8 +655,15 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
+		// Only a real size change forces a sixel repaint; a duplicate
+		// size message (same dimensions) must not erase and repaint
+		// every image pointlessly.
+		changed := a.width != msg.Width || a.height != msg.Height
 		a.width = msg.Width
 		a.height = msg.Height
+		if changed {
+			a.forceSixelRepaint = true
+		}
 		return a, nil
 
 	case scrollFlushMsg:
@@ -1975,6 +1995,14 @@ func (a *App) SetImageContext(ctx imgrender.ImageContext) {
 	a.threadPanel.SetImageContext(ctx)
 }
 
+// SetSixelFrameStore wires the shared frame store used to correlate
+// every published sixel frame with the Bubble Tea frame that flushes.
+// The store is created in main and shared with FrameOutput; without it
+// the App still renders but publishes nothing.
+func (a *App) SetSixelFrameStore(frames *imgpkg.SixelFrameStore) {
+	a.sixelFrames = frames
+}
+
 // SetEmojiContext forwards the emoji rendering context to both the
 // messages pane and the thread pane. They each hold their own copy
 // because they have independent render caches and call paths.
@@ -2549,8 +2577,7 @@ func (a *App) renderTypingLine() string {
 
 func (a *App) View() tea.View {
 	if v, handled := a.renderEarlyFallback(); handled {
-		v.WindowTitle = a.windowTitle
-		return v
+		return a.finalizeSixelView(v, nil)
 	}
 
 	// Perf instrumentation: wall-clock the main View() path so we can
@@ -2643,7 +2670,6 @@ func (a *App) View() tea.View {
 	v := tea.NewView(screen)
 	v.AltScreen = true
 	v.MouseMode = tea.MouseModeCellMotion
-	v.WindowTitle = a.windowTitle
 	if debuglog.Enabled() {
 		// panel: 0=workspace 1=sidebar 2=messages 3=thread
 		// view:  0=channels 1=threads
@@ -2652,6 +2678,83 @@ func (a *App) View() tea.View {
 			int(a.focusedPanel), int(a.view), a.mode.String(),
 			a.threadVisible, a.sidebarVisible, previewActive)
 	}
+	return a.finalizeSixelView(v, a.collectSixelPlacements(frame))
+}
+
+// collectSixelPlacements gathers the desired sixel placements for the
+// current screen. The preview overlay replaces the messages/thread
+// regions entirely when active, so it takes priority; otherwise every
+// visible window leaf contributes its own placements, mapped through
+// its own rectangle (split windows sit at their own origins, not the
+// unsplit messages-pane origin). The thread pane still renders
+// halfblock.
+func (a *App) collectSixelPlacements(frame panelLayoutFrame) []imgpkg.SixelPlacement {
+	if a.preview.Active() {
+		want := make([]imgpkg.SixelPlacement, 0, 1)
+		if ov := a.preview.Overlay(); ov != nil {
+			if sp := ov.SixelPaint(); sp != nil {
+				if pl, ok := a.absolutePreviewSixelPlacement(*sp); ok {
+					want = append(want, pl)
+				}
+			}
+		}
+		return want
+	}
+	if a.view != ViewChannels {
+		return nil
+	}
+	// The same bounds renderWindowsRegion uses, so leaf rectangles
+	// match the panes actually drawn.
+	bounds := wintree.Rect{
+		X: 0,
+		Y: 0,
+		W: frame.MsgWidth + frame.MsgBorder,
+		H: frame.ContentHeight,
+	}
+	rects := a.wins.ComputeRects(bounds)
+	out := make([]imgpkg.SixelPlacement, 0, 2)
+	for _, id := range a.wins.Leaves() {
+		rect, ok := rects[id]
+		model := a.winModels[id]
+		if !ok || model == nil || rect.W < 1 || rect.H < 1 {
+			continue
+		}
+		out = append(out, absoluteWindowSixelPlacements(
+			model.SixelPlacements(), model.ChromeHeight(), rect, a.layout.SidebarEnd(),
+		)...)
+	}
+	return out
+}
+
+// finalizeSixelView is the single exit point for every App.View path,
+// including the early fallback. It:
+//
+//   - sets the real window title for non-sixel protocols;
+//   - publishes an empty frame when no sixel surface is visible, so old
+//     pixels erase;
+//   - attaches each placement's guard from the complete screen string;
+//   - publishes the frame with the themed erase background and the
+//     pending resize force, then clears the force flag;
+//   - marks the title with the frame ID so FrameOutput can correlate
+//     the exact flushed Bubble Tea frame.
+//
+// It never writes to the terminal; painting happens later in
+// FrameOutput after the text diff for the same frame.
+func (a *App) finalizeSixelView(v tea.View, placements []imgpkg.SixelPlacement) tea.View {
+	if a.imgProtocol != imgpkg.ProtoSixel || a.sixelFrames == nil {
+		v.WindowTitle = a.windowTitle
+		return v
+	}
+	for i := range placements {
+		placements[i].Guard = frameGuard(v.Content, placements[i].Row-1, placements[i].Rows)
+	}
+	id := a.sixelFrames.Publish(imgpkg.SixelFrame{
+		Placements: placements,
+		EraseSGR:   messages.BgANSI(),
+		Force:      a.forceSixelRepaint,
+	})
+	a.forceSixelRepaint = false
+	v.WindowTitle = imgpkg.FrameTitle(a.windowTitle, id)
 	return v
 }
 

--- a/internal/ui/imgrender/imgrender.go
+++ b/internal/ui/imgrender/imgrender.go
@@ -90,9 +90,16 @@ type Hit struct {
 // plus the halfblock fallback used when the image is only partially
 // visible (sixel cannot emit a half-image).
 type SixelEntry struct {
+	// Key is the stable image cache key (file ID + thumb suffix), the
+	// content identity that lets the painter detect a byte-for-byte
+	// different image in the same slot. Empty when no stable key exists
+	// (blockkit-derived entries); the messages pane then hashes the
+	// payload once at construction.
+	Key      string
 	Bytes    []byte
 	Fallback []string
 	Height   int
+	Width    int
 }
 
 // computeImageTarget chooses (cols, rows) for an inline image render.
@@ -386,7 +393,7 @@ func (r *Renderer) RenderBlock(att Block, channel, ts string, availWidth, baseRo
 			var bb bytes.Buffer
 			if err := pr.OnFlush(&bb); err == nil {
 				sxlMap = map[int]SixelEntry{
-					baseRow: {Bytes: bb.Bytes(), Fallback: pr.Fallback, Height: target.Y},
+					baseRow: {Key: key, Bytes: bb.Bytes(), Fallback: pr.Fallback, Height: target.Y, Width: target.X},
 				}
 			}
 		} else if pr.OnFlush != nil {
@@ -419,7 +426,7 @@ func (r *Renderer) RenderBlock(att Block, channel, ts string, availWidth, baseRo
 			var bb bytes.Buffer
 			if err := out.OnFlush(&bb); err == nil {
 				sxlMap = map[int]SixelEntry{
-					baseRow: {Bytes: bb.Bytes(), Fallback: out.Fallback, Height: target.Y},
+					baseRow: {Key: key, Bytes: bb.Bytes(), Fallback: out.Fallback, Height: target.Y, Width: target.X},
 				}
 			}
 		}

--- a/internal/ui/messages/blockkit/types.go
+++ b/internal/ui/messages/blockkit/types.go
@@ -211,6 +211,7 @@ type SixelEntry struct {
 	Bytes    []byte
 	Fallback []string
 	Height   int
+	Width    int
 }
 
 // HitRect is one clickable image footprint expressed in (row, col)

--- a/internal/ui/messages/model.go
+++ b/internal/ui/messages/model.go
@@ -205,9 +205,12 @@ type reactionHitRect struct {
 // plus the halfblock fallback used when the image is only partially
 // visible (Phase 6 cannot emit a half-image with sixel).
 type sixelEntry struct {
+	key      string // stable image cache key; empty -> payload-hash identity
 	bytes    []byte
 	fallback []string // halfblock-equivalent text for partial-visibility frames
 	height   int      // image height in rows
+	width    int      // image width in cells; the erase footprint
+	col      int      // display column within linesNormal where the image starts
 }
 
 // OpenImagePreviewMsg requests opening the full-screen preview overlay
@@ -222,6 +225,10 @@ type OpenImagePreviewMsg struct {
 }
 
 type Model struct {
+	// sixelPaints is the placement set produced by the last View, consumed
+	// by the App's out-of-band painter. See imgpkg.SixelPaint.
+	sixelPaints []imgpkg.SixelPaint
+
 	messages     []MessageItem
 	selected     int
 	channelName  string
@@ -2174,7 +2181,7 @@ func (m *Model) renderMessagePlain(msg MessageItem, width int, avatarStr string,
 		allFlushes = append(allFlushes, res.Flushes...)
 		rowOffset := preAttachmentRows + startInBk
 		for k, v := range res.SixelRows {
-			allSixel[rowOffset+k] = sixelEntry{bytes: v.Bytes, fallback: v.Fallback, height: v.Height}
+			allSixel[rowOffset+k] = sixelEntry{bytes: v.Bytes, fallback: v.Fallback, height: v.Height, width: v.Width}
 		}
 		// Note: res.Hits is intentionally NOT appended to `hits` in
 		// v1. App-level click routing (app.go) currently uses entryHit
@@ -2220,7 +2227,7 @@ func (m *Model) renderMessagePlain(msg MessageItem, width int, avatarStr string,
 		allFlushes = append(allFlushes, res.Flushes...)
 		rowOffset := preAttachmentRows + startInBk
 		for k, v := range res.SixelRows {
-			allSixel[rowOffset+k] = sixelEntry{bytes: v.Bytes, fallback: v.Fallback, height: v.Height}
+			allSixel[rowOffset+k] = sixelEntry{bytes: v.Bytes, fallback: v.Fallback, height: v.Height, width: v.Width}
 		}
 		// Note: res.Hits is intentionally NOT appended to `hits` in
 		// v1. App-level click routing (app.go) currently uses entryHit
@@ -2327,6 +2334,16 @@ func (m *Model) renderMessagePlain(msg MessageItem, width int, avatarStr string,
 
 	if len(allSixel) == 0 {
 		allSixel = nil
+	} else {
+		// Stamp every entry with the message's content column. Block kit,
+		// legacy, and attachment entries all start at contentColBase
+		// within linesNormal; without this the painter would place the
+		// image at the pane's content-left edge (col 0) instead of its
+		// placeholder, shifting it left under the avatar / border.
+		for k, v := range allSixel {
+			v.col = contentColBase
+			allSixel[k] = v
+		}
 	}
 	// Merge body-text + reaction-pill emoji flushes (the named-return
 	// `flushes` slice, appended to at lines ~1811 / ~1914) with
@@ -2397,7 +2414,7 @@ func convertSixelMap(in map[int]imgrender.SixelEntry) map[int]sixelEntry {
 	}
 	out := make(map[int]sixelEntry, len(in))
 	for k, v := range in {
-		out[k] = sixelEntry{bytes: v.Bytes, fallback: v.Fallback, height: v.Height}
+		out[k] = sixelEntry{key: v.Key, bytes: v.Bytes, fallback: v.Fallback, height: v.Height, width: v.Width}
 	}
 	return out
 }
@@ -3037,10 +3054,20 @@ func (m *Model) viewInternal(height, width int, applySelection bool) string {
 	// entries; consumed AFTER the visible slice is fully built so partial
 	// visibility decisions know the slice's final extent.
 	type sixelAction struct {
-		appendBytes []byte // append after visible[row] (full-visibility start row)
-		fallback    string // replace visible[row] with this (partial-visibility row)
+		fallback string // replace visible[row] with this (partial-visibility row)
 	}
 	var sixelActions map[int]sixelAction
+	// Placements for this frame, pane-local. Reset every render: the App
+	// reconciles the full set against what is currently on screen, so a
+	// stale entry here would keep a vanished image alive.
+	pendingSixel := make([]imgpkg.SixelPaint, 0, 2)
+
+	// Whether the "-- more below --" indicator will replace the last
+	// visible row. An image that intersects that row (or the loading
+	// row at the top) is not fully paintable: the indicator assignment
+	// below is authoritative and must stay visible, so such an image
+	// uses half-block fallback instead of an out-of-band placement.
+	moreBelow := m.yOffset+msgAreaHeight < m.totalLines
 
 	for i, e := range entries {
 		if want == 0 {
@@ -3151,18 +3178,42 @@ func (m *Model) viewInternal(height, width int, applySelection bool) string {
 			absStart := entryStart + startRowInEntry
 			absEnd := absStart + sx.height
 			fullyVisible := absStart >= m.yOffset && absEnd <= m.yOffset+msgAreaHeight
+			windowRow := windowRowBase + (startRowInEntry - from)
+			// Indicator rows replace window row 0 (loading hint) and
+			// row msgAreaHeight-1 (more below). An image whose footprint
+			// includes either is not fully paintable: the indicator is
+			// authoritative and must stay visible, so the image takes
+			// the existing partial-visibility fallback path instead.
+			intersectsLoading := m.loading && windowRow <= 0 && windowRow+sx.height > 0
+			intersectsMoreBelow := moreBelow && windowRow <= msgAreaHeight-1 && windowRow+sx.height > msgAreaHeight-1
+			fullyPaintable := fullyVisible && !intersectsLoading && !intersectsMoreBelow
 			if sixelActions == nil {
 				sixelActions = make(map[int]sixelAction)
 			}
-			if fullyVisible {
-				windowRow := windowRowBase + (startRowInEntry - from)
+			if fullyPaintable {
 				if windowRow >= 0 && windowRow < len(visible) {
-					sixelActions[windowRow] = sixelAction{appendBytes: sx.bytes}
+					// Record the placement instead of appending the bytes
+					// to the line. Bytes in the frame string force a
+					// re-emit every render (bubbletea rewrites the line
+					// whenever its content changes, so omitting them once
+					// erases the image) and leave no way to clear a region
+					// the image has left. The App paints these out-of-band
+					// after the frame is flushed; see SixelPlacements.
+					pendingSixel = append(pendingSixel, imgpkg.SixelPaint{
+						Key:   imgpkg.PlacementKey(sx.key, sx.bytes, sx.width, sx.height),
+						Row:   windowRow,
+						Col:   sx.col,
+						Rows:  sx.height,
+						Cols:  sx.width,
+						Bytes: sx.bytes,
+					})
 				}
 				continue
 			}
-			// Partial visibility: walk every row of the image, emitting
-			// fallback for rows that ARE in the visible window.
+			// Partial visibility or an indicator intersection: walk every
+			// row of the image, emitting fallback for rows that ARE in
+			// the visible window. The later indicator assignments
+			// overwrite their rows and remain authoritative.
 			for k := 0; k < sx.height; k++ {
 				abs := absStart + k
 				if abs < m.yOffset || abs >= m.yOffset+msgAreaHeight {
@@ -3184,9 +3235,6 @@ func (m *Model) viewInternal(height, width int, applySelection bool) string {
 		}
 		if act.fallback != "" {
 			visible[row] = act.fallback
-		}
-		if len(act.appendBytes) > 0 {
-			visible[row] = visible[row] + string(act.appendBytes)
 		}
 	}
 
@@ -3239,6 +3287,7 @@ func (m *Model) viewInternal(height, width int, applySelection bool) string {
 	visible = scrollbar.Overlay(visible, width, m.totalLines, m.yOffset, msgAreaHeight,
 		styles.Background, styles.Border, styles.Primary)
 
+	m.sixelPaints = pendingSixel
 	return chrome + "\n" + strings.Join(visible, "\n")
 }
 

--- a/internal/ui/messages/model_test.go
+++ b/internal/ui/messages/model_test.go
@@ -539,19 +539,63 @@ func setupImageMessageModel(t *testing.T, protocol imgpkg.Protocol) *Model {
 	return &m
 }
 
-// TestView_SixelFullVisibility_EmitsBytes asserts that when a sixel-
-// rendered image fits entirely within the visible viewport, the View
-// output contains the actual sixel byte stream (the OnFlush bytes
-// captured into sixelRows during buildCache), not just the sentinel
-// placeholder line. The sixel byte stream begins with the DCS escape
-// "\x1bP" (ESC P) per the DEC standard.
-func TestView_SixelFullVisibility_EmitsBytes(t *testing.T) {
+// TestView_SixelFullVisibility_PublishesPlacement asserts that a fully
+// visible sixel image is published as a placement rather than embedded in
+// the frame string. Bytes in the frame would have to be re-emitted every
+// render (bubbletea rewrites a line whenever its content changes) and
+// could never be erased; the App paints placements out-of-band instead.
+func TestView_SixelFullVisibility_PublishesPlacement(t *testing.T) {
 	m := setupImageMessageModel(t, imgpkg.ProtoSixel)
 	// A tall viewport ensures the entire image (~20 rows + chrome + body)
 	// fits without clipping.
 	out := m.View(60, 80)
-	if !strings.Contains(out, "\x1bP") {
-		t.Errorf("expected View() output to contain a sixel DCS escape (\\x1bP) when the image is fully visible; got %d bytes without it", len(out))
+	if strings.Contains(out, "\x1bP") {
+		t.Error("sixel bytes leaked into the frame string; they must be painted out-of-band")
+	}
+	placements := m.SixelPlacements()
+	if len(placements) != 1 {
+		t.Fatalf("SixelPlacements() = %d, want 1 for a fully visible image", len(placements))
+	}
+	p := placements[0]
+	if len(p.Bytes) == 0 || !strings.HasPrefix(string(p.Bytes), "\x1bP") {
+		t.Error("placement carries no sixel DCS payload")
+	}
+	if p.Rows <= 0 || p.Cols <= 0 {
+		t.Errorf("placement footprint = %dx%d, want a positive erase region", p.Cols, p.Rows)
+	}
+	if p.Key == "" {
+		t.Error("placement has no identity key; the painter cannot detect changes")
+	}
+}
+
+// The published placement's Col must be the message content column
+// (contentColBase), not 0: with Col 0 the painter places the image at
+// the pane's content-left edge, shifting it left under the message
+// border / avatar and away from its placeholder.
+func TestView_SixelPlacementColumnMatchesContentColBase(t *testing.T) {
+	m := setupImageMessageModel(t, imgpkg.ProtoSixel)
+	_ = m.View(80, 60)
+	placements := m.SixelPlacements()
+	if len(placements) != 1 {
+		t.Fatalf("SixelPlacements() = %d, want 1", len(placements))
+	}
+	if placements[0].Col != 1 {
+		t.Fatalf("placement Col = %d, want 1 (contentColBase without avatar)", placements[0].Col)
+	}
+}
+
+// With an avatar the message content moves 5 columns right, so the
+// placement column must shift with it.
+func TestView_SixelPlacementColumnWithAvatar(t *testing.T) {
+	m := setupImageMessageModel(t, imgpkg.ProtoSixel)
+	m.SetAvatarFunc(func(string) string { return "▀▀▀▀\n▄▄▄▄" })
+	_ = m.View(80, 60)
+	placements := m.SixelPlacements()
+	if len(placements) != 1 {
+		t.Fatalf("SixelPlacements() = %d, want 1", len(placements))
+	}
+	if placements[0].Col != 6 {
+		t.Fatalf("placement Col = %d, want 6 (contentColBase with avatar)", placements[0].Col)
 	}
 }
 
@@ -581,6 +625,9 @@ func TestView_SixelPartialVisibility_UsesFallback(t *testing.T) {
 	clipped := m.View(entryHeight/2+m.chromeHeight, 80)
 	if strings.Contains(clipped, "\x1bP") {
 		t.Errorf("expected View() output to OMIT the sixel DCS escape under partial visibility; bytes leaked anyway")
+	}
+	if n := len(m.SixelPlacements()); n != 0 {
+		t.Errorf("SixelPlacements() = %d under partial visibility, want 0 (halfblock fallback covers it)", n)
 	}
 }
 
@@ -1525,5 +1572,105 @@ func TestSetSearchTerms_RedundantCallKeepsCache(t *testing.T) {
 	m.SetSearchTerms([]string{"deploy"})
 	if m.cache == nil {
 		t.Fatal("redundant SetSearchTerms invalidated the render cache")
+	}
+}
+
+// TestSixelIdentity_DifferentStableKeysNeverCollide pins the collision
+// regression: two different images whose payloads encode to the same
+// byte length must not share an identity when their stable cache keys
+// differ. The old length-based key made red and blue 80x64 images both
+// "128/80x64", so a slot swap between them was treated as unchanged and
+// never repainted.
+func TestSixelIdentity_DifferentStableKeysNeverCollide(t *testing.T) {
+	a := sixelEntry{key: "FRED-720", bytes: []byte("same-size-a"), width: 10, height: 5}
+	b := sixelEntry{key: "FBLUE-720", bytes: []byte("same-size-b"), width: 10, height: 5}
+	if len(a.bytes) != len(b.bytes) {
+		t.Fatal("precondition: payload lengths must match")
+	}
+	if imgpkg.PlacementKey(a.key, a.bytes, a.width, a.height) == imgpkg.PlacementKey(b.key, b.bytes, b.width, b.height) {
+		t.Fatalf("different stable keys collided: %q", imgpkg.PlacementKey(a.key, a.bytes, a.width, a.height))
+	}
+}
+
+// TestSixelIdentity_EmptyKeysHashPayload asserts the digest fallback:
+// when no stable key exists, equal-length different payloads still get
+// different identities (payload hashed once at construction time).
+func TestSixelIdentity_EmptyKeysHashPayload(t *testing.T) {
+	a := sixelEntry{bytes: []byte("same-size-a"), width: 10, height: 5}
+	b := sixelEntry{bytes: []byte("same-size-b"), width: 10, height: 5}
+	if len(a.bytes) != len(b.bytes) {
+		t.Fatal("precondition: payload lengths must match")
+	}
+	if imgpkg.PlacementKey(a.key, a.bytes, a.width, a.height) == imgpkg.PlacementKey(b.key, b.bytes, b.width, b.height) {
+		t.Fatalf("equal-length different payloads with empty keys collided: %q", imgpkg.PlacementKey(a.key, a.bytes, a.width, a.height))
+	}
+}
+
+// TestSixelIdentity_GeometryParticipates asserts that a key collision is
+// still broken by a footprint difference.
+func TestSixelIdentity_GeometryParticipates(t *testing.T) {
+	a := sixelEntry{key: "F1-720", bytes: []byte("payload"), width: 10, height: 5}
+	b := sixelEntry{key: "F1-720", bytes: []byte("payload"), width: 11, height: 5}
+	if imgpkg.PlacementKey(a.key, a.bytes, a.width, a.height) == imgpkg.PlacementKey(b.key, b.bytes, b.width, b.height) {
+		t.Fatalf("different target geometry collided: %q", imgpkg.PlacementKey(a.key, a.bytes, a.width, a.height))
+	}
+}
+
+// TestView_SixelIntersectingMoreBelowUsesFallbackAndPublishesNoPlacement
+// asserts that an image whose footprint includes the row later replaced
+// by the "-- more below --" indicator is treated as not fully paintable:
+// no sixel placement is published, the visible rows use half-block
+// fallback, and the indicator stays visible.
+func TestView_SixelIntersectingMoreBelowUsesFallbackAndPublishesNoPlacement(t *testing.T) {
+	m := setupImageMessageModel(t, imgpkg.ProtoSixel)
+	// First render at the same height pins lastViewHeight and marks the
+	// selection as snapped; ScrollUp then moves the viewport to the top
+	// (yOffset 0) so the image is fully visible.
+	_ = m.View(23, 60)
+	m.ScrollUp(1)
+
+	// msgAreaHeight = 22; the image spans window rows 2..21, and the
+	// more-below indicator replaces row 21 — the image's last row.
+	out := m.View(23, 60)
+	if strings.Contains(out, "\x1bP") {
+		t.Errorf("sixel DCS leaked under an indicator-intersecting frame")
+	}
+	if n := len(m.SixelPlacements()); n != 0 {
+		t.Errorf("SixelPlacements() = %d, want 0 when the image intersects the more-below indicator", n)
+	}
+	if !strings.Contains(out, "▀") {
+		t.Errorf("expected half-block fallback rows for the non-indicator rows")
+	}
+	if !strings.Contains(out, "more below") {
+		t.Errorf("more-below indicator missing from output")
+	}
+}
+
+// TestView_SixelIntersectingLoadingRowUsesFallbackAndPublishesNoPlacement
+// is the loading-hint twin: with m.loading true, the loading row replaces
+// window row 0, and an image starting on that row must fall back to
+// half-block rather than publish a placement that would sit under the
+// authoritative hint.
+func TestView_SixelIntersectingLoadingRowUsesFallbackAndPublishesNoPlacement(t *testing.T) {
+	m := setupImageMessageModel(t, imgpkg.ProtoSixel)
+	// First render pins the geometry at this height; the selection snap
+	// bottoms the viewport at yOffset=3 (maxOffset). ScrollUp moves the
+	// image's first row onto window row 0 (yOffset=2).
+	_ = m.View(21, 60)
+	m.SetLoading(true)
+	m.ScrollUp(1)
+
+	out := m.View(21, 60)
+	if strings.Contains(out, "\x1bP") {
+		t.Errorf("sixel DCS leaked under a loading-indicator-intersecting frame")
+	}
+	if n := len(m.SixelPlacements()); n != 0 {
+		t.Errorf("SixelPlacements() = %d, want 0 when the image intersects the loading row", n)
+	}
+	if !strings.Contains(out, "▀") {
+		t.Errorf("expected half-block fallback rows for the non-indicator rows")
+	}
+	if !strings.Contains(out, "Loading older messages") {
+		t.Errorf("loading indicator missing from output")
 	}
 }

--- a/internal/ui/messages/sixelpaint_api.go
+++ b/internal/ui/messages/sixelpaint_api.go
@@ -1,0 +1,12 @@
+package messages
+
+import (
+	imgpkg "github.com/gammons/slk/internal/image"
+)
+
+// SixelPlacements returns the placements the most recent View wants
+// painted, in this pane's local coordinate frame (see
+// imgpkg.SixelPaint). Valid until the next View call. The App converts
+// them to absolute terminal coordinates and paints them out-of-band
+// after the matching Bubble Tea frame flushes.
+func (m *Model) SixelPlacements() []imgpkg.SixelPaint { return m.sixelPaints }

--- a/internal/ui/sixelpaint.go
+++ b/internal/ui/sixelpaint.go
@@ -1,0 +1,121 @@
+package ui
+
+import (
+	"hash/fnv"
+	"strconv"
+	"strings"
+
+	imgpkg "github.com/gammons/slk/internal/image"
+	"github.com/gammons/slk/internal/ui/wintree"
+)
+
+// This file contains the pure View-time sixel placement pipeline: it
+// collects which images the current frame wants, converts pane-local
+// coordinates into absolute 1-based terminal coordinates, and computes
+// the frame guards that detect rewrites underneath an image.
+//
+// It owns no painter and no writer. Publication happens in
+// finalizeSixelView, and the actual terminal writes happen later in
+// internal/image's FrameOutput, after the exact Bubble Tea frame's text
+// diff has been flushed.
+
+// absoluteWindowSixelPlacements converts one window leaf's pane-local
+// placements into absolute 1-based terminal coordinates. rect is the
+// leaf's rectangle relative to the messages region; messagesRegionX is
+// the absolute column where the messages region begins (the sidebar's
+// end).
+//
+// Leaf-relative mapping (mirrors renderUnfocusedWindow / borderedPane):
+//
+//	baseX       = messagesRegionX + rect.X
+//	contentLeft = baseX + 1                         // left border
+//	contentTop  = rect.Y + 1 + chromeHeight         // top border + model chrome
+//	right       = baseX + rect.W - 1                // right border starts here
+//	bottom      = rect.Y + rect.H - 1               // bottom border starts here
+//
+// A placement is rejected when its footprint reaches past the leaf's
+// right or bottom exclusive boundary — each window clips to its own
+// border, not to a global pane edge or status bar. Guards are NOT
+// attached here: finalizeSixelView hashes the complete screen string
+// and stamps every placement after the frame exists.
+func absoluteWindowSixelPlacements(
+	paints []imgpkg.SixelPaint,
+	chromeHeight int,
+	rect wintree.Rect,
+	messagesRegionX int,
+) []imgpkg.SixelPlacement {
+	baseX := messagesRegionX + rect.X
+	contentLeft := baseX + 1
+	contentTop := rect.Y + 1 + chromeHeight
+	right := baseX + rect.W - 1
+	bottom := rect.Y + rect.H - 1
+
+	out := make([]imgpkg.SixelPlacement, 0, len(paints))
+	for _, paint := range paints {
+		if paint.Rows <= 0 || paint.Cols <= 0 {
+			continue
+		}
+		col := contentLeft + paint.Col
+		row := contentTop + paint.Row
+		if col+paint.Cols > right || row+paint.Rows > bottom {
+			continue
+		}
+		out = append(out, imgpkg.SixelPlacement{
+			Key:   paint.Key,
+			Row:   row + 1, // CUP is 1-based
+			Col:   col + 1,
+			Rows:  paint.Rows,
+			Cols:  paint.Cols,
+			Bytes: paint.Bytes,
+		})
+	}
+	return out
+}
+
+// absolutePreviewSixelPlacement converts the preview overlay's
+// panel-local placement into absolute 1-based terminal coordinates.
+//
+// Unlike the messages pane, the preview panel has no border of its own
+// (see renderPreviewPanel: exactSize wraps the raw overlay content
+// directly) and always starts at the top of the content area — its left
+// edge is the same column the messages pane's left border sits at
+// (a.layout.SidebarEnd()), just without the "+1 for the border" the
+// messages pane needs. Preview.View() already fits the image inside its
+// own bounds via fitInto, so unlike the messages pane there is no
+// partial-visibility/scrolling case to clip against here.
+func (a *App) absolutePreviewSixelPlacement(p imgpkg.SixelPaint) (imgpkg.SixelPlacement, bool) {
+	if p.Rows <= 0 || p.Cols <= 0 {
+		return imgpkg.SixelPlacement{}, false
+	}
+	left := a.layout.SidebarEnd() + p.Col
+	top := p.Row
+
+	return imgpkg.SixelPlacement{
+		Key:   p.Key,
+		Row:   top + 1, // CUP is 1-based
+		Col:   left + 1,
+		Rows:  p.Rows,
+		Cols:  p.Cols,
+		Bytes: p.Bytes,
+	}, true
+}
+
+// frameGuard fingerprints the rows of the frame that sit under a
+// placement, starting at 0-based screen row top.
+//
+// A change here means bubbletea rewrote those lines and painted over the
+// image, so the painter must repaint even though the placement is
+// otherwise identical. Hashing a handful of lines per frame is cheap
+// next to re-emitting 60KB of sixel.
+func frameGuard(screen string, top, rows int) string {
+	if screen == "" {
+		return ""
+	}
+	lines := strings.Split(screen, "\n")
+	h := fnv.New64a()
+	for r := top; r < top+rows && r < len(lines); r++ {
+		h.Write([]byte(lines[r]))
+		h.Write([]byte{0})
+	}
+	return strconv.FormatUint(h.Sum64(), 36)
+}

--- a/internal/ui/sixelpaint_test.go
+++ b/internal/ui/sixelpaint_test.go
@@ -1,0 +1,512 @@
+// internal/ui/sixelpaint_test.go
+//
+// absoluteWindowSixelPlacements had zero test coverage despite being flagged (in
+// devdocs/image-problem.md) as the prime suspect for slk's still-open sixel
+// positioning bug. These tests pin its row/col math against the SAME
+// formula already proven correct for real click round-trips in
+// TestMouseClick_OnImageDispatchesOpenPreview (app_imagepreview_test.go):
+//
+//	X_terminal = layout.sidebarEnd + 1 (border) + paneCol
+//	Y_terminal = 1 (border) + chromeHeight + contentRow
+//
+// absoluteWindowSixelPlacements is the same inverse-of-PanelAt mapping, plus the
+// CUP 1-based conversion and the right/bottom clip checks. If these ever
+// disagree with panellayout.go's PanelAt, every sixel image is displaced —
+// exactly the symptom on file.
+package ui
+
+import (
+	"context"
+	stdimage "image"
+	"strconv"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	imgpkg "github.com/gammons/slk/internal/image"
+	"github.com/gammons/slk/internal/ui/imgrender"
+	"github.com/gammons/slk/internal/ui/messages"
+	"github.com/gammons/slk/internal/ui/wintree"
+)
+
+// primeChromeHeight drives one ViewBare call so messagepane.ChromeHeight()
+// reports a real value. absoluteWindowSixelPlacements is only meaningful
+// after a render, same precondition as ChromeHeight's own doc comment.
+func primeChromeHeight(a *App, width, height int) {
+	a.messagepane.SetChannel("general", "")
+	_ = a.messagepane.ViewBare(height, width)
+}
+
+// fullRegionRect mirrors the bounds renderWindowsRegion passes to
+// ComputeRects for the single-window / messages-region case.
+func fullRegionRect(a *App, height int) wintree.Rect {
+	return wintree.Rect{
+		X: 0,
+		Y: 0,
+		W: a.layout.MsgEnd() - a.layout.SidebarEnd(),
+		H: height - 1, // content height: status bar occupies the last row
+	}
+}
+
+// TestAbsoluteWindowSixelPlacements_SingleWindowMatchesPanelAtInverse
+// pins the leaf-relative math for the single full-region window against
+// the SAME formula already proven correct for real click round-trips in
+// TestMouseClick_OnImageDispatchesOpenPreview (app_imagepreview_test.go):
+//
+//	X_terminal = layout.sidebarEnd + 1 (border) + paneCol
+//	Y_terminal = 1 (border) + chromeHeight + contentRow
+//
+// absoluteWindowSixelPlacements is the same inverse-of-PanelAt mapping,
+// plus the CUP 1-based conversion and the leaf-border clip checks.
+func TestAbsoluteWindowSixelPlacements_SingleWindowMatchesPanelAtInverse(t *testing.T) {
+	a := newPanelAtApp()
+	a.height = 24
+	primeChromeHeight(a, 50, 20)
+	chrome := a.messagepane.ChromeHeight()
+	if chrome < 1 {
+		t.Fatalf("precondition: expected chromeHeight >= 1, got %d", chrome)
+	}
+
+	got := absoluteWindowSixelPlacements(
+		[]imgpkg.SixelPaint{{Key: "k", Row: 3, Rows: 4, Cols: 6}},
+		chrome, fullRegionRect(a, a.height), a.layout.SidebarEnd(),
+	)
+	if len(got) != 1 {
+		t.Fatalf("placement rejected for the single full-region window; got %d", len(got))
+	}
+	pl := got[0]
+
+	// Independently derive the expected CUP coordinates via the same
+	// inverse-of-PanelAt formula the mouse-click round-trip test uses,
+	// then convert 0-based -> 1-based CUP.
+	wantX := a.layout.sidebarEnd + 1 + 0 // p.Col is always 0
+	wantY := 1 + chrome + 3
+	wantCol := wantX + 1
+	wantRow := wantY + 1
+
+	if pl.Row != wantRow {
+		t.Errorf("Row = %d, want %d (sidebarEnd=%d chrome=%d)", pl.Row, wantRow, a.layout.sidebarEnd, chrome)
+	}
+	if pl.Col != wantCol {
+		t.Errorf("Col = %d, want %d", pl.Col, wantCol)
+	}
+	if pl.Rows != 4 || pl.Cols != 6 {
+		t.Errorf("footprint = %dx%d, want 6x4", pl.Cols, pl.Rows)
+	}
+}
+
+func TestAbsoluteWindowSixelPlacements_SingleWindowRejectsPastRightEdge(t *testing.T) {
+	a := newPanelAtApp()
+	a.height = 24
+	primeChromeHeight(a, 50, 20)
+
+	// Messages band is [sidebarEnd=25, msgEnd=77), i.e. 52 cols wide
+	// including both border columns, so 50 content cols. A 51-wide
+	// image cannot fit without touching the right border.
+	got := absoluteWindowSixelPlacements(
+		[]imgpkg.SixelPaint{{Key: "k", Row: 0, Rows: 2, Cols: 51}},
+		a.messagepane.ChromeHeight(), fullRegionRect(a, a.height), a.layout.SidebarEnd(),
+	)
+	if len(got) != 0 {
+		t.Fatalf("expected rejection for a placement wider than the pane content")
+	}
+}
+
+func TestAbsoluteWindowSixelPlacements_SingleWindowRejectsPastBottomEdge(t *testing.T) {
+	a := newPanelAtApp()
+	a.height = 24
+	primeChromeHeight(a, 50, 20)
+
+	got := absoluteWindowSixelPlacements(
+		[]imgpkg.SixelPaint{{Key: "k", Row: 0, Rows: 100, Cols: 4}},
+		a.messagepane.ChromeHeight(), fullRegionRect(a, a.height), a.layout.SidebarEnd(),
+	)
+	if len(got) != 0 {
+		t.Fatalf("expected rejection for a placement taller than the pane")
+	}
+}
+
+func TestAbsoluteWindowSixelPlacements_SingleWindowRejectsZeroFootprint(t *testing.T) {
+	a := newPanelAtApp()
+	a.height = 24
+	primeChromeHeight(a, 50, 20)
+
+	for _, p := range []imgpkg.SixelPaint{
+		{Key: "k", Row: 0, Rows: 0, Cols: 4},
+		{Key: "k", Row: 0, Rows: 4, Cols: 0},
+	} {
+		got := absoluteWindowSixelPlacements(
+			[]imgpkg.SixelPaint{p},
+			a.messagepane.ChromeHeight(), fullRegionRect(a, a.height), a.layout.SidebarEnd(),
+		)
+		if len(got) != 0 {
+			t.Fatalf("expected rejection for zero-footprint placement %+v", p)
+		}
+	}
+}
+
+// A right split's placements are offset by the leaf's own origin, not
+// the unsplit messages-pane origin.
+func TestAbsoluteWindowSixelPlacements_RightSplitUsesLeafOrigin(t *testing.T) {
+	rect := wintree.Rect{X: 40, Y: 0, W: 40, H: 24}
+	got := absoluteWindowSixelPlacements(
+		[]imgpkg.SixelPaint{{Key: "right", Row: 3, Col: 0, Rows: 4, Cols: 6}},
+		2, rect, 25,
+	)
+	if len(got) != 1 || got[0].Col != 67 || got[0].Row != 7 {
+		t.Fatalf("placement = %+v, want CUP row=7 col=67", got)
+	}
+}
+
+// A bottom split's placements are offset by the leaf's own vertical
+// origin.
+func TestAbsoluteWindowSixelPlacements_BottomSplitUsesLeafOrigin(t *testing.T) {
+	rect := wintree.Rect{X: 0, Y: 12, W: 80, H: 12}
+	got := absoluteWindowSixelPlacements(
+		[]imgpkg.SixelPaint{{Key: "bottom", Row: 1, Col: 0, Rows: 2, Cols: 5}},
+		2, rect, 25,
+	)
+	if len(got) != 1 || got[0].Col != 27 || got[0].Row != 17 {
+		t.Fatalf("placement = %+v, want CUP row=17 col=27", got)
+	}
+}
+
+// Each leaf clips against its OWN border: a placement inside the global
+// messages band but past a narrow leaf's right edge is rejected.
+func TestAbsoluteWindowSixelPlacements_ClipsAgainstLeafBorders(t *testing.T) {
+	rect := wintree.Rect{X: 40, Y: 0, W: 10, H: 6}
+	// contentLeft = 25+40+1 = 66; right = 25+40+10-1 = 74. Cols=9 ->
+	// col+cols = 75 > 74, so the placement reaches past the leaf border.
+	got := absoluteWindowSixelPlacements(
+		[]imgpkg.SixelPaint{{Key: "wide", Row: 0, Col: 0, Rows: 1, Cols: 9}},
+		2, rect, 25,
+	)
+	if len(got) != 0 {
+		t.Fatalf("wide placement not clipped to the leaf's right border: %+v", got)
+	}
+	// contentTop = 0+1+2 = 3; bottom = 0+6-1 = 5. Rows=5 -> row+rows =
+	// 8 > 5, so the placement reaches past the leaf's bottom border.
+	got = absoluteWindowSixelPlacements(
+		[]imgpkg.SixelPaint{{Key: "tall", Row: 0, Col: 0, Rows: 5, Cols: 1}},
+		2, rect, 25,
+	)
+	if len(got) != 0 {
+		t.Fatalf("tall placement not clipped to the leaf's bottom border: %+v", got)
+	}
+}
+
+// TestCollectSixelPlacements_TwoWindowsFocusedAndUnfocused drives a
+// two-window app where BOTH windows render an inline sixel image and
+// asserts the collector returns one placement inside each leaf
+// rectangle, and that switching focus neither drops the unfocused
+// placement nor moves either origin.
+func TestCollectSixelPlacements_TwoWindowsFocusedAndUnfocused(t *testing.T) {
+	a, w1, w2 := twoWindowApp(t)
+	a.imgProtocol = imgpkg.ProtoSixel
+	setupTwoWindowSixelImages(t, a)
+
+	frame := a.layout.Compute(a.width, a.height, a.workspaceRail.Width(), a.sidebar.Width(), a.sidebarVisible, a.threadVisible)
+	bounds := wintree.Rect{X: 0, Y: 0, W: frame.MsgWidth + frame.MsgBorder, H: frame.ContentHeight}
+	rects := a.wins.ComputeRects(bounds)
+
+	// Render each window's model at its own leaf's size so placements
+	// land in each model's content area.
+	for _, id := range a.wins.Leaves() {
+		rect := rects[id]
+		if rect.W < 1 || rect.H < 1 {
+			t.Fatalf("window %v has a degenerate rect: %+v", id, rect)
+		}
+		_ = a.winModels[id].View(rect.H, rect.W)
+	}
+
+	placements := a.collectSixelPlacements(frame)
+	if len(placements) != 2 {
+		t.Fatalf("placements = %d, want 2 (one per visible window)", len(placements))
+	}
+
+	sidebarEnd := a.layout.SidebarEnd()
+	covered := map[wintree.LeafID]bool{}
+	for _, pl := range placements {
+		col0 := pl.Col - 1
+		row0 := pl.Row - 1
+		inside := false
+		for _, id := range a.wins.Leaves() {
+			r := rects[id]
+			if col0 >= sidebarEnd+r.X && col0 < sidebarEnd+r.X+r.W && row0 >= r.Y && row0 < r.Y+r.H {
+				covered[id] = true
+				inside = true
+				break
+			}
+		}
+		if !inside {
+			t.Fatalf("placement %+v lands outside every leaf rect", pl)
+		}
+	}
+	if len(covered) != 2 {
+		t.Fatalf("placements cover %d windows, want both %v/%v (covered=%v)", len(covered), w1, w2, covered)
+	}
+
+	// Changing focus must not remove the unfocused window's placement
+	// or move either origin.
+	a.focusedWin = w1
+	after := a.collectSixelPlacements(frame)
+	if len(after) != 2 {
+		t.Fatalf("after focus switch placements = %d, want 2", len(after))
+	}
+	for i := range placements {
+		if placements[i].Row != after[i].Row || placements[i].Col != after[i].Col {
+			t.Fatalf("focus switch moved a placement: before %+v after %+v", placements[i], after[i])
+		}
+	}
+}
+
+// setupTwoWindowSixelImages wires a shared sixel image pipeline into
+// every window model of a, with one image-bearing message each, using
+// the same image-cache staging pattern as the messages package's
+// setupImageMessageModel: on-disk PNG, memo prime via Fetch, then a
+// sixel ImageContext with the test cell metrics.
+func setupTwoWindowSixelImages(t *testing.T, a *App) {
+	t.Helper()
+	cache, err := imgpkg.NewCache(t.TempDir(), 10)
+	if err != nil {
+		t.Fatalf("NewCache: %v", err)
+	}
+	fetcher := imgpkg.NewFetcher(cache, nil)
+	const fileID = "F0123ABCD"
+	const key = fileID + "-720"
+	if _, err := cache.Put(key, "png", makeTestPNGBytes(720, 720)); err != nil {
+		t.Fatalf("cache.Put: %v", err)
+	}
+	// Prime the in-memory decoded memo (Fetcher.Cached is memo-only).
+	if _, err := fetcher.Fetch(context.Background(), imgpkg.FetchRequest{
+		Key:    key,
+		URL:    "unused://disk-cache-hits-skip-network",
+		Target: stdimage.Pt(320, 320),
+	}); err != nil {
+		t.Fatalf("Fetch (memo prime): %v", err)
+	}
+	ctx := imgrender.ImageContext{
+		Protocol:   imgpkg.ProtoSixel,
+		Fetcher:    fetcher,
+		CellPixels: stdimage.Pt(8, 16),
+		MaxRows:    20,
+	}
+	a.SetImageContext(ctx)
+	_, _, _, msg := imageBearingMessage(t)
+	for _, m := range a.allWinModels() {
+		m.SetMessages([]messages.MessageItem{msg})
+	}
+}
+
+// TestAbsolutePreviewSixelPlacement_NoBorderOffset pins the one
+// difference from the messages-pane formula: the preview panel has no
+// border of its own (renderPreviewPanel wraps it with exactSize, not a
+// bordered*Pane helper), so unlike absoluteWindowSixelPlacements there is no
+// "+1" for a top/left border — only the sidebar's left edge offset.
+func TestAbsolutePreviewSixelPlacement_NoBorderOffset(t *testing.T) {
+	a := newPanelAtApp()
+	a.height = 24
+
+	p := imgpkg.SixelPaint{Key: "k", Row: 4, Col: 10, Rows: 6, Cols: 20}
+	pl, ok := a.absolutePreviewSixelPlacement(p)
+	if !ok {
+		t.Fatalf("absolutePreviewSixelPlacement rejected a placement that should fit")
+	}
+
+	wantCol := a.layout.sidebarEnd + p.Col + 1 // no border offset, then 1-based CUP
+	wantRow := p.Row + 1
+
+	if pl.Col != wantCol {
+		t.Errorf("Col = %d, want %d (sidebarEnd=%d p.Col=%d)", pl.Col, wantCol, a.layout.sidebarEnd, p.Col)
+	}
+	if pl.Row != wantRow {
+		t.Errorf("Row = %d, want %d (p.Row=%d)", pl.Row, wantRow, p.Row)
+	}
+	if pl.Rows != p.Rows || pl.Cols != p.Cols {
+		t.Errorf("footprint = %dx%d, want %dx%d", pl.Cols, pl.Rows, p.Cols, p.Rows)
+	}
+	if pl.Key != p.Key {
+		t.Errorf("Key = %q, want %q", pl.Key, p.Key)
+	}
+}
+
+func TestAbsolutePreviewSixelPlacement_RejectsZeroFootprint(t *testing.T) {
+	a := newPanelAtApp()
+	a.height = 24
+
+	for _, p := range []imgpkg.SixelPaint{
+		{Key: "k", Row: 0, Col: 0, Rows: 0, Cols: 4},
+		{Key: "k", Row: 0, Col: 0, Rows: 4, Cols: 0},
+	} {
+		if _, ok := a.absolutePreviewSixelPlacement(p); ok {
+			t.Fatalf("expected rejection for zero-footprint placement %+v", p)
+		}
+	}
+}
+
+func TestAbsoluteSixelPlacement_RejectsZeroFootprint(t *testing.T) {
+	a := newPanelAtApp()
+	a.height = 24
+	primeChromeHeight(a, 50, 20)
+
+	for _, p := range []imgpkg.SixelPaint{
+		{Key: "k", Row: 0, Rows: 0, Cols: 4},
+		{Key: "k", Row: 0, Rows: 4, Cols: 0},
+	} {
+		got := absoluteWindowSixelPlacements(
+			[]imgpkg.SixelPaint{p},
+			a.messagepane.ChromeHeight(), fullRegionRect(a, a.height), a.layout.SidebarEnd(),
+		)
+		if len(got) != 0 {
+			t.Fatalf("expected rejection for zero-footprint placement %+v", p)
+		}
+	}
+}
+
+// sixelTestApp returns an App configured for sixel frame publication:
+// protocol sixel plus a fresh frame store, at the zero-size state so the
+// early-fallback path is reachable.
+func sixelTestApp() *App {
+	a := NewApp()
+	a.imgProtocol = imgpkg.ProtoSixel
+	a.sixelFrames = imgpkg.NewSixelFrameStore()
+	return a
+}
+
+// frameIDFromTitle parses the internal frame ID out of a marked
+// WindowTitle. The marker literal lives only in tests.
+func frameIDFromTitle(t *testing.T, title string) uint64 {
+	t.Helper()
+	const marker = "\x1fslk-sixel-frame="
+	idx := strings.Index(title, marker)
+	if idx < 0 {
+		t.Fatalf("title %q carries no frame marker", title)
+	}
+	id, err := strconv.ParseUint(title[idx+len(marker):], 10, 64)
+	if err != nil {
+		t.Fatalf("unparsable frame id in title %q: %v", title, err)
+	}
+	return id
+}
+
+func TestFinalizeSixelView_PublishesPlacementAndMarksTitle(t *testing.T) {
+	a := sixelTestApp()
+	v := tea.NewView("screen\ncontent\nlines")
+	placements := []imgpkg.SixelPlacement{{
+		Key: "k", Row: 2, Col: 3, Rows: 1, Cols: 1,
+		Bytes: []byte("\x1bPqk\x1b\\"),
+	}}
+	out := a.finalizeSixelView(v, placements)
+
+	id := frameIDFromTitle(t, out.WindowTitle)
+	frame, ok := a.sixelFrames.Take(id)
+	if !ok {
+		t.Fatalf("frame %d not published", id)
+	}
+	if len(frame.Placements) != 1 {
+		t.Fatalf("Placements = %d, want 1", len(frame.Placements))
+	}
+	if frame.Placements[0].Key != "k" {
+		t.Fatalf("placement key = %q, want k", frame.Placements[0].Key)
+	}
+	// The guard must be attached from the complete screen string.
+	if frame.Placements[0].Guard == "" {
+		t.Fatal("guard not attached from the frame content")
+	}
+	// The marked title must strip back to the real title.
+	if !strings.HasPrefix(out.WindowTitle, a.windowTitle) {
+		t.Fatalf("marked title %q does not carry real title %q", out.WindowTitle, a.windowTitle)
+	}
+}
+
+// A frame with no visible sixel surface must publish an empty frame so
+// the painter erases any previously painted pixels.
+func TestFinalizeSixelView_EmptyFrameErasesPriorSurface(t *testing.T) {
+	a := sixelTestApp()
+	a.finalizeSixelView(tea.NewView("one"), []imgpkg.SixelPlacement{{
+		Key: "k", Row: 2, Col: 3, Rows: 1, Cols: 1, Bytes: []byte("\x1bPqk\x1b\\"),
+	}})
+
+	out := a.finalizeSixelView(tea.NewView("two"), nil)
+	id := frameIDFromTitle(t, out.WindowTitle)
+	frame, ok := a.sixelFrames.Take(id)
+	if !ok {
+		t.Fatal("second frame not published")
+	}
+	if len(frame.Placements) != 0 {
+		t.Fatalf("empty surface must publish zero placements, got %d", len(frame.Placements))
+	}
+}
+
+// Non-sixel protocols keep the plain real title and never publish a
+// frame or touch the store.
+func TestFinalizeSixelView_NonSixelKeepsRealTitleAndPublishesNothing(t *testing.T) {
+	a := sixelTestApp()
+	a.imgProtocol = imgpkg.ProtoHalfBlock
+
+	out := a.finalizeSixelView(tea.NewView("content"), []imgpkg.SixelPlacement{{
+		Key: "k", Row: 2, Col: 3, Rows: 1, Cols: 1,
+	}})
+	if out.WindowTitle != a.windowTitle {
+		t.Fatalf("title = %q, want real %q", out.WindowTitle, a.windowTitle)
+	}
+	if strings.Contains(out.WindowTitle, "slk-sixel-frame=") {
+		t.Fatalf("non-sixel title carries a frame marker")
+	}
+	if _, ok := a.sixelFrames.Take(1); ok {
+		t.Fatal("non-sixel finalizer must not publish a frame")
+	}
+}
+
+// A real window-size change forces exactly the next published frame;
+// duplicate size messages do not, and the flag is consumed by use.
+func TestWindowSizeChangeForcesExactlyNextSixelFrame(t *testing.T) {
+	a := sixelTestApp()
+
+	first := a.finalizeSixelView(tea.NewView("a"), nil)
+	f1, ok := a.sixelFrames.Take(frameIDFromTitle(t, first.WindowTitle))
+	if !ok || f1.Force {
+		t.Fatalf("initial frame: ok=%v Force=%v, want ok=true Force=false", ok, f1.Force)
+	}
+
+	// A real size change marks the next published frame for repaint.
+	_, _ = a.Update(tea.WindowSizeMsg{Width: 101, Height: 25})
+	forced := a.finalizeSixelView(tea.NewView("b"), nil)
+	f2, ok := a.sixelFrames.Take(frameIDFromTitle(t, forced.WindowTitle))
+	if !ok || !f2.Force {
+		t.Fatalf("frame after real resize: ok=%v Force=%v, want forced", ok, f2.Force)
+	}
+
+	// The flag was consumed: the following frame is not forced.
+	next := a.finalizeSixelView(tea.NewView("c"), nil)
+	f3, ok := a.sixelFrames.Take(frameIDFromTitle(t, next.WindowTitle))
+	if !ok || f3.Force {
+		t.Fatalf("subsequent frame: ok=%v Force=%v, want not forced", ok, f3.Force)
+	}
+
+	// A duplicate size message (same dimensions) must not force again.
+	_, _ = a.Update(tea.WindowSizeMsg{Width: 101, Height: 25})
+	if a.forceSixelRepaint {
+		t.Fatal("duplicate WindowSizeMsg must not set forceSixelRepaint")
+	}
+}
+
+// The pre-measurement fallback view publishes an empty frame so a
+// previous surface is erased even before the first real layout.
+func TestEarlyFallbackPublishesEmptySixelFrame(t *testing.T) {
+	a := sixelTestApp()
+	if a.width != 0 || a.height != 0 {
+		t.Fatal("precondition: early fallback needs zero size")
+	}
+
+	v := a.View()
+	id := frameIDFromTitle(t, v.WindowTitle)
+	frame, ok := a.sixelFrames.Take(id)
+	if !ok {
+		t.Fatal("early fallback must publish a frame")
+	}
+	if len(frame.Placements) != 0 {
+		t.Fatalf("early fallback frame must be empty, got %d placements", len(frame.Placements))
+	}
+}


### PR DESCRIPTION
# Inline images on sixel terminals (WezTerm, iTerm2, foot, mlterm)

## What this fixes

Inline images render as a blurry half-block mosaic on WezTerm and iTerm2 today. This makes them render as real images.

The cause isn't that those terminals lack image support — both speak kitty *graphics*. It's that slk's kitty renderer positions images using the **unicode placeholder extension** (`U=1` with U+10EEEE characters written into the text, `internal/image/kitty.go`). That's a kitty-specific extension, not part of the kitty graphics protocol. A terminal can fully support kitty graphics and still be unusable on that path — WezTerm is exactly that case, and routing it to kitty makes it print the placeholder codepoints as literal glyphs. So sixel is the only viable route for WezTerm, iTerm2, foot and mlterm.

## Why this is more than "emit sixel bytes"

Kitty gets three things from the terminal that sixel doesn't: cell-aware placement, image identity (so the terminal repaints them), and clipping. Sixel pixels are fire-and-forget — nothing repaints them, nothing erases them, and they ignore pane borders entirely. slk has to own the screen region itself.

The previous approach appended sixel bytes into the frame string. That forces re-emission on every render (~283 KB per frame per visible image, measured) because Bubble Tea rewrites a line whenever its content changes — and it offers no way to clear a region an image has left behind.

Instead, `App.View()` publishes an immutable snapshot of the placements it wants into a frame store, tagged with an ID. A writer wrapping the program output (`internal/image/sixelframe.go`) takes the exact frame that actually flushed and reconciles it against what's on screen: unchanged → zero bytes, moved or gone → erase, new or changed → paint.

Three details that took real-terminal iteration to get right:

- **Erase and paint land on opposite sides of the text diff.** ECH blanks the cells it clears, so an erase running after the diff wipes text the diff just wrote — the symptom was messages disappearing while scrolling. Erases now go immediately after the synchronized-output start, paints immediately before its reset.
- **The painter is transactional.** `Plan` computes bytes and next state without mutating; `Commit` runs only after a full successful write. A short write can't leave the painter believing an image is on screen that isn't.
- **Content identity is a hash, not a byte length.** Two different images with the same dimensions and palette depth encode to the same length, so a length-keyed placement treated a slot swap as unchanged and never repainted.

The preview overlay also memoizes its encoded image. `View()` runs after every bubbletea message and the compositor deliberately never memoizes overlay frames, so without it the overlay re-encoded on every keystroke and mouse motion — measured at ~1.4s per encode at full-pane size, which made opening and closing the preview visibly lag. Repeat renders are now ~44µs.

## Scope and limits

- The thread pane and avatars still render half-block on sixel. Avatars are a natural follow-up now that emission is change-gated (the original rationale — re-emitting per avatar per redraw would dominate bandwidth — no longer holds).
- Sixel under tmux is unchanged and still conservative: no probe-verify, and passthrough is bandwidth-hostile. WezTerm-under-tmux therefore still takes the old path.
- **All output now flows through the wrapping writer, not just sixel.** For every other protocol it's a serialized pass-through: frames carry no marker, so no plan is computed and the bytes are forwarded unchanged. `Fd`/`Read`/`Close` delegate so Bubble Tea's `term.File` assertion still finds the TTY. Flagged explicitly because it's the part of this PR that touches users who don't use sixel at all.

## On detection (and #100)

This supersedes #100, which carried the `iTerm.app` → sixel detection change on its own. That change is included here verbatim and extended to WezTerm. Merging it standalone would have made things *worse* for iTerm2 users than the halfblock they have today: it routes them onto sixel, and until the painting work in this PR, sixel meant tiled duplicate images in the preview overlay and stale pixels that survived until a forced repaint. That's why it stayed a draft.

@j4james — on #100 you asked why detection doesn't use a `DA1` device-attributes query instead of matching `TERM_PROGRAM`, and pointed out that pairing it with the kitty query gives a guaranteed response to synchronize against, removing the need for a timeout. You're right, and it would replace the weakest part of this PR: the terminal-name matching in `Detect`, plus the 200ms probe timeout that is exactly what made WezTerm silently fall back to halfblock in the first place.

I've kept this PR to the rendering work, which is independent of *how* the protocol is chosen, so the detection rework can land as its own reviewable change rather than riding along with 2.8k lines of painting logic. Happy to take on that as the immediate follow-up.

## Testing

Sixel positioning can't be verified in CI — there's no terminal. Unit coverage pins what can be pinned: frame correlation and pruning, erase/paint ordering around the sync window, marker stripping, title forwarding, short-write and failed-write non-commit, and an end-to-end test driving a real Bubble Tea program through the writer (`TestSixelFrameOutput_BubbleTeaFlushContract`).

Manually verified in **iTerm2**, **WezTerm** and **Ghostty** — inline images, the `v` preview overlay, scrolling past images, and selecting rows containing images. Ghostty is on the kitty path and was checked specifically because of the output-path change noted above; it is unaffected.

`go build`, `go vet` and `go test ./...` pass.
