### PR TITLE
fix: add newly opened conversations to the channel finder

### DIFF
--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -4478,7 +4478,7 @@ func (h *rtmEventHandler) OnThreadSubscriptionChanged(channelID, threadTS, lastR
 // unread/last-read state), upserts the SQLite cache row, mirrors
 // channelNames/Types maps used by the notifier, and — if the
 // workspace is active — forwards a ConversationOpenedMsg to the UI
-// so the live sidebar updates.
+// so the live sidebar and channel finder (Ctrl+P) both update.
 func (h *rtmEventHandler) OnConversationOpened(ch slack.Channel) {
 	if h.wsCtx == nil {
 		return
@@ -4532,8 +4532,9 @@ func (h *rtmEventHandler) OnConversationOpened(ch slack.Channel) {
 		return
 	}
 	h.program.Send(ui.ConversationOpenedMsg{
-		TeamID: h.workspaceID,
-		Item:   item,
+		TeamID:     h.workspaceID,
+		Item:       item,
+		FinderItem: finderItem,
 	})
 }
 

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -176,7 +176,7 @@ type WorkspaceContext struct {
 	// decide whether to draw the "Threads list unavailable" banner.
 	SubscriptionsAvailable bool
 	Channels               []sidebar.ChannelItem
-	// FinderItems is the list shown in the Ctrl+T finder: the channels
+	// FinderItems is the list shown in the Ctrl+P finder: the channels
 	// the user has joined. Channels they have not joined are not held
 	// here at all — they arrive per query from the finder's debounced
 	// channels/search and live only in the finder component.
@@ -4509,7 +4509,7 @@ func (h *rtmEventHandler) OnConversationOpened(ch slack.Channel) {
 		// path. On dedupe, the existing finder entry was added at
 		// bootstrap (or a prior open) and carries no unread state to
 		// refresh, so re-appending would double-list the channel in
-		// Ctrl+T.
+		// Ctrl+P.
 		finderItem.LastVisited = h.wsCtx.LastVisitedByChannel[ch.ID]
 		h.wsCtx.FinderItems = append(h.wsCtx.FinderItems, finderItem)
 	}

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gammons/slk/internal/cache"
 	"github.com/gammons/slk/internal/ids"
 	imgpkg "github.com/gammons/slk/internal/image"
+	"github.com/gammons/slk/internal/ui/channelfinder"
 	"github.com/gammons/slk/internal/ui/compose"
 	"github.com/gammons/slk/internal/ui/messages"
 	"github.com/gammons/slk/internal/ui/sidebar"
@@ -2993,6 +2994,12 @@ func TestConversationOpenedMsg_SidebarReceivesItemAndUnread(t *testing.T) {
 			Name: "alice, bob",
 			Type: "group_dm",
 		},
+		FinderItem: channelfinder.Item{
+			ID:     "G1",
+			Name:   "alice, bob",
+			Type:   "group_dm",
+			Joined: true,
+		},
 	})
 
 	// Capture sidebar version so we can verify the inbound NewMessageMsg
@@ -3023,6 +3030,18 @@ func TestConversationOpenedMsg_SidebarReceivesItemAndUnread(t *testing.T) {
 	if app.sidebar.Version() == verBefore {
 		t.Errorf("expected sidebar.Version() to bump after inactive-channel NewMessageMsg, stayed at %d", verBefore)
 	}
+
+	// G1 must also be present in the channel finder (Ctrl+P) immediately,
+	// not just after the next workspace activation.
+	foundInFinder := false
+	for _, it := range app.channelFinder.Items() {
+		if it.ID == "G1" {
+			foundInFinder = true
+		}
+	}
+	if !foundInFinder {
+		t.Errorf("G1 not in channel finder after ConversationOpenedMsg")
+	}
 }
 
 func TestConversationOpenedMsg_InactiveWorkspaceIgnored(t *testing.T) {
@@ -3032,13 +3051,19 @@ func TestConversationOpenedMsg_InactiveWorkspaceIgnored(t *testing.T) {
 
 	// Event for a different workspace must NOT mutate the active sidebar.
 	app.Update(ConversationOpenedMsg{
-		TeamID: "T2",
-		Item:   sidebar.ChannelItem{ID: "G1", Name: "alice, bob", Type: "group_dm"},
+		TeamID:     "T2",
+		Item:       sidebar.ChannelItem{ID: "G1", Name: "alice, bob", Type: "group_dm"},
+		FinderItem: channelfinder.Item{ID: "G1", Name: "alice, bob", Type: "group_dm", Joined: true},
 	})
 
 	for _, it := range app.sidebar.AllItems() {
 		if it.ID == "G1" {
 			t.Errorf("G1 unexpectedly added to active sidebar from inactive-workspace event")
+		}
+	}
+	for _, it := range app.channelFinder.Items() {
+		if it.ID == "G1" {
+			t.Errorf("G1 unexpectedly added to channel finder from inactive-workspace event")
 		}
 	}
 }

--- a/internal/ui/channelfinder/model.go
+++ b/internal/ui/channelfinder/model.go
@@ -113,6 +113,33 @@ func (m *Model) extractSynthetic() []Item {
 	return synth
 }
 
+// Upsert adds item to the finder, or replaces the existing entry with the
+// same ID in place. Used when a single new conversation becomes known
+// outside of a full SetItems refresh (e.g. a live im_created/mpim_open WS
+// event or a Ctrl+N-initiated DM), so it shows up in Ctrl+P immediately
+// instead of waiting for the next workspace activation to pick up
+// WorkspaceContext.FinderItems. LastVisited is preserved from the existing
+// entry when the incoming item doesn't specify one.
+func (m *Model) Upsert(item Item) {
+	for i := range m.items {
+		if m.items[i].ID == item.ID {
+			if item.LastVisited == 0 {
+				item.LastVisited = m.items[i].LastVisited
+			}
+			item.Synthetic = m.items[i].Synthetic
+			m.items[i] = item
+			if m.visible {
+				m.filter()
+			}
+			return
+		}
+	}
+	m.items = append(m.items, item)
+	if m.visible {
+		m.filter()
+	}
+}
+
 // MarkJoined flips the Joined bit on a channel that the user just joined,
 // so it stops rendering as dimmed and the next Enter on it skips the join
 // step.

--- a/internal/ui/channelfinder/model_test.go
+++ b/internal/ui/channelfinder/model_test.go
@@ -287,6 +287,60 @@ func TestSetBrowseableReplacesPreviousBrowseable(t *testing.T) {
 	}
 }
 
+func TestUpsertRefiltersVisibleQuery(t *testing.T) {
+	m := New()
+	m.SetItems([]Item{{ID: "C1", Name: "general", Type: "channel", Joined: true}})
+	m.Open()
+	m.HandleKey("z")
+	m.HandleKey("e")
+	m.HandleKey("d")
+	if got := m.FilteredItems(); len(got) != 0 {
+		t.Fatalf("setup: filtered items = %+v, want none", got)
+	}
+
+	m.Upsert(Item{ID: "D1", Name: "zed person", Type: "dm", Joined: true})
+
+	got := m.FilteredItems()
+	if len(got) != 1 || got[0].ID != "D1" {
+		t.Errorf("filtered items after Upsert = %+v, want D1", got)
+	}
+}
+
+func TestUpsertReplacesByIDAndPreservesLastVisited(t *testing.T) {
+	m := New()
+	m.SetItems([]Item{{
+		ID: "C1", Name: "old name", Type: "channel", Joined: false, LastVisited: 123,
+	}})
+
+	m.Upsert(Item{ID: "C1", Name: "new name", Type: "private", Joined: true})
+
+	got := m.Items()
+	if len(got) != 1 {
+		t.Fatalf("items after Upsert = %+v, want one replacement", got)
+	}
+	if got[0].Name != "new name" || got[0].Type != "private" || !got[0].Joined {
+		t.Errorf("replacement = %+v, want updated descriptive fields", got[0])
+	}
+	if got[0].LastVisited != 123 {
+		t.Errorf("replacement LastVisited = %d, want preserved value 123", got[0].LastVisited)
+	}
+}
+
+func TestUpsertConvertsBrowseableEntryInPlace(t *testing.T) {
+	m := New()
+	m.SetBrowseable([]Item{{ID: "C9", Name: "announcements", Type: "channel", Joined: false}})
+
+	m.Upsert(Item{ID: "C9", Name: "announcements", Type: "channel", Joined: true})
+
+	got := m.Items()
+	if len(got) != 1 {
+		t.Fatalf("items after Upsert = %+v, want one converted entry, not a duplicate", got)
+	}
+	if !got[0].Joined {
+		t.Errorf("item %q: Joined = false, want true", got[0].ID)
+	}
+}
+
 func TestEnterReturnsJoinedFlag(t *testing.T) {
 	m := New()
 	// LastVisited values pin the order: C1 (joined) appears first, C2

--- a/internal/ui/msgs.go
+++ b/internal/ui/msgs.go
@@ -267,11 +267,12 @@ type (
 	// im_created, group_joined, or channel_joined event. The TeamID
 	// disambiguates events for inactive workspaces; only events whose
 	// TeamID matches the currently-active workspace mutate the live
-	// sidebar — others are persisted in the workspace's WorkspaceContext
-	// for when the user switches in.
+	// sidebar and channel finder — others are persisted in the
+	// workspace's WorkspaceContext for when the user switches in.
 	ConversationOpenedMsg struct {
-		TeamID string
-		Item   sidebar.ChannelItem
+		TeamID     string
+		Item       sidebar.ChannelItem
+		FinderItem channelfinder.Item
 	}
 	// SectionsRefreshedMsg is sent when a workspace's Slack-native
 	// section state has mutated (via channel_section_* WS events) and

--- a/internal/ui/reducer_workspace.go
+++ b/internal/ui/reducer_workspace.go
@@ -19,8 +19,8 @@
 //	                          compose draft), push new channels/users/
 //	                          emoji, apply theme, restore the last
 //	                          channel viewed for this workspace.
-//	ConversationOpenedMsg   - WS event: a DM/MPIM just opened.
-//	                          Upsert into the active sidebar.
+//	ConversationOpenedMsg   - WS event: a conversation just opened.
+//	                          Upsert into the active sidebar and finder.
 //	SectionsRefreshedMsg    - cache notice: sidebar sections were
 //	                          reorganized. Re-push channel items
 //	                          for the active workspace.
@@ -83,8 +83,8 @@ var reduceWorkspace reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
 			}
 		}
 		// Inactive-workspace events update WorkspaceContext.Channels
-		// from the rtmEventHandler in cmd/slk/main.go (Task 6);
-		// App.Update only mutates the active sidebar.
+		// and FinderItems from the rtmEventHandler in cmd/slk/main.go;
+		// App.Update only mutates the active workspace's UI models.
 		return nil, true
 
 	case SectionsRefreshedMsg:

--- a/internal/ui/reducer_workspace.go
+++ b/internal/ui/reducer_workspace.go
@@ -74,6 +74,13 @@ var reduceWorkspace reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
 	case ConversationOpenedMsg:
 		if m.TeamID == a.activeTeamID {
 			a.sidebar.UpsertItem(m.Item)
+			// FinderItem is populated by today's one sender
+			// (cmd/slk's rtmEventHandler); guard against a future
+			// sender that forgets to set it, which would otherwise
+			// silently append an ID: "" row to the finder.
+			if m.FinderItem.ID != "" {
+				a.channelFinder.Upsert(m.FinderItem)
+			}
 		}
 		// Inactive-workspace events update WorkspaceContext.Channels
 		// from the rtmEventHandler in cmd/slk/main.go (Task 6);


### PR DESCRIPTION
## Problem

When somebody messages you for the first time while slk is running, the new conversation appears in the sidebar and you can open it and reply normally.

But if you later press Ctrl+P and search for that person, they do not appear in the channel picker. The conversation exists and is usable from the sidebar—the picker is simply out of date. It only picks up the new DM after switching workspaces or restarting slk.

The same problem affects newly opened group DMs and channels.

Internally, Slack delivers these conversations through `im_created`, `im_open`, `mpim_open`, `group_joined`, and `channel_joined` WebSocket events. `OnConversationOpened` already persisted the new conversation and updated the active sidebar, but the running Ctrl+P finder never received the new item.

## Fix

Carry the finder item in `ConversationOpenedMsg` and upsert it into the active workspace's channel finder alongside the sidebar item.

The new `channelfinder.Model.Upsert` behavior:

- Adds conversations that are not yet present.
- Replaces an existing entry with the same channel ID instead of creating a duplicate.
- Converts an existing browseable result into a joined conversation.
- Preserves the existing `LastVisited` value when the incoming event has no recency information.
- Refilters immediately when Ctrl+P is already open.

Inactive-workspace events continue to update `WorkspaceContext.Channels` and `WorkspaceContext.FinderItems`. Switching to that workspace later rebuilds both UI models from the updated context.

## Tests

New in this PR:

- Finder insertion and visible-query refiltering (`TestUpsertRefiltersVisibleQuery`).
- Same-ID replacement without duplication (`TestUpsertReplacesByIDAndPreservesLastVisited`).
- `LastVisited` preservation during replacement.
- Converting an existing browseable (non-joined) entry into a joined one in place, rather than duplicating it (`TestUpsertConvertsBrowseableEntryInPlace`).
- Active-workspace `ConversationOpenedMsg` reaching both the sidebar and channel finder, and inactive-workspace messages leaving the active finder unchanged.

The `im_created`, `im_open`, `mpim_open`, `group_joined`, and `channel_joined` dispatch tests already existed on main and are unchanged here; they're listed for context, not as new coverage.

Verification:

- `go test -count=1 -race ./internal/ui/channelfinder ./internal/ui ./cmd/slk`
- `go test -count=1 ./...`
- `go vet ./...`
- `go build ./cmd/slk`
- `git diff --check`

Manual first-time-DM verification was not available because it requires another Slack user to initiate a previously nonexistent conversation.
