### PR TITLE
feat: colored usernames (opt-in via colored_usernames config)

### DIFF
--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -1108,6 +1108,7 @@ func run() error {
 	app.SetTypingEnabled(cfg.Animations.TypingIndicators)
 	app.SetSidebarStaleThreshold(time.Duration(cfg.Sidebar.HideInactiveAfterDays) * 24 * time.Hour)
 	app.SetMouseWheelLines(cfg.Appearance.MouseWheelLines)
+	app.SetColoredUsernames(cfg.Appearance.ColoredUsernames)
 
 	// Wire theme switcher
 	app.SetThemeItems(styles.ThemeNames())

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -96,6 +96,10 @@ type Appearance struct {
 	// East-Asian-Wide convention; 1 is an escape hatch if 2 looks too
 	// large in a given font. Clamped to {1, 2} at load time.
 	EmojiCells int `toml:"emoji_cells"`
+	// ColoredUsernames, when true, colors each user's name deterministically
+	// by hashing their user ID — mirroring how Slack clients assign stable
+	// per-user colors. Default off.
+	ColoredUsernames bool `toml:"colored_usernames"`
 }
 
 type Animations struct {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1984,6 +1984,15 @@ func (a *App) SetAvatarFunc(fn messages.AvatarFunc) {
 	a.threadPanel.SetAvatarFunc(fn)
 }
 
+// SetColoredUsernames enables or disables deterministic per-user coloring
+// of usernames across all message panes and the thread panel.
+func (a *App) SetColoredUsernames(enabled bool) {
+	for _, m := range a.allWinModels() {
+		m.SetColoredUsernames(enabled)
+	}
+	a.threadPanel.SetColoredUsernames(enabled)
+}
+
 // SetImageContext configures the inline-image rendering pipeline on the
 // messages pane. Should be called once at startup, before the first
 // View(). Pass a zero-valued ImageContext to disable inline rendering.

--- a/internal/ui/messages/model.go
+++ b/internal/ui/messages/model.go
@@ -366,6 +366,12 @@ type Model struct {
 	// color is baked into viewEntry.linesSelected during buildCache, so
 	// SetFocused must invalidate the cache.
 	focused bool
+
+	// coloredUsernames enables deterministic per-user coloring of the
+	// username in each message row. Set from config via
+	// SetColoredUsernames; invalidates the render cache so existing rows
+	// pick up the new coloring.
+	coloredUsernames bool
 }
 
 // SetFocused records whether the messages pane currently holds user focus
@@ -1329,6 +1335,15 @@ func (m *Model) SetUserNames(names map[string]string) {
 	m.dirty()
 }
 
+// SetColoredUsernames enables or disables deterministic per-user coloring
+// of usernames. Invalidates the render cache so existing rows re-render
+// with the new coloring.
+func (m *Model) SetColoredUsernames(enabled bool) {
+	m.coloredUsernames = enabled
+	m.cache = nil
+	m.dirty()
+}
+
 // SetCurrentUser records the authenticated user ID so UpdateReaction can
 // flag the current user's own reactions (HasReacted) correctly.
 func (m *Model) SetCurrentUser(userID string) {
@@ -1914,7 +1929,7 @@ func (m *Model) blockkitContext(msg MessageItem, userNames, channelNames map[str
 func (m *Model) renderMessagePlain(msg MessageItem, width int, avatarStr string, userNames map[string]string, channelNames map[string]string, isSelected bool, stats *entryPerfStats) (
 	content string, flushes []func(io.Writer) error, sixelRows map[int]sixelEntry, hits []entryHit, reactionHits []reactionEntryHit,
 ) {
-	line := styles.Username.Render(msg.UserName) + lipgloss.NewStyle().Background(styles.Background).Render("  ") + styles.Timestamp.Render(msg.Timestamp)
+	line := styles.Username(msg.UserID, m.coloredUsernames).Render(msg.UserName) + lipgloss.NewStyle().Background(styles.Background).Render("  ") + styles.Timestamp.Render(msg.Timestamp)
 
 	// If we have an avatar, reserve space on the left for it
 	contentWidth := width - 4

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -2,6 +2,7 @@
 package styles
 
 import (
+	"hash/fnv"
 	"image/color"
 
 	"charm.land/lipgloss/v2"
@@ -114,10 +115,25 @@ var (
 			Padding(0, 1)
 
 	// Messages
-	Username = lipgloss.NewStyle().
-			Background(Background).
-			Foreground(Primary).
-			Bold(true)
+
+	// UserColorPalette is the fixed set of colors used to deterministically
+	// color usernames by hashing user IDs, mirroring how Slack clients assign
+	// stable per-user colors. Mid-brightness colors are chosen for adequate
+	// contrast on both dark and light theme backgrounds.
+	UserColorPalette = []color.Color{
+		lipgloss.Color("#E01E5A"),
+		lipgloss.Color("#3B82F6"),
+		lipgloss.Color("#2EB67D"),
+		lipgloss.Color("#8B5CF6"),
+		lipgloss.Color("#F43F5E"),
+		lipgloss.Color("#06B6D4"),
+		lipgloss.Color("#F97316"),
+		lipgloss.Color("#10B981"),
+		lipgloss.Color("#6366F1"),
+		lipgloss.Color("#C026D3"),
+		lipgloss.Color("#0EA5E9"),
+		lipgloss.Color("#DB2777"),
+	}
 
 	Timestamp = lipgloss.NewStyle().
 			Background(Background).
@@ -392,6 +408,33 @@ func SelectionBorderColor(focused bool) color.Color {
 	return TextMuted
 }
 
+// UserColor returns a deterministic color for the given user ID by hashing
+// it into UserColorPalette via FNV-1a. Returns Primary for empty IDs (e.g.
+// some bot messages) so they fall back to the theme default.
+func UserColor(userID string) color.Color {
+	if userID == "" {
+		return Primary
+	}
+	h := fnv.New32a()
+	h.Write([]byte(userID))
+	return UserColorPalette[h.Sum32()%uint32(len(UserColorPalette))]
+}
+
+// Username returns a lipgloss style for rendering a username. When colored
+// is true and userID is non-empty, the foreground color is deterministically
+// derived from userID via UserColor. Otherwise the theme default (Primary)
+// is used.
+func Username(userID string, colored bool) lipgloss.Style {
+	fg := Primary
+	if colored && userID != "" {
+		fg = UserColor(userID)
+	}
+	return lipgloss.NewStyle().
+		Background(Background).
+		Foreground(fg).
+		Bold(true)
+}
+
 func buildStyles() {
 	FocusedBorder = lipgloss.NewStyle().
 		BorderStyle(lipgloss.ThickBorder()).BorderForeground(Primary).BorderBackground(Background).Background(Background)
@@ -415,8 +458,6 @@ func buildStyles() {
 		Background(Error).Foreground(lipgloss.Color("#FFFFFF")).Padding(0, 1)
 	SectionHeader = lipgloss.NewStyle().
 		Background(SidebarBackground).Foreground(SidebarTextMuted).Bold(true).Padding(0, 1)
-	Username = lipgloss.NewStyle().
-		Background(Background).Foreground(Primary).Bold(true)
 	Timestamp = lipgloss.NewStyle().
 		Background(Background).Foreground(TextMuted).Italic(true)
 	MessageText = lipgloss.NewStyle().

--- a/internal/ui/styles/styles_test.go
+++ b/internal/ui/styles/styles_test.go
@@ -1,6 +1,7 @@
 package styles
 
 import (
+	"fmt"
 	"image/color"
 	"testing"
 
@@ -137,5 +138,51 @@ func TestApply_ResetsSelectionColorsBetweenThemes(t *testing.T) {
 	r, g, b, _ := SelectionBackground.RGBA()
 	if r>>8 == 0xAB && g>>8 == 0xCD && b>>8 == 0xEF {
 		t.Fatal("SelectionBackground leaked from previous theme; must reset to default when new theme omits it")
+	}
+}
+
+func TestUserColorDeterministic(t *testing.T) {
+	c1 := UserColor("U12345")
+	c2 := UserColor("U12345")
+	if !colorEqual(c1, c2) {
+		t.Fatal("same userID must return same color")
+	}
+}
+
+func TestUserColorEmptyFallback(t *testing.T) {
+	Apply("dark", config.Theme{})
+	if !colorEqual(UserColor(""), Primary) {
+		t.Fatal("empty userID must fall back to Primary")
+	}
+}
+
+func TestUserColorPaletteSpread(t *testing.T) {
+	seen := map[string]bool{}
+	for _, id := range []string{"U1", "U2", "U3", "U4", "U5", "U6", "U7", "U8", "U9", "U10", "U11", "U12"} {
+		r, g, b, _ := UserColor(id).RGBA()
+		key := fmt.Sprintf("%02x%02x%02x", r>>8, g>>8, b>>8)
+		seen[key] = true
+	}
+	if len(seen) < 8 {
+		t.Fatalf("poor distribution: only %d distinct colors for 12 users", len(seen))
+	}
+}
+
+func TestUsernameColoredToggle(t *testing.T) {
+	Apply("dark", config.Theme{})
+	// colored=false → Primary foreground
+	s := Username("U123", false)
+	if !colorEqual(s.GetForeground(), Primary) {
+		t.Fatal("Username with colored=false must use Primary")
+	}
+	// colored=true → UserColor foreground
+	s = Username("U123", true)
+	if !colorEqual(s.GetForeground(), UserColor("U123")) {
+		t.Fatal("Username with colored=true must use UserColor")
+	}
+	// colored=true + empty userID → Primary fallback
+	s = Username("", true)
+	if !colorEqual(s.GetForeground(), Primary) {
+		t.Fatal("Username with empty userID must fall back to Primary")
 	}
 }

--- a/internal/ui/thread/model.go
+++ b/internal/ui/thread/model.go
@@ -96,6 +96,7 @@ type Model struct {
 	threadTS          string
 	selected          int
 	focused           bool
+	coloredUsernames  bool
 	avatarFn          messages.AvatarFunc
 	userNames         map[string]string
 	channelNames      map[string]string
@@ -586,6 +587,14 @@ func (m *Model) SetAvatarFunc(fn messages.AvatarFunc) {
 func (m *Model) SetUserNames(names map[string]string) {
 	m.userNames = names
 	m.userNamesV++
+	m.InvalidateCache()
+}
+
+// SetColoredUsernames enables or disables deterministic per-user coloring
+// of usernames. Invalidates the render cache so existing rows re-render
+// with the new coloring.
+func (m *Model) SetColoredUsernames(enabled bool) {
+	m.coloredUsernames = enabled
 	m.InvalidateCache()
 }
 
@@ -1787,7 +1796,7 @@ func (m *Model) blockkitContext(msg messages.MessageItem, userNames, channelName
 }
 
 func (m *Model) renderThreadMessage(msg messages.MessageItem, width int, userNames map[string]string, channelNames map[string]string, isSelected bool) (string, []func(io.Writer) error, []reactionEntryHit) {
-	line := styles.Username.Render(msg.UserName) + lipgloss.NewStyle().Background(styles.Background).Render("  ") + styles.Timestamp.Render(msg.Timestamp)
+	line := styles.Username(msg.UserID, m.coloredUsernames).Render(msg.UserName) + lipgloss.NewStyle().Background(styles.Background).Render("  ") + styles.Timestamp.Render(msg.Timestamp)
 
 	contentWidth := width - 4
 	if contentWidth < 20 {

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -15,6 +15,7 @@ theme = "dracula"
 timestamp_format = "3:04 PM"
 image_protocol = "auto"   # auto | kitty | sixel | halfblock | off
 max_image_rows = 20       # cap inline image height in terminal rows
+colored_usernames = false # color each user's name by ID hash (Slack-style)
 
 [animations]
 enabled = true

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -97,5 +97,6 @@ See [[Terminal Compatibility|Terminal-Compatibility]] for which protocol your te
 - Drop-in custom themes (`~/.config/slk/themes/*.toml`)
 - Live theme switcher (`Ctrl+y`)
 - TOML config for appearance, animations, notifications, and channel sections
+- Deterministic per-user username coloring, opt-in via `colored_usernames`
 
 See [[Configuration]] for the full `config.toml` reference and [[Keybindings]] for the key map.


### PR DESCRIPTION
Closes #51

## Summary

Add deterministic per-user coloring for usernames, mirroring how Slack clients assign stable colors by hashing user IDs.

- FNV-1a hash → 12-color palette (mid-brightness, theme-independent)
- Applies to both message list and thread replies
- Bot messages (empty userID) fall back to the theme Primary color
- Bold styling preserved from the original Username style

## Configuration

Opt-in via `~/.config/slk/config.toml`:

```toml
[appearance]
colored_usernames = true
```

Default: off.

## Implementation

- Replaces the static `var Username` (lipgloss style) with `func Username(userID string, colored bool) lipgloss.Style` in `internal/ui/styles/styles.go`
- `UserColor(userID)` hashes the ID via FNV-1a and picks from `UserColorPalette` (12 mid-brightness colors)
- When `colored=false` or `userID=""`, falls back to `Primary` — identical to the previous behavior
- Config flag wired through `App.SetColoredUsernames` → `messages.Model` + `thread.Model` setters, with cache invalidation

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` — 3054 tests pass (54 packages)
- [x] `TestUserColorDeterministic` — same userID → same color
- [x] `TestUserColorEmptyFallback` — empty userID → Primary
- [x] `TestUserColorPaletteSpread` — 12 distinct users → ≥8 distinct colors
- [x] `TestUsernameColoredToggle` — colored=false → Primary, colored=true → UserColor