### PR TITLE
fix(kitty): encode images at the terminal's measured cell size

### DIFF
--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -108,7 +108,7 @@ type WorkspaceContext struct {
 	// Edge is the edgeapi client for this workspace: the
 	// conditional-revalidation and server-side-search endpoints. Nil
 	// only if construction failed, and every caller nil-checks.
-	Edge       *edge.Client
+	Edge *edge.Client
 	// EdgeHealth records whether edge resolution is working for this
 	// workspace this session. bootstrap marks it degraded on a
 	// wholesale failure; the user resolver reads it to skip batch
@@ -1063,14 +1063,13 @@ func run() error {
 	// per visible avatar per redraw would dominate the bandwidth budget.
 	avatarCache := avatar.NewCache(imageFetcher, imgpkg.KittyRendererInstance(), proto == imgpkg.ProtoKitty)
 
-	// Cell pixel metrics for sizing decisions.
+	// Cell pixel metrics for image encoding. Sixel uses them for its
+	// absolute raster dimensions; kitty places by cell but uses them to
+	// transmit enough source pixels for the terminal's native cell
+	// resolution. SetCellPixels retains its 8x16 fallback when the
+	// terminal reports no usable geometry.
 	pxW, pxH := imgpkg.CellPixels(int(os.Stdout.Fd()))
 	debuglog.ImgRender("cell pixels: %dx%d", pxW, pxH)
-	// Sixel encodes at absolute pixel dimensions — the terminal paints
-	// one sixel pixel per device pixel rather than scaling into a cell
-	// box the way kitty does. Hand it the measured metrics so an image
-	// occupying N rows of layout is encoded N*cellHeight pixels tall and
-	// actually lands on those rows.
 	imgpkg.SetCellPixels(pxW, pxH)
 
 	// Wire the inline-image pipeline into the messages pane. SendMsg

--- a/internal/image/kitty.go
+++ b/internal/image/kitty.go
@@ -226,8 +226,14 @@ func (k *KittyRenderer) RenderKey(key string, target image.Point) Render {
 		payload, payloadHit := k.payloads[payloadKey]
 		k.mu.Unlock()
 		if !payloadHit {
-			pxW := target.X * 8
-			pxH := target.Y * 16
+			// Encode against the terminal's real cell size, not a
+			// hardcoded 8x16. The placement is by cell either way, so
+			// this does not move the image — it decides how many
+			// pixels the terminal has to work with when it scales the
+			// image across those cells. See measuredCellPixels.
+			cw, ch := measuredCellPixels()
+			pxW := target.X * cw
+			pxH := target.Y * ch
 			resized := image.NewRGBA(image.Rect(0, 0, pxW, pxH))
 			draw.BiLinear.Scale(resized, resized.Bounds(), src, src.Bounds(), draw.Over, nil)
 			var pngBuf bytes.Buffer

--- a/internal/image/kitty_cellpx_test.go
+++ b/internal/image/kitty_cellpx_test.go
@@ -1,0 +1,108 @@
+// internal/image/kitty_cellpx_test.go
+//
+// Kitty places by cell (c=<cols>,r=<rows>), so the cell size does not
+// affect WHERE an image lands — but it decides how many pixels the
+// terminal has to scale across those cells. Encoding against a cell
+// smaller than the real one hands the terminal a low-resolution source
+// which it then upscales. See measuredCellPixels.
+package image
+
+import (
+	"bytes"
+	"encoding/base64"
+	"image"
+	"image/color"
+	imgpng "image/png"
+	"testing"
+)
+
+// decodedPayloadSize renders key at target and returns the pixel
+// dimensions of the PNG the renderer would transmit.
+func decodedPayloadSize(t *testing.T, k *KittyRenderer, key string, target image.Point) (int, int) {
+	t.Helper()
+	k.RenderKey(key, target)
+
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	if len(k.payloads) != 1 {
+		t.Fatalf("expected exactly one cached payload, got %d", len(k.payloads))
+	}
+	for _, b64 := range k.payloads {
+		raw, err := base64.StdEncoding.DecodeString(b64)
+		if err != nil {
+			t.Fatalf("payload is not valid base64: %v", err)
+		}
+		cfg, err := imgpng.DecodeConfig(bytes.NewReader(raw))
+		if err != nil {
+			t.Fatalf("payload is not a decodable PNG: %v", err)
+		}
+		return cfg.Width, cfg.Height
+	}
+	return 0, 0
+}
+
+func solidTestImage(w, h int) image.Image {
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			img.Set(x, y, color.RGBA{R: 200, G: 100, B: 50, A: 255})
+		}
+	}
+	return img
+}
+
+func TestKittyPayload_EncodesAtMeasuredCellSize(t *testing.T) {
+	resetCellPixels(t)
+	SetCellPixels(14, 34)
+	t.Cleanup(func() { resetCellPixels(t) })
+
+	k := NewKittyRenderer(NewRegistry())
+	src := solidTestImage(1024, 328)
+	k.SetSource("k", src)
+
+	target := image.Pt(40, 10)
+	w, h := decodedPayloadSize(t, k, "k", target)
+
+	if wantW, wantH := 40*14, 10*34; w != wantW || h != wantH {
+		t.Errorf("payload = %dx%d, want %dx%d (target cells x measured cell size)", w, h, wantW, wantH)
+	}
+}
+
+// With no measurement the 8x16 fallback keeps the previous behaviour,
+// so terminals that answer nothing render exactly as before.
+func TestKittyPayload_FallsBackTo8x16(t *testing.T) {
+	resetCellPixels(t)
+
+	k := NewKittyRenderer(NewRegistry())
+	src := solidTestImage(1024, 328)
+	k.SetSource("k", src)
+
+	target := image.Pt(40, 10)
+	w, h := decodedPayloadSize(t, k, "k", target)
+
+	if wantW, wantH := 40*8, 10*16; w != wantW || h != wantH {
+		t.Errorf("payload = %dx%d, want the %dx%d fallback", w, h, wantW, wantH)
+	}
+}
+
+// The regression this fixes: on a HiDPI cell the old hardcode supplied
+// materially fewer pixels than the box could display.
+func TestKittyPayload_HiDPIBeatsTheOldHardcode(t *testing.T) {
+	target := image.Pt(40, 10)
+	src := solidTestImage(1024, 328)
+
+	resetCellPixels(t)
+	k1 := NewKittyRenderer(NewRegistry())
+	k1.SetSource("k", src)
+	oldW, oldH := decodedPayloadSize(t, k1, "k", target)
+
+	SetCellPixels(14, 34)
+	t.Cleanup(func() { resetCellPixels(t) })
+	k2 := NewKittyRenderer(NewRegistry())
+	k2.SetSource("k", src)
+	newW, newH := decodedPayloadSize(t, k2, "k", target)
+
+	if newW <= oldW || newH <= oldH {
+		t.Errorf("hidpi payload %dx%d is not sharper than the old %dx%d", newW, newH, oldW, oldH)
+	}
+}

--- a/internal/image/sixel.go
+++ b/internal/image/sixel.go
@@ -21,13 +21,22 @@ const (
 )
 
 // cellPxW / cellPxH hold the terminal's measured cell size in pixels.
+// BOTH encoders need them, for different reasons.
 //
-// Unlike kitty — which transmits c=<cols>,r=<rows> and lets the terminal
-// scale the image into that cell box — sixel has no cell-aware placement:
-// the terminal paints one sixel pixel per device pixel and advances the
-// cursor by the image's own height. So the encoded pixel dimensions ARE
-// the on-screen size, and they must be derived from the real cell metrics
-// or the image won't line up with the rows the layout reserved for it.
+// Sixel has no cell-aware placement: the terminal paints one sixel pixel
+// per device pixel and advances the cursor by the image's own height, so
+// the encoded pixel dimensions ARE the on-screen size and must come from
+// the real cell metrics or the image won't line up with the rows the
+// layout reserved for it.
+//
+// Kitty does place by cell — c=<cols>,r=<rows> — so its LAYOUT is correct
+// whatever we encode at. Its resolution is not. The terminal scales the
+// transmitted image across the cell box, so encoding against a cell that
+// is smaller than the real one hands it fewer pixels than the box can
+// show and it upscales the difference. On a HiDPI terminal reporting a
+// 14x34 cell, the old hardcoded 8x16 supplied 57% of the horizontal and
+// 47% of the vertical resolution available — which reads as a soft,
+// low-resolution image, most visibly on screenshots of text.
 //
 // Set once at startup from CellPixels() before any rendering goroutine
 // runs; atomics keep that safe against the prerender worker pool.
@@ -36,21 +45,21 @@ var (
 	cellPxH atomic.Int32
 )
 
-// SetCellPixels records the terminal's cell size for sixel encoding.
+// SetCellPixels records the terminal's cell size for image encoding.
 // Non-positive values are ignored, so a terminal that reports nothing
 // keeps the 8x16 default. Call once during startup.
 func SetCellPixels(w, h int) {
 	if w <= 0 || h <= 0 {
-		debuglog.ImgRender("sixel.SetCellPixels: ignoring non-positive cell size %dx%d", w, h)
+		debuglog.ImgRender("image.SetCellPixels: ignoring non-positive cell size %dx%d", w, h)
 		return
 	}
 	cellPxW.Store(int32(w))
 	cellPxH.Store(int32(h))
-	debuglog.ImgRender("sixel.SetCellPixels: cell_w=%d cell_h=%d", w, h)
+	debuglog.ImgRender("image.SetCellPixels: cell_w=%d cell_h=%d", w, h)
 }
 
-// sixelCellPixels returns the cell size to encode against.
-func sixelCellPixels() (int, int) {
+// measuredCellPixels returns the cell size to encode against.
+func measuredCellPixels() (int, int) {
 	w, h := int(cellPxW.Load()), int(cellPxH.Load())
 	if w <= 0 || h <= 0 {
 		return defaultCellPxW, defaultCellPxH
@@ -79,7 +88,7 @@ func (s *SixelRenderer) Render(img image.Image, target image.Point) Render {
 		return Render{Cells: target}
 	}
 
-	cw, ch := sixelCellPixels()
+	cw, ch := measuredCellPixels()
 	pxW := target.X * cw
 	pxH := target.Y * ch
 	resized := image.NewRGBA(image.Rect(0, 0, pxW, pxH))

--- a/internal/image/sixel_cellpx_test.go
+++ b/internal/image/sixel_cellpx_test.go
@@ -19,9 +19,9 @@ func resetCellPixels(t *testing.T) {
 
 func TestSixelCellPixels_DefaultsTo8x16(t *testing.T) {
 	resetCellPixels(t)
-	w, h := sixelCellPixels()
+	w, h := measuredCellPixels()
 	if w != 8 || h != 16 {
-		t.Errorf("sixelCellPixels() = %dx%d, want 8x16 default", w, h)
+		t.Errorf("measuredCellPixels() = %dx%d, want 8x16 default", w, h)
 	}
 }
 
@@ -30,8 +30,8 @@ func TestSetCellPixels_UsesMeasuredMetrics(t *testing.T) {
 	SetCellPixels(14, 33)
 	t.Cleanup(func() { resetCellPixels(t) })
 
-	if w, h := sixelCellPixels(); w != 14 || h != 33 {
-		t.Errorf("sixelCellPixels() = %dx%d, want 14x33", w, h)
+	if w, h := measuredCellPixels(); w != 14 || h != 33 {
+		t.Errorf("measuredCellPixels() = %dx%d, want 14x33", w, h)
 	}
 }
 
@@ -39,8 +39,8 @@ func TestSetCellPixels_IgnoresNonPositive(t *testing.T) {
 	resetCellPixels(t)
 	SetCellPixels(0, 33)
 	SetCellPixels(14, -1)
-	if w, h := sixelCellPixels(); w != 8 || h != 16 {
-		t.Errorf("sixelCellPixels() = %dx%d, want the 8x16 default to survive bad input", w, h)
+	if w, h := measuredCellPixels(); w != 8 || h != 16 {
+		t.Errorf("measuredCellPixels() = %dx%d, want the 8x16 default to survive bad input", w, h)
 	}
 }
 


### PR DESCRIPTION
## Problem

The kitty renderer encoded image payloads using a hardcoded 8×16 pixels per terminal cell:

```go
pxW := target.X * 8
pxH := target.Y * 16
```

The terminal still placed the image correctly because the kitty graphics protocol uses `c=<columns>` and `r=<rows>` to define its cell footprint. However, it had to upscale the undersized PNG across that footprint, reducing image quality on HiDPI terminals.

For example, a terminal reporting 14×34 pixel cells received only 57% of the available horizontal resolution and 47% of the available vertical resolution. The result was visibly soft, especially for screenshots containing small text.

slk already measured the actual terminal cell geometry through `CellPixels`, but those measurements were only used by the sixel encoder.

## Fix

Use the measured terminal cell size when building kitty PNG payloads:

```go
cw, ch := measuredCellPixels()
pxW := target.X * cw
pxH := target.Y * ch
```

The existing sixel-specific helper is renamed to `measuredCellPixels` because both encoders now use it:

- Sixel needs the measurements for correct on-screen dimensions.
- Kitty needs them to transmit enough source pixels for the terminal's native cell resolution.

The kitty placement dimensions remain unchanged, so this affects image resolution without changing layout. Terminals that do not provide usable measurements retain the previous 8×16 fallback.

On Retina-sized cells this produces larger payloads, roughly 3× in the observed geometry. The cell measurement is fixed before rendering starts, and encoded payloads remain cached per image and target cell size, so the resize and PNG encoding cost is paid once per cached payload.

## Tests

New kitty payload tests decode the actual cached PNG and verify:

- Its dimensions match the measured terminal cell size.
- The previous 8×16 behavior remains as the fallback.
- HiDPI measurements produce a higher-resolution payload than the old hardcode.

The existing sixel cell-geometry tests continue to cover measured dimensions, invalid measurements, and raster scaling.

Verification:

- `go test -count=1 -race ./internal/image`
- `go test -count=1 ./...`
- `go vet ./...`
- `go build ./cmd/slk`
- `git diff --check`
- Manual visual test passed with the branch build.