### PR TITLE
fix: unread dot that can never be cleared when the message is unfetchable

### DIFF
--- a/cmd/slk/channel_mark_ts_test.go
+++ b/cmd/slk/channel_mark_ts_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/gammons/slk/internal/cache"
+	"github.com/gammons/slk/internal/ui/messages"
+)
+
+// TestChannelMarkTS pins the fetch outcomes that decide whether a
+// channel is marked read, and at which timestamp.
+func TestChannelMarkTS(t *testing.T) {
+	// Slack's `latest` for a dormant channel: real, long past, and
+	// naming a message conversations.history will not return.
+	const slackLatest = "1776079647.792389"
+	latest := func() string { return slackLatest }
+
+	tests := []struct {
+		name   string
+		items  []messages.MessageItem
+		state  cache.ReadState
+		lookup func() string
+		want   string
+	}{
+		{
+			name:   "fetch failed: never mark, even when flagged unread",
+			items:  nil,
+			state:  cache.ReadState{HasUnread: true},
+			lookup: latest,
+			want:   "",
+		},
+		{
+			name:   "empty and already read: nothing to do",
+			items:  []messages.MessageItem{},
+			state:  cache.ReadState{HasUnread: false},
+			lookup: latest,
+			want:   "",
+		},
+		{
+			// The dormant / retention-limited channel. Marking at
+			// Slack's own `latest` clears the unread without
+			// fabricating recency the channel never had.
+			name:   "empty but flagged unread: mark at Slack's latest",
+			items:  []messages.MessageItem{},
+			state:  cache.ReadState{LastReadTS: "1718264828.618929", HasUnread: true},
+			lookup: latest,
+			want:   slackLatest,
+		},
+		{
+			name:   "empty, unread, but latest unknown: do not guess",
+			items:  []messages.MessageItem{},
+			state:  cache.ReadState{HasUnread: true},
+			lookup: func() string { return "" },
+			want:   "",
+		},
+		{
+			name:   "empty, unread, no lookup wired: do not mark",
+			items:  []messages.MessageItem{},
+			state:  cache.ReadState{HasUnread: true},
+			lookup: nil,
+			want:   "",
+		},
+		{
+			name:   "has messages: mark at the newest one",
+			items:  []messages.MessageItem{{TS: "100.000001"}, {TS: "200.000002"}},
+			state:  cache.ReadState{HasUnread: true},
+			lookup: latest,
+			want:   "200.000002",
+		},
+		{
+			name:   "has messages while already read: still marks newest",
+			items:  []messages.MessageItem{{TS: "300.000003"}},
+			state:  cache.ReadState{HasUnread: false},
+			lookup: latest,
+			want:   "300.000003",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := channelMarkTS(tt.items, tt.state, tt.lookup); got != tt.want {
+				t.Errorf("channelMarkTS() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestChannelMarkTSNoLookupWhenMessagesPresent guards the cost side:
+// the `latest` lookup is a network call, and it must not fire on the
+// ordinary path where the newest fetched message already answers the
+// question.
+func TestChannelMarkTSNoLookupWhenMessagesPresent(t *testing.T) {
+	called := false
+	items := []messages.MessageItem{{TS: "400.000004"}}
+	got := channelMarkTS(items, cache.ReadState{HasUnread: true}, func() string {
+		called = true
+		return "999.000000"
+	})
+	if called {
+		t.Error("looked up Slack's latest even though the fetch returned messages")
+	}
+	if got != "400.000004" {
+		t.Errorf("got %q, want the newest fetched message", got)
+	}
+}
+
+// TestChannelMarkTSNoLookupWhenAlreadyRead is the same guard for a
+// channel that is empty but carries no unread flag.
+func TestChannelMarkTSNoLookupWhenAlreadyRead(t *testing.T) {
+	called := false
+	channelMarkTS([]messages.MessageItem{}, cache.ReadState{HasUnread: false}, func() string {
+		called = true
+		return "999.000000"
+	})
+	if called {
+		t.Error("looked up Slack's latest for a channel with nothing unread")
+	}
+}
+
+// TestChannelMarkTSStaysStale is the regression guard for the bug this
+// helper's second revision fixed. Marking a dormant channel at the wall
+// clock cleared the dot but made the channel look freshly read, and the
+// sidebar's staleness filter (hide_inactive_after_days) then pinned it
+// to the sidebar for the whole threshold window. Marking at Slack's
+// real `latest` keeps the channel as old as it actually is.
+func TestChannelMarkTSStaysStale(t *testing.T) {
+	const slackLatest = "1776079647.792389" // ~127 days before the `now` below
+	const now = "1787053312.000000"
+
+	got := channelMarkTS(
+		[]messages.MessageItem{},
+		cache.ReadState{LastReadTS: "1718264828.618929", HasUnread: true},
+		func() string { return slackLatest },
+	)
+	if got == now {
+		t.Fatal("marked at the wall clock; that fabricates recency and defeats the staleness filter")
+	}
+	if got != slackLatest {
+		t.Fatalf("got %q, want Slack's latest %q", got, slackLatest)
+	}
+	// It must still be newer than the stale last_read, or
+	// conversations.mark is a silent no-op and the dot survives.
+	if got <= "1718264828.618929" {
+		t.Fatalf("mark ts %q must be newer than last_read", got)
+	}
+}

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -1451,10 +1451,13 @@ func run() error {
 				state, _ := db.GetChannelReadState(chIDStr)
 				lastReadTS := state.LastReadTS
 
-				// Mark channel as read up to the latest message
-				if len(msgItems) > 0 {
-					latestTS := msgItems[len(msgItems)-1].TS
-					markChannelReadAsync(ctx, wctx, db, p, chIDStr, latestTS)
+				// Mark channel as read up to the latest message, or --
+				// for a channel Slack calls unread but whose unread
+				// message we can never fetch -- up to now.
+				if ts := channelMarkTS(msgItems, state, func() string {
+					return latestFromCounts(wctx.Client, chIDStr)
+				}); ts != "" {
+					markChannelReadAsync(ctx, wctx, db, p, chIDStr, ts)
 				}
 
 				return ui.MessagesLoadedMsg{
@@ -3058,6 +3061,79 @@ func summarizeCachedRows(rows []cache.Message) string {
 	}
 	return fmt.Sprintf("count=%d oldest=%s newest=%s",
 		len(rows), rows[0].TS, rows[len(rows)-1].TS)
+}
+
+// channelMarkTS decides which timestamp a just-fetched channel should
+// be marked read at, or "" for "do not mark".
+//
+// It relies on fetchChannelMessages's nil-vs-[] contract:
+//
+//	nil -> the history call FAILED. We know nothing; never mark.
+//	[]  -> Slack authoritatively says the channel has no fetchable
+//	       messages.
+//	non-empty -> mark up to the newest message, as always.
+//
+// The [] case is why this helper exists. Slack's client.counts reports
+// has_unreads by comparing the channel's `latest` against `last_read`,
+// and it does so even when `latest` is no longer retrievable --
+// conversations.history then answers ok=true with messages:[] and
+// is_limited:true (a dormant channel on a retention-limited plan).
+// The result is an unread dot on a channel that renders "No messages
+// yet", and every mark-read path is gated on having at least one
+// message, so opening the channel cannot clear it. The dot is
+// permanent.
+//
+// slackLatest is consulted only in that case, and supplies Slack's
+// `latest` for the channel. Marking at that timestamp -- rather than
+// at the wall clock -- matters for more than tidiness: last_read_ts
+// also feeds the sidebar's staleness filter
+// (hide_inactive_after_days), so marking "now" would fabricate
+// recency the channel never had and pin a dormant channel to the
+// sidebar for the whole threshold window. The real `latest` is
+// typically long past it, so the channel correctly ages out.
+//
+// Returning "" when `latest` is unknown is deliberate: a wrong
+// timestamp here is worse than a dot that clears on the next open.
+//
+// Gating on state.HasUnread keeps this from firing a pointless
+// conversations.mark -- and a pointless lookup -- every time an
+// ordinary empty channel is opened.
+func channelMarkTS(msgItems []messages.MessageItem, state cache.ReadState, slackLatest func() string) string {
+	switch {
+	case len(msgItems) > 0:
+		return msgItems[len(msgItems)-1].TS
+	case msgItems != nil && state.HasUnread:
+		if slackLatest == nil {
+			return ""
+		}
+		return slackLatest()
+	default:
+		return ""
+	}
+}
+
+// latestFromCounts asks Slack for the channel's `latest` timestamp.
+//
+// client.counts is the only endpoint that reports it: conversations
+// .info omits `latest` entirely, and conversations.history cannot
+// return a message that has aged out of the plan's retention window --
+// which is precisely the situation this is called in.
+//
+// Returns "" on any failure. Callers treat that as "do not mark",
+// so a transient error costs one unread dot, not a wrong read state.
+func latestFromCounts(client *slackclient.Client, channelID string) string {
+	unreads, _, err := client.GetUnreadCounts()
+	if err != nil {
+		debuglog.Cache("latestFromCounts: channel=%s client.counts failed: %v", channelID, err)
+		return ""
+	}
+	for _, u := range unreads {
+		if u.ChannelID == channelID {
+			return u.Latest
+		}
+	}
+	debuglog.Cache("latestFromCounts: channel=%s absent from client.counts", channelID)
+	return ""
 }
 
 // markChannelReadAsync fires Slack's conversations.mark plus the local

--- a/internal/slack/client.go
+++ b/internal/slack/client.go
@@ -928,6 +928,13 @@ type UnreadInfo struct {
 	Count     int
 	HasUnread bool
 	LastRead  string // Slack message timestamp
+	// Latest is the channel's newest message timestamp as Slack knows
+	// it. It is what client.counts compares against LastRead to decide
+	// HasUnread, and it can name a message conversations.history will
+	// not return -- on a retention-limited plan the message that makes
+	// a channel unread may have aged out of the fetchable window.
+	// Empty when Slack omits it.
+	Latest string
 }
 
 // ThreadsAggregate captures Slack's server-side notion of whether the
@@ -978,17 +985,20 @@ func (c *Client) GetUnreadCounts() ([]UnreadInfo, ThreadsAggregate, error) {
 			MentionCount       int    `json:"mention_count"`
 			UnreadCountDisplay int    `json:"unread_count_display,omitempty"`
 			LastRead           string `json:"last_read"`
+			Latest             string `json:"latest"`
 		} `json:"channels"`
 		Mpims []struct {
 			ID           string `json:"id"`
 			HasUnreads   bool   `json:"has_unreads"`
 			MentionCount int    `json:"mention_count"`
 			LastRead     string `json:"last_read"`
+			Latest       string `json:"latest"`
 		} `json:"mpims"`
 		Ims []struct {
 			ID         string `json:"id"`
 			HasUnreads bool   `json:"has_unreads"`
 			LastRead   string `json:"last_read"`
+			Latest     string `json:"latest"`
 		} `json:"ims"`
 		// Threads is the workspace-wide thread-subscription rollup.
 		// Slack returns this top-level when the user has subscribed
@@ -1016,6 +1026,7 @@ func (c *Client) GetUnreadCounts() ([]UnreadInfo, ThreadsAggregate, error) {
 			ChannelID: ch.ID,
 			LastRead:  ch.LastRead,
 			HasUnread: ch.HasUnreads,
+			Latest:    ch.Latest,
 		}
 		if ch.HasUnreads {
 			info.Count = ch.MentionCount
@@ -1030,6 +1041,7 @@ func (c *Client) GetUnreadCounts() ([]UnreadInfo, ThreadsAggregate, error) {
 			ChannelID: ch.ID,
 			LastRead:  ch.LastRead,
 			HasUnread: ch.HasUnreads,
+			Latest:    ch.Latest,
 		}
 		if ch.HasUnreads {
 			info.Count = max(ch.MentionCount, 1)
@@ -1041,6 +1053,7 @@ func (c *Client) GetUnreadCounts() ([]UnreadInfo, ThreadsAggregate, error) {
 			ChannelID: ch.ID,
 			LastRead:  ch.LastRead,
 			HasUnread: ch.HasUnreads,
+			Latest:    ch.Latest,
 		}
 		if ch.HasUnreads {
 			info.Count = 1


### PR DESCRIPTION
## What breaks

A channel shows an unread dot in the sidebar while the message pane reads **"No messages yet"**, and nothing the user does clears it. Opening the channel does not help. The dot is permanent.

## Why

`client.counts` decides `has_unreads` by comparing a channel's `latest` against `last_read` — and it does so even when `latest` is no longer retrievable. On a retention-limited plan, a dormant channel gives these three answers at the same time:

```
client.counts          has_unreads: true
                       last_read:   1718264828.618929   (Jun 2024)
                       latest:      1776079647.792389   (Apr 2026)

conversations.history  ok: true, messages: [], is_limited: true

conversations.info     properties.is_dormant: true
```

Slack is not wrong, and neither is `slk` for storing the flag — the unread message genuinely exists, it has simply aged out of the fetchable window. It can never be displayed, and therefore never read.

The problem is that **every** mark-read path was gated on having at least one message:

| Location | Gate |
|---|---|
| `cmd/slk/main.go` — `Fetch` | `if len(msgItems) > 0` |
| `internal/ui/reducer_channels.go` — Tier 1 | `if len(cached) == 0 { return nil, false }` |
| `markChannelReadAsync` | early return on `ts == ""` |

With no message there is no timestamp to mark at, so `conversations.mark` was never sent.

## The fix

`channelMarkTS` picks the mark timestamp from the nil-vs-`[]` contract `fetchChannelMessages` already documents and honours:

| Fetch result | Meaning | Action |
|---|---|---|
| `nil` | history call **failed** | mark nothing — we know nothing |
| `[]` + `has_unread` | Slack has nothing to show us | mark at Slack's `latest` |
| `[]` + already read | ordinary empty channel | do nothing |
| non-empty | normal case | mark at newest message (unchanged) |

### Why `latest` and not `time.Now()`

This is the part worth reading, because the obvious implementation is wrong in a way that is easy to miss.

`last_read_ts` does not only drive the unread dot. It is also what the sidebar's staleness filter reads: `IsStale` hides a channel once `now - last_read_ts` exceeds `hide_inactive_after_days` (30 by default), and it treats an unread channel as *never* stale.

So a dormant channel is pinned to the sidebar by `has_unread`. Marking it at the wall clock clears the dot — and then pins it right back for the full threshold window, because it now claims the user just read a channel whose newest message is months old. The symptom moves; the channel still will not go away.

Marking at Slack's real `latest` clears the dot **and** leaves the channel its true age, so the staleness filter ages it out on its own. On the workspace this was found on, that is 127 days past the threshold.

I found this the hard way: the first version of this patch used `time.Now()`, and the channel stayed in the sidebar with no dot. `TestChannelMarkTSStaysStale` is the regression guard.

### Where `latest` comes from

`client.counts` is the only endpoint that reports it. `conversations.info` omits the field entirely, and `conversations.history` cannot return a message that has aged out of the retention window — which is the whole situation. `UnreadInfo` now carries it.

The lookup is a network call, so it fires **only** on the branch that needs it: an authoritative empty fetch on a channel flagged unread. Two tests pin that it does not fire on the ordinary paths.

When `latest` cannot be determined, the channel is left unmarked. A dot that clears on the next open is a smaller error than a read state written from a guess.

### Why it marks through Slack

Boot's `ReplaceWorkspaceReadState` re-applies `client.counts` as authoritative, so a local-only clear would light the dot again on the next start. It has to be `conversations.mark`.

The `nil` case is what keeps this safe: a transient network failure returns `nil`, never `[]`, so a failed fetch can never mark a channel with real unread messages as read.

## Testing

`cmd/slk/channel_mark_ts_test.go` covers every branch, both "no lookup on the ordinary paths" guards, and the staleness regression above.

Verified end to end against a live workspace, including resetting the channel's read state back to the broken condition and reproducing the whole cycle: the dot clears, `client.counts` then reports `has_unreads: false`, and the channel drops out of the sidebar.

Full suite passes.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
