### PR TITLE
fix: make thread parent message selectable

### DIFF
--- a/internal/ui/thread/model.go
+++ b/internal/ui/thread/model.go
@@ -89,6 +89,10 @@ type reactionHitRect struct {
 
 // Model represents the thread panel UI component.
 // It displays a parent message and its replies with cursor navigation.
+// parentSelected is the sentinel value of Model.selected meaning the
+// cursor sits on the parent message (the row above reply index 0).
+const parentSelected = -1
+
 type Model struct {
 	parent            messages.MessageItem
 	replies           []messages.MessageItem
@@ -121,6 +125,11 @@ type Model struct {
 	// overlay/extraction skips them naturally.
 	entryOffsets []int
 	totalLines   int
+
+	// parentEntry mirrors the rendered parent message at the start of
+	// viewContent. It provides the same plain-text and column metadata as
+	// reply entries so mouse selection can address the parent.
+	parentEntry viewEntry
 
 	// View-level cache -- bordered content ready for viewport
 	viewContent       string
@@ -308,11 +317,12 @@ func (m *Model) SetThread(parent messages.MessageItem, replies []messages.Messag
 	m.threadTS = threadTS
 	// Per the doc comment, the cursor starts at the bottom (newest reply)
 	// so a long thread opens scrolled to the latest activity rather than
-	// jammed up at the parent message.
+	// jammed up at the parent message. A reply-less thread selects the
+	// parent (parentSelected) so message ops still have a target.
 	if len(replies) > 0 {
 		m.selected = len(replies) - 1
 	} else {
-		m.selected = 0
+		m.selected = parentSelected
 	}
 	// Force the next View() to re-snap the viewport to the new selection.
 	// Without this, opening a thread whose newest-reply index matches the
@@ -433,7 +443,7 @@ func (m *Model) Clear() {
 	m.replies = nil
 	m.channelID = ""
 	m.threadTS = ""
-	m.selected = 0
+	m.selected = parentSelected
 	m.InvalidateCache()
 }
 
@@ -533,7 +543,7 @@ func (m *Model) RemoveMessageByTS(ts string) bool {
 			}
 			if m.selected >= len(m.replies) {
 				if len(m.replies) == 0 {
-					m.selected = 0
+					m.selected = parentSelected
 				} else {
 					m.selected = len(m.replies) - 1
 				}
@@ -671,6 +681,12 @@ func (m *Model) SetChannelNames(names map[string]string) {
 
 // SelectedReply returns the currently selected reply, or nil if none.
 func (m *Model) SelectedReply() *messages.MessageItem {
+	// The parent is a selectable row like any reply — returning it here
+	// makes every SelectedReply-driven message op (react, permalink,
+	// yank, open links) work on the thread's first message too.
+	if m.selected == parentSelected && m.parent.TS != "" {
+		return &m.parent
+	}
 	if m.selected < 0 || m.selected >= len(m.replies) {
 		return nil
 	}
@@ -726,7 +742,9 @@ func (m *Model) MoveUp() {
 	if m.reactionNavActive {
 		m.ExitReactionNav()
 	}
-	if m.selected > 0 {
+	// The parent row (parentSelected, index -1) sits above the first
+	// reply, so the cursor can move one step past index 0.
+	if m.selected > parentSelected {
 		m.selected--
 		m.dirty()
 	}
@@ -835,114 +853,108 @@ func (m *Model) ClampReactionNav() {
 
 // UpdateReaction updates the reaction state for a specific message in the thread.
 func (m *Model) UpdateReaction(messageTS, emojiName, userID string, remove bool) {
-	for i, reply := range m.replies {
-		if reply.TS == messageTS {
-			if remove {
-				for j, r := range reply.Reactions {
-					if r.Emoji == emojiName {
-						// Idempotent: only decrement if userID was present.
-						newIDs := messages.RemoveUserID(r.UserIDs, userID)
-						if len(newIDs) == len(r.UserIDs) && r.Count <= len(r.UserIDs) {
-							// Duplicate echo of an already-applied removal
-							// (un-listed reactor, non-truncated list) — skip.
-							// When Count > len(UserIDs) the list is truncated,
-							// so the removal is real; fall through to decrement.
-							break
-						}
-						r.UserIDs = newIDs
-						r.Count--
-						if userID == m.currentUserID {
-							r.HasReacted = false
-						}
-						if r.Count <= 0 {
-							m.replies[i].Reactions = append(reply.Reactions[:j], reply.Reactions[j+1:]...)
-						} else {
-							m.replies[i].Reactions[j] = r
-						}
-						break
-					}
-				}
-			} else {
-				found := false
-				for j, r := range reply.Reactions {
-					if r.Emoji == emojiName {
-						// Idempotent: only increment if userID is newly added,
-						// so an optimistic update + its WS echo don't double-count.
-						newIDs := messages.AppendUserID(r.UserIDs, userID)
-						if len(newIDs) != len(r.UserIDs) {
-							r.UserIDs = newIDs
-							r.Count++
-						}
-						if userID == m.currentUserID {
-							r.HasReacted = true
-						}
-						m.replies[i].Reactions[j] = r
-						found = true
-						break
-					}
-				}
-				if !found {
-					m.replies[i].Reactions = append(m.replies[i].Reactions, messages.ReactionItem{
-						Emoji:      emojiName,
-						Count:      1,
-						HasReacted: userID == m.currentUserID,
-						UserIDs:    messages.AppendUserID(nil, userID),
-					})
-				}
+	var msg *messages.MessageItem
+	if m.parent.TS == messageTS {
+		msg = &m.parent
+	} else {
+		for i := range m.replies {
+			if m.replies[i].TS == messageTS {
+				msg = &m.replies[i]
+				break
 			}
-			m.InvalidateCache()
-			if m.reactionNavActive {
-				m.ClampReactionNav()
+		}
+	}
+	if msg == nil {
+		return
+	}
+
+	m.updateMessageReaction(msg, emojiName, userID, remove)
+	m.InvalidateCache()
+	if m.reactionNavActive {
+		m.ClampReactionNav()
+	}
+}
+
+// updateMessageReaction applies one idempotent reaction event to msg.
+func (m *Model) updateMessageReaction(msg *messages.MessageItem, emojiName, userID string, remove bool) {
+	if remove {
+		for j, r := range msg.Reactions {
+			if r.Emoji != emojiName {
+				continue
+			}
+			newIDs := messages.RemoveUserID(r.UserIDs, userID)
+			if len(newIDs) == len(r.UserIDs) && r.Count <= len(r.UserIDs) {
+				return
+			}
+			r.UserIDs = newIDs
+			r.Count--
+			if userID == m.currentUserID {
+				r.HasReacted = false
+			}
+			if r.Count <= 0 {
+				msg.Reactions = append(msg.Reactions[:j], msg.Reactions[j+1:]...)
+			} else {
+				msg.Reactions[j] = r
 			}
 			return
 		}
+		return
 	}
+
+	for j, r := range msg.Reactions {
+		if r.Emoji != emojiName {
+			continue
+		}
+		newIDs := messages.AppendUserID(r.UserIDs, userID)
+		if len(newIDs) != len(r.UserIDs) {
+			r.UserIDs = newIDs
+			r.Count++
+		}
+		if userID == m.currentUserID {
+			r.HasReacted = true
+		}
+		msg.Reactions[j] = r
+		return
+	}
+	msg.Reactions = append(msg.Reactions, messages.ReactionItem{
+		Emoji:      emojiName,
+		Count:      1,
+		HasReacted: userID == m.currentUserID,
+		UserIDs:    messages.AppendUserID(nil, userID),
+	})
 }
 
 // ClickAt handles a mouse click at the given y-coordinate (the pane-local
 // y returned by App.panelAt — measured from the panel's top border, so
-// y=0..chromeHeight-1 sits inside the chrome (header / separator / parent
-// message / separator) and y=chromeHeight onward is reply content). Clicks
-// in the chrome are ignored.
+// y=0..chromeHeight-1 sits inside the chrome (header + separator) and
+// y=chromeHeight onward is the scrolling parent+replies content). Clicks
+// in the chrome are ignored: absoluteLineAt clamps them to the first
+// content line, which would otherwise read as a click on the parent.
 func (m *Model) ClickAt(y int) {
-	if len(m.replies) == 0 || len(m.cache) == 0 {
+	if y < m.chromeHeight {
 		return
 	}
-	contentY := y - m.chromeHeight
-	if contentY < 0 {
-		return // click on chrome — ignore
+	entry, _, messageTS, ok := m.selectionEntryAt(m.absoluteLineAt(y))
+	if !ok {
+		return
 	}
-	absoluteY := contentY + m.vp.YOffset()
-
-	currentLine := 0
-	for _, e := range m.cache {
-		h := e.height
-		if h == 0 {
-			h = 1
-		}
-		if absoluteY >= currentLine && absoluteY < currentLine+h {
-			if m.selected != e.replyIdx {
-				m.selected = e.replyIdx
-				m.viewCacheValid = false
-				m.dirty()
-			}
-			return
-		}
-		currentLine += h
-		// Inter-reply separators occupy 1 line in the bordered viewContent
-		// but are NOT inside any cache entry. Skip a line between entries
-		// so click coordinates stay in sync with viewContent.
-		currentLine++
+	selected := entry.replyIdx
+	if messageTS == m.parent.TS {
+		selected = parentSelected
+	}
+	if m.selected != selected {
+		m.selected = selected
+		m.viewCacheValid = false
+		m.dirty()
 	}
 }
 
 // BeginSelectionAt anchors a new selection at the given pane-local
 // coordinates (App.panelAt's coordinate system: 0 == panel content top,
-// just below the border). Clicks on the chrome (header / separator /
-// parent message / separator at pane-local y < chromeHeight) are
-// ignored — there's no reply content there to anchor on. The selection
-// becomes Active. Out-of-range inputs that don't land on any cache
-// entry are silently no-ops.
+// just below the border). Chrome rows (header + separator at
+// y < chromeHeight) are ignored; the scrolling parent+replies content
+// begins at chromeHeight. The selection becomes Active. Out-of-range
+// inputs that do not land on a message entry are silently no-ops.
 func (m *Model) BeginSelectionAt(viewportY, x int) {
 	if viewportY < m.chromeHeight {
 		return
@@ -1019,13 +1031,12 @@ func (m *Model) ClearSelection() {
 func (m *Model) HasSelection() bool { return m.hasSelection }
 
 // ScrollHintForDrag returns -1 if the cursor is within 1 row of the top
-// edge of the reply-content area, +1 if within 1 row of the bottom, else 0.
+// edge of the scrolling content, +1 if within 1 row of the bottom, else 0.
 // The incoming viewportY is pane-local (0 == top of panel content, just
-// below the border); we offset by m.chromeHeight so "top edge" is measured
-// against the reply content, not the chrome (header / separator / parent
-// message / separator). A cursor sitting on the chrome is treated the same
-// as the top content row, so an upward drag keeps auto-scrolling toward
-// older replies.
+// below the border). We offset by m.chromeHeight so the top edge is measured
+// below the header and separator. A cursor sitting on chrome is treated as
+// the top content row, so an upward drag keeps auto-scrolling toward older
+// messages.
 func (m *Model) ScrollHintForDrag(viewportY int) int {
 	h := m.lastViewHeight
 	if h <= 0 {
@@ -1043,13 +1054,11 @@ func (m *Model) ScrollHintForDrag(viewportY int) int {
 
 // absoluteLineAt converts a pane-local y coordinate to an absolute line
 // index inside m.viewContent (the bordered content the viewport scrolls
-// through). The incoming viewportY is what App.panelAt returns: zero at
-// the panel's content top (just below the border), so rows
-// 0..chromeHeight-1 are the thread chrome (header / separator / parent /
-// separator) and chromeHeight onward is reply content. We strip the chrome
-// offset before mapping into viewContent lines, clamping negative
-// (in-chrome) values to the first content line. The result is clamped to
-// [0, totalLines-1] for out-of-range inputs.
+// through). Rows 0..chromeHeight-1 are the thread chrome (header +
+// separator); chromeHeight onward is scrolling parent+replies content. We
+// strip the chrome offset before mapping into viewContent lines, clamping
+// negative (in-chrome) values to the first content line. The result is
+// clamped to [0, totalLines-1] for out-of-range inputs.
 func (m *Model) absoluteLineAt(viewportY int) int {
 	contentY := viewportY - m.chromeHeight
 	if contentY < 0 {
@@ -1065,35 +1074,42 @@ func (m *Model) absoluteLineAt(viewportY int) int {
 	return abs
 }
 
+// selectionEntryAt returns the rendered message entry containing absLine.
+// Parent lines begin at zero; reply lines use parent-inclusive offsets.
+func (m *Model) selectionEntryAt(absLine int) (*viewEntry, int, string, bool) {
+	if m.parent.TS != "" && absLine >= 0 && absLine < m.parentEntry.height {
+		return &m.parentEntry, 0, m.parent.TS, true
+	}
+	for i := range m.cache {
+		start := m.entryOffsets[i]
+		if absLine >= start && absLine < start+m.cache[i].height {
+			return &m.cache[i], start, m.replies[m.cache[i].replyIdx].TS, true
+		}
+	}
+	return nil, 0, "", false
+}
+
 // anchorAt converts an absolute line + display column into an Anchor.
 // `col` is the mouse's display column (relative to the reply area's
 // content). We subtract contentColOffset to get the plain column, then
 // clamp to plain-line width. Returns ok=false when no entry covers the
 // line (inter-reply separator) or when the cache is empty.
 func (m *Model) anchorAt(absLine, col int) (selection.Anchor, bool) {
-	for i, e := range m.cache {
-		start := m.entryOffsets[i]
-		end := start + e.height
-		if absLine < start || absLine >= end {
-			continue
-		}
-		j := absLine - start
-		plainCol := col - e.contentColOffset
-		if plainCol < 0 {
-			plainCol = 0
-		}
-		if j < len(e.linesPlain) {
-			if w := messages.DisplayWidthOfPlain(e.linesPlain[j]); plainCol > w {
-				plainCol = w
-			}
-		}
-		var msgID string
-		if e.replyIdx >= 0 && e.replyIdx < len(m.replies) {
-			msgID = m.replies[e.replyIdx].TS
-		}
-		return selection.Anchor{MessageID: msgID, Line: j, Col: plainCol}, true
+	entry, start, messageTS, ok := m.selectionEntryAt(absLine)
+	if !ok {
+		return selection.Anchor{}, false
 	}
-	return selection.Anchor{}, false
+	line := absLine - start
+	plainCol := col - entry.contentColOffset
+	if plainCol < 0 {
+		plainCol = 0
+	}
+	if line < len(entry.linesPlain) {
+		if width := messages.DisplayWidthOfPlain(entry.linesPlain[line]); plainCol > width {
+			plainCol = width
+		}
+	}
+	return selection.Anchor{MessageID: messageTS, Line: line, Col: plainCol}, true
 }
 
 // resolveAnchor returns the absolute line + plain col for an Anchor.
@@ -1102,12 +1118,18 @@ func (m *Model) resolveAnchor(a selection.Anchor) (absLine, col int, ok bool) {
 	if a.MessageID == "" {
 		return 0, 0, false
 	}
+	if a.MessageID == m.parent.TS {
+		if a.Line < 0 || a.Line >= m.parentEntry.height {
+			return 0, 0, false
+		}
+		return a.Line, a.Col, true
+	}
 	idx, found := m.replyIDToIdx[a.MessageID]
 	if !found || idx >= len(m.cache) {
 		return 0, 0, false
 	}
-	e := m.cache[idx]
-	if a.Line < 0 || a.Line >= e.height {
+	entry := m.cache[idx]
+	if a.Line < 0 || a.Line >= entry.height {
 		return 0, 0, false
 	}
 	return m.entryOffsets[idx] + a.Line, a.Col, true
@@ -1124,47 +1146,43 @@ func (m *Model) SelectionText() string {
 	loA, hiA := m.selRange.Normalize()
 	loLine, loCol, ok1 := m.resolveAnchor(loA)
 	hiLine, hiCol, ok2 := m.resolveAnchor(hiA)
-	if !ok1 || !ok2 {
-		return ""
-	}
-	if loLine > hiLine || (loLine == hiLine && loCol >= hiCol) {
+	if !ok1 || !ok2 || loLine > hiLine || (loLine == hiLine && loCol >= hiCol) {
 		return ""
 	}
 	var b strings.Builder
-	for i, e := range m.cache {
-		entryStart := m.entryOffsets[i]
-		entryEnd := entryStart + e.height
-		if entryEnd <= loLine {
-			continue
-		}
-		if entryStart > hiLine {
-			break
-		}
-		for j, plain := range e.linesPlain {
-			absLine := entryStart + j
-			if absLine < loLine {
-				continue
-			}
-			if absLine > hiLine {
-				break
-			}
-			from := 0
-			to := messages.DisplayWidthOfPlain(plain)
-			if absLine == loLine {
-				from = loCol
-			}
-			if absLine == hiLine {
-				to = hiCol
-			}
-			seg := messages.SliceColumns(plain, from, to)
-			seg = strings.TrimRight(seg, " ")
-			b.WriteString(seg)
-			if absLine != hiLine {
-				b.WriteByte('\n')
-			}
-		}
+	appendSelectionText(&b, 0, m.parentEntry, loLine, loCol, hiLine, hiCol)
+	for i, entry := range m.cache {
+		appendSelectionText(&b, m.entryOffsets[i], entry, loLine, loCol, hiLine, hiCol)
 	}
 	return strings.TrimRight(b.String(), "\n")
+}
+
+func appendSelectionText(b *strings.Builder, entryStart int, entry viewEntry, loLine, loCol, hiLine, hiCol int) {
+	entryEnd := entryStart + entry.height
+	if entryEnd <= loLine || entryStart > hiLine {
+		return
+	}
+	for line, plain := range entry.linesPlain {
+		absLine := entryStart + line
+		if absLine < loLine {
+			continue
+		}
+		if absLine > hiLine {
+			break
+		}
+		from := 0
+		to := messages.DisplayWidthOfPlain(plain)
+		if absLine == loLine {
+			from = loCol
+		}
+		if absLine == hiLine {
+			to = hiCol
+		}
+		b.WriteString(strings.TrimRight(messages.SliceColumns(plain, from, to), " "))
+		if absLine != hiLine {
+			b.WriteByte('\n')
+		}
+	}
 }
 
 // applySelectionOverlay returns viewContent with selection-style
@@ -1186,25 +1204,15 @@ func (m *Model) applySelectionOverlay(content string) string {
 	selStyle := styles.SelectionStyle()
 	lines := strings.Split(content, "\n")
 	for absLine := loLine; absLine <= hiLine && absLine < len(lines); absLine++ {
-		entryIdx := -1
-		for i := range m.cache {
-			start := m.entryOffsets[i]
-			if absLine >= start && absLine < start+m.cache[i].height {
-				entryIdx = i
-				break
-			}
-		}
-		if entryIdx < 0 {
-			continue // separator line between replies
-		}
-		e := m.cache[entryIdx]
-		j := absLine - m.entryOffsets[entryIdx]
-		if j < 0 || j >= len(e.linesPlain) {
+		entry, entryStart, _, ok := m.selectionEntryAt(absLine)
+		if !ok {
 			continue
 		}
-		plain := e.linesPlain[j]
-		styled := lines[absLine]
-
+		line := absLine - entryStart
+		if line < 0 || line >= len(entry.linesPlain) {
+			continue
+		}
+		plain := entry.linesPlain[line]
 		from := 0
 		to := messages.DisplayWidthOfPlain(plain)
 		if absLine == loLine {
@@ -1222,9 +1230,9 @@ func (m *Model) applySelectionOverlay(content string) string {
 		if from >= to {
 			continue
 		}
-		dispFrom := from + e.contentColOffset
-		dispTo := to + e.contentColOffset
-
+		styled := lines[absLine]
+		dispFrom := from + entry.contentColOffset
+		dispTo := to + entry.contentColOffset
 		styledWidth := ansi.StringWidth(styled)
 		if dispFrom >= styledWidth {
 			continue
@@ -1234,8 +1242,7 @@ func (m *Model) applySelectionOverlay(content string) string {
 		}
 		prefix := ansi.Cut(styled, 0, dispFrom)
 		suffix := ansi.Cut(styled, dispTo, styledWidth)
-		seg := messages.SliceColumns(plain, from, to)
-		lines[absLine] = prefix + selStyle.Render(seg) + suffix
+		lines[absLine] = prefix + selStyle.Render(messages.SliceColumns(plain, from, to)) + suffix
 	}
 	return strings.Join(lines, "\n")
 }
@@ -1323,7 +1330,28 @@ func (m *Model) View(height, width int) string {
 	// parent attachments are rare and threading flushes through the cache
 	// lifecycle adds complexity; reply flushes and hit rects ARE captured
 	// in the per-reply loop below.
-	parentContent, _, _ := m.renderThreadMessage(m.parent, width, m.userNames, m.channelNames, false)
+	parentIsSelected := m.selected == parentSelected
+	parentContent, _, _ := m.renderThreadMessage(m.parent, width, m.userNames, m.channelNames, parentIsSelected)
+	m.parentEntry = viewEntry{
+		linesPlain:       messages.PlainLines(parentContent),
+		height:           lipgloss.Height(parentContent),
+		contentColOffset: 1,
+	}
+	// Selection border for the parent row mirrors the per-reply
+	// cache-build treatment (borderSelect / borderInvis below): thick
+	// left border + tint when the cursor sits on the parent, invisible
+	// border otherwise so the parent's width matches the reply rows.
+	if parentIsSelected {
+		parentContent = lipgloss.NewStyle().BorderStyle(thickLeftBorder).BorderLeft(true).
+			BorderForeground(styles.SelectionBorderColor(m.focused)).
+			BorderBackground(styles.SelectionTintColor(m.focused)).
+			Background(styles.SelectionTintColor(m.focused)).
+			Render(parentContent)
+	} else {
+		parentContent = lipgloss.NewStyle().BorderStyle(thickLeftBorder).BorderLeft(true).
+			BorderForeground(styles.Background).BorderBackground(styles.Background).
+			Render(parentContent)
+	}
 	parentSeparator := lipgloss.NewStyle().
 		Width(width).
 		Background(styles.Background).
@@ -1539,6 +1567,11 @@ func (m *Model) View(height, width int) string {
 		allRows := []string{parentBlock}
 		startLine := 0
 		endLine := 0
+		if parentIsSelected {
+			// Parent row occupies lines 0..parentBlockHeight; the
+			// snap-to-selection math below scrolls to the top.
+			endLine = parentBlockHeight
+		}
 		currentLine := parentBlockHeight
 		// kittyFlushBuf collects per-image kitty APC upload bytes for
 		// every cached entry (the thread cache holds only the open

--- a/internal/ui/thread/model_test.go
+++ b/internal/ui/thread/model_test.go
@@ -284,8 +284,11 @@ func TestRemoveMessageByTS_LastBecomesEmpty(t *testing.T) {
 	if len(m.replies) != 0 {
 		t.Error("expected empty replies")
 	}
-	if m.SelectedReply() != nil {
-		t.Error("SelectedReply should be nil when empty")
+	// With no replies left the cursor falls back to the parent row
+	// (parentSelected) so message ops still have a target.
+	sel := m.SelectedReply()
+	if sel == nil || sel.TS != "P1" {
+		t.Errorf("SelectedReply = %+v, want parent (TS P1) when replies empty", sel)
 	}
 }
 

--- a/internal/ui/thread/parent_selection_test.go
+++ b/internal/ui/thread/parent_selection_test.go
@@ -1,0 +1,153 @@
+package thread
+
+import (
+	"testing"
+
+	"github.com/gammons/slk/internal/ui/messages"
+	"github.com/gammons/slk/internal/ui/selection"
+)
+
+// The parent message is a selectable row: MoveUp from the first reply
+// lands on it, and SelectedReply returns it so every message operation
+// (react, permalink, yank, open links) works on the parent too.
+// Regression: the cursor was clamped to the replies slice, making the
+// first message of every thread impossible to select or react to.
+
+func newThreadWithReplies(replyCount int) *Model {
+	m := New()
+	parent := messages.MessageItem{TS: "100.0", UserID: "U1", Text: "parent"}
+	var replies []messages.MessageItem
+	for i := 0; i < replyCount; i++ {
+		replies = append(replies, messages.MessageItem{
+			TS: "101." + string(rune('0'+i)), UserID: "U2", Text: "reply",
+		})
+	}
+	m.SetThread(parent, replies, "C1", "100.0")
+	return m
+}
+
+func TestMoveUpFromFirstReplySelectsParent(t *testing.T) {
+	m := newThreadWithReplies(2)
+	m.GoToTop()
+	m.MoveUp()
+	sel := m.SelectedReply()
+	if sel == nil || sel.TS != "100.0" {
+		t.Fatalf("SelectedReply = %+v, want parent (TS 100.0)", sel)
+	}
+}
+
+func TestMoveDownFromParentSelectsFirstReply(t *testing.T) {
+	m := newThreadWithReplies(2)
+	m.GoToTop()
+	m.MoveUp() // parent
+	m.MoveDown()
+	sel := m.SelectedReply()
+	if sel == nil || sel.TS != "101.0" {
+		t.Fatalf("SelectedReply = %+v, want first reply (TS 101.0)", sel)
+	}
+}
+
+func TestMoveUpFromParentStays(t *testing.T) {
+	m := newThreadWithReplies(1)
+	m.GoToTop()
+	m.MoveUp()
+	m.MoveUp() // no-op at top
+	sel := m.SelectedReply()
+	if sel == nil || sel.TS != "100.0" {
+		t.Fatalf("SelectedReply = %+v, want parent after double MoveUp", sel)
+	}
+}
+
+func TestEmptyThreadSelectsParent(t *testing.T) {
+	m := newThreadWithReplies(0)
+	sel := m.SelectedReply()
+	if sel == nil || sel.TS != "100.0" {
+		t.Fatalf("SelectedReply = %+v, want parent in reply-less thread", sel)
+	}
+}
+
+func TestAddReplySelectsNewestFromParent(t *testing.T) {
+	m := newThreadWithReplies(0)
+	m.AddReply(messages.MessageItem{TS: "102.0", UserID: "U2", Text: "new"})
+	sel := m.SelectedReply()
+	if sel == nil || sel.TS != "102.0" {
+		t.Fatalf("SelectedReply = %+v, want newest reply", sel)
+	}
+}
+
+func TestClearedThreadSelectsNothing(t *testing.T) {
+	m := newThreadWithReplies(1)
+	m.Clear()
+	if sel := m.SelectedReply(); sel != nil {
+		t.Fatalf("SelectedReply = %+v, want nil after Clear", sel)
+	}
+}
+
+func TestClickAtParentSelectsParent(t *testing.T) {
+	m := newThreadWithReplies(1)
+	m.View(20, 80)
+
+	m.ClickAt(m.chromeHeight)
+
+	sel := m.SelectedReply()
+	if sel == nil || sel.TS != "100.0" {
+		t.Fatalf("SelectedReply = %+v, want parent (TS 100.0)", sel)
+	}
+}
+
+// Making the parent clickable must not make the chrome clickable: the
+// header rows sit above the scrolling content, and absoluteLineAt clamps
+// them onto the parent's first line, so ClickAt needs its own guard.
+func TestClickAtChromeKeepsSelection(t *testing.T) {
+	m := newThreadWithReplies(2)
+	m.View(20, 80)
+	before := m.selected
+
+	m.ClickAt(0)
+
+	if m.selected != before {
+		t.Fatalf("selected = %d after clicking the header, want %d (unchanged)",
+			m.selected, before)
+	}
+}
+
+func TestUpdateReactionUpdatesParent(t *testing.T) {
+	m := newThreadWithReplies(1)
+	m.SetCurrentUser("U1")
+
+	m.UpdateReaction("100.0", "eyes", "U1", false)
+	if len(m.parent.Reactions) != 1 || !m.parent.Reactions[0].HasReacted {
+		t.Fatalf("parent reactions = %+v, want current-user eyes", m.parent.Reactions)
+	}
+
+	m.UpdateReaction("100.0", "eyes", "U1", true)
+	if len(m.parent.Reactions) != 0 {
+		t.Fatalf("parent reactions = %+v, want none", m.parent.Reactions)
+	}
+}
+
+func TestBeginSelectionAtParentAnchorsParent(t *testing.T) {
+	m := newThreadWithReplies(1)
+	m.View(20, 80)
+
+	m.BeginSelectionAt(m.chromeHeight, 1)
+
+	if !m.hasSelection || m.selRange.Start.MessageID != "100.0" {
+		t.Fatalf("selection = %+v, want parent anchor", m.selRange)
+	}
+}
+
+func TestSelectionTextIncludesParent(t *testing.T) {
+	m := newThreadWithReplies(1)
+	m.View(20, 80)
+	m.selRange = selection.Range{
+		Start:  selection.Anchor{MessageID: "100.0", Line: 1, Col: 0},
+		End:    selection.Anchor{MessageID: "100.0", Line: 1, Col: 1},
+		Active: false,
+	}
+	m.hasSelection = true
+
+	if got := m.SelectionText(); got == "" {
+		t.Fatal("SelectionText() = empty, want parent text")
+	}
+}


### PR DESCRIPTION
## Problem

In the thread panel, the selection cursor could only land on **replies**. The parent (the first message that started the thread) was never selectable, so there was no way to react to it, copy its text/permalink, or run any message op against the message that opened the thread. Pressing `k` from the top reply had nowhere to go.

## Fix

Introduce a `parentSelected` (`-1`) sentinel for `Model.selected`:

- `SelectedReply()` returns the parent message when the sentinel is active, so every existing message op (react, copy, permalink, yank) targets it with no per-callsite changes.
- `MoveUp()` from the first reply now lands on the parent instead of stopping; `MoveDown()` moves back into the replies.
- Click and initial-selection paths recognise the parent row.
- The view highlights the parent row when it's selected.

## Tests

New `parent_selection_test.go` covers: parent becomes selectable, `SelectedReply()` resolves to the parent, up/down navigation crosses the parent boundary, and ops target the parent. `go test ./...` passes.