### PR TITLE
fix(sidebar): resolve DM usernames on first paint

### DIFF
--- a/cmd/slk/bootstrap_adapters.go
+++ b/cmd/slk/bootstrap_adapters.go
@@ -455,6 +455,39 @@ func bootConversations(res *bootstrap.Result) []slack.Channel {
 	return out
 }
 
+// fillIMUsers copies counterparty user IDs from userBoot's ims[] onto
+// IM conversations that lack them.
+//
+// users.conversations is the sidebar's primary source, but its IM
+// objects are not guaranteed to carry `user` — Slack's conversation
+// payload sometimes omits it, and slack-go then leaves Channel.User
+// empty. buildChannelItem names a DM from that field (falling back to
+// the raw user ID), and an empty User means the sidebar row is blank
+// and the unresolved-DM sweep has nothing to fetch. userBoot's ims[]
+// always include `user`; overlaying them is how a DM gets a name when
+// GetChannels succeeded. Existing User values are left alone.
+func fillIMUsers(channels []slack.Channel, ims []boot.IM) {
+	if len(channels) == 0 || len(ims) == 0 {
+		return
+	}
+	byID := make(map[string]string, len(ims))
+	for _, im := range ims {
+		if im.UserID != "" {
+			byID[im.ID] = im.UserID
+		}
+	}
+	for i := range channels {
+		uid, ok := byID[channels[i].ID]
+		if !ok {
+			continue
+		}
+		channels[i].IsIM = true
+		if channels[i].User == "" {
+			channels[i].User = uid
+		}
+	}
+}
+
 // hydrateFirstSight inserts cache rows for the conversations and users
 // this boot learned about that the cache has never seen.
 //

--- a/cmd/slk/bootstrap_adapters_test.go
+++ b/cmd/slk/bootstrap_adapters_test.go
@@ -754,6 +754,33 @@ func TestBootMutedChannels_MergesBothPrefs(t *testing.T) {
 	}
 }
 
+func TestFillIMUsers_CopiesCounterpartyFromBoot(t *testing.T) {
+	// users.conversations IMs with an empty User would render as a
+	// blank sidebar row; userBoot's ims[] carry the counterparty id.
+	channels := []slack.Channel{
+		{GroupConversation: slack.GroupConversation{Conversation: slack.Conversation{ID: "D1", IsIM: true}}},
+		{GroupConversation: slack.GroupConversation{Conversation: slack.Conversation{ID: "D2", IsIM: true, User: "U_KEEP"}}},
+		{GroupConversation: slack.GroupConversation{Conversation: slack.Conversation{ID: "C1"}}},
+	}
+	fillIMUsers(channels, []boot.IM{
+		{ID: "D1", UserID: "U1"},
+		{ID: "D2", UserID: "U_BOOT"},
+		{ID: "D3", UserID: "U3"},
+	})
+	if got := channels[0].User; got != "U1" {
+		t.Errorf("D1 User = %q; want U1 from userBoot", got)
+	}
+	if !channels[0].IsIM {
+		t.Error("D1 lost IsIM")
+	}
+	if got := channels[1].User; got != "U_KEEP" {
+		t.Errorf("D2 User = %q; want the users.conversations value left alone", got)
+	}
+	if channels[2].User != "" || channels[2].IsIM {
+		t.Errorf("C1 was touched: User=%q IsIM=%v", channels[2].User, channels[2].IsIM)
+	}
+}
+
 func TestBootConversations_MapsWhatTheSidebarBuilderReads(t *testing.T) {
 	// buildChannelItem reads ID, Name, Topic, IsIM, IsMpIM, IsPrivate,
 	// IsMember and User. Every one of those has to survive the trip

--- a/cmd/slk/channelitem_test.go
+++ b/cmd/slk/channelitem_test.go
@@ -41,6 +41,27 @@ func TestBuildChannelItem_DM(t *testing.T) {
 	}
 }
 
+func TestBuildChannelItem_DMUnknownFallsBackToUserID(t *testing.T) {
+	wctx := &WorkspaceContext{
+		BotUserIDs:        map[string]bool{},
+		UserNames:         map[string]string{},
+		UserNamesByHandle: map[string]string{},
+	}
+	ch := slack.Channel{
+		GroupConversation: slack.GroupConversation{
+			Conversation: slack.Conversation{
+				ID:   "D1",
+				IsIM: true,
+				User: "U123",
+			},
+		},
+	}
+	item, _ := buildChannelItem(ch, wctx, config.Config{}, "T1")
+	if item.Name != "U123" {
+		t.Errorf("Name = %q, want the user ID when UserNames has no entry", item.Name)
+	}
+}
+
 func TestBuildChannelItem_GroupDM(t *testing.T) {
 	wctx := &WorkspaceContext{
 		BotUserIDs:        map[string]bool{},

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -108,7 +108,7 @@ type WorkspaceContext struct {
 	// Edge is the edgeapi client for this workspace: the
 	// conditional-revalidation and server-side-search endpoints. Nil
 	// only if construction failed, and every caller nil-checks.
-	Edge       *edge.Client
+	Edge *edge.Client
 	// EdgeHealth records whether edge resolution is working for this
 	// workspace this session. bootstrap marks it degraded on a
 	// wholesale failure; the user resolver reads it to skip batch
@@ -2543,20 +2543,34 @@ func connectWorkspace(ctx context.Context, token slackclient.Token, db *cache.DB
 		debuglog.General("workspace %s: users.conversations failed: %v", token.TeamName, err)
 		channels = bootConversations(res)
 	}
+	// Overlay IM counterparty ids from userBoot even when
+	// users.conversations succeeded: its IM objects sometimes omit
+	// `user`, and without that id the sidebar row is the raw (empty)
+	// Channel.User and the unresolved-DM sweep has nothing to fetch.
+	fillIMUsers(channels, res.IMs)
 	if len(channels) == 0 {
 		log.Printf("workspace %s: no conversations from either users.conversations or client.userBoot; the sidebar will be empty", token.TeamName)
 	}
+
+	// Resolve DM counterparties before buildChannelItem so the first
+	// sidebar paint already has display names, matching what the
+	// README screenshot shows. This is still on the connect goroutine,
+	// so writing wctx.UserNames is safe. Misses stay in UnresolvedDMs
+	// and the async sweep below covers them.
+	seedDMDisplayNames(wctx, channels)
 
 	for _, ch := range channels {
 		item, finderItem := buildChannelItem(ch, wctx, cfg, client.TeamID())
 		upsertChannelInDB(db, ch, item.Type, client.TeamID())
 
 		if ch.IsIM {
-			if _, ok := wctx.UserNames[ch.User]; !ok {
-				wctx.UnresolvedDMs = append(wctx.UnresolvedDMs, UnresolvedDM{
-					ChannelID: ch.ID,
-					UserID:    ch.User,
-				})
+			if ch.User != "" {
+				if name, ok := wctx.UserNames[ch.User]; !ok || name == "" {
+					wctx.UnresolvedDMs = append(wctx.UnresolvedDMs, UnresolvedDM{
+						ChannelID: ch.ID,
+						UserID:    ch.User,
+					})
+				}
 			}
 			if cachedUser, err := db.GetUser(ch.User); err == nil && cachedUser.Presence != "" {
 				item.Presence = cachedUser.Presence
@@ -2841,6 +2855,101 @@ func resolveUser(client *slackclient.Client, userID string, userNames map[string
 	return userID, false
 }
 
+// edgeUserDisplayName is the display → real → handle chain used
+// everywhere a user record from edge users/info is shown. Empty means
+// the record resolved nothing and the caller must fall back.
+func edgeUserDisplayName(u edge.User) string {
+	if u.Profile.DisplayName != "" {
+		return u.Profile.DisplayName
+	}
+	if u.Profile.RealName != "" {
+		return u.Profile.RealName
+	}
+	return u.Name
+}
+
+// seedDMDisplayNames batch-resolves IM counterparties that are not yet
+// in wctx.UserNames and writes the results into the in-memory maps
+// buildChannelItem reads. Must run on the connectWorkspace goroutine
+// before the UI is told the workspace is ready — after that,
+// wctx.UserNames has other readers and PatchUserName is the only safe
+// writer.
+func seedDMDisplayNames(wctx *WorkspaceContext, channels []slack.Channel) {
+	if wctx == nil || wctx.UserResolver == nil {
+		return
+	}
+	if wctx.UserNames == nil {
+		wctx.UserNames = make(map[string]string)
+	}
+	if wctx.UserNamesByHandle == nil {
+		wctx.UserNamesByHandle = make(map[string]string)
+	}
+	if wctx.BotUserIDs == nil {
+		wctx.BotUserIDs = make(map[string]bool)
+	}
+	seen := make(map[string]struct{})
+	ids := make([]string, 0)
+	for _, ch := range channels {
+		if !ch.IsIM || ch.User == "" {
+			continue
+		}
+		if _, dup := seen[ch.User]; dup {
+			continue
+		}
+		seen[ch.User] = struct{}{}
+		if name, ok := wctx.UserNames[ch.User]; ok && name != "" {
+			continue
+		}
+		ids = append(ids, ch.User)
+	}
+	if len(ids) == 0 {
+		return
+	}
+	for _, u := range wctx.UserResolver.ResolveNow(ids) {
+		name := edgeUserDisplayName(u)
+		if name == "" {
+			continue
+		}
+		wctx.UserNames[u.ID] = name
+		if u.Name != "" {
+			wctx.UserNamesByHandle[u.Name] = name
+		}
+		if u.IsBot {
+			wctx.BotUserIDs[u.ID] = true
+		}
+	}
+}
+
+// patchWorkspaceDM renames a DM (and re-buckets an app DM) on the
+// workspace's in-memory channel lists so a later workspace switch
+// still shows the resolved name. DMNameResolvedMsg only patches the
+// active sidebar.
+func patchWorkspaceDM(wctx *WorkspaceContext, channelID, name string, isBot bool) {
+	if wctx == nil || channelID == "" || name == "" {
+		return
+	}
+	for i := range wctx.Channels {
+		if wctx.Channels[i].ID != channelID {
+			continue
+		}
+		wctx.Channels[i].Name = name
+		if isBot && wctx.Channels[i].Type == "dm" {
+			wctx.Channels[i].Type = "app"
+		}
+		break
+	}
+	for i := range wctx.FinderItems {
+		if wctx.FinderItems[i].ID != channelID {
+			continue
+		}
+		wctx.FinderItems[i].Name = name
+		if isBot && wctx.FinderItems[i].Type == "dm" {
+			wctx.FinderItems[i].Type = "app"
+		}
+		break
+	}
+}
+
 // resolveDMNames resolves the display names of unresolved DM
 // counterparties, one edge users/info batch for the whole sweep, with
 // the per-user resolveUser loop as the fallback for ids edge did not
@@ -2854,21 +2963,20 @@ func resolveUser(client *slackclient.Client, userID string, userNames map[string
 func resolveDMNames(wctx *WorkspaceContext, db *cache.DB, avatarCache *avatar.Cache, send func(tea.Msg)) {
 	dmIDs := make([]string, 0, len(wctx.UnresolvedDMs))
 	for _, dm := range wctx.UnresolvedDMs {
-		dmIDs = append(dmIDs, dm.UserID)
+		if dm.UserID != "" {
+			dmIDs = append(dmIDs, dm.UserID)
+		}
 	}
 	byEdge := make(map[string]edge.User)
 	for _, u := range wctx.UserResolver.ResolveNow(dmIDs) {
 		byEdge[u.ID] = u
 	}
 	for _, dm := range wctx.UnresolvedDMs {
+		if dm.UserID == "" {
+			continue
+		}
 		if u, ok := byEdge[dm.UserID]; ok {
-			name := u.Profile.DisplayName
-			if name == "" {
-				name = u.Profile.RealName
-			}
-			if name == "" {
-				name = u.Name
-			}
+			name := edgeUserDisplayName(u)
 			if name != "" {
 				// edge users/info carries no is_app_user: a Slack app's DM
 				// resolved here may bucket as "dm" rather than "app" until
@@ -2878,8 +2986,10 @@ func resolveDMNames(wctx *WorkspaceContext, db *cache.DB, avatarCache *avatar.Ca
 				if u.IsBot {
 					wctx.BotUserIDs[dm.UserID] = true
 				}
+				patchWorkspaceDM(wctx, dm.ChannelID, name, u.IsBot)
 				if send != nil {
 					send(ui.DMNameResolvedMsg{
+						TeamID:      wctx.TeamID,
 						ChannelID:   dm.ChannelID,
 						DisplayName: name,
 						IsBot:       u.IsBot,
@@ -2897,12 +3007,16 @@ func resolveDMNames(wctx *WorkspaceContext, db *cache.DB, avatarCache *avatar.Ca
 		if isBot {
 			wctx.BotUserIDs[dm.UserID] = true
 		}
-		if resolved != dm.UserID && send != nil {
-			send(ui.DMNameResolvedMsg{
-				ChannelID:   dm.ChannelID,
-				DisplayName: resolved,
-				IsBot:       isBot,
-			})
+		if resolved != dm.UserID {
+			patchWorkspaceDM(wctx, dm.ChannelID, resolved, isBot)
+			if send != nil {
+				send(ui.DMNameResolvedMsg{
+					TeamID:      wctx.TeamID,
+					ChannelID:   dm.ChannelID,
+					DisplayName: resolved,
+					IsBot:       isBot,
+				})
+			}
 		}
 	}
 }

--- a/cmd/slk/save_theme.go
+++ b/cmd/slk/save_theme.go
@@ -125,6 +125,55 @@ func sanitizeComment(s string) string {
 	return strings.TrimSpace(b.String())
 }
 
+// findWorkspaceSectionStart returns the line index of the [workspaces.*]
+// header to write into for tomlKey/teamID, or -1 if none exists.
+//
+// Order: the literal tomlKey header, then a legacy [workspaces.<teamID>]
+// header, then any slug-keyed block whose team_id field matches. That
+// last fallback is load-bearing — saveWorkspaceVersionTS used to look
+// only for [workspaces.<tomlKey>], and when tomlKey was the raw team ID
+// it appended a second block next to the slug-keyed one, which Load
+// then rejected as a duplicate workspace.
+func findWorkspaceSectionStart(lines []string, tomlKey, teamID string) int {
+	headers := make([]string, 0, 2)
+	if tomlKey != "" {
+		headers = append(headers, "[workspaces."+tomlKey+"]")
+	}
+	if teamID != "" && teamID != tomlKey {
+		headers = append(headers, "[workspaces."+teamID+"]")
+	}
+	for i, line := range lines {
+		t := strings.TrimSpace(line)
+		for _, h := range headers {
+			if t == h {
+				return i
+			}
+		}
+	}
+	if teamID == "" {
+		return -1
+	}
+	sectionStart := -1
+	for i, line := range lines {
+		t := strings.TrimSpace(line)
+		if strings.HasPrefix(t, "[") {
+			if strings.HasPrefix(t, "[workspaces.") {
+				sectionStart = i
+			} else {
+				sectionStart = -1
+			}
+			continue
+		}
+		if sectionStart < 0 {
+			continue
+		}
+		if strings.HasPrefix(t, "team_id") && strings.Contains(t, teamID) {
+			return sectionStart
+		}
+	}
+	return -1
+}
+
 // saveGlobalTheme rewrites the [appearance] theme line in config.toml.
 // If the file has no theme line, it appends a new [appearance] section.
 // Existing comments and ordering are preserved (textual rewrite, not
@@ -190,15 +239,7 @@ func saveWorkspaceTheme(configPath, tomlKey, teamID, teamName, themeName string)
 	}
 	lines := strings.Split(string(data), "\n")
 
-	header := fmt.Sprintf("[workspaces.%s]", tomlKey)
-
-	sectionStart := -1
-	for i, line := range lines {
-		if strings.TrimSpace(line) == header {
-			sectionStart = i
-			break
-		}
-	}
+	sectionStart := findWorkspaceSectionStart(lines, tomlKey, teamID)
 
 	if sectionStart >= 0 {
 		end := len(lines)

--- a/cmd/slk/save_version_ts.go
+++ b/cmd/slk/save_version_ts.go
@@ -60,15 +60,7 @@ func saveWorkspaceVersionTS(configPath, tomlKey, teamID, teamName, versionTS str
 	}
 	lines := strings.Split(string(data), "\n")
 
-	header := fmt.Sprintf("[workspaces.%s]", tomlKey)
-
-	sectionStart := -1
-	for i, line := range lines {
-		if strings.TrimSpace(line) == header {
-			sectionStart = i
-			break
-		}
-	}
+	sectionStart := findWorkspaceSectionStart(lines, tomlKey, teamID)
 
 	if sectionStart >= 0 {
 		end := len(lines)

--- a/cmd/slk/save_version_ts_test.go
+++ b/cmd/slk/save_version_ts_test.go
@@ -76,6 +76,36 @@ func TestSaveWorkspaceVersionTS_DoesNotTouchOtherWorkspaces(t *testing.T) {
 	}
 }
 
+func TestSaveWorkspaceVersionTS_WritesIntoSlugWhenCalledWithTeamIDKey(t *testing.T) {
+	// workspaceTOMLKey falls back to the raw team ID when the in-memory
+	// config has no matching block. The on-disk file still has the
+	// slug-keyed section from --add-workspace. Writing a second
+	// [workspaces.<teamID>] block is what made Load refuse to start
+	// ("both reference team_id").
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	initial := "# Obvious AI\n[workspaces.obvious-ai]\nteam_id = \"T099JCA82HJ\"\n"
+	if err := os.WriteFile(path, []byte(initial), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := saveWorkspaceVersionTS(path, "T099JCA82HJ", "T099JCA82HJ", "Obvious AI", "1788174451"); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	out := string(mustRead(t, path))
+	if strings.Count(out, "[workspaces.") != 1 {
+		t.Errorf("expected a single workspace section, got:\n%s", out)
+	}
+	if !strings.Contains(out, "[workspaces.obvious-ai]") {
+		t.Errorf("slug section was not the write target:\n%s", out)
+	}
+	if strings.Contains(out, "[workspaces.T099JCA82HJ]") {
+		t.Errorf("appended a leftover team-ID block:\n%s", out)
+	}
+	if !strings.Contains(out, `version_ts = "1788174451"`) {
+		t.Errorf("version_ts missing:\n%s", out)
+	}
+}
+
 func TestSaveWorkspaceVersionTS_CreatesFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "sub", "config.toml")

--- a/cmd/slk/save_width.go
+++ b/cmd/slk/save_width.go
@@ -26,15 +26,7 @@ func saveWorkspaceWidth(configPath, tomlKey, teamID, teamName string, width int)
 	}
 	lines := strings.Split(string(data), "\n")
 
-	header := fmt.Sprintf("[workspaces.%s]", tomlKey)
-
-	sectionStart := -1
-	for i, line := range lines {
-		if strings.TrimSpace(line) == header {
-			sectionStart = i
-			break
-		}
-	}
+	sectionStart := findWorkspaceSectionStart(lines, tomlKey, teamID)
 
 	if sectionStart >= 0 {
 		end := len(lines)

--- a/cmd/slk/user_resolver_test.go
+++ b/cmd/slk/user_resolver_test.go
@@ -15,6 +15,8 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/gammons/slk/internal/slack/edge"
 	"github.com/gammons/slk/internal/ui"
+	"github.com/gammons/slk/internal/ui/sidebar"
+	"github.com/slack-go/slack"
 )
 
 // TestUserResolver_BoundsConcurrentRequests is the second half of the
@@ -446,13 +448,18 @@ func TestResolveDMNames(t *testing.T) {
 		edgeUserRecord("U_APP", "someapp", "Some App", "", "T1", 1, true),
 	}}
 	wctx := &WorkspaceContext{
-		TeamID:       "T1",
-		UserNames:    map[string]string{},
-		BotUserIDs:   map[string]bool{},
-		UserResolver: newUserResolver("T1", nil, db, nil, nil, batcher, nil),
+		TeamID:            "T1",
+		UserNames:         map[string]string{},
+		UserNamesByHandle: map[string]string{},
+		BotUserIDs:        map[string]bool{},
+		UserResolver:      newUserResolver("T1", nil, db, nil, nil, batcher, nil),
 		UnresolvedDMs: []UnresolvedDM{
 			{ChannelID: "D_ALICE", UserID: "U_ALICE"},
 			{ChannelID: "D_APP", UserID: "U_APP"},
+		},
+		Channels: []sidebar.ChannelItem{
+			{ID: "D_ALICE", Name: "U_ALICE", Type: "dm", DMUserID: "U_ALICE"},
+			{ID: "D_APP", Name: "U_APP", Type: "dm", DMUserID: "U_APP"},
 		},
 	}
 	var mu sync.Mutex
@@ -481,6 +488,9 @@ func TestResolveDMNames(t *testing.T) {
 	if alice == nil || alice.DisplayName != "Alice A" {
 		t.Errorf("D_ALICE got %+v; want a DMNameResolvedMsg naming Alice A", alice)
 	}
+	if alice != nil && alice.TeamID != "T1" {
+		t.Errorf("D_ALICE TeamID = %q; want T1 so the UI ignores other workspaces", alice.TeamID)
+	}
 	if app == nil || app.DisplayName != "Some App" || !app.IsBot {
 		t.Errorf("D_APP got %+v; want a DMNameResolvedMsg naming Some App with IsBot true — that flag re-buckets the row into the Apps section", app)
 	}
@@ -489,5 +499,41 @@ func TestResolveDMNames(t *testing.T) {
 	}
 	if n := len(batcher.calls()); n != 1 {
 		t.Errorf("the sweep made %d edge calls; want 1 for any number of DMs", n)
+	}
+	byID := map[string]sidebar.ChannelItem{}
+	for _, ch := range wctx.Channels {
+		byID[ch.ID] = ch
+	}
+	if got := byID["D_ALICE"]; got.Name != "Alice A" {
+		t.Errorf("wctx.Channels D_ALICE Name = %q; want Alice A so a workspace switch still shows the resolved name", got.Name)
+	}
+	if got := byID["D_APP"]; got.Name != "Some App" || got.Type != "app" {
+		t.Errorf("wctx.Channels D_APP = {Name:%q Type:%q}; want Some App / app", got.Name, got.Type)
+	}
+}
+
+func TestSeedDMDisplayNames_FillsUserNamesFromEdge(t *testing.T) {
+	db := newTestDB(t)
+	batcher := &fakeBatcher{res: []edge.User{
+		edgeUserRecord("U1", "alice", "Alice A", "", "T1", 1, false),
+	}}
+	wctx := &WorkspaceContext{
+		TeamID:            "T1",
+		UserNames:         map[string]string{},
+		UserNamesByHandle: map[string]string{},
+		BotUserIDs:        map[string]bool{},
+		UserResolver:      newUserResolver("T1", nil, db, nil, nil, batcher, nil),
+	}
+	channels := []slack.Channel{{
+		GroupConversation: slack.GroupConversation{
+			Conversation: slack.Conversation{ID: "D1", IsIM: true, User: "U1"},
+		},
+	}}
+	seedDMDisplayNames(wctx, channels)
+	if got := wctx.UserNames["U1"]; got != "Alice A" {
+		t.Errorf("UserNames[U1] = %q; want Alice A — sidebar DMs read this map at first paint", got)
+	}
+	if got := wctx.UserNamesByHandle["alice"]; got != "Alice A" {
+		t.Errorf("UserNamesByHandle[alice] = %q; want Alice A", got)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -462,6 +462,48 @@ team_id = "T01ABCDEF"
 	}
 }
 
+func TestLoadWorkspacesMergesLegacyTeamIDKeyIntoSlug(t *testing.T) {
+	// saveWorkspaceVersionTS used to append [workspaces.<teamID>] when
+	// it could not find the slug header, so a real config looks like
+	// this after the first boot. Two slugs for the same team is still
+	// an error (TestLoadWorkspacesDuplicateTeamID); a leftover team-ID
+	// key next to the slug that owns that team is prefs, not a second
+	// workspace.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	data := []byte(`
+[workspaces.work]
+team_id = "T01ABCDEF"
+theme = "dracula"
+
+[workspaces.T01ABCDEF]
+version_ts = "1788174451"
+`)
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if _, ok := cfg.Workspaces["T01ABCDEF"]; ok {
+		t.Fatal("leftover team-ID key should be dropped after merge")
+	}
+	ws, ok := cfg.Workspaces["work"]
+	if !ok {
+		t.Fatalf("expected slug key 'work', got %v", cfg.Workspaces)
+	}
+	if ws.TeamID != "T01ABCDEF" {
+		t.Errorf("TeamID = %q, want T01ABCDEF", ws.TeamID)
+	}
+	if ws.Theme != "dracula" {
+		t.Errorf("Theme = %q, want dracula (slug fields must survive the merge)", ws.Theme)
+	}
+	if ws.VersionTS != "1788174451" {
+		t.Errorf("VersionTS = %q, want the leftover block's 1788174451", ws.VersionTS)
+	}
+}
+
 func TestLoadWorkspacesMixedKeys(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")

--- a/internal/config/workspaces.go
+++ b/internal/config/workspaces.go
@@ -48,12 +48,17 @@ func Slugify(s string) string {
 // blocks). Returns an error if a slug-keyed block lacks team_id, if
 // two slugs map to the same team_id, or if a slug-keyed block's
 // team_id field is itself not a Slack-team-ID-shaped string.
+//
+// A leftover [workspaces.<teamID>] block next to a slug-keyed block
+// for the same team is not a duplicate workspace — it is how
+// saveWorkspaceVersionTS used to persist version_ts when it could not
+// find the slug header. Those prefs are merged into the slug block
+// and the leftover key is dropped so Load does not refuse to start.
 func resolveWorkspaceKeys(ws map[string]Workspace) (map[string]Workspace, error) {
 	if len(ws) == 0 {
 		return ws, nil
 	}
-	out := make(map[string]Workspace, len(ws))
-	seenTeamID := make(map[string]string, len(ws)) // teamID -> first slug we saw
+	prepared := make(map[string]Workspace, len(ws))
 	for key, w := range ws {
 		switch {
 		case w.TeamID != "":
@@ -71,13 +76,62 @@ func resolveWorkspaceKeys(ws map[string]Workspace) (map[string]Workspace, error)
 				"workspace %q is missing team_id (the TOML key is a slug, "+
 					"so the block must set team_id explicitly)", key)
 		}
-		if first, dup := seenTeamID[w.TeamID]; dup {
+		prepared[key] = w
+	}
+
+	slugForTeam := make(map[string]string, len(prepared)) // teamID -> slug key
+	for key, w := range prepared {
+		if key == w.TeamID {
+			continue
+		}
+		if first, dup := slugForTeam[w.TeamID]; dup {
 			return nil, fmt.Errorf(
 				"workspaces %q and %q both reference team_id %q",
 				first, key, w.TeamID)
 		}
-		seenTeamID[w.TeamID] = key
+		slugForTeam[w.TeamID] = key
+	}
+
+	out := make(map[string]Workspace, len(prepared))
+	for key, w := range prepared {
+		if key != w.TeamID {
+			continue
+		}
+		if slug, ok := slugForTeam[w.TeamID]; ok {
+			prepared[slug] = mergeWorkspacePrefs(prepared[slug], w)
+			continue
+		}
 		out[key] = w
 	}
+	for _, slug := range slugForTeam {
+		out[slug] = prepared[slug]
+	}
 	return out, nil
+}
+
+// mergeWorkspacePrefs copies unset preference fields from src into dst.
+// Used when a leftover team-ID-keyed block sits beside a slug-keyed
+// block for the same team: the slug keeps identity, the leftover
+// donates version_ts / theme / width / etc. that were saved under
+// the team-ID key. Non-empty dst fields win.
+func mergeWorkspacePrefs(dst, src Workspace) Workspace {
+	if dst.VersionTS == "" {
+		dst.VersionTS = src.VersionTS
+	}
+	if dst.Theme == "" {
+		dst.Theme = src.Theme
+	}
+	if dst.SidebarWidth == 0 {
+		dst.SidebarWidth = src.SidebarWidth
+	}
+	if dst.Order == 0 {
+		dst.Order = src.Order
+	}
+	if dst.UseSlackSections == nil {
+		dst.UseSlackSections = src.UseSlackSections
+	}
+	if len(dst.Sections) == 0 {
+		dst.Sections = src.Sections
+	}
+	return dst
 }

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -2980,6 +2980,45 @@ func TestThreadMarkedRemoteMsg_ReadClearsRow(t *testing.T) {
 	}
 }
 
+func TestDMNameResolvedMsg_RenamesSidebarDM(t *testing.T) {
+	app := NewApp()
+	app.activeTeamID = "T1"
+	app.SetChannels([]sidebar.ChannelItem{
+		{ID: "D1", Name: "U123", Type: "dm", DMUserID: "U123"},
+	})
+	app.Update(DMNameResolvedMsg{TeamID: "T1", ChannelID: "D1", DisplayName: "Alice"})
+	got := app.sidebar.Items()
+	if len(got) != 1 || got[0].Name != "Alice" {
+		t.Errorf("sidebar DM = %+v; want Name Alice", got)
+	}
+}
+
+func TestDMNameResolvedMsg_IgnoresOtherWorkspace(t *testing.T) {
+	app := NewApp()
+	app.activeTeamID = "T1"
+	app.SetChannels([]sidebar.ChannelItem{
+		{ID: "D1", Name: "U123", Type: "dm", DMUserID: "U123"},
+	})
+	app.Update(DMNameResolvedMsg{TeamID: "T2", ChannelID: "D1", DisplayName: "Alice"})
+	got := app.sidebar.Items()
+	if len(got) != 1 || got[0].Name != "U123" {
+		t.Errorf("inactive-workspace DMNameResolvedMsg mutated the active sidebar: %+v", got)
+	}
+}
+
+func TestUserResolvedMsg_RenamesSidebarDM(t *testing.T) {
+	app := NewApp()
+	app.activeTeamID = "T1"
+	app.SetChannels([]sidebar.ChannelItem{
+		{ID: "D1", Name: "U123", Type: "dm", DMUserID: "U123"},
+	})
+	app.Update(UserResolvedMsg{TeamID: "T1", UserID: "U123", DisplayName: "Alice", IsBot: false})
+	got := app.sidebar.Items()
+	if len(got) != 1 || got[0].Name != "Alice" {
+		t.Errorf("sidebar DM = %+v; want Name Alice from UserResolvedMsg", got)
+	}
+}
+
 func TestConversationOpenedMsg_SidebarReceivesItemAndUnread(t *testing.T) {
 	app := NewApp()
 	app.activeTeamID = "T1"

--- a/internal/ui/msgs.go
+++ b/internal/ui/msgs.go
@@ -199,6 +199,7 @@ type (
 		ChannelID string
 	}
 	DMNameResolvedMsg struct {
+		TeamID      string
 		ChannelID   string
 		DisplayName string
 		// IsBot is true when the resolved peer is a Slack app or bot.

--- a/internal/ui/reducer_workspace.go
+++ b/internal/ui/reducer_workspace.go
@@ -28,8 +28,8 @@
 //	                          roundtrip): patch the sidebar entry
 //	                          and re-render.
 //	UserResolvedMsg         - per-user display-name resolved:
-//	                          patch any in-history references in
-//	                          both messages pane and thread panel.
+//	                          patch in-history references and any
+//	                          sidebar DM whose peer is this user.
 //	UserExternalMsg         - per-user external/internal flag
 //	                          resolved: update the cache + re-push
 //	                          SetUserNames so styling refreshes.
@@ -90,6 +90,9 @@ var reduceWorkspace reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
 		return nil, true
 
 	case DMNameResolvedMsg:
+		if m.TeamID != "" && m.TeamID != a.activeTeamID {
+			return nil, true
+		}
 		items := a.sidebar.Items()
 		for i := range items {
 			if items[i].ID != m.ChannelID {
@@ -112,10 +115,32 @@ var reduceWorkspace reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
 			mp.PatchUserName(m.UserID, m.DisplayName)
 		}
 		a.threadPanel.PatchUserName(m.UserID, m.DisplayName)
-		// IsBot affects DM channel-type classification, but that's
-		// orchestrated by DMNameResolvedMsg; this handler is only
-		// the in-history name patch. IsBot is carried for forward
-		// compatibility but not consumed here.
+		// Also rename any sidebar DM whose peer is this user. The
+		// unresolved-DM sweep sends DMNameResolvedMsg for the same
+		// purpose, but UserResolvedMsg is what the batched edge path
+		// emits, and a DM that was painted as its user ID would
+		// otherwise stay that way until a workspace switch rebuilt
+		// the sidebar from wctx.Channels.
+		if m.DisplayName != "" {
+			items := a.sidebar.Items()
+			changed := false
+			for i := range items {
+				if items[i].DMUserID != m.UserID {
+					continue
+				}
+				if items[i].Name != m.DisplayName {
+					items[i].Name = m.DisplayName
+					changed = true
+				}
+				if m.IsBot && items[i].Type == "dm" {
+					items[i].Type = "app"
+					changed = true
+				}
+			}
+			if changed {
+				a.SetChannels(items)
+			}
+		}
 		return nil, true
 
 	case UserExternalMsg:


### PR DESCRIPTION
## Why

DM sidebar rows were often blank (or a raw user ID). `users.conversations` IM objects sometimes omit `user`, so `buildChannelItem` had nothing to name and the unresolved-DM sweep had nothing to fetch. Resolutions also failed to survive a workspace switch because only the active sidebar was patched.

## What

- Overlay IM counterparties from `client.userBoot` `ims[]` onto conversations that lack `user` (`fillIMUsers`).
- Batch-resolve display names from edge **before** the first sidebar paint (`seedDMDisplayNames`).
- Persist resolved names onto `wctx.Channels` / finder items (`patchWorkspaceDM`).
- `DMNameResolvedMsg` carries `TeamID` so a late resolution from an inactive workspace cannot rename the active sidebar.
- `UserResolvedMsg` also renames matching sidebar DMs.

## Test plan

- [x] `go test ./cmd/slk/ ./internal/ui/ ./internal/config/`
- [ ] Connect a workspace with DMs whose conversations payload omits `user`; first paint should show display names, not blank rows.
- [ ] Switch away and back; resolved names should still be there.

**Merge after #166** (stack 2/4). This branch contains PR1 + this commit. GitHub will show only this commit once #166 is merged.