### PR TITLE
fix: label day dividers by calendar day, not local-vs-UTC elapsed time

### DIFF
--- a/internal/ui/messages/dateseparator_test.go
+++ b/internal/ui/messages/dateseparator_test.go
@@ -1,0 +1,55 @@
+// internal/ui/messages/dateseparator_test.go
+package messages
+
+import (
+	"strconv"
+	"testing"
+	"time"
+)
+
+// FormatDateSeparator must agree with DateFromTS, which derives its date
+// string from the local day. Running the pair under a zone east of UTC
+// used to label yesterday's messages "Today", because the parsed date
+// (UTC midnight) was subtracted from a local midnight.
+func TestFormatDateSeparatorAcrossTimezones(t *testing.T) {
+	zones := []string{"UTC", "Europe/Kyiv", "Europe/Berlin", "Asia/Tokyo", "America/New_York", "Pacific/Kiritimati"}
+	for _, name := range zones {
+		t.Run(name, func(t *testing.T) {
+			// Loaded per subtest so a zone missing from the host's tzdata
+			// skips only itself instead of the whole table.
+			loc, err := time.LoadLocation(name)
+			if err != nil {
+				t.Skipf("tzdata for %s unavailable: %v", name, err)
+			}
+
+			orig := time.Local
+			time.Local = loc
+			t.Cleanup(func() { time.Local = orig })
+
+			now := time.Now()
+			cases := []struct {
+				offsetDays int
+				want       string
+			}{
+				{0, "Today"},
+				{-1, "Yesterday"},
+				{-2, now.AddDate(0, 0, -2).Format("Monday")},
+				{-6, now.AddDate(0, 0, -6).Format("Monday")},
+				{-7, now.AddDate(0, 0, -7).Format("Monday, January 2, 2006")},
+			}
+			for _, tc := range cases {
+				// Mid-day so the timestamp is unambiguously on its day.
+				ts := time.Date(now.Year(), now.Month(), now.Day(), 12, 0, 0, 0, loc).
+					AddDate(0, 0, tc.offsetDays)
+				got := FormatDateSeparator(DateFromTS(formatSlackTS(ts)))
+				if got != tc.want {
+					t.Errorf("offset %d days: got %q, want %q", tc.offsetDays, got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+func formatSlackTS(t time.Time) string {
+	return strconv.FormatInt(t.Unix(), 10) + ".000000"
+}

--- a/internal/ui/messages/model.go
+++ b/internal/ui/messages/model.go
@@ -3492,16 +3492,21 @@ func FormatDateSeparator(dateStr string) string {
 	if err != nil {
 		return dateStr
 	}
+	// Compare calendar days, not elapsed time: both endpoints are anchored
+	// to UTC midnight so the delta is always a whole number of days.
 	now := time.Now()
-	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
-	diff := today.Sub(d).Hours() / 24
+	// time.Parse already yields UTC midnight; restating it is defensive, not
+	// load-bearing.
+	dDay := time.Date(d.Year(), d.Month(), d.Day(), 0, 0, 0, 0, time.UTC)
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	days := int(today.Sub(dDay).Hours() / 24)
 
 	switch {
-	case diff < 1:
+	case days <= 0:
 		return "Today"
-	case diff < 2:
+	case days == 1:
 		return "Yesterday"
-	case diff < 7:
+	case days < 7:
 		return d.Format("Monday")
 	default:
 		return d.Format("Monday, January 2, 2006")


### PR DESCRIPTION
## Problem

In any timezone east of UTC, day dividers were off by one day. Messages sent yesterday rendered under a `── Today ──` separator, the day before yesterday appeared as `── Yesterday ──`, and a message from exactly a week ago showed a bare weekday name where it should show the full date.

`DateFromTS` derives its date string from the **local** day:

```go
return time.Unix(sec, 0).Format("2006-01-02")
```

`FormatDateSeparator` then re-parsed that string with `time.Parse`, which returns **UTC** midnight, and subtracted it from a **local** midnight:

```go
d, err := time.Parse("2006-01-02", dateStr)          // UTC midnight
today := time.Date(..., now.Location())              // local midnight
diff := today.Sub(d).Hours() / 24
```

The two endpoints sit in different zones, so the delta came up short by exactly the UTC offset. At UTC+2, yesterday measured 22h → `22/24 = 0.92` → `diff < 1` → `"Today"`, and every older label slipped one position down the same chain.

West of UTC the offset pads the delta rather than shrinking it, so the labels stayed correct there — which is why this went unnoticed.

## Fix

Compare calendar days instead of elapsed time. Both midnights are anchored to the same zone before subtracting, and the switch runs on an integer day count:

```go
now := time.Now()
dDay := time.Date(d.Year(), d.Month(), d.Day(), 0, 0, 0, 0, time.UTC)
today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
days := int(today.Sub(dDay).Hours() / 24)

switch {
case days <= 0:
    return "Today"
case days == 1:
    return "Yesterday"
case days < 7:
    return d.Format("Monday")
default:
    return d.Format("Monday, January 2, 2006")
}
```

Anchoring both endpoints to UTC also makes DST structurally irrelevant to the comparison rather than something the arithmetic has to survive: the delta is a whole number of days by construction, where the fractional comparison could be perturbed by a 23- or 25-hour local day. To be clear about what is and isn't verified — no test here exercises a DST-shortened day, so that is a property of the shape of the fix, not a separately tested one.

The thread pane renders its dividers through the same two exported helpers (`internal/ui/thread/model.go`), so it is fixed by the same change.

## Test plan

- New `internal/ui/messages/dateseparator_test.go` drives the real `DateFromTS` → `FormatDateSeparator` pair across six zones spanning UTC−5 to UTC+14: UTC, Europe/Kyiv, Europe/Berlin, Asia/Tokyo, America/New_York, Pacific/Kiritimati.
- Confirmed the test actually reproduces the bug — with the source change reverted and the test kept, every east-of-UTC zone fails with exactly the reported symptom:

  ```
  --- FAIL: TestFormatDateSeparatorAcrossTimezones/Asia/Tokyo
      offset -1 days: got "Today", want "Yesterday"
      offset -2 days: got "Yesterday", want "Sunday"
  ```

- Each zone is loaded inside its own `t.Run`, so a zone missing from the host's tzdata skips only that subtest instead of the whole table.
- `go test ./... -race` — all packages ok
- `go build -ldflags="-s -w" -trimpath ./...`, `go vet ./...`, `git diff --check`
- Verified in a live session at UTC+2: a message from the previous afternoon now sits under `── Yesterday ──`, with `── Today ──` correctly introducing the first message of the current day.

