### PR TITLE
feat: add visual mode text selection

### DIFF
--- a/internal/ui/app_selection_test.go
+++ b/internal/ui/app_selection_test.go
@@ -25,6 +25,43 @@ func newTestAppWithMessages(t *testing.T) *App {
 	return a
 }
 
+func TestVisualMode_SelectsWithMotionsAndYanks(t *testing.T) {
+	a := newTestAppWithMessages(t)
+	a.focusedPanel = PanelMessages
+	a.SetClipboardAvailable(true)
+	var copied string
+	a.SetClipboardWriter(func(_ clipboard.Format, data []byte) <-chan struct{} {
+		copied = string(data)
+		return nil
+	})
+
+	_, _ = a.Update(tea.KeyPressMsg{Code: 'v', Text: "v"})
+	if a.mode != ModeVisual || !a.messagepane.HasSelection() {
+		t.Fatalf("v did not enter visual mode with a selection: mode=%v selected=%v", a.mode, a.messagepane.HasSelection())
+	}
+	for range 4 {
+		_, _ = a.Update(tea.KeyPressMsg{Code: 'l', Text: "l"})
+	}
+	_, cmd := a.Update(tea.KeyPressMsg{Code: 'y', Text: "y"})
+	_ = cmd()
+	if copied == "" {
+		t.Fatal("y did not copy the visual selection")
+	}
+	if a.mode != ModeNormal {
+		t.Fatalf("mode after yank = %v, want NORMAL", a.mode)
+	}
+}
+
+func TestVisualMode_EscapeCancelsSelection(t *testing.T) {
+	a := newTestAppWithMessages(t)
+	a.focusedPanel = PanelMessages
+	_, _ = a.Update(tea.KeyPressMsg{Code: 'v', Text: "v"})
+	_, _ = a.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if a.mode != ModeNormal || a.messagepane.HasSelection() {
+		t.Fatalf("Esc did not cancel visual mode: mode=%v selected=%v", a.mode, a.messagepane.HasSelection())
+	}
+}
+
 // drainBatch fully expands a tea.Cmd (including nested tea.BatchMsg) and
 // returns all leaf messages. Test-only; ignores nil cmds.
 func drainBatch(cmd tea.Cmd) []tea.Msg {

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -11,6 +11,7 @@ type KeyMap struct {
 	Enter               key.Binding
 	Escape              key.Binding
 	InsertMode          key.Binding
+	VisualMode          key.Binding
 	CommandMode         key.Binding
 	SearchMode          key.Binding
 	SearchNext          key.Binding
@@ -70,6 +71,7 @@ func DefaultKeyMap() KeyMap {
 		Enter:           key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "open/confirm")),
 		Escape:          key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "back")),
 		InsertMode:      key.NewBinding(key.WithKeys("i"), key.WithHelp("i", "insert mode")),
+		VisualMode:      key.NewBinding(key.WithKeys("v"), key.WithHelp("v", "visual mode")),
 		CommandMode:     key.NewBinding(key.WithKeys(":"), key.WithHelp(":", "command mode")),
 		SearchMode:      key.NewBinding(key.WithKeys("/"), key.WithHelp("/", "search")),
 		SearchNext:      key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "next match")),
@@ -97,7 +99,7 @@ func DefaultKeyMap() KeyMap {
 		Edit:            key.NewBinding(key.WithKeys("E"), key.WithHelp("E", "edit message")),
 		Delete:          key.NewBinding(key.WithKeys("D"), key.WithHelp("D", "delete message")),
 		CopyPermalink:   key.NewBinding(key.WithKeys("Y", "C"), key.WithHelp("Y/C", "copy permalink")),
-		OpenPreview:     key.NewBinding(key.WithKeys("O", "v"), key.WithHelp("O/v", "open image preview")),
+		OpenPreview:     key.NewBinding(key.WithKeys("O"), key.WithHelp("O", "open image preview")),
 		OpenLink:        key.NewBinding(key.WithKeys("o"), key.WithHelp("o", "open link in message")),
 		MarkUnread:      key.NewBinding(key.WithKeys("U"), key.WithHelp("U", "mark unread")),
 		// Keyless: ctrl+w is reserved as the window-command prefix

--- a/internal/ui/messages/model.go
+++ b/internal/ui/messages/model.go
@@ -2686,6 +2686,75 @@ func (m *Model) HasSelection() bool {
 	return m.hasSelection
 }
 
+// BeginVisualSelection starts a character-wise selection at the beginning of
+// the currently selected message. The first display cell is selected, matching
+// Vim's inclusive visual-mode cursor.
+func (m *Model) BeginVisualSelection() bool {
+	for _, e := range m.cache {
+		if e.msgIdx != m.selected || e.msgIdx < 0 || len(e.linesPlain) == 0 {
+			continue
+		}
+		id := m.messages[e.msgIdx].TS
+		start := selection.Anchor{MessageID: id}
+		end := start
+		if w := displayWidthOfPlain(e.linesPlain[0]); w > 0 {
+			end.Col = 1
+		}
+		m.selRange = selection.Range{Start: start, End: end, Active: true}
+		m.hasSelection = true
+		return true
+	}
+	return false
+}
+
+// MoveVisualSelection moves the active selection end within its message.
+func (m *Model) MoveVisualSelection(motion string) {
+	if !m.hasSelection {
+		return
+	}
+	a := m.selRange.End
+	idx, ok := m.messageIDToEntryIdx[a.MessageID]
+	if !ok || idx >= len(m.cache) {
+		return
+	}
+	e := m.cache[idx]
+	switch motion {
+	case "h", "left":
+		if a.Col > 0 {
+			a.Col--
+		}
+	case "l", "right":
+		if w := displayWidthOfPlain(e.linesPlain[a.Line]); a.Col < w {
+			a.Col++
+		}
+	case "j", "down":
+		if a.Line+1 < len(e.linesPlain) {
+			a.Line++
+			if w := displayWidthOfPlain(e.linesPlain[a.Line]); a.Col > w {
+				a.Col = w
+			}
+		}
+	case "k", "up":
+		if a.Line > 0 {
+			a.Line--
+			if w := displayWidthOfPlain(e.linesPlain[a.Line]); a.Col > w {
+				a.Col = w
+			}
+		}
+	case "0":
+		a.Col = 0
+	case "$":
+		a.Col = displayWidthOfPlain(e.linesPlain[a.Line])
+	}
+	m.selRange.End = a
+}
+
+func (m *Model) SwapSelectionEnds() {
+	if m.hasSelection {
+		m.selRange.Start, m.selRange.End = m.selRange.End, m.selRange.Start
+	}
+}
+
 // ScrollHintForDrag returns -1 if the cursor is within 1 row of the top
 // edge of the message-content area, +1 if within 1 row of the bottom, else 0.
 // The incoming viewportY is pane-local (0 == top of panel content, just

--- a/internal/ui/messages/selection_test.go
+++ b/internal/ui/messages/selection_test.go
@@ -78,6 +78,23 @@ func TestSelection_ClearRemovesSelection(t *testing.T) {
 	}
 }
 
+func TestVisualSelection_MotionsAndSwapEnds(t *testing.T) {
+	m := newTestModel(60)
+	if !m.BeginVisualSelection() {
+		t.Fatal("BeginVisualSelection returned false")
+	}
+	initial := m.SelectionText()
+	m.MoveVisualSelection("$")
+	if got := m.SelectionText(); len(got) <= len(initial) {
+		t.Fatalf("$ did not extend selection: initial=%q got=%q", initial, got)
+	}
+	m.SwapSelectionEnds()
+	m.MoveVisualSelection("l")
+	if !m.HasSelection() {
+		t.Fatal("moving the swapped end cleared selection")
+	}
+}
+
 func TestSelection_ScrollHintForDrag(t *testing.T) {
 	m := newTestModel(60)
 	// View() set lastViewHeight to msgAreaHeight = height - chromeHeight.

--- a/internal/ui/mode.go
+++ b/internal/ui/mode.go
@@ -20,6 +20,7 @@ const (
 	ModeReactionsView
 	ModeLinkPicker
 	ModeWorkspaceSearch
+	ModeVisual
 )
 
 // IsModalOverlay reports whether the mode is a full-screen modal
@@ -84,6 +85,8 @@ func (m Mode) String() string {
 		return "LINKS"
 	case ModeWorkspaceSearch:
 		return "WS-SEARCH"
+	case ModeVisual:
+		return "VISUAL"
 	default:
 		return "UNKNOWN"
 	}

--- a/internal/ui/mode_handlers.go
+++ b/internal/ui/mode_handlers.go
@@ -64,6 +64,7 @@ var modeHandlers = map[Mode]modeHandler{
 	ModeReactionsView:        handleReactionsViewMode,
 	ModeLinkPicker:           handleLinkPickerMode,
 	ModeWorkspaceSearch:      handleWorkspaceSearchMode,
+	ModeVisual:               handleVisualMode,
 }
 
 // normalizeFinderKey maps a tea.KeyMsg to the plain-string form the

--- a/internal/ui/mode_normal.go
+++ b/internal/ui/mode_normal.go
@@ -52,6 +52,12 @@ func handleNormalMode(a *App, msg tea.KeyMsg) tea.Cmd {
 	}
 
 	switch {
+	case key.Matches(msg, a.keys.VisualMode):
+		if a.beginVisualSelection() {
+			a.SetMode(ModeVisual)
+		}
+		return nil
+
 	case key.Matches(msg, a.keys.InsertMode):
 		a.SetMode(ModeInsert)
 		// In the Threads view there is no main compose box -- the

--- a/internal/ui/mode_visual.go
+++ b/internal/ui/mode_visual.go
@@ -1,0 +1,82 @@
+package ui
+
+import (
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/gammons/slk/internal/ui/statusbar"
+	"golang.design/x/clipboard"
+)
+
+// handleVisualMode implements character-wise Vim selection over the rendered
+// text of the selected message or reply. h/j/k/l and 0/$ move the active end,
+// o swaps ends, y copies, and Esc cancels.
+func handleVisualMode(a *App, msg tea.KeyMsg) tea.Cmd {
+	switch msg.String() {
+	case "esc", "v":
+		a.clearSelections()
+		a.SetMode(ModeNormal)
+	case "h", "left", "j", "down", "k", "up", "l", "right", "0", "$":
+		a.moveVisualSelection(msg.String())
+	case "o":
+		a.swapVisualSelectionEnds()
+	case "y":
+		text := a.visualSelectionText()
+		if text == "" {
+			return nil
+		}
+		a.finishVisualSelection()
+		a.SetMode(ModeNormal)
+		return func() tea.Msg {
+			if !a.clipboardAvailable {
+				return statusbar.CopyFailedMsg{}
+			}
+			_ = a.clipboardWrite(clipboard.FmtText, []byte(text))
+			return statusbar.CopiedMsg{N: len([]rune(text))}
+		}
+	}
+	return nil
+}
+
+func (a *App) beginVisualSelection() bool {
+	switch a.focusedPanel {
+	case PanelMessages:
+		return a.messagepane.BeginVisualSelection()
+	case PanelThread:
+		return a.threadPanel.BeginVisualSelection()
+	}
+	return false
+}
+
+func (a *App) moveVisualSelection(motion string) {
+	if a.focusedPanel == PanelMessages {
+		a.messagepane.MoveVisualSelection(motion)
+	} else if a.focusedPanel == PanelThread {
+		a.threadPanel.MoveVisualSelection(motion)
+	}
+}
+
+func (a *App) swapVisualSelectionEnds() {
+	if a.focusedPanel == PanelMessages {
+		a.messagepane.SwapSelectionEnds()
+	} else if a.focusedPanel == PanelThread {
+		a.threadPanel.SwapSelectionEnds()
+	}
+}
+
+func (a *App) visualSelectionText() string {
+	if a.focusedPanel == PanelMessages {
+		return a.messagepane.SelectionText()
+	}
+	if a.focusedPanel == PanelThread {
+		return a.threadPanel.SelectionText()
+	}
+	return ""
+}
+
+func (a *App) finishVisualSelection() {
+	if a.focusedPanel == PanelMessages {
+		_, _ = a.messagepane.EndSelection()
+	} else if a.focusedPanel == PanelThread {
+		_, _ = a.threadPanel.EndSelection()
+	}
+}

--- a/internal/ui/thread/model.go
+++ b/internal/ui/thread/model.go
@@ -994,6 +994,79 @@ func (m *Model) ClearSelection() {
 // pinned-on-screen post-drag.
 func (m *Model) HasSelection() bool { return m.hasSelection }
 
+// BeginVisualSelection starts a character-wise selection at the beginning of
+// the selected reply. The first display cell is selected.
+func (m *Model) BeginVisualSelection() bool {
+	for _, e := range m.cache {
+		if e.replyIdx != m.selected || e.replyIdx < 0 || len(e.linesPlain) == 0 {
+			continue
+		}
+		id := m.replies[e.replyIdx].TS
+		start := selection.Anchor{MessageID: id}
+		end := start
+		if w := messages.DisplayWidthOfPlain(e.linesPlain[0]); w > 0 {
+			end.Col = 1
+		}
+		m.selRange = selection.Range{Start: start, End: end, Active: true}
+		m.hasSelection = true
+		m.dirty()
+		return true
+	}
+	return false
+}
+
+// MoveVisualSelection moves the active selection end within its reply.
+func (m *Model) MoveVisualSelection(motion string) {
+	if !m.hasSelection {
+		return
+	}
+	a := m.selRange.End
+	idx, ok := m.replyIDToIdx[a.MessageID]
+	if !ok || idx >= len(m.cache) {
+		return
+	}
+	e := m.cache[idx]
+	switch motion {
+	case "h", "left":
+		if a.Col > 0 {
+			a.Col--
+		}
+	case "l", "right":
+		if w := messages.DisplayWidthOfPlain(e.linesPlain[a.Line]); a.Col < w {
+			a.Col++
+		}
+	case "j", "down":
+		if a.Line+1 < len(e.linesPlain) {
+			a.Line++
+			if w := messages.DisplayWidthOfPlain(e.linesPlain[a.Line]); a.Col > w {
+				a.Col = w
+			}
+		}
+	case "k", "up":
+		if a.Line > 0 {
+			a.Line--
+			if w := messages.DisplayWidthOfPlain(e.linesPlain[a.Line]); a.Col > w {
+				a.Col = w
+			}
+		}
+	case "0":
+		a.Col = 0
+	case "$":
+		a.Col = messages.DisplayWidthOfPlain(e.linesPlain[a.Line])
+	}
+	if a != m.selRange.End {
+		m.selRange.End = a
+		m.dirty()
+	}
+}
+
+func (m *Model) SwapSelectionEnds() {
+	if m.hasSelection {
+		m.selRange.Start, m.selRange.End = m.selRange.End, m.selRange.Start
+		m.dirty()
+	}
+}
+
 // ScrollHintForDrag returns -1 if the cursor is within 1 row of the top
 // edge of the reply-content area, +1 if within 1 row of the bottom, else 0.
 // The incoming viewportY is pane-local (0 == top of panel content, just

--- a/internal/ui/thread/selection_test.go
+++ b/internal/ui/thread/selection_test.go
@@ -73,6 +73,18 @@ func TestThreadSelection_ClickWithoutDragReturnsEmpty(t *testing.T) {
 	}
 }
 
+func TestThreadVisualSelection_Motions(t *testing.T) {
+	m := newTestThread()
+	if !m.BeginVisualSelection() {
+		t.Fatal("BeginVisualSelection returned false")
+	}
+	initial := m.SelectionText()
+	m.MoveVisualSelection("$")
+	if got := m.SelectionText(); len(got) <= len(initial) {
+		t.Fatalf("$ did not extend selection: initial=%q got=%q", initial, got)
+	}
+}
+
 func TestThreadSelection_ClearOnSetThread(t *testing.T) {
 	m := newTestThread()
 	m.BeginSelectionAt(firstContentY(m), 0)


### PR DESCRIPTION
## Summary

Add Vim-style visual mode so users can select and copy part of a channel message or thread reply with the keyboard.

## Changes

- Add `v` / `VISUAL` mode with h/j/k/l, arrow, 0/$, and endpoint-swap motions
- Add `y` clipboard yank and Esc cancellation for messages and thread replies
- Keep image preview available on `O` and add selection/mode coverage

## Testing

- `go test ./...` (2,176 tests passed)