### PR TITLE
Fix skin-toned ZWJ emoji URL construction

### DIFF
--- a/internal/emoji/url.go
+++ b/internal/emoji/url.go
@@ -157,8 +157,17 @@ var skinToneCodepoints = [...]rune{
 
 // ComposeSkinTonedCodepoints decomposes a skin-toned shortcode name
 // (either Slack's "::skin-tone-N" or kyokomi's "_toneN" form), looks
-// up the base shortcode in the kyokomi codemap, and appends the
-// matching skin-tone modifier codepoint.
+// up the base shortcode in the kyokomi codemap, and inserts the
+// matching skin-tone modifier codepoint right after the base (first)
+// codepoint.
+//
+// The skin-tone modifier applies to the base emoji — the first
+// codepoint in the sequence. For simple emojis (e.g. 👍 = U+1F44D)
+// this is equivalent to appending. For ZWJ sequences (e.g.
+// 🏃‍➡️ = U+1F3C3 U+200D U+27A1 U+FE0F) the modifier MUST go
+// after the base codepoint and BEFORE the ZWJ, producing
+// "1f3c3-1f3fb-200d-27a1-fe0f" — NOT "1f3c3-200d-27a1-fe0f-1f3fb",
+// which 404s on Slack's CDN.
 //
 // Used by URLForShortcode as a fallback for skin-toned variants that
 // aren't pre-resolved in kyokomi's codemap (e.g. ":+1_tone3:" is not
@@ -181,9 +190,14 @@ func ComposeSkinTonedCodepoints(name string) ([]rune, bool) {
 	if !ok {
 		return nil, false
 	}
+	// Insert the skin-tone modifier after the first codepoint (the
+	// base emoji), before any ZWJ / VS16 tail. This matches the
+	// codepoint ordering Slack's CDN uses for skin-toned ZWJ emoji
+	// assets.
 	out := make([]rune, len(baseCps)+1)
-	copy(out, baseCps)
-	out[len(baseCps)] = skinToneCodepoints[tone]
+	out[0] = baseCps[0]
+	out[1] = skinToneCodepoints[tone]
+	copy(out[2:], baseCps[1:])
 	return out, true
 }
 

--- a/internal/emoji/url_test.go
+++ b/internal/emoji/url_test.go
@@ -146,6 +146,12 @@ func TestComposeSkinTonedCodepoints(t *testing.T) {
 		{"slack +1 tone 2", "+1::skin-tone-2", []rune{0x1F44D, 0x1F3FC}, true},
 		// kyokomi form.
 		{"kyokomi wave tone 5", "wave_tone5", []rune{0x1F44B, 0x1F3FF}, true},
+		// ZWJ sequence: the modifier belongs after the base codepoint,
+		// before the ZWJ tail. Appending it instead builds a filename
+		// Slack's CDN 404s. Every other case here has a single-codepoint
+		// base, where the two orderings are indistinguishable.
+		{"zwj person_running_facing_right tone 2", "person_running_facing_right::skin-tone-2",
+			[]rune{0x1F3C3, 0x1F3FC, 0x200D, 0x27A1, 0xFE0F}, true},
 		// No tone suffix.
 		{"no suffix", "thumbsup", nil, false},
 		// Tone out of range.
@@ -178,6 +184,9 @@ func TestURLForShortcode_SkinTonedFallback(t *testing.T) {
 		{"thumbsup slack form", "thumbsup::skin-tone-2", CDNBaseURL + "1f44d-1f3fc.png"},
 		{"+1 slack form (alias)", "+1::skin-tone-3", CDNBaseURL + "1f44d-1f3fd.png"},
 		{"+1_tone3 (kyokomi miss)", "+1_tone3", CDNBaseURL + "1f44d-1f3fd.png"},
+		// The ordering above, end to end as a CDN filename.
+		{"zwj slack form", "person_running_facing_right::skin-tone-2",
+			CDNBaseURL + "1f3c3-1f3fc-200d-27a1-fe0f.png"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
Skin-toned variants of ZWJ emoji — e.g. `:person_running_facing_right::skin-tone-2:` — built a CDN filename that 404s, so those reactions silently rendered with no image.

`ComposeSkinTonedCodepoints` appended the tone modifier to the end of the sequence:

```
1f3c3-200d-27a1-fe0f-1f3fc.png   404
```

A skin-tone modifier applies to the character immediately before it, so it belongs directly after the base codepoint, ahead of the ZWJ tail:

```
1f3c3-1f3fc-200d-27a1-fe0f.png   ✓
```

This is Unicode sequence semantics rather than a Slack-specific quirk; the CDN filenames just follow the codepoint order. For single-codepoint emoji like 👍, "after the base" and "at the end" are the same position, which is why ordinary skin tones were never affected.

## Tests

Two cases added — one at the codepoint level, one end-to-end as a CDN filename.

Worth noting for review: `TestComposeSkinTonedCodepoints` already existed, but every case used a single-codepoint base, where the two orderings are indistinguishable. The whole table passed identically before and after the fix. The new cases fail against the old implementation with the appended-modifier ordering.