### PR TITLE
Detect sixel support via DA1 instead of a TERM allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,12 @@ tmux show -gv allow-passthrough
 Expected output: `on` (or `all`).
 
 If passthrough is off, `slk` detects this at startup and falls back to
-half-block rendering automatically — no config change needed. To force a
-specific renderer regardless of detection, set `image_protocol` in
-`config.toml` to `kitty`, `sixel`, `halfblock`, or `off`.
+half-block rendering automatically — no config change needed. Outside a
+multiplexer, terminals that don't do kitty graphics are asked whether
+they speak sixel (a DA1 query), so sixel-capable terminals get real
+pixels instead of the half-block mosaic. To force a specific renderer
+regardless of detection, set `image_protocol` in `config.toml` to
+`kitty`, `sixel`, `halfblock`, or `off`.
 
 ## Unread indicator in tmux
 

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -995,6 +995,37 @@ func run() error {
 			}
 		}
 	}
+
+	// Sixel capability probe (issue #116). Detect only knows the handful
+	// of terminals it can name from $TERM / $TERM_PROGRAM, so plenty of
+	// sixel-capable terminals (xterm -ti vt340, DomTerm, toyterm, foot
+	// behind a generic TERM, …) land on halfblock and render the blocky
+	// mosaic even though real pixels would work. Ask the terminal
+	// directly via DA1 before settling for halfblock.
+	//
+	// Only in auto mode — an explicit image_protocol=halfblock must stay
+	// half-block — and never inside a multiplexer: tmux keeps sixel off
+	// by policy (see Detect's doc comment) and zellij has no sixel path
+	// at all, so probing there only risks paying the full timeout for an
+	// answer we would ignore.
+	if proto == imgpkg.ProtoHalfBlock &&
+		imgpkg.IsAutoProtocol(cfg.Appearance.ImageProtocol) &&
+		os.Getenv("TMUX") == "" && os.Getenv("ZELLIJ") == "" &&
+		term.IsTerminal(int(os.Stdin.Fd())) {
+		state, err := term.MakeRaw(int(os.Stdin.Fd()))
+		if err != nil {
+			debuglog.ImgRender("sixel probe skipped: cannot enter raw mode: %v", err)
+		} else {
+			ok := imgpkg.ProbeSixel(os.Stdout, os.Stdin, 200*time.Millisecond)
+			if rerr := term.Restore(int(os.Stdin.Fd()), state); rerr != nil {
+				debuglog.ImgRender("term restore after sixel probe: %v", rerr)
+			}
+			if ok {
+				debuglog.ImgRender("sixel probe succeeded, upgrading halfblock to sixel")
+				proto = imgpkg.ProtoSixel
+			}
+		}
+	}
 	debuglog.ImgRender("image protocol: %s", proto)
 
 	// Reconcile the emoji-as-images flag with the post-probe protocol.

--- a/internal/image/capability.go
+++ b/internal/image/capability.go
@@ -51,6 +51,19 @@ var tmuxClientTerm = func() string {
 	return strings.TrimSpace(string(out))
 }
 
+// IsAutoProtocol reports whether cfg asks for automatic detection —
+// i.e. anything other than the four explicit protocol names Detect
+// honors. Callers use this to decide whether they may refine Detect's
+// answer with an interactive probe: an explicit "halfblock" must stay
+// half-block even if the terminal turns out to speak sixel.
+func IsAutoProtocol(cfg string) bool {
+	switch strings.ToLower(strings.TrimSpace(cfg)) {
+	case "off", "halfblock", "sixel", "kitty":
+		return false
+	}
+	return true
+}
+
 // Detect picks the rendering protocol for the current terminal.
 // cfg is the user's config value (e.g. "auto", "kitty", "sixel", "halfblock", "off").
 // Anything other than the four explicit values is treated as "auto".
@@ -103,7 +116,11 @@ func Detect(env Env, cfg string) Protocol {
 		// Sixel-under-tmux is also halfblock — see function doc.
 		return ProtoHalfBlock
 	}
-	if env.Term == "foot" || env.Term == "mlterm" {
+	// Prefix match: foot ships both "foot" and "foot-extra" terminfo
+	// entries and picks between them per install, and mlterm appends
+	// variants like "mlterm-256color". Both are sixel-capable in every
+	// variant.
+	if strings.HasPrefix(env.Term, "foot") || strings.HasPrefix(env.Term, "mlterm") {
 		return ProtoSixel
 	}
 	// iTerm2 and WezTerm both support kitty *graphics*, but not the

--- a/internal/image/capability_test.go
+++ b/internal/image/capability_test.go
@@ -121,7 +121,10 @@ func TestDetect_KittyByEnvVar(t *testing.T) {
 func TestDetect_Sixel(t *testing.T) {
 	cases := []Env{
 		{Term: "foot"},
+		// foot installs ship either terminfo entry; both are sixel.
+		{Term: "foot-extra"},
 		{Term: "mlterm"},
+		{Term: "mlterm-256color"},
 		// iTerm2 has no working kitty graphics implementation (the
 		// startup probe would time out and downgrade to halfblock),
 		// but it does support sixel — real pixels instead of the
@@ -146,6 +149,29 @@ func TestDetect_FallbackHalfBlock(t *testing.T) {
 	env := Env{Term: "xterm-256color", Colorterm: "truecolor"}
 	if got := Detect(env, "auto"); got != ProtoHalfBlock {
 		t.Errorf("want halfblock fallback, got %v", got)
+	}
+}
+
+// IsAutoProtocol gates the startup sixel probe: only an auto config may
+// be refined from halfblock up to sixel (issue #116).
+func TestIsAutoProtocol(t *testing.T) {
+	cases := []struct {
+		cfg  string
+		want bool
+	}{
+		{"auto", true},
+		{"", true},
+		{"bogus", true},
+		{"off", false},
+		{"halfblock", false},
+		{"HalfBlock", false},
+		{"  sixel  ", false},
+		{"kitty", false},
+	}
+	for _, tc := range cases {
+		if got := IsAutoProtocol(tc.cfg); got != tc.want {
+			t.Errorf("IsAutoProtocol(%q) = %v, want %v", tc.cfg, got, tc.want)
+		}
 	}
 }
 

--- a/internal/image/probe.go
+++ b/internal/image/probe.go
@@ -53,7 +53,7 @@ func ProbeKittyGraphics(w io.Writer, r io.Reader, timeout time.Duration) bool {
 	start := time.Now()
 
 	if f, ok := r.(*os.File); ok {
-		ok, bytesRead, reason := pollProbe(int(f.Fd()), timeout)
+		ok, bytesRead, reason := pollProbe(int(f.Fd()), timeout, scanForOK)
 		debuglog.ImgRender("probe: ok=%v reason=%s bytes_read=%d elapsed_ms=%d",
 			ok, reason, bytesRead, time.Since(start).Milliseconds())
 		return ok
@@ -61,6 +61,95 @@ func ProbeKittyGraphics(w io.Writer, r io.Reader, timeout time.Duration) bool {
 
 	// Test fallback for non-*os.File readers.
 	return probeViaGoroutine(r, timeout)
+}
+
+// ProbeSixel sends a Primary Device Attributes query (CSI c) and reports
+// whether the reply advertises sixel graphics — attribute 4 in the
+// DA1 response, e.g. `\e[?62;1;4;6;22c` from xterm -ti vt340.
+//
+// This is the same runtime check img2sixel / chafa use, and it is the
+// only reliable one: the set of sixel-capable terminals is open-ended
+// (foot, xterm, mlterm, WezTerm, contour, DomTerm, toyterm, …) and
+// several of them share a generic TERM value, so a TERM allowlist
+// silently downgrades them to the half-block mosaic (issue #116).
+//
+// Every terminal answers DA1, including ones with no sixel support, so
+// unlike the kitty probe a timeout here means "no reply at all" (a
+// multiplexer swallowed it, or stdin isn't really the terminal) rather
+// than "no sixel". Both outcomes are reported as false.
+//
+// Inputs match ProbeKittyGraphics: w is the terminal writer, r the
+// terminal reader in raw mode, timeout the reply deadline. Must run
+// before bubbletea takes over stdin.
+func ProbeSixel(w io.Writer, r io.Reader, timeout time.Duration) bool {
+	if _, err := io.WriteString(w, "\x1b[c"); err != nil {
+		return false
+	}
+
+	start := time.Now()
+
+	if f, ok := r.(*os.File); ok {
+		ok, bytesRead, reason := pollProbe(int(f.Fd()), timeout, scanForSixelDA)
+		debuglog.ImgRender("sixel probe: ok=%v reason=%s bytes_read=%d elapsed_ms=%d",
+			ok, reason, bytesRead, time.Since(start).Milliseconds())
+		return ok
+	}
+
+	// Test fallback for non-*os.File readers.
+	return probeViaGoroutineScan(r, timeout, scanForSixelDA)
+}
+
+// probeViaGoroutineScan is the generic goroutine-based probe used for
+// non-*os.File readers (tests only — see probeViaGoroutine). It reads
+// byte by byte, re-running scan over everything collected so far, and
+// stops at the first complete reply.
+func probeViaGoroutineScan(r io.Reader, timeout time.Duration, scan func([]byte) (bool, bool)) bool {
+	ch := make(chan bool, 1)
+	go func() {
+		br := bufio.NewReader(r)
+		var collected []byte
+		for {
+			b, err := br.ReadByte()
+			if err != nil {
+				ch <- false
+				return
+			}
+			collected = append(collected, b)
+			if matched, ok := scan(collected); matched {
+				ch <- ok
+				return
+			}
+		}
+	}()
+	select {
+	case ok := <-ch:
+		return ok
+	case <-time.After(timeout):
+		return false
+	}
+}
+
+// scanForSixelDA returns (matched, ok). matched is true once a complete
+// DA1 reply (CSI ? … c) is present in buf; ok is true when that reply
+// lists attribute 4 (sixel graphics). Attributes are semicolon-
+// separated and must match exactly — "14" or "24" are unrelated
+// capabilities, so a substring test would be wrong.
+func scanForSixelDA(buf []byte) (matched, ok bool) {
+	i := bytes.Index(buf, []byte("\x1b[?"))
+	if i < 0 {
+		return false, false
+	}
+	tail := buf[i+3:] // skip past \x1b[?
+	j := bytes.IndexByte(tail, 'c')
+	if j < 0 {
+		return false, false
+	}
+	for _, attr := range bytes.Split(tail[:j], []byte(";")) {
+		if bytes.Equal(attr, []byte("4")) {
+			return true, true
+		}
+	}
+	return true, false
 }
 
 // probeViaGoroutine is the legacy goroutine-based probe. Retained for

--- a/internal/image/probe_other.go
+++ b/internal/image/probe_other.go
@@ -4,14 +4,16 @@ package image
 
 import "time"
 
-// pollProbe stub for non-unix platforms (Windows). The kitty graphics
-// protocol is not used in any meaningful Windows terminal, so reaching
-// this stub means the env-detect was wrong; safest behavior is to
-// report failure so the caller downgrades to halfblock.
+// pollProbe stub for non-unix platforms (Windows). Neither the kitty
+// graphics protocol nor sixel is used in any meaningful Windows
+// terminal, so reaching this stub means the env-detect was wrong;
+// safest behavior is to report failure so the caller downgrades to
+// halfblock.
 //
 // Returns (false, 0, "unsupported_platform") unconditionally.
-func pollProbe(fd int, timeout time.Duration) (bool, int, string) {
+func pollProbe(fd int, timeout time.Duration, scan func([]byte) (bool, bool)) (bool, int, string) {
 	_ = fd
 	_ = timeout
+	_ = scan
 	return false, 0, "unsupported_platform"
 }

--- a/internal/image/probe_test.go
+++ b/internal/image/probe_test.go
@@ -81,6 +81,99 @@ func TestProbeKittyGraphics_NoStdinTheftAfterTimeout(t *testing.T) {
 	}
 }
 
+func TestScanForSixelDA(t *testing.T) {
+	cases := []struct {
+		name        string
+		buf         string
+		wantMatched bool
+		wantOK      bool
+	}{
+		{"xterm vt340", "\x1b[?63;1;2;4;6;9;15;22c", true, true},
+		{"foot", "\x1b[?62;4;22c", true, true},
+		{"sixel only", "\x1b[?4c", true, true},
+		{"no sixel", "\x1b[?62;1;6;22c", true, false},
+		// Attributes are semicolon-separated values, not substrings:
+		// 14 / 24 / 41 are unrelated capabilities.
+		{"substring not attribute", "\x1b[?14;24;41c", true, false},
+		{"incomplete: no terminator", "\x1b[?62;4;22", false, false},
+		{"incomplete: no csi", "62;4;22c", false, false},
+		{"empty", "", false, false},
+		// Terminals emit the reply amid whatever else is in flight.
+		{"leading noise", "junk\x1b[?62;4;22c", true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			matched, ok := scanForSixelDA([]byte(tc.buf))
+			if matched != tc.wantMatched || ok != tc.wantOK {
+				t.Errorf("scanForSixelDA(%q) = (%v, %v), want (%v, %v)",
+					tc.buf, matched, ok, tc.wantMatched, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestProbeSixel_SendsDA1AndFailsOnTimeout(t *testing.T) {
+	var w bytes.Buffer
+	if ok := ProbeSixel(&w, blockingReader{}, 50*time.Millisecond); ok {
+		t.Error("expected probe to fail on timeout")
+	}
+	if w.String() != "\x1b[c" {
+		t.Errorf("expected DA1 query, got %q", w.String())
+	}
+}
+
+func TestProbeSixel_ReadsReply(t *testing.T) {
+	cases := []struct {
+		reply string
+		want  bool
+	}{
+		{"\x1b[?63;1;2;4;6;9;15;22c", true},
+		{"\x1b[?62;1;6;22c", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.reply, func(t *testing.T) {
+			var w bytes.Buffer
+			r := strings.NewReader(tc.reply)
+			if got := ProbeSixel(&w, r, time.Second); got != tc.want {
+				t.Errorf("ProbeSixel with reply %q = %v, want %v", tc.reply, got, tc.want)
+			}
+		})
+	}
+}
+
+// The poll-based production path (real *os.File) must reach the same
+// answer as the goroutine fallback, and must not leave a reader behind
+// that steals bytes from bubbletea afterwards (the issue #50 hazard).
+func TestProbeSixel_PollPathOnRealPipe(t *testing.T) {
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	defer pr.Close()
+	defer pw.Close()
+
+	if _, err := pw.Write([]byte("\x1b[?62;4;22c")); err != nil {
+		t.Fatalf("pipe write: %v", err)
+	}
+	var w bytes.Buffer
+	if ok := ProbeSixel(&w, pr, time.Second); !ok {
+		t.Fatal("expected sixel-capable DA1 reply to be recognized")
+	}
+
+	if _, err := pw.Write([]byte{'X'}); err != nil {
+		t.Fatalf("pipe write: %v", err)
+	}
+	if err := pr.SetReadDeadline(time.Now().Add(500 * time.Millisecond)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	buf := make([]byte, 1)
+	n, err := pr.Read(buf)
+	if err != nil || n != 1 || buf[0] != 'X' {
+		t.Fatalf("expected to read 'X' from pipe after probe; got n=%d err=%v buf=%q",
+			n, err, buf[:n])
+	}
+}
+
 type blockingReader struct{}
 
 func (blockingReader) Read(p []byte) (int, error) {

--- a/internal/image/probe_unix.go
+++ b/internal/image/probe_unix.go
@@ -9,16 +9,21 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// pollProbe reads from fd up to timeout, looking for a kitty graphics
-// ;OK reply. Synchronous (no goroutine) so no leak is possible. Uses
-// poll(2) with a millisecond timeout to wait for readable data, then
-// performs ONE read(2) per ready cycle into a fixed-size buffer.
+// pollProbe reads from fd up to timeout, handing everything collected
+// so far to scan until it reports a complete reply. Synchronous (no
+// goroutine) so no leak is possible. Uses poll(2) with a millisecond
+// timeout to wait for readable data, then performs ONE read(2) per
+// ready cycle into a fixed-size buffer.
+//
+// scan is scanForOK for the kitty graphics probe and scanForSixelDA for
+// the sixel DA1 probe: it returns (matched, ok) where matched means the
+// reply is complete and ok is the capability answer.
 //
 // Returns (ok, bytesRead, reason). reason is a short identifier
 // suitable for logging:
 //
-//	"got_ok"          -- kitty graphics OK reply seen
-//	"got_reply_no_ok" -- a kitty graphics reply was seen but not ;OK
+//	"got_ok"          -- an affirmative reply was seen
+//	"got_reply_no_ok" -- a complete reply was seen, but negative
 //	"timeout"         -- the deadline elapsed before any reply
 //	"poll_err:<err>"  -- poll(2) returned an error
 //	"read_err:<err>"  -- read(2) returned an error
@@ -30,7 +35,7 @@ import (
 // The startup window is ~200ms; the rare user keystroke landing in
 // that window would also have been eaten by the prior goroutine-based
 // implementation, so this is not a regression.
-func pollProbe(fd int, timeout time.Duration) (bool, int, string) {
+func pollProbe(fd int, timeout time.Duration, scan func([]byte) (bool, bool)) (bool, int, string) {
 	deadline := time.Now().Add(timeout)
 	var collected []byte
 	var buf [256]byte
@@ -72,7 +77,7 @@ func pollProbe(fd int, timeout time.Duration) (bool, int, string) {
 		}
 		bytesRead += rn
 		collected = append(collected, buf[:rn]...)
-		if matched, ok := scanForOK(collected); matched {
+		if matched, ok := scan(collected); matched {
 			if ok {
 				return true, bytesRead, "got_ok"
 			}

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -28,7 +28,7 @@
 
 ## Images
 
-- Inline image attachments render automatically in the messages pane: kitty graphics protocol on capable terminals (kitty, ghostty, recent WezTerm), sixel on foot/mlterm, half-block (`▀`) fallback everywhere else
+- Inline image attachments render automatically in the messages pane: kitty graphics protocol on capable terminals (kitty, ghostty, recent WezTerm), sixel on foot/mlterm and on any terminal that advertises sixel in its DA1 reply (xterm with sixel support, DomTerm, toyterm, …), half-block (`▀`) fallback everywhere else
 - User avatars use the same kitty graphics path on capable terminals for sharper pixels; sixel and other terminals fall back to half-block
 - Click any inline image (or press `O` on the selected message) for a full-screen in-app preview
 - `Enter` from the preview launches the OS image viewer

--- a/wiki/Terminal-Compatibility.md
+++ b/wiki/Terminal-Compatibility.md
@@ -14,7 +14,26 @@ something from the top of the list for the richest experience.
 | **Alacritty**         | half-block           | half-block         | yes (≥0.11) | yes              | Fast and reliable, but no inline images.                    |
 | **gnome-terminal** (recent) | half-block     | half-block         | yes         | yes              |                                                             |
 | **mlterm**            | sixel                | half-block         | partial     | partial          |                                                             |
+| **xterm** (`-ti vt340`) | sixel              | half-block         | yes         | yes              | Detected at startup via DA1; plain `xterm` without the sixel-capable emulation is half-block. |
+| **other sixel terminals** | sixel            | half-block         | varies      | varies           | DomTerm, toyterm, contour, WezTerm and friends are picked up by the startup DA1 probe. |
 | **screen**            | half-block           | half-block         | no          | no               | No working OSC 52 path; consider switching to tmux.         |
+
+## How the image protocol is picked
+
+With `image_protocol = "auto"` (the default) slk checks, in order:
+
+1. kitty graphics, when the terminal announces itself as kitty/ghostty —
+   confirmed at startup with a graphics-protocol probe.
+2. sixel, for terminals slk recognizes by name (foot, mlterm, WezTerm,
+   iTerm2) **or** that answer the startup DA1 query (`CSI c`) with
+   attribute `4`. This catches sixel terminals slk has never heard of,
+   including xterm built with sixel support, DomTerm and toyterm.
+3. half-block (`▀`) otherwise.
+
+If your terminal renders images as chunky half-block mosaics but
+`img2sixel` works in it, run slk with `SLK_DEBUG=1` and look for the
+`sixel probe:` line in the debug log. Set `image_protocol = "sixel"`
+explicitly if the terminal answers DA1 without advertising sixel.
 
 ## Inside tmux
 


### PR DESCRIPTION
Terminals that speak sixel were rendering the half-block mosaic because auto-detection only recognized sixel by name: TERM of "foot" or "mlterm", or TERM_PROGRAM of iTerm/WezTerm. Every other sixel-capable terminal -- xterm -ti vt340, DomTerm, toyterm, foot behind its foot-extra terminfo -- fell through to halfblock, which is what issue #116 reports as "blocky" output. Measuring the screenshots there confirms it: the blocks are flat and exactly cellW x cellH/2, the half-block signature, while img2sixel in the same terminals shows per-device-pixel detail.

Ask the terminal instead of guessing. ProbeSixel sends a Primary Device Attributes query (CSI c) and looks for attribute 4 in the reply, the same runtime check img2sixel and chafa use. Attributes are compared exactly so 14 / 24 / 41 don't false-positive.

The probe runs at startup only when detection already landed on halfblock, the config is auto (an explicit image_protocol=halfblock must stay half-block), and we're outside tmux/zellij -- tmux keeps sixel off by policy and zellij has no sixel path, so probing there would only risk paying the timeout for an answer we'd ignore. It also runs after a failed kitty probe, so that downgrade path gets a sixel chance too.

pollProbe is now parameterized by a scan function and shared with the kitty probe, keeping the poll(2)-based no-goroutine-leak path from issue #50. Detect also prefix-matches foot* / mlterm* so foot-extra works without needing the probe at all.

Fixes #116