### PR TITLE
fix(release): build darwin binaries with cgo so Ctrl+V paste works

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,4 +61,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.12.2
+          # v2.13.0+ is required for go1.27 (which setup-go's "stable"
+          # now resolves to); older binaries panic in go/types with
+          # "file requires newer Go version go1.27".
+          version: v2.13.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,12 @@ permissions:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    # macOS runner, not Ubuntu: the darwin build sets CGO_ENABLED=1 so
+    # clipboard paste works (issue #156), and cgo for darwin needs the
+    # Apple SDK at link time. Go on macOS still cross-compiles the
+    # CGO_ENABLED=0 linux/windows targets, and nfpm runs fine there, so a
+    # single job covers every artifact.
+    runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,7 +8,36 @@ before:
   hooks:
     - go mod tidy
 
+# Two build entries because of cgo:
+#
+#   * darwin NEEDS CGO_ENABLED=1: golang.design/x/clipboard reads the macOS
+#     pasteboard through Cocoa, which is cgo-only. The CGO_ENABLED=0 cask
+#     binary made clipboard.Init() fail at startup and silently disabled
+#     Ctrl+V smart-paste (issue #156). This requires the release workflow
+#     to run on a macOS runner.
+#   * linux/windows stay CGO_ENABLED=0: static binaries are what make the
+#     deb/rpm/apk packages and the Windows zip portable. Linux Wayland paste
+#     works without cgo (slk shells out to wl-paste); Linux X11 paste needs
+#     cgo + libX11, and dynamically linking it would break musl/Alpine and
+#     minimal containers, so release binaries keep X11 paste disabled.
 builds:
+  - id: slk-darwin
+    main: ./cmd/slk
+    binary: slk
+    env:
+      - CGO_ENABLED=1
+    goos:
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
   - id: slk
     main: ./cmd/slk
     binary: slk
@@ -16,7 +45,6 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
-      - darwin
       - windows
     goarch:
       - amd64


### PR DESCRIPTION
## Problem

The Homebrew cask binary (and all release artifacts) were built with `CGO_ENABLED=0`. `golang.design/x/clipboard` reads the macOS pasteboard through Cocoa, which is cgo-only, so `clipboard.Init()` failed at startup with `clipboard: cannot use when CGO_ENABLED=0` and slk silently disabled the whole Ctrl+V smart-paste path.

Fixes #156 — confirmed by the reporter that a `CGO_ENABLED=1` rebuild resolves it.

## Changes

- **`.goreleaser.yaml`**: split the single build entry in two —
  - `slk-darwin`: `CGO_ENABLED=1` so clipboard init succeeds and the binary links Cocoa/AppKit/Foundation
  - `slk` (linux/windows): stays `CGO_ENABLED=0`, keeping the static binaries that make the deb/rpm/apk packages and Windows zip portable
- **`.github/workflows/release.yml`**: release job now runs on `macos-latest`, since cgo for darwin needs the Apple SDK at link time. Go on macOS still cross-compiles the `CGO_ENABLED=0` linux/windows targets, and nfpm runs fine on macOS, so a single job still produces every artifact (archives, checksums, packages, Homebrew cask).

## Validation

- `goreleaser check` passes
- `goreleaser build --snapshot --single-target` succeeds (linux/amd64 static build; the darwin cgo build can only run on the macOS runner)
- The real end-to-end test is the next tag; the config mirrors the reporter's verified local fix

## Known remaining gap (out of scope)

Linux X11 paste in release binaries stays disabled: enabling it would require `CGO_ENABLED=1` + dynamically linking libX11, which breaks musl/Alpine and minimal systems. Wayland paste is unaffected (slk shells out to `wl-paste`, pure Go). The issue's secondary suggestion — a visible UI warning when clipboard init fails instead of silently disabling paste — could be a follow-up.