### PR TITLE
fix(config): merge leftover [workspaces.<teamID>] blocks

### DIFF
--- a/cmd/slk/save_theme.go
+++ b/cmd/slk/save_theme.go
@@ -125,6 +125,55 @@ func sanitizeComment(s string) string {
 	return strings.TrimSpace(b.String())
 }
 
+// findWorkspaceSectionStart returns the line index of the [workspaces.*]
+// header to write into for tomlKey/teamID, or -1 if none exists.
+//
+// Order: the literal tomlKey header, then a legacy [workspaces.<teamID>]
+// header, then any slug-keyed block whose team_id field matches. That
+// last fallback is load-bearing — saveWorkspaceVersionTS used to look
+// only for [workspaces.<tomlKey>], and when tomlKey was the raw team ID
+// it appended a second block next to the slug-keyed one, which Load
+// then rejected as a duplicate workspace.
+func findWorkspaceSectionStart(lines []string, tomlKey, teamID string) int {
+	headers := make([]string, 0, 2)
+	if tomlKey != "" {
+		headers = append(headers, "[workspaces."+tomlKey+"]")
+	}
+	if teamID != "" && teamID != tomlKey {
+		headers = append(headers, "[workspaces."+teamID+"]")
+	}
+	for i, line := range lines {
+		t := strings.TrimSpace(line)
+		for _, h := range headers {
+			if t == h {
+				return i
+			}
+		}
+	}
+	if teamID == "" {
+		return -1
+	}
+	sectionStart := -1
+	for i, line := range lines {
+		t := strings.TrimSpace(line)
+		if strings.HasPrefix(t, "[") {
+			if strings.HasPrefix(t, "[workspaces.") {
+				sectionStart = i
+			} else {
+				sectionStart = -1
+			}
+			continue
+		}
+		if sectionStart < 0 {
+			continue
+		}
+		if strings.HasPrefix(t, "team_id") && strings.Contains(t, teamID) {
+			return sectionStart
+		}
+	}
+	return -1
+}
+
 // saveGlobalTheme rewrites the [appearance] theme line in config.toml.
 // If the file has no theme line, it appends a new [appearance] section.
 // Existing comments and ordering are preserved (textual rewrite, not
@@ -190,15 +239,7 @@ func saveWorkspaceTheme(configPath, tomlKey, teamID, teamName, themeName string)
 	}
 	lines := strings.Split(string(data), "\n")
 
-	header := fmt.Sprintf("[workspaces.%s]", tomlKey)
-
-	sectionStart := -1
-	for i, line := range lines {
-		if strings.TrimSpace(line) == header {
-			sectionStart = i
-			break
-		}
-	}
+	sectionStart := findWorkspaceSectionStart(lines, tomlKey, teamID)
 
 	if sectionStart >= 0 {
 		end := len(lines)

--- a/cmd/slk/save_version_ts.go
+++ b/cmd/slk/save_version_ts.go
@@ -60,15 +60,7 @@ func saveWorkspaceVersionTS(configPath, tomlKey, teamID, teamName, versionTS str
 	}
 	lines := strings.Split(string(data), "\n")
 
-	header := fmt.Sprintf("[workspaces.%s]", tomlKey)
-
-	sectionStart := -1
-	for i, line := range lines {
-		if strings.TrimSpace(line) == header {
-			sectionStart = i
-			break
-		}
-	}
+	sectionStart := findWorkspaceSectionStart(lines, tomlKey, teamID)
 
 	if sectionStart >= 0 {
 		end := len(lines)

--- a/cmd/slk/save_version_ts_test.go
+++ b/cmd/slk/save_version_ts_test.go
@@ -76,6 +76,36 @@ func TestSaveWorkspaceVersionTS_DoesNotTouchOtherWorkspaces(t *testing.T) {
 	}
 }
 
+func TestSaveWorkspaceVersionTS_WritesIntoSlugWhenCalledWithTeamIDKey(t *testing.T) {
+	// workspaceTOMLKey falls back to the raw team ID when the in-memory
+	// config has no matching block. The on-disk file still has the
+	// slug-keyed section from --add-workspace. Writing a second
+	// [workspaces.<teamID>] block is what made Load refuse to start
+	// ("both reference team_id").
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	initial := "# Obvious AI\n[workspaces.obvious-ai]\nteam_id = \"T099JCA82HJ\"\n"
+	if err := os.WriteFile(path, []byte(initial), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := saveWorkspaceVersionTS(path, "T099JCA82HJ", "T099JCA82HJ", "Obvious AI", "1788174451"); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	out := string(mustRead(t, path))
+	if strings.Count(out, "[workspaces.") != 1 {
+		t.Errorf("expected a single workspace section, got:\n%s", out)
+	}
+	if !strings.Contains(out, "[workspaces.obvious-ai]") {
+		t.Errorf("slug section was not the write target:\n%s", out)
+	}
+	if strings.Contains(out, "[workspaces.T099JCA82HJ]") {
+		t.Errorf("appended a leftover team-ID block:\n%s", out)
+	}
+	if !strings.Contains(out, `version_ts = "1788174451"`) {
+		t.Errorf("version_ts missing:\n%s", out)
+	}
+}
+
 func TestSaveWorkspaceVersionTS_CreatesFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "sub", "config.toml")

--- a/cmd/slk/save_width.go
+++ b/cmd/slk/save_width.go
@@ -26,15 +26,7 @@ func saveWorkspaceWidth(configPath, tomlKey, teamID, teamName string, width int)
 	}
 	lines := strings.Split(string(data), "\n")
 
-	header := fmt.Sprintf("[workspaces.%s]", tomlKey)
-
-	sectionStart := -1
-	for i, line := range lines {
-		if strings.TrimSpace(line) == header {
-			sectionStart = i
-			break
-		}
-	}
+	sectionStart := findWorkspaceSectionStart(lines, tomlKey, teamID)
 
 	if sectionStart >= 0 {
 		end := len(lines)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -462,6 +462,48 @@ team_id = "T01ABCDEF"
 	}
 }
 
+func TestLoadWorkspacesMergesLegacyTeamIDKeyIntoSlug(t *testing.T) {
+	// saveWorkspaceVersionTS used to append [workspaces.<teamID>] when
+	// it could not find the slug header, so a real config looks like
+	// this after the first boot. Two slugs for the same team is still
+	// an error (TestLoadWorkspacesDuplicateTeamID); a leftover team-ID
+	// key next to the slug that owns that team is prefs, not a second
+	// workspace.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	data := []byte(`
+[workspaces.work]
+team_id = "T01ABCDEF"
+theme = "dracula"
+
+[workspaces.T01ABCDEF]
+version_ts = "1788174451"
+`)
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if _, ok := cfg.Workspaces["T01ABCDEF"]; ok {
+		t.Fatal("leftover team-ID key should be dropped after merge")
+	}
+	ws, ok := cfg.Workspaces["work"]
+	if !ok {
+		t.Fatalf("expected slug key 'work', got %v", cfg.Workspaces)
+	}
+	if ws.TeamID != "T01ABCDEF" {
+		t.Errorf("TeamID = %q, want T01ABCDEF", ws.TeamID)
+	}
+	if ws.Theme != "dracula" {
+		t.Errorf("Theme = %q, want dracula (slug fields must survive the merge)", ws.Theme)
+	}
+	if ws.VersionTS != "1788174451" {
+		t.Errorf("VersionTS = %q, want the leftover block's 1788174451", ws.VersionTS)
+	}
+}
+
 func TestLoadWorkspacesMixedKeys(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")

--- a/internal/config/workspaces.go
+++ b/internal/config/workspaces.go
@@ -48,12 +48,17 @@ func Slugify(s string) string {
 // blocks). Returns an error if a slug-keyed block lacks team_id, if
 // two slugs map to the same team_id, or if a slug-keyed block's
 // team_id field is itself not a Slack-team-ID-shaped string.
+//
+// A leftover [workspaces.<teamID>] block next to a slug-keyed block
+// for the same team is not a duplicate workspace — it is how
+// saveWorkspaceVersionTS used to persist version_ts when it could not
+// find the slug header. Those prefs are merged into the slug block
+// and the leftover key is dropped so Load does not refuse to start.
 func resolveWorkspaceKeys(ws map[string]Workspace) (map[string]Workspace, error) {
 	if len(ws) == 0 {
 		return ws, nil
 	}
-	out := make(map[string]Workspace, len(ws))
-	seenTeamID := make(map[string]string, len(ws)) // teamID -> first slug we saw
+	prepared := make(map[string]Workspace, len(ws))
 	for key, w := range ws {
 		switch {
 		case w.TeamID != "":
@@ -71,13 +76,62 @@ func resolveWorkspaceKeys(ws map[string]Workspace) (map[string]Workspace, error)
 				"workspace %q is missing team_id (the TOML key is a slug, "+
 					"so the block must set team_id explicitly)", key)
 		}
-		if first, dup := seenTeamID[w.TeamID]; dup {
+		prepared[key] = w
+	}
+
+	slugForTeam := make(map[string]string, len(prepared)) // teamID -> slug key
+	for key, w := range prepared {
+		if key == w.TeamID {
+			continue
+		}
+		if first, dup := slugForTeam[w.TeamID]; dup {
 			return nil, fmt.Errorf(
 				"workspaces %q and %q both reference team_id %q",
 				first, key, w.TeamID)
 		}
-		seenTeamID[w.TeamID] = key
+		slugForTeam[w.TeamID] = key
+	}
+
+	out := make(map[string]Workspace, len(prepared))
+	for key, w := range prepared {
+		if key != w.TeamID {
+			continue
+		}
+		if slug, ok := slugForTeam[w.TeamID]; ok {
+			prepared[slug] = mergeWorkspacePrefs(prepared[slug], w)
+			continue
+		}
 		out[key] = w
 	}
+	for _, slug := range slugForTeam {
+		out[slug] = prepared[slug]
+	}
 	return out, nil
+}
+
+// mergeWorkspacePrefs copies unset preference fields from src into dst.
+// Used when a leftover team-ID-keyed block sits beside a slug-keyed
+// block for the same team: the slug keeps identity, the leftover
+// donates version_ts / theme / width / etc. that were saved under
+// the team-ID key. Non-empty dst fields win.
+func mergeWorkspacePrefs(dst, src Workspace) Workspace {
+	if dst.VersionTS == "" {
+		dst.VersionTS = src.VersionTS
+	}
+	if dst.Theme == "" {
+		dst.Theme = src.Theme
+	}
+	if dst.SidebarWidth == 0 {
+		dst.SidebarWidth = src.SidebarWidth
+	}
+	if dst.Order == 0 {
+		dst.Order = src.Order
+	}
+	if dst.UseSlackSections == nil {
+		dst.UseSlackSections = src.UseSlackSections
+	}
+	if len(dst.Sections) == 0 {
+		dst.Sections = src.Sections
+	}
+	return dst
 }


### PR DESCRIPTION
## Why

`saveWorkspaceVersionTS` (and theme/width saves) looked only for `[workspaces.<tomlKey>]`. When `tomlKey` fell back to the raw Slack team ID, slk appended a second `[workspaces.T…]` block next to the slug-keyed one from `--add-workspace`. `Load` then refused to start with `workspaces "…" and "…" both reference team_id`.

## What

- Treat a leftover `[workspaces.<teamID>]` next to a slug-keyed block for the same team as prefs, not a duplicate workspace.
- Merge unset fields (`version_ts`, `theme`, `sidebar_width`, …) into the slug block and drop the leftover key.
- Shared `findWorkspaceSectionStart` writes subsequent saves into the existing slug section (or a block whose `team_id` matches).

Two slug-keyed blocks for the same `team_id` are still an error.

## Test plan

- [x] `go test ./internal/config/ ./cmd/slk/`
- [ ] Load a config that has both `[workspaces.my-team]` and `[workspaces.T…]` for the same team; slk should start and keep the slug's theme plus the leftover `version_ts`.

Merge first in this stack (1/4). Independent of the later sidebar/Activity PRs except that they sit on top of this commit.