### PR TITLE
Sync thread subscriptions on boot and reconnect, throttled and staggered

### DIFF
--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -160,10 +160,12 @@ type WorkspaceContext struct {
 	// us the workspace has zero unread threads, we trust that and
 	// suppress the heuristic-derived flags entirely.
 	ThreadsHasUnreads bool
-	// ThreadSubsOnce gates the workspace's one
-	// subscriptions.thread.getView fetch, fired on the first open of
-	// the Threads view. See ensureThreadSubscriptions.
-	ThreadSubsOnce sync.Once
+	// ThreadSubsGate throttles the workspace's
+	// subscriptions.thread.getView fetches to one per
+	// threadSubsSyncInterval. Fired on workspace-ready, on Threads
+	// view activation, and by the reconnect/wake catch-up. See
+	// ensureThreadSubscriptions.
+	ThreadSubsGate threadSubsGate
 	// SubscriptionsAvailable indicates whether the most recent
 	// threadSubscriptionSync attempt succeeded in fetching Slack's
 	// authoritative thread-subscription list. true on bootstrap
@@ -1744,24 +1746,24 @@ func run() error {
 					SubscriptionsAvailable: wctx.SubscriptionsAvailable,
 				}
 			},
-			// First open of the Threads view for this workspace is what
-			// pays for subscriptions.thread.getView, instead of every
-			// boot and (before that) every reconnect. Returns
-			// immediately; the list renders from cache and refreshes
-			// via ThreadsListDirtyMsg when the fetch lands.
+			// Workspace-ready (boot) is the primary trigger, with
+			// Threads-view activation as the safety net; the gate
+			// inside ensureThreadSubscriptions collapses both to one
+			// throttled, staggered getView sweep per workspace.
+			// Returns immediately; the list renders from cache and
+			// refreshes via ThreadsListDirtyMsg when the fetch lands.
+			//
+			// ByID, not Active: boot fires this for every workspace
+			// as it connects, including background ones the user may
+			// never activate this session — on Enterprise Grid those
+			// are exactly the workspaces whose threads would
+			// otherwise stay stale.
 			EnsureSubscriptions: func(teamID ids.TeamID) {
-				wctx := router.Active()
-				if wctx == nil || string(teamID) != wctx.TeamID {
+				wctx := router.ByID(string(teamID))
+				if wctx == nil || wctx.Client == nil {
 					return
 				}
-				ensureThreadSubscriptions(ctx, &wctx.ThreadSubsOnce,
-					&threadSubscriptionSync{
-						client:      wctx.Client,
-						db:          db,
-						workspaceID: wctx.TeamID,
-						availableCb: func(available bool) { wctx.SubscriptionsAvailable = available },
-					},
-					func() { p.Send(ui.ThreadsListDirtyMsg{TeamID: wctx.TeamID}) })
+				ensureWorkspaceThreadSubs(ctx, wctx, db, p.Send)
 			},
 			ChannelLastRead: func(channelID ids.ChannelID) string {
 				wctx := router.Active()
@@ -2021,6 +2023,12 @@ func run() error {
 						LastReadTS: state.LastReadTS,
 					})
 				},
+				// Reconnect/wake kick for the throttled thread-
+				// subscription sync; the gate inside decides whether a
+				// getView sweep actually runs.
+				ensureThreadSubs: func() {
+					ensureWorkspaceThreadSubs(context.Background(), wctx, db, p.Send)
+				},
 			}
 			wctx.RTMHandler = handler
 			wctx.ConnMgr = slackclient.NewConnectionManager(wctx.Client, handler)
@@ -2260,6 +2268,7 @@ func connectWorkspace(ctx context.Context, token slackclient.Token, db *cache.DB
 		BotUserIDs:           make(map[string]bool),
 		CustomEmoji:          make(map[string]string),
 		LastVisitedByChannel: make(map[string]int64),
+		ThreadSubsGate:       threadSubsGate{window: threadSubsSyncInterval},
 	}
 	wctx.SubscriptionsAvailable = true
 
@@ -2438,12 +2447,13 @@ func connectWorkspace(ctx context.Context, token slackclient.Token, db *cache.DB
 		wctx.MuteStore = store
 	}
 
-	// Thread subscriptions are deliberately NOT fetched here. They are
-	// pulled on the first open of the Threads view, by
-	// ensureThreadSubscriptions via the threads list fetcher. See that
-	// function for why: the call paginates to a 1000-item hard cap,
-	// ~62 requests per workspace on a real account, and the Threads
-	// view is not on screen at boot.
+	// Thread subscriptions are deliberately NOT fetched here. The
+	// trigger is the WorkspaceReadyMsg the reducer handles after
+	// connectWorkspace returns: ensureThreadSubscriptions runs the
+	// sync throttled (one sweep per threadSubsSyncInterval) and
+	// staggered per workspace, so a Grid boot doesn't fire every
+	// workspace's ~62-request paginated sweep in the same second.
+	// See that function for the full rationale.
 
 	// There is deliberately no workspace-wide user fetch here.
 	//
@@ -3843,6 +3853,14 @@ type rtmEventHandler struct {
 	//
 	// nil in tests that construct a handler for unrelated events.
 	refreshChannel func(ctx context.Context, channelID string)
+
+	// ensureThreadSubs kicks the workspace's throttled thread-
+	// subscription sync (subscriptions.thread.getView). The reconnect
+	// catch-up fires it on every pass — the threadSubsGate inside
+	// owns the real throttling, so the kick itself is free.
+	//
+	// nil in tests that construct a handler for unrelated events.
+	ensureThreadSubs func()
 }
 
 func (h *rtmEventHandler) OnMessage(channelID, userID, ts, text, threadTS, subtype string, edited bool, files []slack.File, blocks slack.Blocks, attachments []slack.Attachment, botID, username string) {
@@ -4222,6 +4240,15 @@ func (h *rtmEventHandler) refreshActiveMembership() {
 func (h *rtmEventHandler) syncOnReconnect(trigger string) bool {
 	if h.wsCtx == nil || h.db == nil || h.wsCtx.Client == nil {
 		return false
+	}
+	// Threads: same "socket replays nothing" gap as the channel pass
+	// below. Fired BEFORE the dedupe check and unconditionally: the
+	// threadSubsGate inside throttles to one sweep per
+	// threadSubsSyncInterval, so the kick costs nothing when the last
+	// sync was recent, and a long offline gap must not have its
+	// reconciliation skipped just because a channel pass ran 10 s ago.
+	if h.ensureThreadSubs != nil {
+		h.ensureThreadSubs()
 	}
 	if !h.backfillGate.tryStart(time.Now()) {
 		debuglog.Backfill("team=%s trigger=%s skipped reason=dedupe", h.workspaceID, trigger)

--- a/cmd/slk/reconnect_sync.go
+++ b/cmd/slk/reconnect_sync.go
@@ -62,6 +62,12 @@ type teaSender interface {
 //  2. Mark every other channel stale, so it revalidates when opened.
 //  3. Refresh the channel actually on screen, through the same path a
 //     channel switch uses.
+//
+// Thread subscriptions are NOT one of the steps. They rejoined the
+// reconnect path later, but at the handler level (syncOnReconnect's
+// ensureThreadSubs kick) with their own 30-minute throttle — one
+// paginated sweep per window, not the unbounded per-reconnect phase
+// measured above.
 type reconnectSync struct {
 	client      reconnectClient
 	db          *cache.DB

--- a/cmd/slk/reconnect_sync_test.go
+++ b/cmd/slk/reconnect_sync_test.go
@@ -385,3 +385,68 @@ func TestReconnect_NoActiveChannelMakesNoHistoryCall(t *testing.T) {
 		t.Errorf("calls = %v; want only client.counts", got)
 	}
 }
+
+// The socket replays nothing, so after a wake-from-sleep or reconnect
+// the thread_subscriptions table is missing every subscription,
+// unsubscription, mark and reply from the gap. The reconnect catch-up
+// must kick the (throttled) subscription sync alongside the channel
+// work — without the kick, threads stay stale until the next boot.
+func TestSyncOnReconnect_KicksThreadSubscriptionSync(t *testing.T) {
+	kicked := make(chan struct{}, 1)
+	h := &rtmEventHandler{
+		db:              newTestDB(t),
+		wsCtx:           &WorkspaceContext{Client: &slackclient.Client{}},
+		backfillGate:    dedupeGate{window: 30 * time.Second},
+		activeChannelID: func() string { return "" },
+		ensureThreadSubs: func() {
+			kicked <- struct{}{}
+		},
+	}
+
+	if !h.syncOnReconnect("wake") {
+		t.Fatal("syncOnReconnect was deduped on its first call")
+	}
+	select {
+	case <-kicked:
+	case <-time.After(time.Second):
+		t.Fatal("reconnect catch-up did not kick the thread subscription sync")
+	}
+}
+
+// The kick is a trigger, not a fetch: threadSubsGate inside
+// ensureThreadSubscriptions decides whether a sweep actually runs.
+// A reconnect flap that passes the 30 s dedupe must still cost zero
+// getView requests when the last sync was recent — but the wiring
+// must not hold the kick back either, or a long offline gap followed
+// by a flap would defer the reconciliation indefinitely. The handler
+// therefore fires unconditionally and stays dumb about throttling.
+func TestSyncOnReconnect_KickSurvivesDedupedPass(t *testing.T) {
+	kicked := make(chan struct{}, 2)
+	h := &rtmEventHandler{
+		db:              newTestDB(t),
+		wsCtx:           &WorkspaceContext{Client: &slackclient.Client{}},
+		backfillGate:    dedupeGate{window: 30 * time.Second},
+		activeChannelID: func() string { return "" },
+		ensureThreadSubs: func() {
+			kicked <- struct{}{}
+		},
+	}
+
+	h.syncOnReconnect("reconnect")
+	if h.syncOnReconnect("reconnect") {
+		t.Fatal("second pass inside the dedupe window should have been suppressed")
+	}
+	select {
+	case <-kicked:
+	case <-time.After(time.Second):
+		t.Fatal("first pass did not kick the thread subscription sync")
+	}
+	select {
+	case <-kicked:
+		// Both designs are defensible; this pins "kick even when the
+		// channel pass was deduped", since the thread gate throttles
+		// anyway and the kick is free.
+	case <-time.After(time.Second):
+		t.Fatal("deduped pass did not forward the kick to the thread gate, which owns the real throttle")
+	}
+}

--- a/cmd/slk/thread_subscriptions.go
+++ b/cmd/slk/thread_subscriptions.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"sync"
+	"sync/atomic"
 	"time"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/gammons/slk/internal/cache"
 	"github.com/gammons/slk/internal/debuglog"
 	slackclient "github.com/gammons/slk/internal/slack"
+	"github.com/gammons/slk/internal/ui"
 )
 
 // threadSubscriptionLister is the one call this file makes:
@@ -125,34 +128,120 @@ func (s *threadSubscriptionSync) sync(ctx context.Context) error {
 	return nil
 }
 
-// ensureThreadSubscriptions runs one subscription sync per workspace
-// per session, in the background, and returns immediately.
+// threadSubsSyncInterval is the minimum gap between a workspace's
+// subscriptions.thread.getView sweeps. The call paginates to a
+// 1000-item hard cap, measured at ~62 requests per workspace on a real
+// account, so it cannot run on every trigger: boot, Threads-view
+// activation and every WS reconnect would otherwise multiply it. 30
+// minutes bounds the request volume while keeping the list fresh
+// across the gaps the socket cannot cover (app closed, laptop asleep
+// — the socket replays nothing).
+const threadSubsSyncInterval = 30 * time.Minute
+
+// threadSubsStagger hands out startup slots across workspaces. On
+// Enterprise Grid every workspace becomes ready in the same second
+// (connectWorkspace runs per-workspace goroutines), and an unstaggered
+// first sync would fire N paginated getView sweeps at once. Slot i
+// waits i*threadSubsStaggerStep before its first sync. Re-syncs never
+// wait — the interval above already thins them out.
+var threadSubsStagger atomic.Int64
+
+// threadSubsStaggerStep is a var so tests can shrink it.
+var threadSubsStaggerStep = 15 * time.Second
+
+// threadSubsGate admits at most one subscription sync per window per
+// workspace, and never two concurrently. It replaces the sync.Once
+// that gated the fetch when only the first Threads-view open triggered
+// it: a Once cannot express "again after a long offline gap", which is
+// exactly when the table goes stale.
+type threadSubsGate struct {
+	mu      sync.Mutex
+	last    time.Time
+	running bool
+	window  time.Duration
+}
+
+// tryStart reports whether a sync may begin at `now`. first is true
+// only for the workspace's first-ever admission, which is what the
+// startup stagger keys off. last is recorded at admission, not
+// completion, so a failed sync cannot be retried into a hammering
+// loop against a rate-limited endpoint.
+func (g *threadSubsGate) tryStart(now time.Time) (first, ok bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.running {
+		return false, false
+	}
+	if !g.last.IsZero() && now.Sub(g.last) < g.window {
+		return false, false
+	}
+	first = g.last.IsZero()
+	g.last = now
+	g.running = true
+	return first, true
+}
+
+func (g *threadSubsGate) done() {
+	g.mu.Lock()
+	g.running = false
+	g.mu.Unlock()
+}
+
+// ensureWorkspaceThreadSubs is the single construction site for the
+// throttled subscription sync, shared by every trigger: the
+// ThreadService closure (workspace-ready boot + Threads-view
+// activation) and the RTM handler's reconnect/wake catch-up.
+func ensureWorkspaceThreadSubs(ctx context.Context, wctx *WorkspaceContext, db *cache.DB, send func(tea.Msg)) {
+	ensureThreadSubscriptions(ctx, &wctx.ThreadSubsGate,
+		&threadSubscriptionSync{
+			client:      wctx.Client,
+			db:          db,
+			workspaceID: wctx.TeamID,
+			availableCb: func(available bool) { wctx.SubscriptionsAvailable = available },
+		},
+		func() { send(ui.ThreadsListDirtyMsg{TeamID: wctx.TeamID}) })
+}
+
+// ensureThreadSubscriptions starts a subscription sync in the
+// background when the gate admits one, and returns immediately
+// either way.
 //
-// It is called from the Threads view's list fetch, which is where the
-// data is first needed. It used to run at boot — before that, on every
-// reconnect — and the Threads view is not what the user is looking at
-// when slk starts, so the cost was paid by everyone and used by the
-// few who open it.
+// Triggers: workspace-ready (boot), Threads-view activation, and the
+// reconnect/wake catch-up. The gate collapses those to at most one
+// sync per threadSubsSyncInterval per workspace: within a session the
+// thread_subscription_changed WS events keep the table current, so
+// re-fetching more often buys nothing.
 //
-// The Once is not an optimisation. The list fetch runs on activation
-// AND on every ThreadsListDirtyMsg, including the one onDone sends, so
-// an ungated trigger would loop. And the call is not cheap:
-// subscriptions.thread.getView paginates to a 1000-item hard cap,
-// measured at ~62 requests per workspace on a real account. Within a
-// session the thread_subscription_changed WS events keep the table
-// current, which is what makes once enough.
+// The workspace's first sync waits out its stagger slot first, so a
+// Grid boot doesn't fire every workspace's sweep in the same second.
+// A sync admitted by boot that is still in its stagger sleep when the
+// user opens the Threads view is fine — the view renders from cache
+// and refreshes via onDone's ThreadsListDirtyMsg.
 //
 // onDone fires only on success — telling the view to re-read a cache
 // that a failed fetch did not change would be a wasted round trip.
-func ensureThreadSubscriptions(ctx context.Context, once *sync.Once, s *threadSubscriptionSync, onDone func()) {
-	once.Do(func() {
-		go func() {
-			if err := s.sync(ctx); err != nil {
-				return
+func ensureThreadSubscriptions(ctx context.Context, gate *threadSubsGate, s *threadSubscriptionSync, onDone func()) {
+	first, ok := gate.tryStart(time.Now())
+	if !ok {
+		return
+	}
+	go func() {
+		defer gate.done()
+		if first {
+			slot := threadSubsStagger.Add(1) - 1
+			if delay := time.Duration(slot) * threadSubsStaggerStep; delay > 0 {
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(delay):
+				}
 			}
-			if onDone != nil {
-				onDone()
-			}
-		}()
-	})
+		}
+		if err := s.sync(ctx); err != nil {
+			return
+		}
+		if onDone != nil {
+			onDone()
+		}
+	}()
 }

--- a/cmd/slk/thread_subscriptions_test.go
+++ b/cmd/slk/thread_subscriptions_test.go
@@ -156,19 +156,73 @@ func TestThreadSubscriptions_SuccessTriggersAvailabilityCallback(t *testing.T) {
 	}
 }
 
-func TestEnsureThreadSubscriptions_FetchesOncePerWorkspace(t *testing.T) {
-	// The Threads view refetches its list on activation and on every
-	// ThreadsListDirtyMsg — including the one this sync itself sends —
-	// so an ungated trigger here would either loop or fire on every
-	// interaction. subscriptions.thread.getView paginates to a
-	// 1000-item hard cap, measured at 62 requests per workspace on a
-	// real account, which makes "once" the difference between a
-	// deferred cost and a much worse one.
+// zeroStagger neutralises the cross-workspace startup stagger for
+// tests that don't exercise it, and restores it afterwards. Without
+// this the package-global slot counter would hand later tests delays
+// of minutes.
+func zeroStagger(t *testing.T) {
+	t.Helper()
+	oldStep := threadSubsStaggerStep
+	threadSubsStagger.Store(0)
+	threadSubsStaggerStep = 0
+	t.Cleanup(func() {
+		threadSubsStaggerStep = oldStep
+		threadSubsStagger.Store(0)
+	})
+}
+
+func TestThreadSubsGate_FirstSyncAdmittedOnce(t *testing.T) {
+	g := &threadSubsGate{window: time.Hour}
+	now := time.Now()
+
+	first, ok := g.tryStart(now)
+	if !ok || !first {
+		t.Fatalf("first tryStart = (%v, %v); want (true, true)", first, ok)
+	}
+	g.done()
+
+	if _, ok := g.tryStart(now.Add(30 * time.Minute)); ok {
+		t.Fatal("tryStart inside the window admitted a second sync")
+	}
+	first, ok = g.tryStart(now.Add(2 * time.Hour))
+	if !ok {
+		t.Fatal("tryStart after the window did not admit a re-sync")
+	}
+	if first {
+		t.Error("re-sync reported first=true; the startup stagger must apply exactly once per workspace")
+	}
+	g.done()
+}
+
+func TestThreadSubsGate_BlocksWhileRunning(t *testing.T) {
+	// A second trigger landing mid-sync (view opened while the boot
+	// sync is still paginating) must not double the request volume,
+	// even when the throttle window has technically elapsed.
+	g := &threadSubsGate{window: 0}
+	if _, ok := g.tryStart(time.Now()); !ok {
+		t.Fatal("first tryStart not admitted")
+	}
+	if _, ok := g.tryStart(time.Now().Add(time.Hour)); ok {
+		t.Fatal("tryStart admitted while a sync is still running")
+	}
+	g.done()
+	if _, ok := g.tryStart(time.Now().Add(time.Hour)); !ok {
+		t.Fatal("tryStart after done() not admitted")
+	}
+}
+
+// The Threads view refetches its list on activation and on every
+// ThreadsListDirtyMsg — including the one this sync itself sends — so
+// an ungated trigger here would either loop or fire on every
+// interaction. subscriptions.thread.getView paginates to a 1000-item
+// hard cap, measured at 62 requests per workspace on a real account.
+func TestEnsureThreadSubscriptions_FetchesOnceWithinWindow(t *testing.T) {
+	zeroStagger(t)
 	db := newTestDB(t)
 	fake := &fakeSubscriptions{response: []slackclient.ThreadSubscriptionView{
 		subView("C1", "1700000100.000000", "1700000150.000000", "p1", "U2", true),
 	}}
-	var once sync.Once
+	gate := &threadSubsGate{window: time.Hour}
 	done := make(chan struct{}, 8)
 
 	var wg sync.WaitGroup
@@ -176,7 +230,7 @@ func TestEnsureThreadSubscriptions_FetchesOncePerWorkspace(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			ensureThreadSubscriptions(context.Background(), &once,
+			ensureThreadSubscriptions(context.Background(), gate,
 				newSubscriptionSync(db, fake, nil),
 				func() { done <- struct{}{} })
 		}()
@@ -186,29 +240,127 @@ func TestEnsureThreadSubscriptions_FetchesOncePerWorkspace(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(2 * time.Second):
-		t.Fatal("the first open never completed a subscription sync")
+		t.Fatal("the first trigger never completed a subscription sync")
 	}
 
 	fake.mu.Lock()
 	calls := fake.calls
 	fake.mu.Unlock()
 	if calls != 1 {
-		t.Errorf("ListThreadSubscriptions called %d times; want 1 — the Threads view opens, refreshes and reopens constantly", calls)
+		t.Errorf("ListThreadSubscriptions called %d times; want 1 — boot, activation and dirty-refresh all trigger this", calls)
 	}
 	if len(done) != 0 {
 		t.Errorf("%d extra completions; the notify must fire once, or every one re-triggers the list fetch", len(done))
 	}
 }
 
+// The gate is a throttle, not a latch: after the window elapses a
+// trigger (wake-from-sleep, WS reconnect) syncs again. This is what
+// freshens threads after the app sat offline with a dead socket.
+func TestEnsureThreadSubscriptions_ResyncsAfterWindow(t *testing.T) {
+	zeroStagger(t)
+	db := newTestDB(t)
+	fake := &fakeSubscriptions{response: []slackclient.ThreadSubscriptionView{
+		subView("C1", "1700000100.000000", "1700000150.000000", "p1", "U2", true),
+	}}
+	gate := &threadSubsGate{window: 20 * time.Millisecond}
+	done := make(chan struct{}, 2)
+
+	ensureThreadSubscriptions(context.Background(), gate,
+		newSubscriptionSync(db, fake, nil),
+		func() { done <- struct{}{} })
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first sync never completed")
+	}
+
+	time.Sleep(40 * time.Millisecond)
+	ensureThreadSubscriptions(context.Background(), gate,
+		newSubscriptionSync(db, fake, nil),
+		func() { done <- struct{}{} })
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("re-sync after the window never completed")
+	}
+
+	fake.mu.Lock()
+	calls := fake.calls
+	fake.mu.Unlock()
+	if calls != 2 {
+		t.Errorf("ListThreadSubscriptions called %d times; want 2 (initial + post-window re-sync)", calls)
+	}
+}
+
+// On boot every workspace becomes ready at once; on Enterprise Grid
+// that would fire N paginated getView sweeps in the same second. The
+// first sync per workspace waits slot*step so the sweeps spread out.
+// The stagger applies to the first sync only — later re-syncs are
+// already thinned out by the window and must not wait.
+func TestEnsureThreadSubscriptions_FirstSyncStaggers(t *testing.T) {
+	oldStep := threadSubsStaggerStep
+	threadSubsStaggerStep = 100 * time.Millisecond
+	threadSubsStagger.Store(2) // this workspace drew slot 2 → 200ms delay
+	t.Cleanup(func() {
+		threadSubsStaggerStep = oldStep
+		threadSubsStagger.Store(0)
+	})
+
+	db := newTestDB(t)
+	fake := &fakeSubscriptions{response: []slackclient.ThreadSubscriptionView{
+		subView("C1", "1700000100.000000", "1700000150.000000", "p1", "U2", true),
+	}}
+	gate := &threadSubsGate{window: 50 * time.Millisecond}
+	done := make(chan struct{}, 2)
+
+	ensureThreadSubscriptions(context.Background(), gate,
+		newSubscriptionSync(db, fake, nil),
+		func() { done <- struct{}{} })
+
+	time.Sleep(50 * time.Millisecond)
+	fake.mu.Lock()
+	early := fake.calls
+	fake.mu.Unlock()
+	if early != 0 {
+		t.Fatalf("first sync fetched after 50ms despite a 200ms stagger slot")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("staggered first sync never completed")
+	}
+
+	// Re-sync after the window: no stagger, runs immediately even
+	// though the slot counter says this process has booted workspaces.
+	time.Sleep(60 * time.Millisecond)
+	ensureThreadSubscriptions(context.Background(), gate,
+		newSubscriptionSync(db, fake, nil),
+		func() { done <- struct{}{} })
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("re-sync after the window never completed")
+	}
+	fake.mu.Lock()
+	calls := fake.calls
+	fake.mu.Unlock()
+	if calls != 2 {
+		t.Errorf("ListThreadSubscriptions called %d times; want 2 (staggered first + immediate re-sync)", calls)
+	}
+}
+
 func TestEnsureThreadSubscriptions_FailureDoesNotNotify(t *testing.T) {
 	// A ThreadsListDirtyMsg after a failed fetch would send the view
 	// back to the same cache it already rendered, for nothing.
+	zeroStagger(t)
 	db := newTestDB(t)
 	fake := &fakeSubscriptions{err: errors.New("boom")}
-	var once sync.Once
+	gate := &threadSubsGate{window: time.Hour}
 	notified := make(chan struct{}, 1)
 
-	ensureThreadSubscriptions(context.Background(), &once,
+	ensureThreadSubscriptions(context.Background(), gate,
 		newSubscriptionSync(db, fake, nil),
 		func() { notified <- struct{}{} })
 

--- a/internal/slack/client.go
+++ b/internal/slack/client.go
@@ -3,6 +3,7 @@ package slackclient
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -1466,6 +1467,20 @@ func (c *Client) ShouldReload(ctx context.Context) (string, error) {
 	return strconv.FormatInt(srr.RecommendedBuildVersion, 10), nil
 }
 
+// rateLimitError is what postForm returns on HTTP 429, carrying the
+// server-advised Retry-After so callers can sleep and retry the same
+// page instead of failing the whole sweep. Slack's internal endpoints
+// answer 429 (not ok=false ratelimited) when a paginated loop outruns
+// the limiter.
+type rateLimitError struct {
+	method     string
+	retryAfter time.Duration
+}
+
+func (e *rateLimitError) Error() string {
+	return fmt.Sprintf("calling %s: rate limited (HTTP 429), retry after %s", e.method, e.retryAfter)
+}
+
 // postForm performs a cookie-aware POST to an endpoint under
 // c.apiBaseURL with form values. The xoxc token is injected into the
 // form body — the same convention slack-go and the official browser
@@ -1505,6 +1520,12 @@ func (c *Client) postForm(ctx context.Context, method string, form url.Values) (
 	// non-2xx here is a transport/proxy/edge failure whose body is HTML
 	// at best: reporting it as a JSON parse failure at the call site
 	// (as this used to) hides what actually happened.
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return nil, &rateLimitError{
+			method:     method,
+			retryAfter: parseRetryAfter(resp.Header.Get("Retry-After"), 5*time.Second),
+		}
+	}
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		return nil, fmt.Errorf("calling %s: HTTP %s: %s", method, resp.Status, truncateForLog(raw))
 	}
@@ -1729,14 +1750,35 @@ const listThreadSubscriptionsHardCap = 1000
 // Returns (nil, err) on network failure or ok=false JSON. The caller
 // (the reconnect backfill phase) treats any error as "subscriptions
 // unavailable" and surfaces the UI banner.
+// listThreadSubscriptionsMaxRateLimitRetries bounds how often one
+// paginated sweep retries a 429ing page. The caller is a background
+// sync; an endpoint that keeps limiting after a few server-advised
+// waits is failed back to the UI banner and the caller's throttle
+// window instead of sleeping forever.
+const listThreadSubscriptionsMaxRateLimitRetries = 3
+
 func (c *Client) ListThreadSubscriptions(ctx context.Context) ([]ThreadSubscriptionView, error) {
 	var all []ThreadSubscriptionView
 	currentTS := ""
+	rateLimitRetries := 0
 	for {
 		body, err := c.callListThreadSubscriptions(ctx, currentTS)
 		if err != nil {
+			var rl *rateLimitError
+			if errors.As(err, &rl) && rateLimitRetries < listThreadSubscriptionsMaxRateLimitRetries {
+				rateLimitRetries++
+				// Retry the SAME page: currentTS deliberately does
+				// not advance.
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(rl.retryAfter):
+				}
+				continue
+			}
 			return nil, err
 		}
+		rateLimitRetries = 0
 		var resp listThreadSubscriptionsResponse
 		if err := json.Unmarshal(body, &resp); err != nil {
 			return nil, fmt.Errorf("parsing subscriptions.thread.getView: %w (body=%s)", err, truncateForLog(body))

--- a/internal/slack/client_test.go
+++ b/internal/slack/client_test.go
@@ -2019,6 +2019,66 @@ func TestListThreadSubscriptions_ReturnsErrorOnNotOK(t *testing.T) {
 	}
 }
 
+func TestListThreadSubscriptions_RetriesOnRateLimit(t *testing.T) {
+	var calls int
+	var capturedCurrentTS []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		_ = r.ParseForm()
+		capturedCurrentTS = append(capturedCurrentTS, r.PostForm.Get("current_ts"))
+		if calls == 1 {
+			w.Header().Set("Retry-After", "0") // retry immediately, keep test fast
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok": true, "threads": [], "has_more": false, "max_ts": ""}`))
+	}))
+	defer srv.Close()
+
+	c := &Client{token: "xoxc-test", cookie: "d-cookie", apiBaseURL: srv.URL + "/api/"}
+	got, err := c.ListThreadSubscriptions(context.Background())
+	if err != nil {
+		t.Fatalf("ListThreadSubscriptions: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 API calls (1 rate-limited + 1 retry), got %d", calls)
+	}
+	if len(got) != 0 {
+		t.Errorf("len(got) = %d, want 0", len(got))
+	}
+	// On rate-limit the cursor must NOT advance — the retry hits the same page.
+	if capturedCurrentTS[0] != "" || capturedCurrentTS[1] != "" {
+		t.Errorf("current_ts = %v, want [\"\", \"\"]", capturedCurrentTS)
+	}
+}
+
+func TestListThreadSubscriptions_GivesUpAfterRepeatedRateLimits(t *testing.T) {
+	// A persistently 429ing endpoint must not spin the background sync
+	// forever: bound the retries, return the error, let the UI banner
+	// and the caller's throttle window back off instead.
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Retry-After", "0")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	c := &Client{token: "xoxc-test", cookie: "d-cookie", apiBaseURL: srv.URL + "/api/"}
+	_, err := c.ListThreadSubscriptions(context.Background())
+	if err == nil {
+		t.Fatal("expected error after repeated 429s, got nil")
+	}
+	if !strings.Contains(err.Error(), "rate") {
+		t.Errorf("error = %q, want it to mention rate limiting", err.Error())
+	}
+	// 1 initial + bounded retries; unbounded would hang this test.
+	if calls < 2 || calls > 5 {
+		t.Errorf("calls = %d, want a small bounded retry count (2..5)", calls)
+	}
+}
+
 func TestNewClient_UsesBrowserTransport(t *testing.T) {
 	var gotHeaders http.Header
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/ui/reducer_threads.go
+++ b/internal/ui/reducer_threads.go
@@ -145,9 +145,11 @@ var reduceThreads reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
 		if a.activeTeamID != "" {
 			threads := a.threads
 			team := ids.TeamID(a.activeTeamID)
-			// Opening the view is what pays for the subscription
-			// fetch. It returns immediately and refreshes the list via
-			// ThreadsListDirtyMsg when it lands, so the ListFetch
+			// Activation is the sync's safety-net trigger (boot via
+			// workspace-ready is the primary one). The implementation
+			// throttles, so this fires unconditionally; it returns
+			// immediately and refreshes the list via
+			// ThreadsListDirtyMsg when a fetch lands, so the ListFetch
 			// below still renders from cache first.
 			batch = append(batch, func() tea.Msg {
 				threads.EnsureSubscriptions(team)

--- a/internal/ui/reducer_threads_test.go
+++ b/internal/ui/reducer_threads_test.go
@@ -8,15 +8,18 @@ import (
 	"github.com/gammons/slk/internal/ids"
 )
 
-// TestApp_OnlyThreadsViewActivationEnsuresSubscriptions pins where the
-// subscriptions.thread.getView fetch is allowed to happen.
+// TestApp_WorkspaceReadyAndActivationBothEnsureSubscriptions pins where
+// the subscriptions.thread.getView fetch is triggered.
 //
-// The list fetcher runs on workspace-ready too, because the sidebar
-// shows a Threads unread badge before the user ever opens the view —
-// but that read is cache-only. Hanging the network sync off it puts a
-// ~62-request paginated call back into every boot, which is what this
-// task removed.
-func TestApp_OnlyThreadsViewActivationEnsuresSubscriptions(t *testing.T) {
+// Boot is a trigger because the socket replays nothing: an app that
+// was closed (or asleep) for days missed every thread_subscription_
+// changed event, and rendering the threads view from the days-old
+// SQLite snapshot is the staleness this fetch fixes. Activation stays
+// a trigger as a safety net. Collapsing both to one actual network
+// sweep per workspace is the main-package gate's job
+// (threadSubsGate) — the reducer deliberately fires unconditionally
+// and stays dumb about throttling.
+func TestApp_WorkspaceReadyAndActivationBothEnsureSubscriptions(t *testing.T) {
 	app := NewApp()
 	ensured := make(chan string, 4)
 	app.SetThreadService(NewThreadService(ThreadServiceFuncs{
@@ -34,8 +37,11 @@ func TestApp_OnlyThreadsViewActivationEnsuresSubscriptions(t *testing.T) {
 	}
 	select {
 	case team := <-ensured:
-		t.Fatalf("workspace-ready ensured subscriptions for %s; that fetch belongs to the first Threads-view open", team)
-	case <-time.After(50 * time.Millisecond):
+		if team != "T1" {
+			t.Errorf("workspace-ready ensured subscriptions for %q; want T1", team)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("workspace-ready did not ensure subscriptions; a workspace slk never opens the Threads view on stays stale for the whole session")
 	}
 
 	app.activeTeamID = "T1"
@@ -46,9 +52,9 @@ func TestApp_OnlyThreadsViewActivationEnsuresSubscriptions(t *testing.T) {
 	select {
 	case team := <-ensured:
 		if team != "T1" {
-			t.Errorf("ensured subscriptions for %q; want T1", team)
+			t.Errorf("activation ensured subscriptions for %q; want T1", team)
 		}
 	case <-time.After(100 * time.Millisecond):
-		t.Fatal("opening the Threads view did not ensure subscriptions; the list would render from a cache nothing ever fills")
+		t.Fatal("opening the Threads view did not ensure subscriptions")
 	}
 }

--- a/internal/ui/reducer_workspace.go
+++ b/internal/ui/reducer_workspace.go
@@ -239,6 +239,17 @@ func reduceWorkspaceReady(a *App, m WorkspaceReadyMsg) tea.Cmd {
 	threads := a.threads
 	team := ids.TeamID(m.TeamID)
 	batch = append(batch, func() tea.Msg { return threads.ListFetch(team) })
+	// Boot is also the subscription sync's primary trigger: the socket
+	// replays nothing, so after any offline gap (app closed, laptop
+	// asleep) the cached thread_subscriptions table is stale and only
+	// subscriptions.thread.getView reconciles it. Fires for EVERY
+	// workspace, not just the active one — the reducer stays dumb;
+	// the main-package gate collapses this to one throttled, staggered
+	// network sweep per workspace.
+	batch = append(batch, func() tea.Msg {
+		threads.EnsureSubscriptions(team)
+		return nil
+	})
 	return tea.Batch(batch...)
 }
 

--- a/internal/ui/services.go
+++ b/internal/ui/services.go
@@ -158,15 +158,17 @@ type ThreadService interface {
 	// ThreadsListLoadedMsg).
 	ListFetch(teamID ids.TeamID) tea.Msg
 
-	// EnsureSubscriptions makes sure the workspace's thread
-	// subscriptions have been fetched from Slack at least once this
-	// session, in the background.
+	// EnsureSubscriptions kicks the workspace's throttled thread-
+	// subscription sync (subscriptions.thread.getView) in the
+	// background. Called on workspace-ready and on Threads-view
+	// activation; the implementation collapses those to at most one
+	// network sweep per throttle window, so callers fire
+	// unconditionally.
 	//
 	// Separate from ListFetch because ListFetch is cache-only and runs
 	// on workspace-ready (for the sidebar's Threads badge), whereas
-	// this issues subscriptions.thread.getView, which paginates to a
-	// 1000-item hard cap — measured at ~62 requests per workspace.
-	// Only opening the Threads view is worth that.
+	// this may issue subscriptions.thread.getView, which paginates to
+	// a 1000-item hard cap — measured at ~62 requests per workspace.
 	EnsureSubscriptions(teamID ids.TeamID)
 
 	// ChannelLastRead returns the parent channel's last_read_ts so


### PR DESCRIPTION
## Problem

The threads view went stale after any offline gap (app closed for days, laptop asleep). Root cause:

- Startup rendered the threads list **cache-only** — no network fetch.
- The Slack socket **replays nothing** missed while disconnected.
- The only `subscriptions.thread.getView` sync ran **once per session**, gated by `sync.Once`, and only on first Threads-view open.
- Reconnect/wake catch-up deliberately discarded all thread state.

## Fix

- **Boot trigger**: `WorkspaceReady` now fires `EnsureSubscriptions` for *every* workspace (via `router.ByID`, so background Enterprise Grid workspaces sync too). Threads-view activation stays as a safety-net trigger.
- **Throttle, not latch**: `sync.Once` replaced by `threadSubsGate` — at most one paginated sweep per 30-minute window per workspace, never two concurrently. This keeps the per-session request cost identical to today while allowing re-sync after long offline gaps.
- **Grid-friendly stagger**: each workspace's first sync waits `slot × 15s`, so a multi-workspace boot doesn't fire N ~62-request sweeps in the same second.
- **Reconnect/wake kick**: `syncOnReconnect` fires the gated sync; the gate owns throttling so the kick costs nothing when a sync is recent.
- **429 handling**: `postForm` surfaces a typed `rateLimitError` carrying `Retry-After`; `ListThreadSubscriptions` sleeps and retries the same page (cursor does not advance), bounded to 3 retries instead of hard-failing into the banner.

## Testing

- New tests: gate semantics (throttle window, first-sync flag, concurrent exclusion), ensure triggers (once-per-window, re-sync after window, first-sync stagger, no notify on failure), 429 retry/give-up, reducer boot trigger, reconnect kick (incl. surviving a deduped pass).
- The test pinning the old activation-only behavior was rewritten to pin the new boot+activation behavior.
- `go test -race ./cmd/slk/ ./internal/slack/ ./internal/ui/` passes; `go vet` clean. (`TestUserResolver_BatchesMissesThroughEdge` flakes identically on the untouched baseline — pre-existing.)

Out of scope (follow-up possible): reply counts / "last reply by" per thread still only refresh when a thread is opened.