### PR TITLE
feat(ui): add y keybinding to copy message text

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -53,7 +53,7 @@ Last updated: 2026-05-03
 - [x] Message editing (`E` on own message; reuses compose with stash/restore draft)
 - [x] Message deletion (`D` on own message; centered confirmation overlay)
 - [x] Paste-to-upload via `Ctrl+V` in insert mode (clipboard image, file path, or text fallback) using Slack's V2 file-upload API; multiple attachments + caption send together; status-bar progress + error toasts
-- [x] OSC 52 clipboard integration for message selection and permalink copying
+- [x] OSC 52 clipboard integration for message selection, message text (`y`), and permalink copying (`Y` / `C`)
 - [x] In-place update on `message_changed` echoes (no duplicate row on edit)
 - [x] Live removal on `message_deleted` echoes from any client
 - [x] @mention autocomplete in compose (inline picker, translates to <@UserID> on send)

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1008,6 +1008,38 @@ func (a *App) toggleReactionOnMessageItem(channelIDStr string, msg messages.Mess
 	}
 }
 
+// copyMessageOfSelected copies the text of the currently-selected message or
+// thread reply to the system clipboard via OSC 52 and emits a status-bar toast.
+func (a *App) copyMessageOfSelected() tea.Cmd {
+	var msg messages.MessageItem
+	switch a.focusedPanel {
+	case PanelMessages:
+		m, ok := a.messagepane.SelectedMessage()
+		if !ok {
+			return nil
+		}
+		msg = m
+	case PanelThread:
+		reply := a.threadPanel.SelectedReply()
+		if reply == nil {
+			return nil
+		}
+		msg = *reply
+	default:
+		return nil
+	}
+
+	text := messages.MessageTextSource(msg)
+	if text == "" {
+		return func() tea.Msg { return ToastMsg{Text: "Message has no text"} }
+	}
+	n := len([]rune(text))
+	return tea.Batch(
+		a.clipboardWrite(text),
+		func() tea.Msg { return statusbar.CopiedMsg{N: n} },
+	)
+}
+
 // copyPermalinkOfSelected resolves the currently-selected message or thread
 // reply, calls the permalink fetcher, and returns a tea.Cmd that writes the
 // URL to the clipboard and emits a status-bar toast.

--- a/internal/ui/copy_message_test.go
+++ b/internal/ui/copy_message_test.go
@@ -1,0 +1,188 @@
+package ui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/gammons/slk/internal/ui/messages"
+	"github.com/gammons/slk/internal/ui/messages/blockkit"
+	"github.com/gammons/slk/internal/ui/statusbar"
+	"github.com/slack-go/slack"
+)
+
+func drainForCopiedMsg(msg tea.Msg) (statusbar.CopiedMsg, bool) {
+	switch v := msg.(type) {
+	case statusbar.CopiedMsg:
+		return v, true
+	case tea.BatchMsg:
+		for _, c := range v {
+			if c == nil {
+				continue
+			}
+			if cm, ok := drainForCopiedMsg(c()); ok {
+				return cm, true
+			}
+		}
+	}
+	return statusbar.CopiedMsg{}, false
+}
+
+func TestCopyMessage_FromMessagesPane_Y(t *testing.T) {
+	app := NewApp()
+	var copied string
+	app.SetClipboardWriter(func(text string) tea.Cmd {
+		copied = text
+		return nil
+	})
+	app.activeChannelID = "C123"
+	app.focusedPanel = PanelMessages
+	app.messagepane.SetMessages([]messages.MessageItem{
+		{TS: "1700000001.000200", UserName: "alice", Text: "hello world 🔥"},
+	})
+
+	cmd := app.handleNormalMode(tea.KeyPressMsg{Code: 'y', Text: "y"})
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd from y key")
+	}
+	msg := cmd()
+	cMsg, found := drainForCopiedMsg(msg)
+	if !found {
+		t.Fatalf("expected statusbar.CopiedMsg in batch, got %#v", msg)
+	}
+	if copied != "hello world 🔥" {
+		t.Errorf("clipboard = %q, want 'hello world 🔥'", copied)
+	}
+	wantRunes := len([]rune("hello world 🔥"))
+	if cMsg.N != wantRunes {
+		t.Errorf("CopiedMsg.N = %d, want %d", cMsg.N, wantRunes)
+	}
+}
+
+func TestCopyMessage_FromThreadPane(t *testing.T) {
+	app := NewApp()
+	var copied string
+	app.SetClipboardWriter(func(text string) tea.Cmd {
+		copied = text
+		return nil
+	})
+	parent := messages.MessageItem{TS: "1700000000.000100", UserName: "alice", Text: "parent"}
+	replies := []messages.MessageItem{
+		{TS: "1700000000.000100", UserName: "alice", Text: "parent"},
+		{TS: "1700000050.000400", UserName: "bob", Text: "reply message"},
+	}
+	app.threadPanel.SetThread(parent, replies, "C999", "1700000000.000100")
+	app.threadVisible = true
+	app.focusedPanel = PanelThread
+	for i := 0; i < len(replies); i++ {
+		sel := app.threadPanel.SelectedReply()
+		if sel != nil && sel.TS == "1700000050.000400" {
+			break
+		}
+		app.threadPanel.MoveDown()
+	}
+
+	cmd := app.handleNormalMode(tea.KeyPressMsg{Code: 'y', Text: "y"})
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd from y key")
+	}
+	msg := cmd()
+	cMsg, found := drainForCopiedMsg(msg)
+	if !found {
+		t.Fatalf("expected statusbar.CopiedMsg in batch, got %#v", msg)
+	}
+	if copied != "reply message" {
+		t.Errorf("clipboard = %q, want 'reply message'", copied)
+	}
+	if cMsg.N != len("reply message") {
+		t.Errorf("CopiedMsg.N = %d, want %d", cMsg.N, len("reply message"))
+	}
+}
+
+func TestCopyMessage_NothingSelectedNoop(t *testing.T) {
+	app := NewApp()
+	app.activeChannelID = "C123"
+	app.focusedPanel = PanelMessages
+
+	cmd := app.handleNormalMode(tea.KeyPressMsg{Code: 'y', Text: "y"})
+	if cmd != nil {
+		t.Fatalf("expected nil cmd when nothing selected, got %#v", cmd)
+	}
+}
+
+func TestCopyMessage_EmptyTextMessage(t *testing.T) {
+	app := NewApp()
+	app.activeChannelID = "C123"
+	app.focusedPanel = PanelMessages
+	app.messagepane.SetMessages([]messages.MessageItem{
+		{TS: "1.0", UserName: "alice", Text: ""},
+	})
+
+	cmd := app.handleNormalMode(tea.KeyPressMsg{Code: 'y', Text: "y"})
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd for empty text message")
+	}
+	msg := cmd()
+	toast, ok := msg.(ToastMsg)
+	if !ok {
+		t.Fatalf("expected ToastMsg, got %T (%#v)", msg, msg)
+	}
+	if toast.Text != "Message has no text" {
+		t.Errorf("toast.Text = %q, want 'Message has no text'", toast.Text)
+	}
+}
+
+func TestCopyMessage_RichTextBlockReconstructsMrkdwn(t *testing.T) {
+	app := NewApp()
+	var copied string
+	app.SetClipboardWriter(func(text string) tea.Cmd {
+		copied = text
+		return nil
+	})
+	app.activeChannelID = "C123"
+	app.focusedPanel = PanelMessages
+	app.messagepane.SetMessages([]messages.MessageItem{
+		{
+			TS:       "1.0",
+			UserName: "bot",
+			Text:     "lossy fallback",
+			Blocks: []blockkit.Block{
+				blockkit.RichTextBlock{
+					Elements: []slack.RichTextElement{
+						&slack.RichTextSection{
+							Type: slack.RTESection,
+							Elements: []slack.RichTextSectionElement{
+								&slack.RichTextSectionTextElement{Type: slack.RTSEText, Text: "Line 1"},
+								&slack.RichTextSectionTextElement{Type: slack.RTSEText, Text: "\n"},
+								&slack.RichTextSectionTextElement{Type: slack.RTSEText, Text: "Line 2"},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	cmd := app.handleNormalMode(tea.KeyPressMsg{Code: 'y', Text: "y"})
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd from y key")
+	}
+	msg := cmd()
+	_, found := drainForCopiedMsg(msg)
+	if !found {
+		t.Fatalf("expected statusbar.CopiedMsg in batch, got %#v", msg)
+	}
+	want := "Line 1\nLine 2"
+	if copied != want {
+		t.Errorf("clipboard = %q, want %q", copied, want)
+	}
+}
+
+func TestDefaultKeyMap_CopyMessage(t *testing.T) {
+	km := DefaultKeyMap()
+	if km.CopyMessage.Help().Key != "y" {
+		t.Errorf("CopyMessage key help = %q, want 'y'", km.CopyMessage.Help().Key)
+	}
+	if km.CopyMessage.Help().Desc != "copy message" {
+		t.Errorf("CopyMessage desc help = %q, want 'copy message'", km.CopyMessage.Help().Desc)
+	}
+}

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -37,6 +37,7 @@ type KeyMap struct {
 	ReactionNav         key.Binding
 	Edit                key.Binding
 	Delete              key.Binding
+	CopyMessage         key.Binding
 	CopyPermalink       key.Binding
 	OpenPreview         key.Binding
 	OpenLink            key.Binding
@@ -99,6 +100,7 @@ func DefaultKeyMap() KeyMap {
 		ReactionNav:     key.NewBinding(key.WithKeys("R"), key.WithHelp("R", "navigate reactions")),
 		Edit:            key.NewBinding(key.WithKeys("E"), key.WithHelp("E", "edit message")),
 		Delete:          key.NewBinding(key.WithKeys("D"), key.WithHelp("D", "delete message")),
+		CopyMessage:     key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "copy message")),
 		CopyPermalink:   key.NewBinding(key.WithKeys("Y", "C"), key.WithHelp("Y/C", "copy permalink")),
 		OpenPreview:     key.NewBinding(key.WithKeys("O", "v"), key.WithHelp("O/v", "open image preview")),
 		OpenLink:        key.NewBinding(key.WithKeys("o"), key.WithHelp("o", "open link in message")),

--- a/internal/ui/mode_normal.go
+++ b/internal/ui/mode_normal.go
@@ -10,8 +10,8 @@
 //     (page), G (bottom), Tab/h/l (focus next/prev), Ctrl-o/i
 //     (nav back/forward through visited channels)
 //   - layout toggles: s (sidebar), t (thread)
-//   - message ops: y (copy permalink), E (edit), D (delete),
-//     M (mark unread), O (open image preview)
+//   - message ops: y (copy message), Y/C (copy permalink), E (edit), D (delete),
+//     U (mark unread), O/v (open image preview)
 //   - reaction nav sub-state: r enters; arrows + Enter select
 //     (delegated to handleReactionNav / handleThreadReactionNav)
 //   - window commands: Ctrl-W prefix arms a pending sub-state; the
@@ -256,6 +256,9 @@ func handleNormalMode(a *App, msg tea.KeyMsg) tea.Cmd {
 
 	case key.Matches(msg, a.keys.SaveThread):
 		return a.saveThreadToFile()
+
+	case key.Matches(msg, a.keys.CopyMessage):
+		return a.copyMessageOfSelected()
 
 	case key.Matches(msg, a.keys.CopyPermalink):
 		return a.copyPermalinkOfSelected()

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -16,6 +16,7 @@
 - Edited / threaded message indicators
 - ANSI-aware wrapping and truncation (no broken color codes mid-line)
 - Drag-to-copy: drag the mouse across messages to highlight them; release to copy plain text to the system clipboard via OSC 52
+- Copy message text (`y`) and copy permalink (`Y` / `C`) to the system clipboard via OSC 52
 
 ## Compose
 

--- a/wiki/Keybindings.md
+++ b/wiki/Keybindings.md
@@ -34,6 +34,7 @@
 | `D` | Normal (message) | Delete your own message (with confirmation) |
 | `U` | Normal (message) | Mark selected message and everything newer as unread |
 | `S` | Normal (thread) | Save thread to markdown file (`~/.local/share/slk/exports/` or `$XDG_DATA_HOME/slk/exports/`) |
+| `y` | Normal (message) | Copy message text |
 | `Y` / `C` | Normal (message) | Copy message permalink |
 | `O` / `v` | Normal (message) | Open full-screen image preview |
 | `Esc` / `q` | Preview | Close preview |

--- a/wiki/Tradeoffs-and-Non-Goals.md
+++ b/wiki/Tradeoffs-and-Non-Goals.md
@@ -6,7 +6,6 @@ slk is intentionally not a 1:1 port of the desktop client. Some Slack features a
 
 - Slack-side search (`Ctrl+/` / `:search`)
 - File uploads and downloads
-- OSC 52 clipboard yank (`yy`)
 - Quiet hours and per-channel mute
 - Custom keybinding overrides
 


### PR DESCRIPTION
## Summary
- Adds `CopyMessage` keybinding on `y` in normal mode for copying the selected message or thread reply text.
- Reconstructs mrkdwn for Block Kit rich text blocks via `MessageTextSource`.
- Writes text to system clipboard via OSC 52 and displays a `Copied N chars` status bar toast.
- Includes unit tests in `internal/ui/copy_message_test.go` and updates documentation.