### PR TITLE
fix: fetch the full workspace custom emoji list

### DIFF
--- a/cmd/slk/customemoji.go
+++ b/cmd/slk/customemoji.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+
+	"github.com/gammons/slk/internal/ui"
+)
+
+// customEmojiLister is the one-method slice of *slackclient.Client that
+// the emoji fetch needs. Mirrors reconnectClient in reconnect_sync.go:
+// a narrow interface keeps the fetch testable without a live client,
+// and fails compilation if the surface grows.
+type customEmojiLister interface {
+	// ListCustomEmoji is emoji.list: the workspace's entire custom
+	// emoji set. Distinct from conversations.view's Emojis field,
+	// which is only the emoji the fetched conversation happens to use.
+	ListCustomEmoji(ctx context.Context) (map[string]string, error)
+}
+
+// fetchWorkspaceEmoji publishes the workspace's full custom emoji set
+// and tells the UI to re-render with it.
+//
+// It runs UNCONDITIONALLY, and that is the whole point of it. Bootstrap
+// may already have published a map, but conversations.view returns only
+// the emoji the restored conversation uses — a per-conversation subset,
+// not the workspace's set. An earlier version skipped emoji.list
+// whenever that subset was non-empty, which left every channel other
+// than the restored one rendering custom emoji as literal `:name:`.
+// TestFetchWorkspaceEmoji_RunsEvenWhenBootstrapPublishedASubset pins
+// that so the short-circuit cannot come back.
+//
+// Best-effort: on error nothing is published and nothing is sent, so
+// the bootstrap subset (or the built-ins) stays in place rather than
+// being cleared.
+//
+// Intended to be run in a goroutine, after WorkspaceReadyMsg, so it
+// never blocks first paint.
+func fetchWorkspaceEmoji(ctx context.Context, wctx *WorkspaceContext, client customEmojiLister, sender teaSender, teamID string) {
+	emojis, err := client.ListCustomEmoji(ctx)
+	if err != nil {
+		return
+	}
+	wctx.SetCustomEmoji(emojis)
+	if sender != nil {
+		sender.Send(ui.CustomEmojisLoadedMsg{
+			TeamID:      teamID,
+			CustomEmoji: emojis,
+		})
+	}
+}

--- a/cmd/slk/customemoji_test.go
+++ b/cmd/slk/customemoji_test.go
@@ -1,8 +1,13 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"sync"
 	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/gammons/slk/internal/ui"
 )
 
 func TestWorkspaceContextCustomEmojiDefaultsEmpty(t *testing.T) {
@@ -51,5 +56,128 @@ func TestWorkspaceContextCustomEmojiConcurrentAccess(t *testing.T) {
 	wg.Wait()
 	if got := wctx.CustomEmoji()["party-parrot"]; got != "https://example.test/parrot.gif" {
 		t.Errorf("CustomEmoji()[party-parrot] = %q, want the published URL", got)
+	}
+}
+
+// fakeEmojiLister records ListCustomEmoji calls so a test can assert
+// the fetch actually happened, not merely that state changed.
+type fakeEmojiLister struct {
+	mu     sync.Mutex
+	calls  int
+	result map[string]string
+	err    error
+}
+
+func (f *fakeEmojiLister) ListCustomEmoji(_ context.Context) (map[string]string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	return f.result, f.err
+}
+
+func (f *fakeEmojiLister) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+// captureEmojiSender records messages dispatched into the tea loop.
+type captureEmojiSender struct {
+	mu   sync.Mutex
+	msgs []tea.Msg
+}
+
+func (c *captureEmojiSender) Send(m tea.Msg) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.msgs = append(c.msgs, m)
+}
+
+func (c *captureEmojiSender) snapshot() []tea.Msg {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]tea.Msg(nil), c.msgs...)
+}
+
+// TestFetchWorkspaceEmoji_RunsEvenWhenBootstrapPublishedASubset is the
+// regression guard for this whole change.
+//
+// conversations.view returns only the emoji the restored conversation
+// uses. The previous code treated a non-empty CustomEmoji() as "already
+// fetched" and returned early, so every other channel rendered custom
+// emoji as literal :name:. Re-adding that short-circuit must fail here.
+func TestFetchWorkspaceEmoji_RunsEvenWhenBootstrapPublishedASubset(t *testing.T) {
+	wctx := &WorkspaceContext{}
+	// Bootstrap publishes the one emoji the restored channel used.
+	wctx.SetCustomEmoji(map[string]string{"from-boot": "https://example.test/boot.png"})
+
+	api := &fakeEmojiLister{result: map[string]string{
+		"from-boot":    "https://example.test/boot.png",
+		"party-parrot": "https://example.test/parrot.gif",
+	}}
+	sender := &captureEmojiSender{}
+
+	fetchWorkspaceEmoji(context.Background(), wctx, api, sender, "T1")
+
+	if got := api.callCount(); got != 1 {
+		t.Fatalf("ListCustomEmoji calls = %d, want 1 — a non-empty bootstrap subset must NOT suppress emoji.list", got)
+	}
+	if got := wctx.CustomEmoji(); len(got) != 2 || got["party-parrot"] == "" {
+		t.Errorf("CustomEmoji() = %v, want the full workspace set", got)
+	}
+}
+
+// A failed emoji.list must leave the bootstrap subset intact rather
+// than clearing it: a partial set renders more emoji than none.
+func TestFetchWorkspaceEmoji_ErrorKeepsBootstrapSubset(t *testing.T) {
+	wctx := &WorkspaceContext{}
+	wctx.SetCustomEmoji(map[string]string{"from-boot": "https://example.test/boot.png"})
+
+	api := &fakeEmojiLister{err: errors.New("ratelimited")}
+	sender := &captureEmojiSender{}
+
+	fetchWorkspaceEmoji(context.Background(), wctx, api, sender, "T1")
+
+	if got := wctx.CustomEmoji()["from-boot"]; got != "https://example.test/boot.png" {
+		t.Errorf("CustomEmoji()[from-boot] = %q, want the bootstrap entry preserved on error", got)
+	}
+	if msgs := sender.snapshot(); len(msgs) != 0 {
+		t.Errorf("sent %d messages on error, want 0 — a failed fetch must not tell the UI to re-render", len(msgs))
+	}
+}
+
+// The UI only picks up the new set when the follow-up message lands,
+// and it must be tagged with the workspace it belongs to.
+func TestFetchWorkspaceEmoji_SendsLoadedMsgForItsTeam(t *testing.T) {
+	wctx := &WorkspaceContext{}
+	api := &fakeEmojiLister{result: map[string]string{"party-parrot": "https://example.test/parrot.gif"}}
+	sender := &captureEmojiSender{}
+
+	fetchWorkspaceEmoji(context.Background(), wctx, api, sender, "T_OTHER")
+
+	msgs := sender.snapshot()
+	if len(msgs) != 1 {
+		t.Fatalf("sent %d messages, want 1", len(msgs))
+	}
+	loaded, ok := msgs[0].(ui.CustomEmojisLoadedMsg)
+	if !ok {
+		t.Fatalf("message type = %T, want ui.CustomEmojisLoadedMsg", msgs[0])
+	}
+	if loaded.TeamID != "T_OTHER" {
+		t.Errorf("TeamID = %q, want T_OTHER — an untagged message would repaint the wrong workspace", loaded.TeamID)
+	}
+	if loaded.CustomEmoji["party-parrot"] == "" {
+		t.Errorf("CustomEmoji = %v, want the fetched set", loaded.CustomEmoji)
+	}
+}
+
+// A nil sender must not panic: the fetch is best-effort and runs in a
+// bare goroutine, so a panic there would take the process down.
+func TestFetchWorkspaceEmoji_NilSenderDoesNotPanic(t *testing.T) {
+	wctx := &WorkspaceContext{}
+	api := &fakeEmojiLister{result: map[string]string{"a": "b"}}
+	fetchWorkspaceEmoji(context.Background(), wctx, api, nil, "T1")
+	if wctx.CustomEmoji()["a"] != "b" {
+		t.Error("CustomEmoji() should still be published with a nil sender")
 	}
 }

--- a/cmd/slk/customemoji_test.go
+++ b/cmd/slk/customemoji_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestWorkspaceContextCustomEmojiDefaultsEmpty(t *testing.T) {
+	var wctx WorkspaceContext
+	if got := wctx.CustomEmoji(); got == nil || len(got) != 0 {
+		t.Errorf("CustomEmoji() before load = %v, want empty non-nil map", got)
+	}
+}
+
+// SetCustomEmoji replaces rather than merges: emoji.list returns the
+// workspace's whole set, so the bootstrap subset it lands on top of is
+// a strict subset and merging would only keep stale entries alive.
+func TestWorkspaceContextCustomEmojiReplaces(t *testing.T) {
+	wctx := &WorkspaceContext{}
+	wctx.SetCustomEmoji(map[string]string{"from-boot": "https://example.test/boot.png"})
+	wctx.SetCustomEmoji(map[string]string{"from-list": "https://example.test/list.png"})
+
+	got := wctx.CustomEmoji()
+	if _, ok := got["from-boot"]; ok {
+		t.Errorf("CustomEmoji() = %v, want the bootstrap entry replaced, not merged", got)
+	}
+	if got["from-list"] != "https://example.test/list.png" {
+		t.Errorf("CustomEmoji()[from-list] = %q, want the emoji.list URL", got["from-list"])
+	}
+}
+
+// The emoji.list fetch publishes the map from a background goroutine
+// while the workspace-switch cmd reads it to build WorkspaceSwitchedMsg.
+// Run under -race to catch a regression back to a plain map field.
+func TestWorkspaceContextCustomEmojiConcurrentAccess(t *testing.T) {
+	wctx := &WorkspaceContext{}
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			wctx.SetCustomEmoji(map[string]string{"party-parrot": "https://example.test/parrot.gif"})
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			_ = wctx.CustomEmoji()["party-parrot"]
+		}
+	}()
+	wg.Wait()
+	if got := wctx.CustomEmoji()["party-parrot"]; got != "https://example.test/parrot.gif" {
+		t.Errorf("CustomEmoji()[party-parrot] = %q, want the published URL", got)
+	}
+}

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -185,17 +185,24 @@ type WorkspaceContext struct {
 	TeamName      string
 	UserID        string
 	UnresolvedDMs []UnresolvedDM
-	CustomEmoji   map[string]string // emoji name -> URL or "alias:target"
+	// customEmoji holds this workspace's emoji name -> URL (or
+	// "alias:target") map. Access it via CustomEmoji/SetCustomEmoji,
+	// never directly.
+	//
+	// atomic.Pointer for the same reason as userGroups below: the
+	// background emoji.list fetch writes it while the workspace-switch
+	// cmd goroutine reads it. It used to be a plain map, exempted on
+	// the grounds that its single background write only happened on the
+	// rare conversations.history fallback; that stopped being true once
+	// emoji.list was restored to the normal path.
+	customEmoji atomic.Pointer[map[string]string]
 	// userGroups holds this workspace's usergroup ID -> handle map.
 	// Access it via UserGroups/SetUserGroups, never directly.
 	//
 	// atomic.Pointer (not a plain map) because the write happens on the
 	// background usergroups.list fetch goroutine while reads happen on
 	// the bubbletea Update/cmd goroutines (workspace switch, search) and
-	// on the RTM event loop (notification body stripping). This is where
-	// UserGroups differs from the CustomEmoji field it otherwise mirrors:
-	// CustomEmoji is only ever consumed through the tea message loop, so
-	// its single background write is never read cross-goroutine.
+	// on the RTM event loop (notification body stripping).
 	//
 	// The stored map is published once and never mutated afterwards, so
 	// readers need no further synchronization.
@@ -242,6 +249,22 @@ func (w *WorkspaceContext) UserGroups() map[string]string {
 // workspace. The caller must not mutate the map afterwards.
 func (w *WorkspaceContext) SetUserGroups(groups map[string]string) {
 	w.userGroups.Store(&groups)
+}
+
+// CustomEmoji returns this workspace's emoji name -> URL map, or an
+// empty map before the first publish.
+func (w *WorkspaceContext) CustomEmoji() map[string]string {
+	if m := w.customEmoji.Load(); m != nil {
+		return *m
+	}
+	return map[string]string{}
+}
+
+// SetCustomEmoji publishes an emoji name -> URL (or "alias:target")
+// map for this workspace. The caller must not mutate the map
+// afterwards.
+func (w *WorkspaceContext) SetCustomEmoji(emojis map[string]string) {
+	w.customEmoji.Store(&emojis)
 }
 
 // workspaceRouter holds the program-wide "active workspace" pointer.
@@ -1908,7 +1931,7 @@ func run() error {
 			UserNames:        wctx.UserNames,
 			ExternalUsers:    external,
 			UserID:           wctx.UserID,
-			CustomEmoji:      wctx.CustomEmoji,
+			CustomEmoji:      wctx.CustomEmoji(),
 			UserGroups:       wctx.UserGroups(),
 			SectionsProvider: sectionsProviderAdapter{store: wctx.SectionStore},
 		}
@@ -2101,28 +2124,29 @@ func run() error {
 				UserNames:        wctx.UserNames,
 				ExternalUsers:    external,
 				UserID:           wctx.UserID,
-				CustomEmoji:      wctx.CustomEmoji,  // from conversations.view, or filled by the goroutine below
-				UserGroups:       wctx.UserGroups(), // empty at this point; filled by the goroutine below
+				CustomEmoji:      wctx.CustomEmoji(), // bootstrap subset; replaced by the goroutine below
+				UserGroups:       wctx.UserGroups(),  // empty at this point; filled by the goroutine below
 				SectionsProvider: sectionsProviderAdapter{store: wctx.SectionStore},
 				InitialActive:    isInitial,
 				LastChannelID:    mostRecentlyVisitedChannel(wctx.LastVisitedByChannel),
 			})
 
-			// Fetch workspace custom emojis in the background. When done,
-			// send a follow-up so the active compose can refresh its
-			// emoji picker entries. Best-effort: failure leaves the picker
-			// using built-ins only.
+			// Fetch the workspace's custom emoji in the background. When
+			// done, send a follow-up so message rendering and the emoji
+			// picker pick up the full set.
+			//
+			// This runs unconditionally. Bootstrap may already have
+			// published the handful conversations.view returned for the
+			// restored channel, but that is a per-conversation subset —
+			// only emoji.list knows the workspace. Best-effort: on
+			// failure nothing is sent, so the bootstrap subset (or the
+			// built-ins) stays in place rather than being cleared.
 			go func(teamID string) {
-				// Nothing to fetch when conversations.view already
-				// returned them, which is the normal path.
-				if len(wctx.CustomEmoji) > 0 {
-					return
-				}
 				emojis, err := wctx.Client.ListCustomEmoji(ctx)
 				if err != nil {
 					return
 				}
-				wctx.CustomEmoji = emojis
+				wctx.SetCustomEmoji(emojis)
 				p.Send(ui.CustomEmojisLoadedMsg{
 					TeamID:      teamID,
 					CustomEmoji: emojis,
@@ -2307,7 +2331,6 @@ func connectWorkspace(ctx context.Context, token slackclient.Token, db *cache.DB
 		AvatarURLs:           &sync.Map{},
 		UserNamesByHandle:    make(map[string]string),
 		BotUserIDs:           make(map[string]bool),
-		CustomEmoji:          make(map[string]string),
 		LastVisitedByChannel: make(map[string]int64),
 		ThreadSubsGate:       threadSubsGate{window: threadSubsSyncInterval},
 	}
@@ -2424,13 +2447,20 @@ func connectWorkspace(ctx context.Context, token slackclient.Token, db *cache.DB
 	// and hydrateFirstSight writes the cache rows the sidebar's
 	// channel list is later reconciled against.
 	applyBootUsers(wctx, res)
-	// conversations.view returns the workspace's custom emoji next to
-	// the history it was asked for, which is what emoji.list would
-	// have gone and fetched separately. Empty on the
-	// conversations.history fallback and when no channel was opened —
-	// the background fetch below still covers those.
+	// conversations.view returns the custom emoji THAT CONVERSATION
+	// USES next to the history it was asked for — not the workspace's
+	// set. An earlier version of this code read it as the latter and
+	// skipped emoji.list whenever it was non-empty, which left every
+	// channel other than the restored one rendering its custom emoji as
+	// literal `:name:`.
+	//
+	// So it is published as a head start, not an answer: the first
+	// channel's emoji resolve without waiting on a round trip, and the
+	// emoji.list fetch in run() replaces this with the full set as soon
+	// as it lands. Empty on the conversations.history fallback and when
+	// no channel was opened; emoji.list covers those the same way.
 	if len(res.Emojis) > 0 {
-		wctx.CustomEmoji = res.Emojis
+		wctx.SetCustomEmoji(res.Emojis)
 	}
 	hydrateFirstSight(db, client.TeamID(), res)
 

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -108,7 +108,7 @@ type WorkspaceContext struct {
 	// Edge is the edgeapi client for this workspace: the
 	// conditional-revalidation and server-side-search endpoints. Nil
 	// only if construction failed, and every caller nil-checks.
-	Edge       *edge.Client
+	Edge *edge.Client
 	// EdgeHealth records whether edge resolution is working for this
 	// workspace this session. bootstrap marks it degraded on a
 	// wholesale failure; the user resolver reads it to skip batch
@@ -2132,26 +2132,11 @@ func run() error {
 			})
 
 			// Fetch the workspace's custom emoji in the background. When
-			// done, send a follow-up so message rendering and the emoji
-			// picker pick up the full set.
-			//
-			// This runs unconditionally. Bootstrap may already have
-			// published the handful conversations.view returned for the
-			// restored channel, but that is a per-conversation subset —
-			// only emoji.list knows the workspace. Best-effort: on
-			// failure nothing is sent, so the bootstrap subset (or the
-			// built-ins) stays in place rather than being cleared.
-			go func(teamID string) {
-				emojis, err := wctx.Client.ListCustomEmoji(ctx)
-				if err != nil {
-					return
-				}
-				wctx.SetCustomEmoji(emojis)
-				p.Send(ui.CustomEmojisLoadedMsg{
-					TeamID:      teamID,
-					CustomEmoji: emojis,
-				})
-			}(wctx.TeamID)
+			// done, a follow-up message makes rendering and the emoji
+			// picker pick up the full set. Runs unconditionally — see
+			// fetchWorkspaceEmoji for why the bootstrap subset must not
+			// be treated as an answer.
+			go fetchWorkspaceEmoji(ctx, wctx, wctx.Client, p, wctx.TeamID)
 
 			// Fetch workspace usergroups in the background. When done,
 			// send a follow-up so render caches and compose pickers can

--- a/internal/slack/boot/view.go
+++ b/internal/slack/boot/view.go
@@ -325,11 +325,17 @@ type ViewResult struct {
 	// that would otherwise be thrown away and refetched.
 	Channels []ViewChannelEntry `json:"channels"`
 
-	// Emojis replaces the emoji.list call. It is an OBJECT keyed by
-	// emoji name with a URL value — NOT an array, despite being the
-	// plural of a thing. Modelling it as a slice fails the whole
-	// decode. Same shape trap as boot.Subteams, in the other
-	// direction.
+	// Emojis is the custom emoji THIS CONVERSATION USES, scoped like
+	// Users and Channels are — it does NOT replace emoji.list, which
+	// returns the workspace's whole set. The captured response carries
+	// three entries. Reading it as the workspace set is a real bug
+	// that shipped once: every other channel then renders its custom
+	// emoji as literal `:name:`.
+	//
+	// It is an OBJECT keyed by emoji name with a URL value — NOT an
+	// array, despite being the plural of a thing. Modelling it as a
+	// slice fails the whole decode. Same shape trap as boot.Subteams,
+	// in the other direction.
 	Emojis map[string]string `json:"emojis"`
 
 	// Channel is the conversation that was opened.
@@ -364,8 +370,10 @@ type viewResponse struct {
 // This is the official client's channel-open call. One request returns
 // the history, the users and bots that authored it, the channels it
 // mentions and the custom emoji it uses — replacing slk's
-// conversations.history plus a users.info per distinct author plus
-// emoji.list.
+// conversations.history plus a users.info per distinct author.
+//
+// It does NOT replace emoji.list: everything it returns beside the
+// history is scoped to that conversation. See the Emojis field.
 //
 // # The channel param: verified off Grid, unverified on it
 //

--- a/internal/slack/client.go
+++ b/internal/slack/client.go
@@ -37,7 +37,7 @@ type SlackAPI interface {
 	GetUsersInConversationContext(ctx context.Context, params *slack.GetUsersInConversationParameters) ([]string, string, error)
 	GetUserInfo(user string) (*slack.User, error)
 	GetBotInfoContext(ctx context.Context, parameters slack.GetBotInfoParameters) (*slack.Bot, error)
-	GetEmoji() (map[string]string, error)
+	GetEmojiContext(ctx context.Context) (map[string]string, error)
 	PostMessage(channelID string, options ...slack.MsgOption) (string, string, error)
 	UpdateMessage(channelID, timestamp string, options ...slack.MsgOption) (string, string, string, error)
 	DeleteMessage(channelID, timestamp string) (string, string, error)
@@ -832,7 +832,12 @@ func (c *Client) GetUserGroups(ctx context.Context) ([]slack.UserGroup, error) {
 // emoji.list API. Returns a map of emoji name -> URL or "alias:targetname".
 // The map is empty if the workspace has no custom emojis.
 func (c *Client) ListCustomEmoji(ctx context.Context) (map[string]string, error) {
-	emojis, err := c.api.GetEmoji()
+	// GetEmojiContext, not GetEmoji: the latter hardcodes
+	// context.Background() internally, so ctx was silently dropped and
+	// a shutdown could not cancel this. Harmless while the call only
+	// ran on the rare conversations.history fallback; it now runs on
+	// every workspace connect.
+	emojis, err := c.api.GetEmojiContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("listing custom emoji: %w", err)
 	}

--- a/internal/slack/client_test.go
+++ b/internal/slack/client_test.go
@@ -197,7 +197,7 @@ func (m *mockSlackAPI) GetBotInfoContext(ctx context.Context, parameters slack.G
 	return nil, fmt.Errorf("bot not found")
 }
 
-func (m *mockSlackAPI) GetEmoji() (map[string]string, error) {
+func (m *mockSlackAPI) GetEmojiContext(_ context.Context) (map[string]string, error) {
 	if m.getEmojiFn != nil {
 		return m.getEmojiFn()
 	}


### PR DESCRIPTION
## Problem

Custom emoji resolution was limited to the conversation restored at startup.

`conversations.view` returns the custom emoji used by that conversation, not the workspace's complete custom emoji set. slk stored that partial map during bootstrap and then skipped the background `emoji.list` request whenever the map was non-empty.

As a result, custom emoji used in other channels rendered as literal `:name:` text in messages and reaction pills. Standard emoji and custom emoji present in the restored channel continued to work, which made the failure appear channel-specific.

## Fix

Treat the map returned by `conversations.view` as an early, conversation-scoped subset:

- Publish it immediately so the restored channel can render without waiting for another request.
- Always fetch `emoji.list` once the workspace connects.
- Replace the subset with the authoritative workspace-wide map when that request succeeds.
- Preserve the bootstrap subset if `emoji.list` fails instead of clearing working emoji data.

Restoring the background write means it can now overlap with workspace-switch reads. `WorkspaceContext` therefore publishes the map through an `atomic.Pointer`, following the existing user-group map pattern.

The `conversations.view` documentation is also corrected to state that its emoji data is conversation-scoped and does not replace `emoji.list`.

The request cost is one `emoji.list` call per workspace connection.

## Tests

New tests cover:

- The zero-value `WorkspaceContext` returning a non-nil empty map.
- The workspace-wide result replacing rather than merging with the bootstrap subset.
- Concurrent publication and reads under the race detector.

Verification:

- `go test -race ./cmd/slk`
- `go test ./...`
- `go vet ./...`
- `go build ./cmd/slk`
- Verified in a live workspace: after starting on one channel, custom emoji unique to another channel rendered correctly in message text and reaction pills.