### PR TITLE
Fix reaction count fg lost after kitty image placement

### DIFF
--- a/internal/ui/messages/model.go
+++ b/internal/ui/messages/model.go
@@ -2031,7 +2031,6 @@ func (m *Model) renderMessagePlain(msg MessageItem, width int, avatarStr string,
 					emojiStr = ":" + legacyName + ":"
 				}
 			}
-			pillText := fmt.Sprintf("%s%d", emojiStr, r.Count)
 			var style lipgloss.Style
 			if isSelected && m.reactionNavActive && i == m.reactionNavIndex {
 				style = styles.ReactionPillSelected
@@ -2040,17 +2039,7 @@ func (m *Model) renderMessagePlain(msg MessageItem, width int, avatarStr string,
 			} else {
 				style = styles.ReactionPillOther
 			}
-			// The kitty image placement encodes the image ID in the
-			// fg color and ends with \e[39m (fg → default), wiping
-			// the pill style's fg before the count prints. Re-assert
-			// the style's fg between the placement and the count.
-			if placedFlush != nil {
-				if fg := style.GetForeground(); fg != nil {
-					pillText = emojiStr +
-						ansi.Style{}.ForegroundColor(fg).String() +
-						strconv.Itoa(r.Count)
-				}
-			}
+			pillText := ReactionPillText(emojiStr, r.Count, style, placedFlush != nil)
 			pills = append(pills, style.Render(pillText))
 			pillEmojis = append(pillEmojis, r.Emoji)
 			// Image emoji in reaction pills land in the same per-frame

--- a/internal/ui/messages/model.go
+++ b/internal/ui/messages/model.go
@@ -2040,6 +2040,17 @@ func (m *Model) renderMessagePlain(msg MessageItem, width int, avatarStr string,
 			} else {
 				style = styles.ReactionPillOther
 			}
+			// The kitty image placement encodes the image ID in the
+			// fg color and ends with \e[39m (fg → default), wiping
+			// the pill style's fg before the count prints. Re-assert
+			// the style's fg between the placement and the count.
+			if placedFlush != nil {
+				if fg := style.GetForeground(); fg != nil {
+					pillText = emojiStr +
+						ansi.Style{}.ForegroundColor(fg).String() +
+						strconv.Itoa(r.Count)
+				}
+			}
 			pills = append(pills, style.Render(pillText))
 			pillEmojis = append(pillEmojis, r.Emoji)
 			// Image emoji in reaction pills land in the same per-frame

--- a/internal/ui/messages/reactionpill.go
+++ b/internal/ui/messages/reactionpill.go
@@ -1,0 +1,37 @@
+// internal/ui/messages/reactionpill.go
+//
+// Shared reaction-pill text construction (issue #133).
+//
+// The messages pane and the thread panel each render their own copy of
+// the reaction-pill loop. The kitty-placement fix below has to be
+// present in both or the bug returns in whichever one drifts, so the
+// logic lives here and both call it.
+package messages
+
+import (
+	"strconv"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// ReactionPillText builds a pill's inner text: the emoji followed by
+// its count.
+//
+// placedAsImage reports whether emojiStr is a kitty image placement
+// rather than a glyph. A placement encodes the image ID in the
+// foreground color and ends by resetting it (\e[39m, fg → default),
+// which wipes the pill style's own foreground before the count digit
+// prints — leaving the count uncolored while the rest of the pill
+// keeps its color. Re-asserting the style's foreground between the
+// placement and the count restores it.
+//
+// No nil check on the foreground: lipgloss returns black rather than
+// nil for a style that never set one, so a guard would be dead code.
+// Every pill style sets a foreground anyway.
+func ReactionPillText(emojiStr string, count int, style lipgloss.Style, placedAsImage bool) string {
+	if placedAsImage {
+		return emojiStr + ansi.Style{}.ForegroundColor(style.GetForeground()).String() + strconv.Itoa(count)
+	}
+	return emojiStr + strconv.Itoa(count)
+}

--- a/internal/ui/messages/reactionpill_test.go
+++ b/internal/ui/messages/reactionpill_test.go
@@ -1,0 +1,56 @@
+package messages
+
+import (
+	goimage "image"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	emojiutil "github.com/gammons/slk/internal/emoji"
+	imgpkg "github.com/gammons/slk/internal/image"
+	"github.com/gammons/slk/internal/ui/styles"
+)
+
+// Regression test for #133. A kitty image placement encodes the image
+// ID in the foreground color and ends by resetting it (\e[39m), so the
+// count printed after it renders uncolored unless the pill's own
+// foreground is re-asserted in between.
+func TestRenderReactionPill_ImageEmojiKeepsCountColor(t *testing.T) {
+	emojiutil.SetImageMode(true, 2)
+	t.Cleanup(func() { emojiutil.SetImageMode(false, 2) })
+
+	const placeholder = "\U0010EEEE"
+	url := emojiutil.CDNBaseURL + "1f44d.png"
+	ff := newFakePlaceFetcher()
+	ff.setPrerendered(emojiutil.EmojiCacheKey(url), goimage.Pt(2, 1), imgpkg.Render{
+		Cells:   goimage.Pt(2, 1),
+		Lines:   []string{placeholder + placeholder},
+		OnFlush: func(io.Writer) error { return nil },
+	})
+
+	m := New([]MessageItem{{
+		TS:        "1.0",
+		UserName:  "alice",
+		UserID:    "U1",
+		Text:      "hello",
+		Timestamp: "10:30 AM",
+		Reactions: []ReactionItem{{Emoji: "thumbsup", Count: 3, HasReacted: true}},
+	}}, "general")
+	m.SetEmojiContext(EmojiContext{
+		PlaceCtx: emojiutil.PlaceContext{Fetcher: ff},
+		Cells:    2,
+		Customs:  nil,
+	})
+
+	out := m.View(24, 80)
+	if !strings.Contains(out, placeholder) {
+		t.Fatal("expected an image placement in the pill; the rest of this test proves nothing without one")
+	}
+
+	want := placeholder + ansi.Style{}.ForegroundColor(styles.ReactionPillOwn.GetForeground()).String()
+	if !strings.Contains(out, want) {
+		t.Error("count is not preceded by the pill fg — it renders uncolored " +
+			"while the rest of the pill stays colored (#133)")
+	}
+}

--- a/internal/ui/thread/model.go
+++ b/internal/ui/thread/model.go
@@ -1899,7 +1899,6 @@ func (m *Model) renderThreadMessage(msg messages.MessageItem, width int, userNam
 					emojiStr = ":" + legacyName + ":"
 				}
 			}
-			pillText := fmt.Sprintf("%s%d", emojiStr, r.Count)
 			var style lipgloss.Style
 			if isSelected && m.reactionNavActive && i == m.reactionNavIndex {
 				style = styles.ReactionPillSelected
@@ -1908,17 +1907,7 @@ func (m *Model) renderThreadMessage(msg messages.MessageItem, width int, userNam
 			} else {
 				style = styles.ReactionPillOther
 			}
-			// The kitty image placement encodes the image ID in the
-			// fg color and ends with \e[39m (fg → default), wiping
-			// the pill style's fg before the count prints. Re-assert
-			// the style's fg between the placement and the count.
-			if placedFlush != nil {
-				if fg := style.GetForeground(); fg != nil {
-					pillText = emojiStr +
-						ansi.Style{}.ForegroundColor(fg).String() +
-						fmt.Sprintf("%d", r.Count)
-				}
-			}
+			pillText := messages.ReactionPillText(emojiStr, r.Count, style, placedFlush != nil)
 			pills = append(pills, style.Render(pillText))
 			pillEmojis = append(pillEmojis, r.Emoji)
 			// Image emoji in reaction pills land in the same per-frame

--- a/internal/ui/thread/model.go
+++ b/internal/ui/thread/model.go
@@ -1908,6 +1908,17 @@ func (m *Model) renderThreadMessage(msg messages.MessageItem, width int, userNam
 			} else {
 				style = styles.ReactionPillOther
 			}
+			// The kitty image placement encodes the image ID in the
+			// fg color and ends with \e[39m (fg → default), wiping
+			// the pill style's fg before the count prints. Re-assert
+			// the style's fg between the placement and the count.
+			if placedFlush != nil {
+				if fg := style.GetForeground(); fg != nil {
+					pillText = emojiStr +
+						ansi.Style{}.ForegroundColor(fg).String() +
+						fmt.Sprintf("%d", r.Count)
+				}
+			}
 			pills = append(pills, style.Render(pillText))
 			pillEmojis = append(pillEmojis, r.Emoji)
 			// Image emoji in reaction pills land in the same per-frame


### PR DESCRIPTION
Fixes #133

The kitty unicode-placeholder encodes the image ID in the fg color and resets with `\e[39m` afterward, which wipes the pill style's foreground before the count digit prints. This re-asserts the style's fg between the placement and the count so the own-reaction green (and other pill colors) survive the image path.

Applied in both `internal/ui/messages/model.go` and `internal/ui/thread/model.go` (thread pane has its own copy of the pill loop).

Tested on ghostty (macOS, slk 0.13.1) — reaction counts render green again with `emoji_images = "on"`.

<img width="170" height="41" alt="image" src="https://github.com/user-attachments/assets/efaa7cb0-1c28-49f9-b270-31efba59ce8c" />
