### PR TITLE
fix(slackdesktop): pick the right macOS Safe Storage key when several exist

### DIFF
--- a/cmd/slk/onboarding.go
+++ b/cmd/slk/onboarding.go
@@ -133,7 +133,12 @@ func desktopErrorMessage(err error) string {
 	case errors.Is(err, slackdesktop.ErrNoSecretService):
 		return "No system keyring/secret service found. slk needs it to read the Slack session."
 	case errors.Is(err, slackdesktop.ErrDecryptFailed):
-		return "Could not decrypt the Slack session cookie. Please file an issue with your OS + Slack version."
+		// Keep the wrapped detail: it names which step failed (padding, length,
+		// non-printable result), which is the difference between a diagnosable
+		// report and a round-trip asking what actually broke.
+		return "Could not decrypt the Slack session cookie: " + err.Error() +
+			". If you have had more than one Slack build installed (App Store and standalone), " +
+			"sign out of the one you no longer use. Otherwise please file an issue with your OS + Slack version."
 	default:
 		return "Could not read Slack desktop session: " + err.Error()
 	}

--- a/cmd/slk/onboarding_error_test.go
+++ b/cmd/slk/onboarding_error_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gammons/slk/internal/slackdesktop"
+)
+
+// A bare "file an issue" message threw away the one thing that identifies which
+// decryption step failed, turning a diagnosable fault into a support round-trip.
+func TestDesktopErrorMessageKeepsDecryptDetail(t *testing.T) {
+	err := fmt.Errorf("%w: decrypted value is not printable text (wrong Safe Storage key?)", slackdesktop.ErrDecryptFailed)
+
+	got := desktopErrorMessage(err)
+	if !strings.Contains(got, "not printable text") {
+		t.Errorf("message = %q, want it to carry the wrapped detail", got)
+	}
+}
+
+// The other branches are plain advice with nothing wrapped to surface; they must
+// stay untouched.
+func TestDesktopErrorMessageKnownCauses(t *testing.T) {
+	tests := []struct {
+		err  error
+		want string
+	}{
+		{slackdesktop.ErrDesktopNotFound, "Slack desktop app not found"},
+		{slackdesktop.ErrNotSignedIn, "No Slack workspaces are signed in"},
+		{slackdesktop.ErrCookieDBMissing, "never signed in"},
+		{slackdesktop.ErrKeyringLocked, "keyring is locked"},
+		{slackdesktop.ErrNoSecretService, "No system keyring"},
+		{errors.New("boom"), "boom"},
+	}
+	for _, tc := range tests {
+		if got := desktopErrorMessage(tc.err); !strings.Contains(got, tc.want) {
+			t.Errorf("desktopErrorMessage(%v) = %q, want it to contain %q", tc.err, got, tc.want)
+		}
+	}
+}

--- a/internal/slackdesktop/cookie.go
+++ b/internal/slackdesktop/cookie.go
@@ -1,14 +1,47 @@
 package slackdesktop
 
 import (
+	"fmt"
 	"path/filepath"
 	"runtime"
 )
 
-// decryptCookieValue picks the right key + algorithm for the OS and the
-// value's version prefix. getPassword is the injected keyring/keychain/DPAPI
-// source (may return nil for the linux v10 "peanuts" case).
-func decryptCookieValue(goos string, enc []byte, getPassword func() ([]byte, error)) ([]byte, error) {
+// looksLikeCookieValue reports whether b is a plausible decrypted cookie:
+// non-empty and printable ASCII.
+//
+// decryptCBC's only integrity check is PKCS#7 padding, and that is weak — the
+// final plaintext byte merely has to land in 1..16, so a wrong Safe Storage key
+// survives it about one time in sixteen and yields binary garbage. Sent on as a
+// `d` cookie, net/http silently drops the invalid bytes and Slack answers
+// invalid_auth, which points nowhere near the real fault. Requiring printable
+// ASCII closes that gap: garbage survives with probability (95/256)^len.
+//
+// We deliberately do not require an "xoxd-" prefix — that would break the day
+// Slack renames the cookie — nor a domain-hash prefix, which only exists from
+// Chromium 130 / cookie-DB version 24 onward and would break older installs.
+func looksLikeCookieValue(b []byte) bool {
+	if len(b) == 0 {
+		return false
+	}
+	for _, c := range b {
+		if c < 0x20 || c > 0x7e {
+			return false
+		}
+	}
+	return true
+}
+
+// passwordSource yields every Safe Storage key candidate for this machine, in
+// preference order. A macOS login keychain can hold several items under the
+// same "Slack Safe Storage" service — one per Slack build ever installed — and
+// only trying them tells us which one belongs to the profile we are reading.
+type passwordSource func() ([][]byte, error)
+
+// decryptCookieValue picks the right algorithm for the OS and the value's
+// version prefix, then tries each candidate key until one yields a plausible
+// cookie. getPasswords is the injected keyring/keychain/DPAPI source; it is not
+// consulted at all for the linux v10 "peanuts" case.
+func decryptCookieValue(goos string, enc []byte, getPasswords passwordSource) ([]byte, error) {
 	if len(enc) < 3 {
 		return nil, ErrDecryptFailed
 	}
@@ -16,28 +49,56 @@ func decryptCookieValue(goos string, enc []byte, getPassword func() ([]byte, err
 	body := enc[3:]
 
 	switch goos {
-	case "windows":
-		key, err := getPassword()
-		if err != nil {
-			return nil, err
-		}
-		return decryptGCM(body, key)
-	case "darwin":
-		pw, err := getPassword()
-		if err != nil {
-			return nil, err
-		}
-		return decryptCBC(body, pw, 1003)
-	default: // linux
+	case "windows", "darwin":
+		// Always keyed: DPAPI on Windows, keychain on macOS.
+	default: // linux and others
 		if version == "v10" {
-			return decryptCBC(body, []byte("peanuts"), 1)
+			return checked(decryptCBC(body, []byte("peanuts"), 1))
 		}
-		pw, err := getPassword()
+	}
+
+	pws, err := getPasswords()
+	if err != nil {
+		return nil, err
+	}
+	if len(pws) == 0 {
+		return nil, ErrNoSecretService
+	}
+
+	var lastErr error
+	for _, pw := range pws {
+		out, err := checked(decryptWithKey(goos, body, pw))
 		if err != nil {
-			return nil, err
+			lastErr = err
+			continue
 		}
+		return out, nil
+	}
+	return nil, lastErr
+}
+
+func decryptWithKey(goos string, body, pw []byte) ([]byte, error) {
+	switch goos {
+	case "windows":
+		return decryptGCM(body, pw)
+	case "darwin":
+		return decryptCBC(body, pw, 1003)
+	default: // linux and others
 		return decryptCBC(body, pw, 1)
 	}
+}
+
+// checked rejects a decryption that "succeeded" but produced something no
+// cookie value could be. See looksLikeCookieValue for why padding alone is not
+// enough of a guarantee.
+func checked(out []byte, err error) ([]byte, error) {
+	if err != nil {
+		return nil, err
+	}
+	if !looksLikeCookieValue(out) {
+		return nil, fmt.Errorf("%w: decrypted value is not printable text (wrong Safe Storage key?)", ErrDecryptFailed)
+	}
+	return out, nil
 }
 
 // Cookie reads and decrypts the Slack desktop `d` cookie.
@@ -57,7 +118,7 @@ func Cookie() (string, error) {
 	if plain != "" {
 		return plain, nil
 	}
-	val, err := decryptCookieValue(runtime.GOOS, enc, keyringPassword)
+	val, err := decryptCookieValue(runtime.GOOS, enc, keyringPasswords)
 	if err != nil {
 		return "", err
 	}

--- a/internal/slackdesktop/cookie_test.go
+++ b/internal/slackdesktop/cookie_test.go
@@ -1,12 +1,79 @@
 package slackdesktop
 
-import "testing"
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// wrongKeyPassingPadding returns a password that is NOT the one body was
+// encrypted with, yet whose CBC decryption still satisfies PKCS#7: the last
+// plaintext byte only has to land in 1..16, so a wrong key slips through
+// roughly one time in sixteen. That accident is what let a garbage `d` cookie
+// reach Slack — net/http dropped the non-ASCII bytes and the API answered
+// invalid_auth, far away from the real cause.
+func wrongKeyPassingPadding(t *testing.T, body []byte, rounds int) []byte {
+	t.Helper()
+	for i := range 512 {
+		pw := []byte(fmt.Sprintf("wrong-key-%d", i))
+		if _, err := decryptCBC(body, pw, rounds); err == nil {
+			return pw
+		}
+	}
+	t.Fatal("no wrong key produced valid PKCS#7 padding in 512 tries")
+	return nil
+}
+
+func TestDecryptCookieValueRejectsUnprintableGarbage(t *testing.T) {
+	enc := append([]byte("v10"), cbcEncrypt(t, []byte("xoxd-real-cookie-value"), []byte("real-key"), 1003)...)
+	bad := wrongKeyPassingPadding(t, enc[3:], 1003)
+
+	got, err := decryptCookieValue("darwin", enc, func() ([][]byte, error) {
+		return [][]byte{bad}, nil
+	})
+	if !errors.Is(err, ErrDecryptFailed) {
+		t.Fatalf("err = %v, want ErrDecryptFailed (returned %d bytes: %q)", err, len(got), got)
+	}
+}
+
+// A macOS login keychain can hold more than one "Slack Safe Storage" item —
+// the sandboxed App Store build and the standalone build each create their own,
+// distinguished only by account name. Looking one up by service alone returns
+// an arbitrary match, so the caller must be able to offer every candidate.
+func TestDecryptCookieValueTriesEveryCandidate(t *testing.T) {
+	want := []byte("xoxd-the-real-cookie")
+	enc := append([]byte("v10"), cbcEncrypt(t, want, []byte("standalone-key"), 1003)...)
+
+	calls := 0
+	got, err := decryptCookieValue("darwin", enc, func() ([][]byte, error) {
+		calls++
+		return [][]byte{[]byte("app-store-key"), []byte("standalone-key")}, nil
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want the second candidate to succeed", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	if calls != 1 {
+		t.Errorf("password source called %d times, want 1", calls)
+	}
+}
+
+func TestDecryptCookieValueNoCandidates(t *testing.T) {
+	enc := append([]byte("v10"), cbcEncrypt(t, []byte("xoxd-x"), []byte("k"), 1003)...)
+	if _, err := decryptCookieValue("darwin", enc, func() ([][]byte, error) {
+		return nil, nil
+	}); !errors.Is(err, ErrNoSecretService) {
+		t.Errorf("err = %v, want ErrNoSecretService", err)
+	}
+}
 
 func TestDecryptCookieValueLinuxPeanuts(t *testing.T) {
 	// v10 on linux -> password "peanuts", rounds 1
 	want := []byte("xoxd-linux-peanuts")
 	enc := append([]byte("v10"), cbcEncrypt(t, want, []byte("peanuts"), 1)...)
-	got, err := decryptCookieValue("linux", enc, func() ([]byte, error) { return nil, nil })
+	got, err := decryptCookieValue("linux", enc, func() ([][]byte, error) { return nil, nil })
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -18,7 +85,7 @@ func TestDecryptCookieValueLinuxPeanuts(t *testing.T) {
 func TestDecryptCookieValueLinuxKeyring(t *testing.T) {
 	want := []byte("xoxd-linux-keyring")
 	enc := append([]byte("v11"), cbcEncrypt(t, want, []byte("keyring-pw"), 1)...)
-	got, err := decryptCookieValue("linux", enc, func() ([]byte, error) { return []byte("keyring-pw"), nil })
+	got, err := decryptCookieValue("linux", enc, func() ([][]byte, error) { return [][]byte{[]byte("keyring-pw")}, nil })
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/slackdesktop/password_darwin.go
+++ b/internal/slackdesktop/password_darwin.go
@@ -8,24 +8,141 @@ import (
 	"strings"
 )
 
-// keyringPassword fetches the "Slack Safe Storage" password from the macOS
+const safeStorageService = "Slack Safe Storage"
+
+// keyringPasswords fetches every "Slack Safe Storage" password from the macOS
 // login keychain by shelling out to /usr/bin/security.
 //
 // We deliberately shell out rather than use a Security.framework binding: the
 // release build sets CGO_ENABLED=0 (see .goreleaser.yaml) and cross-compiles
 // darwin from Linux, so a cgo keychain dependency would break the macOS build.
-// `security find-generic-password -w -s "Slack Safe Storage"` prints just the
-// password on stdout.
-func keyringPassword() ([]byte, error) {
-	cmd := exec.Command("/usr/bin/security", "find-generic-password", "-w", "-s", "Slack Safe Storage")
+//
+// A machine that has run more than one Slack build carries more than one item
+// under this service name: the sandboxed App Store build stores its key under
+// account "Slack App Store Key", the standalone build under its own. The two
+// are not interchangeable — each encrypts only its own profile's cookie DB —
+// and `security find-generic-password -s <svc>` returns an arbitrary match. So
+// enumerate the accounts and return every key, most likely first, and let
+// decryptCookieValue settle which one actually belongs to the profile.
+func keyringPasswords() ([][]byte, error) {
+	accounts := orderAccountsForProfile(keychainAccounts(safeStorageService), sandboxedProfile())
+
+	var out [][]byte
+	seen := map[string]bool{}
+	for _, acct := range accounts {
+		pw, err := keychainPassword(safeStorageService, acct)
+		if err != nil || pw == "" || seen[pw] {
+			continue
+		}
+		seen[pw] = true
+		out = append(out, []byte(pw))
+	}
+	if len(out) > 0 {
+		return out, nil
+	}
+
+	// Enumeration told us nothing — dump-keychain unavailable, or output in a
+	// shape we do not recognise. Fall back to the service-only lookup, which is
+	// all slk ever did before and is correct whenever only one item exists.
+	pw, err := keychainPassword(safeStorageService, "")
+	if err != nil || pw == "" {
+		return nil, ErrNoSecretService
+	}
+	return [][]byte{[]byte(pw)}, nil
+}
+
+// keychainPassword reads one secret. `security find-generic-password -w` prints
+// just the password on stdout. An empty account means "match on service alone".
+func keychainPassword(service, account string) (string, error) {
+	args := []string{"find-generic-password", "-w", "-s", service}
+	if account != "" {
+		args = append(args, "-a", account)
+	}
+	cmd := exec.Command("/usr/bin/security", args...)
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	if err := cmd.Run(); err != nil {
-		return nil, ErrNoSecretService
+		return "", err
 	}
-	pw := strings.TrimRight(out.String(), "\r\n")
-	if pw == "" {
-		return nil, ErrNoSecretService
+	return strings.TrimRight(out.String(), "\r\n"), nil
+}
+
+// keychainAccounts lists the account names of every generic-password item with
+// the given service. `security dump-keychain` prints attributes only — never
+// secret material — so this needs no unlock and raises no authorization prompt.
+func keychainAccounts(service string) []string {
+	cmd := exec.Command("/usr/bin/security", "dump-keychain")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return nil
 	}
-	return []byte(pw), nil
+	return parseKeychainAccounts(out.String(), service)
+}
+
+// parseKeychainAccounts scans `security dump-keychain` output for items whose
+// "svce" attribute equals service and returns their "acct" values. Items are
+// introduced by a "keychain:" line, and within one item attributes are printed
+// alphabetically, so "acct" always precedes "svce".
+func parseKeychainAccounts(dump, service string) []string {
+	var out []string
+	acct := ""
+	for line := range strings.SplitSeq(dump, "\n") {
+		t := strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(t, "keychain:"):
+			acct = ""
+		case strings.HasPrefix(t, `"acct"`):
+			acct = keychainAttrValue(t)
+		case strings.HasPrefix(t, `"svce"`):
+			if acct != "" && keychainAttrValue(t) == service {
+				out = append(out, acct)
+			}
+		}
+	}
+	return out
+}
+
+// keychainAttrValue pulls the quoted value out of a dump-keychain attribute
+// line. Values come either bare — `"acct"<blob>="Slack Key"` — or hex-first
+// with the text alongside — `"acct"<blob>=0x536C61636B  "Slack"`; both end in
+// the quoted form. `<NULL>` and non-attribute lines yield "".
+func keychainAttrValue(line string) string {
+	eq := strings.Index(line, "=")
+	if eq < 0 {
+		return ""
+	}
+	v := line[eq+1:]
+	first := strings.Index(v, `"`)
+	last := strings.LastIndex(v, `"`)
+	if first < 0 || last <= first {
+		return ""
+	}
+	return v[first+1 : last]
+}
+
+// sandboxedProfile reports whether the profile we are about to read belongs to
+// the App Store build, whose data lives under ~/Library/Containers.
+func sandboxedProfile() bool {
+	dir, err := ConfigDir()
+	if err != nil {
+		return false
+	}
+	return strings.Contains(dir, "/Library/Containers/")
+}
+
+// orderAccountsForProfile puts the account most likely to match the profile
+// first, so the common case needs a single keychain read — each read can raise
+// an authorization prompt when the item's ACL omits /usr/bin/security.
+func orderAccountsForProfile(accounts []string, sandboxed bool) []string {
+	match := make([]string, 0, len(accounts))
+	rest := make([]string, 0, len(accounts))
+	for _, a := range accounts {
+		if strings.Contains(a, "App Store") == sandboxed {
+			match = append(match, a)
+		} else {
+			rest = append(rest, a)
+		}
+	}
+	return append(match, rest...)
 }

--- a/internal/slackdesktop/password_darwin_test.go
+++ b/internal/slackdesktop/password_darwin_test.go
@@ -1,0 +1,74 @@
+//go:build darwin
+
+package slackdesktop
+
+import (
+	"slices"
+	"testing"
+)
+
+// Real `security dump-keychain` output, trimmed to the attributes we read. Note
+// the two Slack items sharing one service name and differing only by account —
+// the situation that made a service-only lookup return the wrong key.
+const dumpKeychainSample = `keychain: "/Users/x/Library/Keychains/login.keychain-db"
+class: "genp"
+attributes:
+    "acct"<blob>="Slack App Store Key"
+    "desc"<blob>=<NULL>
+    "svce"<blob>="Slack Safe Storage"
+keychain: "/Users/x/Library/Keychains/login.keychain-db"
+class: "genp"
+attributes:
+    "acct"<blob>="Slack Key"
+    "svce"<blob>="Slack Safe Storage"
+keychain: "/Users/x/Library/Keychains/login.keychain-db"
+class: "genp"
+attributes:
+    "acct"<blob>="Chrome"
+    "svce"<blob>="Chrome Safe Storage"
+`
+
+func TestParseKeychainAccounts(t *testing.T) {
+	got := parseKeychainAccounts(dumpKeychainSample, "Slack Safe Storage")
+	want := []string{"Slack App Store Key", "Slack Key"}
+	if !slices.Equal(got, want) {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestParseKeychainAccountsIgnoresOtherServices(t *testing.T) {
+	if got := parseKeychainAccounts(dumpKeychainSample, "Chrome Safe Storage"); !slices.Equal(got, []string{"Chrome"}) {
+		t.Errorf("got %q, want [Chrome]", got)
+	}
+}
+
+func TestKeychainAttrValue(t *testing.T) {
+	tests := []struct {
+		name, line, want string
+	}{
+		{"plain blob", `"acct"<blob>="Slack Key"`, "Slack Key"},
+		{"hex then quoted", `"acct"<blob>=0x536C61636B  "Slack"`, "Slack"},
+		{"null", `"desc"<blob>=<NULL>`, ""},
+		{"no equals", `attributes:`, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := keychainAttrValue(tc.line); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// Each keychain read can raise an authorization prompt, so the candidate that
+// matches the profile we are reading must come first.
+func TestOrderAccountsForProfile(t *testing.T) {
+	accounts := []string{"Slack App Store Key", "Slack Key"}
+
+	if got := orderAccountsForProfile(accounts, false); !slices.Equal(got, []string{"Slack Key", "Slack App Store Key"}) {
+		t.Errorf("standalone profile: got %q, want the non-App-Store key first", got)
+	}
+	if got := orderAccountsForProfile(accounts, true); !slices.Equal(got, []string{"Slack App Store Key", "Slack Key"}) {
+		t.Errorf("sandboxed profile: got %q, want the App Store key first", got)
+	}
+}

--- a/internal/slackdesktop/password_linux.go
+++ b/internal/slackdesktop/password_linux.go
@@ -24,17 +24,24 @@ var slackSecretQueries = []map[string]string{
 	},
 }
 
-// keyringPassword fetches the "Slack Safe Storage" password from the
+// keyringPasswords fetches the "Slack Safe Storage" password from the
 // Secret Service. Slack stores it using Chromium's schema with libsecret
 // implementations and QtKeychain's schema with KDE Wallet.
-func keyringPassword() ([]byte, error) {
+//
+// The Secret Service queries are already attribute-qualified, so unlike macOS
+// there is no ambiguity to resolve here: a single candidate is returned.
+func keyringPasswords() ([][]byte, error) {
 	service, err := gosecret.NewService()
 	if err != nil {
 		return nil, ErrNoSecretService
 	}
 	defer service.Close()
 
-	return findKeyringPassword(service.SearchItems)
+	pw, err := findKeyringPassword(service.SearchItems)
+	if err != nil {
+		return nil, err
+	}
+	return [][]byte{pw}, nil
 }
 
 func findKeyringPassword(searchItems searchSecretItemsFunc) ([]byte, error) {

--- a/internal/slackdesktop/password_windows.go
+++ b/internal/slackdesktop/password_windows.go
@@ -12,9 +12,20 @@ import (
 	"github.com/billgraziano/dpapi"
 )
 
-// keyringPassword returns the AES-256 key from Local State (Windows). On
+// keyringPasswords returns the AES-256 key from Local State (Windows). On
 // Windows this key feeds AES-GCM (not PBKDF2).
-func keyringPassword() ([]byte, error) {
+//
+// Local State is read from the profile directory itself, so there is only ever
+// one candidate — no keychain-style ambiguity to resolve as on macOS.
+func keyringPasswords() ([][]byte, error) {
+	key, err := localStateKey()
+	if err != nil {
+		return nil, err
+	}
+	return [][]byte{key}, nil
+}
+
+func localStateKey() ([]byte, error) {
 	dir, err := ConfigDir()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Addresses #135.

## What happens

`keyringPassword` looks the Safe Storage key up by service name only:

```go
exec.Command("/usr/bin/security", "find-generic-password", "-w", "-s", "Slack Safe Storage")
```

A macOS login keychain can hold **several** generic-password items under that
one service name — a machine that has run both the App Store (sandboxed) build
and the standalone build gets one item per build, distinguished only by their
account name. The keys are not interchangeable: each encrypts only its own
profile's cookie DB. With no `-a`, `security` returns an arbitrary match, so slk
can decrypt one profile's cookies with the other profile's key.

## Evidence from my machine

`configDirForOS` correctly selects the standalone profile — it exists and its
`Cookies` DB is the one Slack is actively writing:

```
EXISTS  ~/Library/Application Support/Slack                       Cookies mtime: today
EXISTS  ~/Library/Containers/com.tinyspeck.slackmacgap/…/Slack     Cookies mtime: 6 months ago
```

But the first keychain item matching the service is the *other* build's:

```
$ security find-generic-password -s "Slack Safe Storage" | grep -E 'acct|svce'
    "acct"<blob>="Slack App Store Key"
    "svce"<blob>="Slack Safe Storage"
```

And the decryption silently produces nonsense. Instrumenting each boundary:

```
layer 1  config dir = ~/Library/Application Support/Slack          ok
layer 2  Cookie()   = len=282 printable=false prefix=""            <-- garbage
layer 3  workspaces                                                ok
layer 4  token from localConfig_v2: len=109 printable=true "xoxc-"  ok
layer 5  net/http: invalid byte 'ë' in Cookie.Value; dropping invalid bytes
         auth test failed: invalid_auth
```

The `xoxc` token is perfectly fine. The `d` cookie is binary, `net/http` drops
the invalid bytes, and Slack answers `invalid_auth` — pointing nowhere near the
key that caused it.

## Why the same bug shows up as two different errors

`decryptCBC`'s only integrity check is PKCS#7 padding, and that check is weak:
the final plaintext byte merely has to land in `1..16`. A wrong key satisfies it
roughly **one time in sixteen**.

The arithmetic on my cookie: 291-byte `encrypted_value`, minus the 3-byte `v10`
prefix = 288 bytes of ciphertext; the plaintext came out 282 bytes, so the
padding byte was `6` — in range, accepted, garbage returned with no error.

So the same wrong key produces either:

- **~15/16** — `bad padding` → `ErrDecryptFailed` → the message in #135, or
- **~1/16** — no error, binary cookie → `invalid_auth` much later.

#135 reports the first. I hit the second. One cause, two symptoms.

## The change

**`internal/slackdesktop/password_darwin.go`** — enumerate the accounts for the
service with `security dump-keychain` (which prints attributes only, never
secret material, so it raises no authorization prompt), then return every key as
a candidate. Candidates are ordered by whether the profile being read is
sandboxed, so the likely one is tried first and the common case still costs a
single keychain read. If enumeration yields nothing — restricted environment,
unexpected output shape — it falls back to today's service-only lookup, so
existing working setups are unaffected.

**`internal/slackdesktop/cookie.go`** — `passwordSource` now yields
`[][]byte` and `decryptCookieValue` tries each candidate until one decrypts to a
plausible cookie. Plausible means non-empty printable ASCII, which closes the
padding gap: garbage now survives with probability `(95/256)^len` instead of
`1/16`. I deliberately did **not** validate against the `xoxd-` prefix (breaks
the day Slack renames the cookie) or the Chromium domain-hash prefix (only
exists from cookie-DB version 24 / Chromium 130, would break older installs).

Per-OS behaviour is preserved exactly, including the Linux `v10`/`peanuts` path
that bypasses the keyring entirely. Linux and Windows return a single candidate —
their lookups are already attribute-qualified, so there is no ambiguity to
resolve there.

**`cmd/slk/onboarding.go`** — stop collapsing every `ErrDecryptFailed` into
"please file an issue"; keep the wrapped reason that names which step failed.
That detail is what turns a report into a diagnosis.

## What I have and have not verified

Verified:

- `go test ./...` green; 6 new tests, 2 adapted. The first one written fails on
  the old code with `err = <nil>` and 22 bytes of binary returned — the
  production bug in miniature.
- Builds and vets clean for `darwin`, `linux` and `windows` with `CGO_ENABLED=0`
  (the release configuration); `golangci-lint` reports 0 issues.

**Not verified: I have not confirmed end-to-end that onboarding now succeeds.**
Reading the keychain requires an interactive authorization I could not complete
in the environment where I prepared this, so the fix is proven by unit tests and
by the diagnostic trace above, not by a successful `--add-workspace` run. Please
weigh that before merging.

## An alternative hypothesis I cannot rule out

What is *proven* on my machine: the active profile is the standalone one, the
first keychain match is the App Store build's key, and the resulting plaintext is
garbage — so the key in use is the wrong one.

What is **not** proven: that a *correct* key is also present in my keychain. I
could not enumerate every item to confirm a second one exists.

That leaves a competing explanation worth noting: both #135 (4.51.185) and my
machine (4.51.180) run Slack **4.51.x**, so a key rotation or storage change in
that series could be the real cause, with the "App Store Key" account name a
coincidence. Against it: the cookie still carries the `v10` prefix and a
CBC-shaped 288-byte body, so the *scheme* has not changed.

The two halves of this patch behave sensibly either way — if a valid key is
present, candidate-trying finds it; if none is, the new printable check plus the
preserved error detail say so precisely instead of surfacing `invalid_auth`
later.

To discriminate, @zzJinux could post the account names on their machine (this
prints attributes only, no secrets):

```
security dump-keychain | grep -A2 '"Slack Safe Storage"' | grep acct
```

Two or more accounts → ambiguous lookup confirmed. Exactly one → the key itself
has changed and this patch improves the diagnostics without fixing the cause.
