### PR TITLE
docs(readme): slim README; move tmux, Homebrew, and AUR details to the wiki

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -178,15 +178,12 @@ release:
 #
 # Two consequences of the move worth knowing:
 #
-#   1. Casks are macOS-only. Homebrew-on-Linux users lose this path and
-#      should use the .deb/.rpm/.apk or the tarball, which is the better
-#      route for them anyway.
-#   2. Existing installs do NOT migrate by themselves. The tap repo needs
-#      a tap_migrations.json containing {"slk": "slk"} and Formula/slk.rb
-#      deleted; only then does `brew upgrade` move someone from the old
-#      formula to the cask. That is manual work in gammons/homebrew-tap,
-#      and it should happen right after the first stable release that
-#      publishes a cask.
+#   1. The cask serves macOS AND Linux (Homebrew supports casks on Linux);
+#      goreleaser generates on_macos and on_linux stanzas pointing at the
+#      per-OS/arch tarballs.
+#   2. The old pre-v0.13.0 formula was deleted from the tap and a
+#      tap_migrations.json containing {"slk": "slk"} added, so `brew
+#      upgrade` moves existing formula installs to the cask.
 #
 # The token is a fine-grained PAT scoped to the homebrew-tap repo with
 # contents:write, stored as HOMEBREW_TAP_GITHUB_TOKEN in this repo's

--- a/README.md
+++ b/README.md
@@ -30,32 +30,20 @@
 - 59 themes + drop-in custom themes, live theme switcher
 - OS desktop notifications on DMs, mentions, and configurable keywords
 
-Full feature breakdown: **[[Features|https://github.com/gammons/slk/wiki/Features]]**
+Full feature breakdown: **[Features](https://github.com/gammons/slk/wiki/Features)**
 
 ## Quick install
 
-**Homebrew** (macOS only):
+**Homebrew** (macOS and Linux):
 
 ```bash
 brew install --cask gammons/tap/slk
 ```
 
-> **Note:** As of v0.13.0, slk is published as a Homebrew Cask (goreleaser v2.10
-> deprecated the `brews`/formula path for prebuilt binaries). Casks are macOS-only;
-> Linuxbrew users should use the tarball or `.deb`/`.rpm`/`.apk` packages below.
-> Existing installs may also need `tap_migrations.json` on the tap (tracked
-> upstream) before `brew upgrade` will move them from the old 0.12.0 formula to
-> the cask — until then, run `brew uninstall slk && brew install --cask gammons/tap/slk`.
-
-**Linux/macOS tarball** (auto-resolves the latest version):
+**Arch Linux** (community-maintained [AUR package](https://aur.archlinux.org/packages/slk)):
 
 ```bash
-VERSION=$(curl -fsSL https://api.github.com/repos/gammons/slk/releases/latest | grep -oE '"tag_name": *"v[^"]+"' | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | sed 's/^v//')
-# Linux x86_64
-curl -fsSL "https://github.com/gammons/slk/releases/latest/download/slk_${VERSION}_linux_x86_64.tar.gz" | tar xz
-# macOS Apple Silicon
-curl -fsSL "https://github.com/gammons/slk/releases/latest/download/slk_${VERSION}_darwin_arm64.tar.gz" | tar xz
-sudo mv slk /usr/local/bin/
+yay -S slk
 ```
 
 **Go:**
@@ -64,7 +52,7 @@ sudo mv slk /usr/local/bin/
 go install -ldflags="-s -w" -trimpath github.com/gammons/slk/cmd/slk@latest
 ```
 
-For `.deb` / `.rpm` / `.apk` packages, Windows, build-from-source, and checksums, see the [Installation wiki page](https://github.com/gammons/slk/wiki/Installation).
+For tarballs, `.deb` / `.rpm` / `.apk` packages, Windows, build-from-source, and the Homebrew formula→cask migration note, see the [Installation wiki page](https://github.com/gammons/slk/wiki/Installation).
 
 ## Setup
 
@@ -79,81 +67,6 @@ slk lists the workspaces you're signed in to; pick the ones you want and
 you're done.
 
 Full walkthrough: [Setup wiki page](https://github.com/gammons/slk/wiki/Setup).
-
-## Enterprise Grid
-
-slk reuses the **desktop app's** existing signed-in session (the same session
-your admin already sanctioned) rather than a browser session, which avoids the
-session-anomaly alerts that browser-token extraction can trigger. If you're on
-Enterprise Grid and still hit a sign-out or security alert after adding a
-workspace, please file an issue — include your OS and Slack desktop version.
-
-See [#5](https://github.com/gammons/slk/issues/5) for history.
-
-## Inline images in tmux
-
-If you run `slk` inside tmux on a Kitty-capable terminal (Kitty, Ghostty,
-WezTerm), images render natively as long as tmux passthrough is enabled:
-
-```tmux
-set -g allow-passthrough on
-```
-
-Reload tmux for the setting to take effect (`tmux kill-server`, then
-reattach). Verify with:
-
-```bash
-tmux show -gv allow-passthrough
-```
-
-Expected output: `on` (or `all`).
-
-If passthrough is off, `slk` detects this at startup and falls back to
-half-block rendering automatically — no config change needed. Outside a
-multiplexer, terminals that don't do kitty graphics are asked whether
-they speak sixel (a DA1 query), so sixel-capable terminals get real
-pixels instead of the half-block mosaic. To force a specific renderer
-regardless of detection, set `image_protocol` in `config.toml` to
-`kitty`, `sixel`, `halfblock`, or `off`.
-
-## Unread indicator in tmux
-
-`slk` sets the terminal window title to reflect unread state — for
-example `slk SW (3) +1` means three channels-with-unreads in the active
-workspace and at least one other workspace also has unreads. The
-two-letter prefix is the active workspace's initials (matching the
-left-rail label).
-
-Outside tmux this just works — modern terminals (Kitty, WezTerm,
-Alacritty, Ghostty, iTerm2, Windows Terminal, gnome-terminal) render
-title changes in their tab/window chrome.
-
-Inside tmux there's an extra step. tmux intercepts the title escape
-from slk, and only re-emits it to the outer terminal when title
-forwarding is on, *and* it uses its own title template by default
-(`#W` = window name) rather than the pane's title. Add both lines to
-`~/.tmux.conf`:
-
-```tmux
-set -g set-titles on
-set -g set-titles-string '#T'
-```
-
-`#T` (active pane title) is what carries slk's string. Reload tmux for
-the setting to take effect (`tmux kill-server`, then reattach). Verify
-with:
-
-```bash
-tmux show -gv set-titles
-tmux show -gv set-titles-string
-```
-
-Expected output: `on` and `#T`.
-
-If you'd prefer slk's unread indicator to work in tmux without any
-config change at all, that's tracked as a follow-up — it requires
-passing the title escape through tmux's DCS passthrough rather than
-relying on `set-titles`. Not in this release.
 
 ## Debugging
 
@@ -173,7 +86,7 @@ Everything lives in the [**wiki**](https://github.com/gammons/slk/wiki):
 - [Features](https://github.com/gammons/slk/wiki/Features) — full feature breakdown
 - [Keybindings](https://github.com/gammons/slk/wiki/Keybindings) — every key, every mode
 - [Configuration](https://github.com/gammons/slk/wiki/Configuration) — `config.toml`, custom themes, XDG paths
-- [Terminal Compatibility](https://github.com/gammons/slk/wiki/Terminal-Compatibility) — what each terminal supports
+- [Terminal Compatibility](https://github.com/gammons/slk/wiki/Terminal-Compatibility) — what each terminal supports, including tmux setup (inline images, unread-title forwarding)
 - [Clipboard and OSC 52](https://github.com/gammons/slk/wiki/Clipboard-and-OSC-52) — copy/paste setup notes
 - [Tradeoffs and Non-Goals](https://github.com/gammons/slk/wiki/Tradeoffs-and-Non-Goals) — roadmap, caveats, TOS notice
 - [Architecture](https://github.com/gammons/slk/wiki/Architecture) — service layout, data layer

--- a/wiki/Installation.md
+++ b/wiki/Installation.md
@@ -29,6 +29,15 @@ curl -fsSLO "https://github.com/gammons/slk/releases/latest/download/slk_${VERSI
 sudo apk add --allow-untrusted "slk_${VERSION}_linux_amd64.apk"
 ```
 
+### Arch Linux
+
+slk is available in the AUR as [`slk`](https://aur.archlinux.org/packages/slk)
+(community-maintained; builds from source):
+
+```bash
+yay -S slk    # or: paru -S slk
+```
+
 ### Tarball (any distro)
 
 Swap `x86_64` for `arm64` on ARM:
@@ -40,6 +49,20 @@ sudo mv slk /usr/local/bin/
 ```
 
 ## macOS
+
+### Homebrew (macOS and Linux)
+
+```bash
+brew install --cask gammons/tap/slk
+```
+
+The cask carries per-OS/arch tarballs and serves both macOS and Linux.
+Anyone who installed via the old pre-v0.13.0 formula is migrated to the
+cask automatically on `brew upgrade` (the formula was removed from the tap
+and a `tap_migrations.json` entry added); if that ever fails, run
+`brew uninstall slk && brew install --cask gammons/tap/slk` once.
+
+### Tarball
 
 ```bash
 VERSION=$(curl -fsSL https://api.github.com/repos/gammons/slk/releases/latest | grep -oE '"tag_name": *"v[^"]+"' | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | sed 's/^v//')

--- a/wiki/Setup.md
+++ b/wiki/Setup.md
@@ -48,3 +48,12 @@ needed), so sessions stay fresh on their own.
 If you ever sign out of the desktop app, just sign back in — slk will pick the
 session back up the next time it needs to re-mint. See the auth caveat in
 [[Tradeoffs and Non-Goals|Tradeoffs-and-Non-Goals]].
+
+## Enterprise Grid
+
+slk reuses the **desktop app's** existing signed-in session (the same session
+your admin already sanctioned) rather than a browser session, which avoids the
+session-anomaly alerts that browser-token extraction can trigger. If you're on
+Enterprise Grid and still hit a sign-out or security alert after adding a
+workspace, please file an issue — include your OS and Slack desktop version.
+See [#5](https://github.com/gammons/slk/issues/5) for history.

--- a/wiki/Terminal-Compatibility.md
+++ b/wiki/Terminal-Compatibility.md
@@ -37,9 +37,56 @@ explicitly if the terminal answers DA1 without advertising sixel.
 
 ## Inside tmux
 
-slk forces half-block for inline images regardless of the
-outer terminal — pixel-protocol pass-through inside tmux is unreliable. OSC 52
-clipboard requires `set -g set-clipboard on` in your tmux config.
+Kitty graphics work inside tmux on kitty-capable terminals (kitty, Ghostty,
+WezTerm) as long as tmux passthrough is enabled:
+
+```tmux
+set -g allow-passthrough on
+```
+
+Reload tmux for the setting to take effect (`tmux kill-server`, then
+reattach). Verify with `tmux show -gv allow-passthrough` — expected: `on`
+(or `all`). If passthrough is off, slk detects this at startup and falls
+back to half-block automatically.
+
+Sixel stays off inside tmux by policy — pixel-protocol pass-through inside
+tmux is unreliable — regardless of the outer terminal.
+
+OSC 52 clipboard requires `set -g set-clipboard on` in your tmux config.
+
+## Unread indicator in the window title
+
+slk sets the terminal window title to reflect unread state — for example
+`slk SW (3) +1` means three channels-with-unreads in the active workspace
+and at least one other workspace also has unreads. The two-letter prefix is
+the active workspace's initials (matching the left-rail label).
+
+Outside tmux this just works — modern terminals (kitty, WezTerm, Alacritty,
+Ghostty, iTerm2, Windows Terminal, gnome-terminal) render title changes in
+their tab/window chrome.
+
+Inside tmux there's an extra step. tmux intercepts the title escape from
+slk and only re-emits it to the outer terminal when title forwarding is on,
+*and* it uses its own title template by default (`#W` = window name) rather
+than the pane's title. Add both lines to `~/.tmux.conf`:
+
+```tmux
+set -g set-titles on
+set -g set-titles-string '#T'
+```
+
+`#T` (active pane title) is what carries slk's string. Reload tmux for the
+setting to take effect (`tmux kill-server`, then reattach). Verify with:
+
+```bash
+tmux show -gv set-titles
+tmux show -gv set-titles-string
+```
+
+Expected output: `on` and `#T`.
+
+Passing the title escape through tmux's DCS passthrough instead — which
+would work with no tmux config at all — is a possible follow-up.
 
 ## Overriding the image protocol
 


### PR DESCRIPTION
## Summary

The README was accumulating operational detail that belongs in the wiki. This trims it (210 → ~120 lines) and, along the way, fixes a few stale or wrong claims:

- **Moved to the wiki:** the inline-images-in-tmux section (`allow-passthrough`) and the unread-title-in-tmux section (`set-titles` / `#T`) now live on the Terminal Compatibility page; the Enterprise Grid note moved to the Setup page.
- **Fixed a wrong wiki claim:** Terminal Compatibility said slk forces half-block in tmux regardless of the outer terminal. In reality kitty graphics work in tmux with `allow-passthrough on`; only sixel is suppressed by policy.
- **Homebrew now documented for macOS and Linux.** The goreleaser-generated cask carries `on_linux` stanzas, and Homebrew supports casks on Linux. Companion tap cleanup (already pushed to gammons/homebrew-tap): deleted the stale v0.12.0 `Formula/slk.rb` that shadowed the cask for plain `brew install`, and added `tap_migrations.json` so old formula installs migrate on `brew upgrade` — completing the plan documented in `.goreleaser.yaml` (whose comment is updated here).
- **AUR:** documented the community-maintained [`slk` AUR package](https://aur.archlinux.org/packages/slk) in the README and on the Installation page.
- **Fixed** the Features link, which used wiki syntax and rendered literally on GitHub.

## Test plan

- Docs-only change plus a comment-only change to `.goreleaser.yaml`; no code touched.
- Verified the tap state directly: `Casks/slk.rb` at 0.15.0 with `on_macos` + `on_linux` blocks; tap push confirmed at https://github.com/gammons/homebrew-tap/commit/1bc70f4