### PR TITLE
fix(slackdesktop): pick the most recently used Slack profile

### DIFF
--- a/cmd/slk/onboarding.go
+++ b/cmd/slk/onboarding.go
@@ -132,6 +132,8 @@ func desktopErrorMessage(err error) string {
 		return "Your system keyring is locked. Unlock it (log in to your desktop session) and retry."
 	case errors.Is(err, slackdesktop.ErrNoSecretService):
 		return "No system keyring/secret service found. slk needs it to read the Slack session."
+	case errors.Is(err, slackdesktop.ErrSecretNotFound):
+		return "No Slack entry found in your keyring. Sign in to the Slack desktop app (and make sure it uses the system keyring), then retry."
 	case errors.Is(err, slackdesktop.ErrDecryptFailed):
 		return "Could not decrypt the Slack session cookie. Please file an issue with your OS + Slack version."
 	default:

--- a/internal/slackdesktop/configdir.go
+++ b/internal/slackdesktop/configdir.go
@@ -21,10 +21,29 @@ func configDirForOS(goos string, getenv func(string) string, exists func(string)
 		}
 		return second
 	default: // linux and others
-		if x := getenv("XDG_CONFIG_DIR"); x != "" {
-			return filepath.Join(x, "Slack")
+		home := getenv("HOME")
+		var candidates []string
+		if x := getenv("XDG_CONFIG_HOME"); x != "" {
+			candidates = append(candidates, filepath.Join(x, "Slack"))
 		}
-		return filepath.Join(getenv("HOME"), ".config", "Slack")
+		if x := getenv("XDG_CONFIG_DIR"); x != "" {
+			candidates = append(candidates, filepath.Join(x, "Slack"))
+		}
+		candidates = append(candidates,
+			filepath.Join(home, ".config", "Slack"),
+			// flatpak (com.slack.Slack)
+			filepath.Join(home, ".var", "app", "com.slack.Slack", "config", "Slack"),
+			// snap
+			filepath.Join(home, "snap", "slack", "current", ".config", "Slack"),
+		)
+		for _, c := range candidates {
+			if exists(c) {
+				return c
+			}
+		}
+		// Nothing found: fall back to the primary location so the
+		// not-found error references the conventional path.
+		return candidates[0]
 	}
 }
 

--- a/internal/slackdesktop/configdir.go
+++ b/internal/slackdesktop/configdir.go
@@ -4,25 +4,82 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"time"
 )
 
+// profileInfo describes a candidate Slack desktop profile directory.
+type profileInfo struct {
+	// lastUsed is the newest mtime among the profile's session files. It
+	// stands in for "when was this Slack install last signed in with", and
+	// is only meaningful when live is true.
+	lastUsed time.Time
+	// live reports whether the directory holds the files needed to pull a
+	// session out of it.
+	live bool
+	// exists reports whether the directory is there at all. A dir that
+	// exists but is not live is still the better thing to name in an error
+	// than a path that was never created.
+	exists bool
+}
+
+// profileProber reports whether a directory is a usable Slack profile and when
+// it was last used. Injected into configDirForOS for testability.
+type profileProber func(dir string) profileInfo
+
+// profileInfoAt probes a real directory on disk. A profile only counts as live
+// when it has both the workspace list and the cookie DB, since either one
+// missing leaves us unable to authenticate.
+func profileInfoAt(dir string) profileInfo {
+	info, err := os.Stat(dir)
+	if err != nil || !info.IsDir() {
+		return profileInfo{}
+	}
+	cookies, err := os.Stat(filepath.Join(dir, "Cookies"))
+	if err != nil {
+		return profileInfo{exists: true}
+	}
+	rootState, err := os.Stat(filepath.Join(dir, "storage", "root-state.json"))
+	if err != nil {
+		return profileInfo{exists: true}
+	}
+
+	newest := cookies.ModTime()
+	if t := rootState.ModTime(); t.After(newest) {
+		newest = t
+	}
+	// The leveldb dir is where the xoxc tokens live; a running Slack touches
+	// it, so it is often the freshest signal of the three.
+	if ldb, err := os.Stat(filepath.Join(dir, "Local Storage", "leveldb")); err == nil {
+		if t := ldb.ModTime(); t.After(newest) {
+			newest = t
+		}
+	}
+	return profileInfo{lastUsed: newest, live: true, exists: true}
+}
+
 // configDirForOS computes the Slack desktop config dir for a given OS.
-// getenv and exists are injected for testability.
-func configDirForOS(goos string, getenv func(string) string, exists func(string) bool) string {
+// getenv and probe are injected for testability.
+//
+// Several Slack packagings can leave a profile directory behind on one machine
+// (a removed .deb next to a flatpak, an unsandboxed profile next to the App
+// Store one). Preferring whichever path exists first picks the leftover just as
+// happily as the live install, and a stale profile yields credentials that
+// Slack rejects with invalid_auth. So among the profiles that look usable, take
+// the most recently used one; candidate order only breaks ties.
+func configDirForOS(goos string, getenv func(string) string, probe profileProber) string {
+	var candidates []string
 	switch goos {
 	case "windows":
+		// Slack on Windows has a single install location.
 		return filepath.Join(getenv("APPDATA"), "Slack")
 	case "darwin":
 		home := getenv("HOME")
-		first := filepath.Join(home, "Library", "Application Support", "Slack")
-		second := filepath.Join(home, "Library", "Containers", "com.tinyspeck.slackmacgap", "Data", "Library", "Application Support", "Slack")
-		if exists(first) {
-			return first
+		candidates = []string{
+			filepath.Join(home, "Library", "Application Support", "Slack"),
+			filepath.Join(home, "Library", "Containers", "com.tinyspeck.slackmacgap", "Data", "Library", "Application Support", "Slack"),
 		}
-		return second
 	default: // linux and others
 		home := getenv("HOME")
-		var candidates []string
 		if x := getenv("XDG_CONFIG_HOME"); x != "" {
 			candidates = append(candidates, filepath.Join(x, "Slack"))
 		}
@@ -36,24 +93,36 @@ func configDirForOS(goos string, getenv func(string) string, exists func(string)
 			// snap
 			filepath.Join(home, "snap", "slack", "current", ".config", "Slack"),
 		)
-		for _, c := range candidates {
-			if exists(c) {
-				return c
-			}
-		}
-		// Nothing found: fall back to the primary location so the
-		// not-found error references the conventional path.
-		return candidates[0]
 	}
+
+	best, firstExisting := "", ""
+	var bestUsed time.Time
+	for _, c := range candidates {
+		info := probe(c)
+		// Strictly After, so the earliest candidate wins a tie.
+		if info.live && (best == "" || info.lastUsed.After(bestUsed)) {
+			best, bestUsed = c, info.lastUsed
+		}
+		if info.exists && firstExisting == "" {
+			firstExisting = c
+		}
+	}
+	if best != "" {
+		return best
+	}
+	// No profile has a session in it. Name a directory that is at least
+	// there, so the caller's error points at the install the user has,
+	// falling back to the conventional path when there is none.
+	if firstExisting != "" {
+		return firstExisting
+	}
+	return candidates[0]
 }
 
 // ConfigDir returns the Slack desktop config dir, or ErrDesktopNotFound if it
 // does not exist on disk.
 func ConfigDir() (string, error) {
-	dir := configDirForOS(runtime.GOOS, os.Getenv, func(p string) bool {
-		info, err := os.Stat(p)
-		return err == nil && info.IsDir()
-	})
+	dir := configDirForOS(runtime.GOOS, os.Getenv, profileInfoAt)
 	info, err := os.Stat(dir)
 	if err != nil || !info.IsDir() {
 		return "", ErrDesktopNotFound

--- a/internal/slackdesktop/configdir_test.go
+++ b/internal/slackdesktop/configdir_test.go
@@ -1,9 +1,22 @@
 package slackdesktop
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
+
+// probeFrom builds a profileProber from a map of dir -> last-used time. Any
+// directory absent from the map probes as not a usable profile.
+func probeFrom(live map[string]time.Time) profileProber {
+	return func(dir string) profileInfo {
+		if t, ok := live[dir]; ok {
+			return profileInfo{lastUsed: t, live: true, exists: true}
+		}
+		return profileInfo{}
+	}
+}
 
 func TestConfigDirForOS(t *testing.T) {
 	env := func(m map[string]string) func(string) string {
@@ -19,24 +32,32 @@ func TestConfigDirForOS(t *testing.T) {
 		{"windows", map[string]string{"APPDATA": `C:\Users\x\AppData\Roaming`}, filepath.Join(`C:\Users\x\AppData\Roaming`, "Slack")},
 	}
 	for _, c := range cases {
-		got := configDirForOS(c.goos, env(c.env), func(string) bool { return false })
+		got := configDirForOS(c.goos, env(c.env), probeFrom(nil))
 		if got != c.want {
 			t.Errorf("configDirForOS(%s) = %q, want %q", c.goos, got, c.want)
 		}
 	}
 }
 
-func TestConfigDirForOSDarwinPrefersFirstExisting(t *testing.T) {
+func TestConfigDirForOSDarwinPrefersLiveProfile(t *testing.T) {
 	home := "/Users/x"
 	first := filepath.Join(home, "Library", "Application Support", "Slack")
-	got := configDirForOS("darwin", func(k string) string {
+	sandboxed := filepath.Join(home, "Library", "Containers", "com.tinyspeck.slackmacgap", "Data", "Library", "Application Support", "Slack")
+	getenv := func(k string) string {
 		if k == "HOME" {
 			return home
 		}
 		return ""
-	}, func(p string) bool { return p == first })
-	if got != first {
+	}
+	stale := time.Date(2025, 6, 5, 0, 0, 0, 0, time.UTC)
+	fresh := time.Date(2026, 8, 21, 0, 0, 0, 0, time.UTC)
+
+	if got := configDirForOS("darwin", getenv, probeFrom(map[string]time.Time{first: stale})); got != first {
 		t.Errorf("darwin config dir = %q, want %q", got, first)
+	}
+	// A leftover unsandboxed profile must not shadow the App Store one.
+	if got := configDirForOS("darwin", getenv, probeFrom(map[string]time.Time{first: stale, sandboxed: fresh})); got != sandboxed {
+		t.Errorf("darwin config dir = %q, want %q", got, sandboxed)
 	}
 }
 
@@ -45,56 +66,176 @@ func TestConfigDirForOSLinuxPackaging(t *testing.T) {
 	native := filepath.Join(home, ".config", "Slack")
 	flatpak := filepath.Join(home, ".var", "app", "com.slack.Slack", "config", "Slack")
 	snap := filepath.Join(home, "snap", "slack", "current", ".config", "Slack")
+	now := time.Date(2026, 8, 21, 0, 0, 0, 0, time.UTC)
 
 	cases := []struct {
-		name   string
-		env    map[string]string
-		exists func(string) bool
-		want   string
+		name string
+		env  map[string]string
+		live map[string]time.Time
+		want string
 	}{
 		{
-			name:   "flatpak only",
-			env:    map[string]string{"HOME": home},
-			exists: func(p string) bool { return p == flatpak },
-			want:   flatpak,
+			name: "flatpak only",
+			env:  map[string]string{"HOME": home},
+			live: map[string]time.Time{flatpak: now},
+			want: flatpak,
 		},
 		{
-			name:   "snap only",
-			env:    map[string]string{"HOME": home},
-			exists: func(p string) bool { return p == snap },
-			want:   snap,
+			name: "snap only",
+			env:  map[string]string{"HOME": home},
+			live: map[string]time.Time{snap: now},
+			want: snap,
 		},
 		{
-			name:   "native preferred over flatpak",
-			env:    map[string]string{"HOME": home},
-			exists: func(p string) bool { return p == native || p == flatpak },
-			want:   native,
+			name: "native wins ties against flatpak",
+			env:  map[string]string{"HOME": home},
+			live: map[string]time.Time{native: now, flatpak: now},
+			want: native,
 		},
 		{
-			name:   "flatpak preferred over snap",
-			env:    map[string]string{"HOME": home},
-			exists: func(p string) bool { return p == flatpak || p == snap },
-			want:   flatpak,
+			name: "flatpak wins ties against snap",
+			env:  map[string]string{"HOME": home},
+			live: map[string]time.Time{flatpak: now, snap: now},
+			want: flatpak,
 		},
 		{
-			name:   "xdg config home preferred when present",
-			env:    map[string]string{"HOME": home, "XDG_CONFIG_HOME": "/cfg"},
-			exists: func(p string) bool { return p == "/cfg/Slack" || p == flatpak },
-			want:   "/cfg/Slack",
+			name: "xdg config home wins ties against flatpak",
+			env:  map[string]string{"HOME": home, "XDG_CONFIG_HOME": "/cfg"},
+			live: map[string]time.Time{"/cfg/Slack": now, flatpak: now},
+			want: "/cfg/Slack",
 		},
 		{
-			name:   "xdg dir set but missing falls through to flatpak",
-			env:    map[string]string{"HOME": home, "XDG_CONFIG_DIR": "/cfg"},
-			exists: func(p string) bool { return p == flatpak },
-			want:   flatpak,
+			name: "xdg dir set but not a profile falls through to flatpak",
+			env:  map[string]string{"HOME": home, "XDG_CONFIG_DIR": "/cfg"},
+			live: map[string]time.Time{flatpak: now},
+			want: flatpak,
 		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := configDirForOS("linux", func(k string) string { return c.env[k] }, c.exists)
+			got := configDirForOS("linux", func(k string) string { return c.env[k] }, probeFrom(c.live))
 			if got != c.want {
 				t.Errorf("configDirForOS(linux) = %q, want %q", got, c.want)
 			}
 		})
+	}
+}
+
+func TestConfigDirForOSLinuxPrefersFreshestProfile(t *testing.T) {
+	home := "/home/x"
+	native := filepath.Join(home, ".config", "Slack")
+	flatpak := filepath.Join(home, ".var", "app", "com.slack.Slack", "config", "Slack")
+	snap := filepath.Join(home, "snap", "slack", "current", ".config", "Slack")
+
+	// A leftover native profile from an uninstalled .deb must not shadow the
+	// flatpak profile actually in use. Both directories exist and both hold a
+	// full set of session files, so only recency tells them apart.
+	stale := time.Date(2025, 6, 5, 0, 0, 0, 0, time.UTC)
+	fresh := time.Date(2026, 8, 21, 21, 23, 0, 0, time.UTC)
+
+	cases := []struct {
+		name string
+		env  map[string]string
+		live map[string]time.Time
+		want string
+	}{
+		{
+			name: "stale native loses to fresh flatpak",
+			env:  map[string]string{"HOME": home},
+			live: map[string]time.Time{native: stale, flatpak: fresh},
+			want: flatpak,
+		},
+		{
+			name: "fresh native beats stale flatpak",
+			env:  map[string]string{"HOME": home},
+			live: map[string]time.Time{native: fresh, flatpak: stale},
+			want: native,
+		},
+		{
+			name: "stale snap loses to fresh flatpak",
+			env:  map[string]string{"HOME": home},
+			live: map[string]time.Time{snap: stale, flatpak: fresh},
+			want: flatpak,
+		},
+		{
+			name: "a native dir that is not a profile never wins",
+			env:  map[string]string{"HOME": home},
+			live: map[string]time.Time{flatpak: stale},
+			want: flatpak,
+		},
+		{
+			name: "xdg config home competes on recency like any native path",
+			env:  map[string]string{"HOME": home, "XDG_CONFIG_HOME": "/cfg"},
+			live: map[string]time.Time{"/cfg/Slack": stale, flatpak: fresh},
+			want: flatpak,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := configDirForOS("linux", func(k string) string { return c.env[k] }, probeFrom(c.live))
+			if got != c.want {
+				t.Errorf("configDirForOS(linux) = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestProfileInfoAtRequiresSessionFiles(t *testing.T) {
+	dir := t.TempDir()
+	if got := profileInfoAt(dir); got.live {
+		t.Errorf("empty dir probed live, want not live")
+	}
+
+	writeFile(t, filepath.Join(dir, "storage", "root-state.json"), `{"workspaces":{}}`)
+	if got := profileInfoAt(dir); got.live {
+		t.Errorf("dir with only root-state.json probed live, want not live")
+	}
+
+	writeFile(t, filepath.Join(dir, "Cookies"), "x")
+	got := profileInfoAt(dir)
+	if !got.live {
+		t.Fatalf("dir with root-state.json and Cookies probed not live, want live")
+	}
+	if got.lastUsed.IsZero() {
+		t.Errorf("lastUsed is zero, want the Cookies mtime")
+	}
+}
+
+func TestProfileInfoAtUsesNewestSessionFile(t *testing.T) {
+	dir := t.TempDir()
+	rootState := filepath.Join(dir, "storage", "root-state.json")
+	cookies := filepath.Join(dir, "Cookies")
+	writeFile(t, rootState, `{"workspaces":{}}`)
+	writeFile(t, cookies, "x")
+
+	old := time.Now().Add(-72 * time.Hour)
+	recent := time.Now().Add(-1 * time.Hour)
+	chtimes(t, rootState, recent)
+	chtimes(t, cookies, old)
+
+	got := profileInfoAt(dir)
+	if !got.live {
+		t.Fatalf("probed not live, want live")
+	}
+	// root-state.json is the newer of the two, so it sets lastUsed.
+	if got.lastUsed.Before(recent.Add(-time.Minute)) {
+		t.Errorf("lastUsed = %v, want about %v (the newest session file)", got.lastUsed, recent)
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func chtimes(t *testing.T, path string, mtime time.Time) {
+	t.Helper()
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/slackdesktop/configdir_test.go
+++ b/internal/slackdesktop/configdir_test.go
@@ -39,3 +39,62 @@ func TestConfigDirForOSDarwinPrefersFirstExisting(t *testing.T) {
 		t.Errorf("darwin config dir = %q, want %q", got, first)
 	}
 }
+
+func TestConfigDirForOSLinuxPackaging(t *testing.T) {
+	home := "/home/x"
+	native := filepath.Join(home, ".config", "Slack")
+	flatpak := filepath.Join(home, ".var", "app", "com.slack.Slack", "config", "Slack")
+	snap := filepath.Join(home, "snap", "slack", "current", ".config", "Slack")
+
+	cases := []struct {
+		name   string
+		env    map[string]string
+		exists func(string) bool
+		want   string
+	}{
+		{
+			name:   "flatpak only",
+			env:    map[string]string{"HOME": home},
+			exists: func(p string) bool { return p == flatpak },
+			want:   flatpak,
+		},
+		{
+			name:   "snap only",
+			env:    map[string]string{"HOME": home},
+			exists: func(p string) bool { return p == snap },
+			want:   snap,
+		},
+		{
+			name:   "native preferred over flatpak",
+			env:    map[string]string{"HOME": home},
+			exists: func(p string) bool { return p == native || p == flatpak },
+			want:   native,
+		},
+		{
+			name:   "flatpak preferred over snap",
+			env:    map[string]string{"HOME": home},
+			exists: func(p string) bool { return p == flatpak || p == snap },
+			want:   flatpak,
+		},
+		{
+			name:   "xdg config home preferred when present",
+			env:    map[string]string{"HOME": home, "XDG_CONFIG_HOME": "/cfg"},
+			exists: func(p string) bool { return p == "/cfg/Slack" || p == flatpak },
+			want:   "/cfg/Slack",
+		},
+		{
+			name:   "xdg dir set but missing falls through to flatpak",
+			env:    map[string]string{"HOME": home, "XDG_CONFIG_DIR": "/cfg"},
+			exists: func(p string) bool { return p == flatpak },
+			want:   flatpak,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := configDirForOS("linux", func(k string) string { return c.env[k] }, c.exists)
+			if got != c.want {
+				t.Errorf("configDirForOS(linux) = %q, want %q", got, c.want)
+			}
+		})
+	}
+}

--- a/internal/slackdesktop/errors.go
+++ b/internal/slackdesktop/errors.go
@@ -8,5 +8,6 @@ var (
 	ErrCookieDBMissing = errors.New("slack cookie database not found")
 	ErrKeyringLocked   = errors.New("system keyring is locked")
 	ErrNoSecretService = errors.New("no system secret service available")
+	ErrSecretNotFound  = errors.New("slack secret not found in system keyring")
 	ErrDecryptFailed   = errors.New("failed to decrypt slack session cookie")
 )

--- a/internal/slackdesktop/password_linux.go
+++ b/internal/slackdesktop/password_linux.go
@@ -53,5 +53,5 @@ func findKeyringPassword(searchItems searchSecretItemsFunc) ([]byte, error) {
 	if foundLocked {
 		return nil, ErrKeyringLocked
 	}
-	return nil, ErrNoSecretService
+	return nil, ErrSecretNotFound
 }

--- a/internal/slackdesktop/password_linux_test.go
+++ b/internal/slackdesktop/password_linux_test.go
@@ -82,7 +82,7 @@ func TestFindKeyringPasswordErrors(t *testing.T) {
 			search: func(map[string]string) ([]*gosecret.Item, []*gosecret.Item, error) {
 				return nil, nil, nil
 			},
-			want: ErrNoSecretService,
+			want: ErrSecretNotFound,
 		},
 		{
 			name: "matching item is locked",

--- a/wiki/Setup.md
+++ b/wiki/Setup.md
@@ -7,7 +7,8 @@ that the Slack desktop app is installed and you're signed in to it.
 ## 1. Sign in to the Slack desktop app
 
 Install the Slack desktop app if you haven't already, and sign in to each
-workspace you want to use in slk.
+workspace you want to use in slk. Native packages, flatpak
+(`com.slack.Slack`), and snap installs are all detected on Linux.
 
 ## 2. Add your workspaces
 


### PR DESCRIPTION
Follow-up to #128, targeting that PR's branch rather than `main` so it can be
folded in before the PR lands.

## The problem

I built #128 to use slk with flatpak Slack on Manjaro. The new detection works,
but slk still couldn't authenticate — every workspace failed with
`auth test failed: invalid_auth`.

The cause isn't detection, it's precedence. I have a leftover profile from a
`.deb` install I stopped using in June 2025, sitting next to the flatpak profile
I actually use:

| path | last touched |
| --- | --- |
| `~/.config/Slack` | 2025-06-05 (removed `.deb`) |
| `~/.var/app/com.slack.Slack/config/Slack` | today (flatpak, live) |

`configDirForOS` returns the first candidate that exists, and `~/.config/Slack`
is checked first. So slk read 14-month-dead cookies and tokens:

```
ConfigDir: /home/yml/.config/Slack
  gophers               CONNECT FAIL: auth test failed: invalid_auth
  lincolnloop           CONNECT FAIL: auth test failed: invalid_auth
  ... (all 8 workspaces)
```

Forcing the flatpak dir via `XDG_CONFIG_HOME` made all of them connect, which
confirmed the diagnosis.

Existence alone can't tell the two apart. Both directories hold a full set of
session files — `Cookies`, `storage/root-state.json`, `Local Storage/leveldb`.
Only the timestamps differ.

## The change

Probe each candidate and take the **most recently used** profile instead of the
first one that exists. Candidate order now only breaks ties, so the existing
preferences (xdg > native > flatpak > snap) still hold when timestamps match.

- A directory counts as a profile only when it has **both**
  `storage/root-state.json` and `Cookies`. Either one missing leaves us unable
  to authenticate anyway.
- Its age is the newest mtime among those two plus `Local Storage/leveldb`. A
  running Slack touches leveldb, so it's often the freshest signal.
- `exists` is tracked separately from `live`, so a directory that's present but
  never signed into still gets named in the resulting error rather than falling
  back to a path that was never created.
- The same fix applies on **darwin**, where a leftover unsandboxed profile can
  shadow the App Store one identically. **Windows** is untouched — single
  install location, returns early.

The test seam changed from `exists func(string) bool` to
`probe func(string) profileInfo`. Existing cases were rewritten onto it and kept
(now expressed as tie-breaks), plus new coverage for recency and for
`profileInfoAt` against real temp dirs.

Note that one previous expectation inverted deliberately: the old
`native preferred over flatpak` case is now `native wins ties against flatpak`.
Unconditional native preference is the bug.

## Verification

- The new tests fail against the old first-existing logic and pass with the fix
  (checked by temporarily neutering the recency comparison).
- End to end on my machine, no env override:

```
ConfigDir: /home/yml/.var/app/com.slack.Slack/config/Slack
  gophers / lincolnloop / pysortium / slackyourdata
  smithsoniandigital / washtimes / temporalio   -> all CONNECT OK
```

- Full suite green (53 packages), `go vet` clean, `gofmt` clean.


