### PR TITLE
fix: clicking a sidebar section header did nothing

### DIFF
--- a/internal/ui/reducer_mouse.go
+++ b/internal/ui/reducer_mouse.go
@@ -5,18 +5,18 @@
 // Owns the two remaining mouse Update arms that act as multi-panel
 // routers:
 //
-//   tea.MouseWheelMsg  - viewport scroll for the panel under the
-//                        cursor (sidebar, messages pane / threads
-//                        view, thread panel). Decoupled from j/k
-//                        selection. Triggers maybeFetchOlderHistory
-//                        on the messages pane when the viewport
-//                        hits the top.
-//   tea.MouseClickMsg  - panel-router: workspace rail (switch
-//                        workspace), sidebar (channel select /
-//                        threads view), messages pane (threads
-//                        click / reaction hit-test / image hit-test
-//                        / drag begin), thread panel (reaction
-//                        hit-test / drag begin).
+//	tea.MouseWheelMsg  - viewport scroll for the panel under the
+//	                     cursor (sidebar, messages pane / threads
+//	                     view, thread panel). Decoupled from j/k
+//	                     selection. Triggers maybeFetchOlderHistory
+//	                     on the messages pane when the viewport
+//	                     hits the top.
+//	tea.MouseClickMsg  - panel-router: workspace rail (switch
+//	                     workspace), sidebar (channel select /
+//	                     threads view), messages pane (threads
+//	                     click / reaction hit-test / image hit-test
+//	                     / drag begin), thread panel (reaction
+//	                     hit-test / drag begin).
 //
 // Free reducer (not controller-absorbed) because both arms route
 // across multiple sub-models: the sidebar, messagepane, threadPanel,
@@ -217,11 +217,21 @@ func reduceMouseClick(a *App, m tea.MouseClickMsg) tea.Cmd {
 				return ChannelSelectedMsg{ID: item.ID, Name: item.Name, Type: item.Type}
 			}
 		}
-		// ClickAt returns ok=false for the synthetic Threads row;
-		// if the click landed there (sidebar updates its own
-		// selection state), activate the threads view.
+		// ClickAt returns ok=false for every row that is not a
+		// channel: the synthetic Threads row and section headers. It
+		// has still moved the sidebar's own selection to the clicked
+		// row, so dispatch on that -- in the same order as
+		// handleEnter, which is the keyboard half of this decision.
+		// The two must stay in step: a row that responds to Enter but
+		// not to a click reads as a dead row.
 		if a.sidebar.IsThreadsSelected() {
 			return func() tea.Msg { return ThreadsViewActivatedMsg{} }
+		}
+		// Section header: expand or collapse it in place, matching the
+		// Enter behaviour. Returns false when the selected row is not
+		// a header.
+		if a.sidebar.ToggleCollapseSelected() {
+			return nil
 		}
 		return nil
 

--- a/internal/ui/reducer_mouse_sidebar_rows_test.go
+++ b/internal/ui/reducer_mouse_sidebar_rows_test.go
@@ -1,0 +1,92 @@
+// internal/ui/reducer_mouse_sidebar_rows_test.go
+package ui
+
+import (
+	"fmt"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/gammons/slk/internal/ui/sidebar"
+)
+
+// TestSidebarClickAgreesWithEnter is the invariant the sidebar's two
+// activation paths must satisfy: every row Enter acts on must respond
+// to a click on that same row, and do the same thing.
+//
+// They had drifted. handleEnter dispatches on the Threads row, on a
+// section header (toggling its collapse state), and on a channel,
+// while reduceMouseClick handled only channels and Threads -- so
+// clicking a section header moved the sidebar selection, drew the
+// highlight, and then returned nil.
+//
+// The sweep is the point. Asserting one row kind at a time would not
+// have caught this, because the row that breaks is always the one
+// nobody thought to write a case for; this walks every row the sidebar
+// renders and compares the two paths on each.
+func TestSidebarClickAgreesWithEnter(t *testing.T) {
+	newApp := func() *App {
+		a := NewApp()
+		a.width = 160
+		a.height = 40
+		a.activeTeamID = "T1"
+		a.sidebarVisible = true
+		a.focusedPanel = PanelSidebar
+		a.sidebar.SetItems([]sidebar.ChannelItem{
+			{ID: "C1", Name: "general", Type: "channel"},
+			{ID: "C2", Name: "random", Type: "channel"},
+		})
+		return a
+	}
+
+	const maxRows = 12
+	activated := 0
+
+	for y := 0; y < maxRows; y++ {
+		// Two independent apps in identical state: one driven by
+		// Enter, one by a click on the same row. Sharing one app would
+		// let the first activation change what the second sees.
+		byEnter, byClick := newApp(), newApp()
+		_, _ = byEnter.View(), byClick.View()
+
+		// Put the Enter-driven app's selection on the row under test
+		// the same way a click would. ClickAt moves the selection for
+		// every row kind; ok=false merely means "not a channel", which
+		// is exactly what the other branches dispatch on.
+		byEnter.sidebar.ClickAt(y)
+		enterMsgs := drainCmd(byEnter.handleEnter())
+
+		// X must land inside the sidebar band, past the workspace rail
+		// -- reduceMouseClick routes on x before it looks at y. Y is
+		// offset by one for the top border.
+		clickMsgs := drainCmd(reduceMouseClick(byClick, tea.MouseClickMsg{
+			Button: tea.MouseLeft, X: byClick.layout.RailWidth() + 1, Y: y + 1,
+		}))
+
+		if fmt.Sprintf("%T", firstMsg(enterMsgs)) != fmt.Sprintf("%T", firstMsg(clickMsgs)) {
+			t.Errorf("row y=%d: Enter produced %T but click produced %T",
+				y, firstMsg(enterMsgs), firstMsg(clickMsgs))
+			continue
+		}
+		if firstMsg(enterMsgs) != nil {
+			activated++
+		}
+		// Rows that act without emitting a message -- a section header
+		// toggling its own collapse state -- must still leave the two
+		// sidebars rendering identically.
+		if got, want := byClick.sidebar.View(30, 30), byEnter.sidebar.View(30, 30); got != want {
+			t.Errorf("row y=%d: click and Enter left different sidebar state", y)
+		}
+	}
+
+	if activated == 0 {
+		t.Fatal("swept every row and none activated on either path; the fixture renders no actionable rows")
+	}
+}
+
+func firstMsg(msgs []tea.Msg) tea.Msg {
+	if len(msgs) == 0 {
+		return nil
+	}
+	return msgs[0]
+}


### PR DESCRIPTION
## What breaks

Clicking a section header in the sidebar does nothing. The row highlights, so it looks like it registered — and then nothing happens. Collapsing or expanding a section is keyboard-only.

It shows up fastest on the **Channels** section, which ships collapsed by default: clicking it open is the obvious first move, and it silently fails.

## Why

The sidebar has two activation paths, and they had drifted apart.

`handleEnter` dispatches on three row kinds:

```go
if a.sidebar.IsThreadsSelected() { ... }      // Threads row
if a.sidebar.ToggleCollapseSelected() { ... } // section header
item, ok := a.sidebar.SelectedItem()          // channel
```

`reduceMouseClick` handled only two of them — channels and Threads:

```go
if item, ok := a.sidebar.ClickAt(sidebarY); ok { ... }  // channel
if a.sidebar.IsThreadsSelected() { ... }                // Threads row
return nil                                              // everything else
```

`ClickAt` returns `ok=false` for *every* non-channel row, and the mouse reducer treated that as "nothing here" after a single special case for Threads. It had already moved the selection to the clicked row — which is what draws the highlight and makes the row look live — and then returned nil.

## The fix

Add the missing branch, in `handleEnter`'s order so the two paths read as the same decision rather than two lists that happen to overlap.

## Testing

The test sweeps **every rendered row** and asserts click and Enter agree on each, instead of asserting one row kind at a time.

That is the deliberate part. A per-row-kind test would have had exactly the blind spot that caused this: the row that broke is the row nobody thought to write a case for. The sweep fails on the section-header row today, and will fail again for the next row kind wired into one path and not the other.

Verified by reverting the fix and confirming the test fails on the defect, so it fails on the bug rather than merely passing on the patch.

Full suite passes.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
