### PR TITLE
fix: --add-workspace can write a config slk refuses to load

### DIFF
--- a/cmd/slk/add_workspace_config.go
+++ b/cmd/slk/add_workspace_config.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	toml "github.com/pelletier/go-toml/v2"
+
 	"github.com/gammons/slk/internal/config"
 )
 
@@ -31,7 +33,20 @@ func uniqueSlug(base string, existing map[string]bool) string {
 // team_id set, prefixed by a "# <teamName>" comment line. The file
 // is created if it does not exist. Existing content is preserved
 // verbatim (textual append, not TOML re-marshal).
+//
+// Writing a second block for a team_id that already has one is a no-op.
+// The slug is what uniqueSlug de-duplicates, and two different slugs
+// can name the same workspace — re-running --add-workspace with an
+// already-configured workspace selected produced exactly that, and
+// config.Load then rejects the file, so slk refuses to start until the
+// user hand-edits it. Keying the skip on team_id rather than on the
+// caller remembering to filter makes the writer safe no matter who
+// calls it.
 func appendWorkspaceConfigBlock(configPath, slug, teamID, teamName string) error {
+	if teamID != "" && configuredTeamIDs(configPath)[teamID] {
+		return nil
+	}
+
 	var existing []byte
 	if data, err := os.ReadFile(configPath); err == nil {
 		existing = data
@@ -59,6 +74,39 @@ func appendWorkspaceConfigBlock(configPath, slug, teamID, teamName string) error
 		return err
 	}
 	return os.WriteFile(configPath, []byte(b.String()), 0644)
+}
+
+// configuredTeamIDs returns the set of team ids already present in
+// configPath. An unreadable or absent file yields an empty set: the
+// caller is about to create it.
+//
+// Decodes the file directly rather than going through config.Load,
+// which validates. Validation is exactly what fails on a config that
+// already carries a duplicate team_id — so routing this through Load
+// would make the duplicate guard useless in the one case it exists
+// for, and the second run would append a third block to a file slk
+// already refuses to start on.
+func configuredTeamIDs(configPath string) map[string]bool {
+	out := map[string]bool{}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return out
+	}
+	var raw struct {
+		Workspaces map[string]struct {
+			TeamID string `toml:"team_id"`
+		} `toml:"workspaces"`
+	}
+	if err := toml.Unmarshal(data, &raw); err != nil {
+		return out
+	}
+	for _, w := range raw.Workspaces {
+		if w.TeamID != "" {
+			out[w.TeamID] = true
+		}
+	}
+	return out
 }
 
 // existingSlugs reads configPath (if present) and returns the set of

--- a/cmd/slk/add_workspace_config_dedupe_test.go
+++ b/cmd/slk/add_workspace_config_dedupe_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Re-running --add-workspace with an already-configured workspace
+// selected used to write a second [workspaces.<slug>-2] block for the
+// same team_id. config.Load rejects that, so slk stopped starting until
+// the config was hand-edited — a picker default turned into a broken
+// install.
+func TestAppendWorkspaceConfigBlock_SkipsTeamIDAlreadyConfigured(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	if err := appendWorkspaceConfigBlock(path, "pucek-com", "T011B427MLP", "pucek.com"); err != nil {
+		t.Fatalf("first append: %v", err)
+	}
+	if err := appendWorkspaceConfigBlock(path, "pucek-com-2", "T011B427MLP", "pucek.com"); err != nil {
+		t.Fatalf("second append: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading config: %v", err)
+	}
+	got := string(data)
+	if n := strings.Count(got, "T011B427MLP"); n != 1 {
+		t.Errorf("team id written %d times, want 1:\n%s", n, got)
+	}
+	if strings.Contains(got, "pucek-com-2") {
+		t.Errorf("duplicate slug block was written:\n%s", got)
+	}
+}
+
+func TestAppendWorkspaceConfigBlock_DifferentTeamsStillAppend(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	appendWorkspaceConfigBlock(path, "one", "T111", "One")
+	appendWorkspaceConfigBlock(path, "two", "T222", "Two")
+
+	data, _ := os.ReadFile(path)
+	got := string(data)
+	for _, want := range []string{"T111", "T222", "[workspaces.one]", "[workspaces.two]"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("config missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestConfiguredTeamIDs(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	if got := configuredTeamIDs(path); len(got) != 0 {
+		t.Errorf("absent config reported %d team ids, want 0", len(got))
+	}
+
+	appendWorkspaceConfigBlock(path, "one", "T111", "One")
+	appendWorkspaceConfigBlock(path, "two", "T222", "Two")
+
+	got := configuredTeamIDs(path)
+	if !got["T111"] || !got["T222"] || len(got) != 2 {
+		t.Errorf("configuredTeamIDs = %v, want exactly T111 and T222", got)
+	}
+}
+
+// Writing to a config that already carries unrelated settings must not
+// disturb them — the writer appends text rather than re-marshalling.
+func TestAppendWorkspaceConfigBlock_PreservesUnrelatedSettings(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	os.WriteFile(path, []byte("[appearance]\nimage_protocol = \"halfblock\"\n"), 0644)
+
+	if err := appendWorkspaceConfigBlock(path, "one", "T111", "One"); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	data, _ := os.ReadFile(path)
+	if !strings.Contains(string(data), `image_protocol = "halfblock"`) {
+		t.Errorf("unrelated setting lost:\n%s", data)
+	}
+}
+
+// The guard must work on a config that is ALREADY broken by a
+// duplicate — that is the state a second --add-workspace run leaves
+// behind, and the state in which a third run would otherwise make
+// things worse. Going through config.Load would return an error here
+// and report "no team ids configured".
+func TestConfiguredTeamIDs_WorksOnAConfigThatFailsValidation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	os.WriteFile(path, []byte(`
+[workspaces.pucek-com]
+team_id = "T011B427MLP"
+
+[workspaces.pucek-com-2]
+team_id = "T011B427MLP"
+`), 0644)
+
+	got := configuredTeamIDs(path)
+	if !got["T011B427MLP"] {
+		t.Fatalf("team id not found in a duplicate-broken config: %v", got)
+	}
+
+	// And appending must therefore be a no-op rather than a third block.
+	if err := appendWorkspaceConfigBlock(path, "pucek-com-3", "T011B427MLP", "pucek.com"); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	data, _ := os.ReadFile(path)
+	if strings.Contains(string(data), "pucek-com-3") {
+		t.Errorf("a third duplicate block was appended:\n%s", data)
+	}
+}
+
+// A hand-written config using single-quoted TOML strings must be read
+// too — slk writes double quotes, but the file is a user's to edit.
+func TestConfiguredTeamIDs_ReadsSingleQuotedValues(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	os.WriteFile(path, []byte("[workspaces.x]\nteam_id = 'T011B427MLP'\n"), 0644)
+
+	if !configuredTeamIDs(path)["T011B427MLP"] {
+		t.Error("single-quoted team_id not recognised")
+	}
+}

--- a/cmd/slk/onboarding.go
+++ b/cmd/slk/onboarding.go
@@ -42,14 +42,36 @@ func addWorkspace() error {
 		return err
 	}
 
-	// Multi-select (all pre-selected).
+	// Pre-select only the workspaces that are not configured yet.
+	//
+	// Selecting everything by default meant re-running --add-workspace
+	// re-added what was already there. That is not merely redundant:
+	// the config writer keyed uniqueness on the slug, so the second run
+	// wrote a second block for the same team_id under "<slug>-2", and
+	// config.Load then rejects the file — slk stops starting until the
+	// user hand-edits it. The writer is now idempotent by team_id, and
+	// this makes the picker say so out loud rather than silently
+	// dropping a selection the user made.
+	already := configuredTeamIDs(filepath.Join(xdgConfig(), "config.toml"))
+
 	var opts []huh.Option[string]
-	for _, w := range workspaces {
-		opts = append(opts, huh.NewOption(fmt.Sprintf("%s  (%s.slack.com)", w.Name, w.Domain), w.TeamID))
-	}
 	chosen := make([]string, 0, len(workspaces))
+	newCount := 0
 	for _, w := range workspaces {
-		chosen = append(chosen, w.TeamID)
+		label := fmt.Sprintf("%s  (%s.slack.com)", w.Name, w.Domain)
+		if already[w.TeamID] {
+			label += "  — już dodany"
+		} else {
+			chosen = append(chosen, w.TeamID)
+			newCount++
+		}
+		opts = append(opts, huh.NewOption(label, w.TeamID))
+	}
+
+	if newCount == 0 {
+		fmt.Println(dimStyle.Render("  Wszystkie workspace'y z aplikacji desktopowej są już dodane."))
+		fmt.Println(dimStyle.Render("  Zaznacz któryś, żeby odświeżyć jego token, albo wyjdź (Ctrl+C)."))
+		fmt.Println()
 	}
 	// huh sizes the MultiSelect option viewport to (Height - title/description
 	// lines); when Height is unset the viewport collapses to a row or two and
@@ -64,7 +86,7 @@ func addWorkspace() error {
 		huh.NewGroup(
 			huh.NewMultiSelect[string]().
 				Title("Workspaces to add").
-				Description("All selected by default; space to toggle, enter to confirm.").
+				Description("Nowe są zaznaczone; spacja przełącza, enter zatwierdza.").
 				Options(opts...).
 				Value(&chosen).
 				Height(visibleRows+4),


### PR DESCRIPTION
## What breaks

Running `slk --add-workspace` a second time can leave `config.toml` in a state `slk` refuses to load, so the client stops starting until the file is hand-edited. A picker default turns into a broken install.

## Why

Two things combine:

1. The picker **pre-selected every workspace**, including ones already configured. Re-running `--add-workspace` to add one workspace therefore re-added all of them by default.
2. The config writer de-duplicated on the **slug**, not the `team_id`. A second pass wrote a second `[workspaces.<slug>-2]` block carrying the same `team_id`.

`config.Load` rejects duplicate team IDs, so the very next launch fails. Worse, the failure is self-perpetuating: `--add-workspace` was one of the few things still runnable, and running it again appended a *third* block to a file `slk` already would not start on.

## The fix

Two changes, deliberately independent so neither depends on the other holding:

**The writer skips a `team_id` it already has.** Keying the guard at the writer rather than on callers remembering to filter makes it hold no matter who calls it, including callers not yet written.

**The picker pre-selects only unconfigured workspaces**, and labels the rest. Re-selecting one is still allowed — that is how you refresh a token — it just no longer happens by accident.

## One implementation note worth flagging

`configuredTeamIDs` decodes `config.toml` directly instead of going through `config.Load`.

This is deliberate. `Load` validates, and validation is exactly what fails on a config that already carries a duplicate. Routing the guard through `Load` would make it useless in the one case it exists for — recovering a file that is already broken — and a third run would keep appending. There is a test that constructs that broken state on purpose to pin this down.

## Testing

`cmd/slk/add_workspace_config_dedupe_test.go` covers the duplicate-`team_id` guard, the slug-collision path, and recovery from an already-broken config.

Full suite passes.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
