### PR TITLE
fix: deliver live thread replies to panels showing a non-active channel

### DIFF
--- a/internal/ui/reducer_send.go
+++ b/internal/ui/reducer_send.go
@@ -273,6 +273,19 @@ func reduceNewMessage(a *App, m NewMessageMsg) tea.Cmd {
 			mm.IncrementReplyCount(m.Message.ThreadTS, m.Message.TS)
 		}
 	}
+	// Route thread replies to the open thread panel keyed on the
+	// PANEL's identity (its channel + thread ts), not the active
+	// channel. The panel can be showing a thread from a non-active
+	// channel — opened from the Threads view, or from a permalink
+	// pointing into another channel; neither path touches
+	// activeChannelID — and live replies must still land.
+	// (Previously this lived inside the active-channel branch below,
+	// so those panels went stale until a reopen forced a refetch.)
+	if a.threadVisible &&
+		m.ChannelID == a.threadPanel.ChannelID() &&
+		m.Message.ThreadTS == a.threadPanel.ThreadTS() {
+		a.threadPanel.AddReply(m.Message)
+	}
 	if m.ChannelID == a.activeChannelID {
 		// "active_channel_no_unread_bump": message arrived for the
 		// FOCUSED channel, so no unread bump is applied -- the user
@@ -280,12 +293,6 @@ func reduceNewMessage(a *App, m NewMessageMsg) tea.Cmd {
 		// entry via MarkChannel/MarkRead elsewhere).
 		debuglog.Cache("NewMessageMsg: channel=%s ts=%s decision=active_channel_no_unread_bump",
 			m.ChannelID, m.Message.TS)
-		// Route thread replies to the thread panel if it matches
-		// the open thread. The panel follows the focused window
-		// (spec §7), so this keeps the legacy focused-channel gate.
-		if a.threadVisible && m.Message.ThreadTS == a.threadPanel.ThreadTS() {
-			a.threadPanel.AddReply(m.Message)
-		}
 	} else {
 		// Message arrived for a channel that is NOT focused -- bump
 		// its unread state so the sidebar shows the dot + bold

--- a/internal/ui/reducer_thread_live_test.go
+++ b/internal/ui/reducer_thread_live_test.go
@@ -1,0 +1,99 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/gammons/slk/internal/ui/messages"
+)
+
+// A WS thread reply must land in the open thread panel based on the
+// PANEL's identity (its channel + thread ts), not the active channel.
+// Regression: threads opened from the Threads view (or left open while
+// focusing another channel) never received live replies — they only
+// appeared after reopening the thread forced a refetch.
+
+// hasReplyTS scans the panel's replies directly — Model.HasReply reads
+// a lazy index built during View(), which never runs in these tests.
+func hasReplyTS(a *App, ts string) bool {
+	for _, r := range a.threadPanel.Replies() {
+		if r.TS == ts {
+			return true
+		}
+	}
+	return false
+}
+
+func openThreadPanel(a *App, channelID, threadTS string) {
+	parent := messages.MessageItem{TS: threadTS, Text: "parent", UserID: "U1"}
+	a.threadPanel.SetThread(parent, nil, channelID, threadTS)
+	a.threadVisible = true
+}
+
+func TestThreadReplyRoutedWhenOtherChannelActive(t *testing.T) {
+	a := NewApp()
+	a.activeChannelID = "C_ACTIVE"
+	openThreadPanel(a, "C_THREAD", "100.0")
+
+	reduceNewMessage(a, NewMessageMsg{
+		ChannelID: "C_THREAD",
+		Message: messages.MessageItem{
+			TS:       "101.0",
+			ThreadTS: "100.0",
+			UserID:   "U2",
+			Text:     "live reply",
+		},
+	})
+
+	if !hasReplyTS(a, "101.0") {
+		t.Errorf("thread panel should receive live reply for its own thread; replies=%+v",
+			a.threadPanel.Replies())
+	}
+}
+
+func TestThreadReplyStillRoutedForActiveChannel(t *testing.T) {
+	a := NewApp()
+	a.activeChannelID = "C1"
+	openThreadPanel(a, "C1", "100.0")
+
+	reduceNewMessage(a, NewMessageMsg{
+		ChannelID: "C1",
+		Message:   messages.MessageItem{TS: "101.0", ThreadTS: "100.0", UserID: "U2", Text: "reply"},
+	})
+
+	if !hasReplyTS(a, "101.0") {
+		t.Error("active-channel thread reply routing regressed")
+	}
+}
+
+func TestThreadReplyForDifferentThreadNotRouted(t *testing.T) {
+	a := NewApp()
+	a.activeChannelID = "C_ACTIVE"
+	openThreadPanel(a, "C_THREAD", "100.0")
+
+	reduceNewMessage(a, NewMessageMsg{
+		ChannelID: "C_THREAD",
+		Message:   messages.MessageItem{TS: "201.0", ThreadTS: "200.0", UserID: "U2", Text: "other thread"},
+	})
+
+	if hasReplyTS(a, "201.0") {
+		t.Error("reply for a different thread must not land in the open panel")
+	}
+}
+
+// A closed thread panel keeps its last channel+thread identity, so the
+// visibility check must gate routing too.
+func TestThreadReplyNotRoutedWhenPanelHidden(t *testing.T) {
+	a := NewApp()
+	a.activeChannelID = "C_ACTIVE"
+	openThreadPanel(a, "C_THREAD", "100.0")
+	a.threadVisible = false
+
+	reduceNewMessage(a, NewMessageMsg{
+		ChannelID: "C_THREAD",
+		Message:   messages.MessageItem{TS: "101.0", ThreadTS: "100.0", UserID: "U2", Text: "reply"},
+	})
+
+	if hasReplyTS(a, "101.0") {
+		t.Error("hidden thread panel must not receive replies")
+	}
+}


### PR DESCRIPTION
## Problem

The open thread panel only received live replies when its thread belonged to the **active** channel. Reply routing lived inside the `if m.ChannelID == a.activeChannelID` branch of `reduceNewMessage`, so a thread panel opened from:

- the **Threads** view, or
- a **permalink** pointing into another channel

(neither of which touches `activeChannelID`) went stale. New replies didn't appear until the panel was closed and reopened, forcing a refetch.

## Fix

Hoist the reply-routing out of the active-channel branch and key it on the **panel's own identity** — its channel *and* its thread ts:

```go
if a.threadVisible &&
    m.ChannelID == a.threadPanel.ChannelID() &&
    m.Message.ThreadTS == a.threadPanel.ThreadTS() {
    a.threadPanel.AddReply(m.Message)
}
```

The new guard also adds the `ChannelID` match the old block lacked, so replies can't be mis-routed to a same-ts thread in a different channel, and there's no double-add (the old branch block is removed).

## Tests

`reducer_thread_live_test.go` covers a reply arriving for an open thread whose channel is not the active channel — it now lands in the panel. `go test ./...` passes.