### PR TITLE
feat(activity): Slack Activity inbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - Real-time messages, edits, deletes, reactions, typing indicators
 - Inline images (kitty graphics / sixel / half-block fallback) with full-screen preview
 - Threads side panel + a workspace-wide threads view
+- Activity inbox (Slack's Activity tab: recents, filters, unread badge)
 - Smart paste: clipboard images, file paths, or text — multiple attachments + caption in one send
 - Slack-native sidebar sections, kept live; or glob-based config sections
 - Automatic auth from the Slack desktop app — no tokens to copy, no Slack App required

--- a/cmd/slk/bootstrap_adapters.go
+++ b/cmd/slk/bootstrap_adapters.go
@@ -455,6 +455,39 @@ func bootConversations(res *bootstrap.Result) []slack.Channel {
 	return out
 }
 
+// fillIMUsers copies counterparty user IDs from userBoot's ims[] onto
+// IM conversations that lack them.
+//
+// users.conversations is the sidebar's primary source, but its IM
+// objects are not guaranteed to carry `user` — Slack's conversation
+// payload sometimes omits it, and slack-go then leaves Channel.User
+// empty. buildChannelItem names a DM from that field (falling back to
+// the raw user ID), and an empty User means the sidebar row is blank
+// and the unresolved-DM sweep has nothing to fetch. userBoot's ims[]
+// always include `user`; overlaying them is how a DM gets a name when
+// GetChannels succeeded. Existing User values are left alone.
+func fillIMUsers(channels []slack.Channel, ims []boot.IM) {
+	if len(channels) == 0 || len(ims) == 0 {
+		return
+	}
+	byID := make(map[string]string, len(ims))
+	for _, im := range ims {
+		if im.UserID != "" {
+			byID[im.ID] = im.UserID
+		}
+	}
+	for i := range channels {
+		uid, ok := byID[channels[i].ID]
+		if !ok {
+			continue
+		}
+		channels[i].IsIM = true
+		if channels[i].User == "" {
+			channels[i].User = uid
+		}
+	}
+}
+
 // hydrateFirstSight inserts cache rows for the conversations and users
 // this boot learned about that the cache has never seen.
 //

--- a/cmd/slk/bootstrap_adapters.go
+++ b/cmd/slk/bootstrap_adapters.go
@@ -88,16 +88,16 @@ func (a viewAdapter) ConversationsView(ctx context.Context, channelID string) (*
 
 // countsAdapter satisfies bootstrap.CountsFetcher.
 //
-// ctx is accepted and discarded, because GetUnreadCounts takes none —
+// ctx is accepted and discarded, because GetCounts takes none —
 // it builds its request with http.NewRequest, not
 // http.NewRequestWithContext. The interface keeps the parameter so that
-// giving GetUnreadCounts a ctx later is a change to one line here
+// giving GetCounts a ctx later is a change to one line here
 // rather than a change to bootstrap's interface, and so that this
 // adapter does not have to pretend cancellation works when it does not.
 type countsAdapter struct{ c *slackclient.Client }
 
 func (a countsAdapter) Counts(_ context.Context) (bootstrap.Counts, error) {
-	unreads, threads, err := a.c.GetUnreadCounts()
+	snap, err := a.c.GetCounts()
 	if err != nil {
 		// Zero value, not a partially-filled one: bootstrap treats a
 		// counts failure as non-fatal and logs it, and handing back
@@ -106,14 +106,15 @@ func (a countsAdapter) Counts(_ context.Context) (bootstrap.Counts, error) {
 		return bootstrap.Counts{}, err
 	}
 	out := bootstrap.Counts{
-		Unreads: make([]bootstrap.Unread, 0, len(unreads)),
+		Unreads: make([]bootstrap.Unread, 0, len(snap.Unreads)),
 		Threads: bootstrap.Threads{
-			HasUnreads:   threads.HasUnreads,
-			UnreadCount:  threads.UnreadCount,
-			MentionCount: threads.MentionCount,
+			HasUnreads:   snap.Threads.HasUnreads,
+			UnreadCount:  snap.Threads.UnreadCount,
+			MentionCount: snap.Threads.MentionCount,
 		},
+		ActivityUnread: snap.Activity.Unread(),
 	}
-	for _, u := range unreads {
+	for _, u := range snap.Unreads {
 		out.Unreads = append(out.Unreads, bootstrap.Unread{
 			ChannelID: u.ChannelID,
 			Count:     u.Count,

--- a/cmd/slk/bootstrap_adapters_test.go
+++ b/cmd/slk/bootstrap_adapters_test.go
@@ -754,6 +754,33 @@ func TestBootMutedChannels_MergesBothPrefs(t *testing.T) {
 	}
 }
 
+func TestFillIMUsers_CopiesCounterpartyFromBoot(t *testing.T) {
+	// users.conversations IMs with an empty User would render as a
+	// blank sidebar row; userBoot's ims[] carry the counterparty id.
+	channels := []slack.Channel{
+		{GroupConversation: slack.GroupConversation{Conversation: slack.Conversation{ID: "D1", IsIM: true}}},
+		{GroupConversation: slack.GroupConversation{Conversation: slack.Conversation{ID: "D2", IsIM: true, User: "U_KEEP"}}},
+		{GroupConversation: slack.GroupConversation{Conversation: slack.Conversation{ID: "C1"}}},
+	}
+	fillIMUsers(channels, []boot.IM{
+		{ID: "D1", UserID: "U1"},
+		{ID: "D2", UserID: "U_BOOT"},
+		{ID: "D3", UserID: "U3"},
+	})
+	if got := channels[0].User; got != "U1" {
+		t.Errorf("D1 User = %q; want U1 from userBoot", got)
+	}
+	if !channels[0].IsIM {
+		t.Error("D1 lost IsIM")
+	}
+	if got := channels[1].User; got != "U_KEEP" {
+		t.Errorf("D2 User = %q; want the users.conversations value left alone", got)
+	}
+	if channels[2].User != "" || channels[2].IsIM {
+		t.Errorf("C1 was touched: User=%q IsIM=%v", channels[2].User, channels[2].IsIM)
+	}
+}
+
 func TestBootConversations_MapsWhatTheSidebarBuilderReads(t *testing.T) {
 	// buildChannelItem reads ID, Name, Topic, IsIM, IsMpIM, IsPrivate,
 	// IsMember and User. Every one of those has to survive the trip

--- a/cmd/slk/bootstrap_adapters_test.go
+++ b/cmd/slk/bootstrap_adapters_test.go
@@ -202,7 +202,8 @@ const countsBody = `{
   "ok": true,
   "channels": [{"id":"C1","has_unreads":true,"mention_count":2,"unread_count_display":5,"last_read":"1.0"}],
   "ims": [{"id":"D1","has_unreads":false,"last_read":"2.0"}],
-  "threads": {"has_unreads":true,"unread_count":3,"mention_count":1}
+  "threads": {"has_unreads":true,"unread_count":3,"mention_count":1},
+  "activity_v2": {"channel":30,"dm":2}
 }`
 
 func TestCountsAdapter_CarriesUnreadsAndTheThreadRollup(t *testing.T) {
@@ -236,6 +237,9 @@ func TestCountsAdapter_CarriesUnreadsAndTheThreadRollup(t *testing.T) {
 	}{counts.Threads.HasUnreads, counts.Threads.UnreadCount, counts.Threads.MentionCount}
 	if got != want {
 		t.Errorf("threads = %+v; want %+v", got, want)
+	}
+	if counts.ActivityUnread != 32 {
+		t.Errorf("ActivityUnread = %d; want 32 (channel+dm)", counts.ActivityUnread)
 	}
 }
 

--- a/cmd/slk/channelitem_test.go
+++ b/cmd/slk/channelitem_test.go
@@ -41,6 +41,27 @@ func TestBuildChannelItem_DM(t *testing.T) {
 	}
 }
 
+func TestBuildChannelItem_DMUnknownFallsBackToUserID(t *testing.T) {
+	wctx := &WorkspaceContext{
+		BotUserIDs:        map[string]bool{},
+		UserNames:         map[string]string{},
+		UserNamesByHandle: map[string]string{},
+	}
+	ch := slack.Channel{
+		GroupConversation: slack.GroupConversation{
+			Conversation: slack.Conversation{
+				ID:   "D1",
+				IsIM: true,
+				User: "U123",
+			},
+		},
+	}
+	item, _ := buildChannelItem(ch, wctx, config.Config{}, "T1")
+	if item.Name != "U123" {
+		t.Errorf("Name = %q, want the user ID when UserNames has no entry", item.Name)
+	}
+}
+
 func TestBuildChannelItem_GroupDM(t *testing.T) {
 	wctx := &WorkspaceContext{
 		BotUserIDs:        map[string]bool{},

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -108,7 +108,7 @@ type WorkspaceContext struct {
 	// Edge is the edgeapi client for this workspace: the
 	// conditional-revalidation and server-side-search endpoints. Nil
 	// only if construction failed, and every caller nil-checks.
-	Edge       *edge.Client
+	Edge *edge.Client
 	// EdgeHealth records whether edge resolution is working for this
 	// workspace this session. bootstrap marks it degraded on a
 	// wholesale failure; the user resolver reads it to skip batch
@@ -2543,20 +2543,34 @@ func connectWorkspace(ctx context.Context, token slackclient.Token, db *cache.DB
 		debuglog.General("workspace %s: users.conversations failed: %v", token.TeamName, err)
 		channels = bootConversations(res)
 	}
+	// Overlay IM counterparty ids from userBoot even when
+	// users.conversations succeeded: its IM objects sometimes omit
+	// `user`, and without that id the sidebar row is the raw (empty)
+	// Channel.User and the unresolved-DM sweep has nothing to fetch.
+	fillIMUsers(channels, res.IMs)
 	if len(channels) == 0 {
 		log.Printf("workspace %s: no conversations from either users.conversations or client.userBoot; the sidebar will be empty", token.TeamName)
 	}
+
+	// Resolve DM counterparties before buildChannelItem so the first
+	// sidebar paint already has display names, matching what the
+	// README screenshot shows. This is still on the connect goroutine,
+	// so writing wctx.UserNames is safe. Misses stay in UnresolvedDMs
+	// and the async sweep below covers them.
+	seedDMDisplayNames(wctx, channels)
 
 	for _, ch := range channels {
 		item, finderItem := buildChannelItem(ch, wctx, cfg, client.TeamID())
 		upsertChannelInDB(db, ch, item.Type, client.TeamID())
 
 		if ch.IsIM {
-			if _, ok := wctx.UserNames[ch.User]; !ok {
-				wctx.UnresolvedDMs = append(wctx.UnresolvedDMs, UnresolvedDM{
-					ChannelID: ch.ID,
-					UserID:    ch.User,
-				})
+			if ch.User != "" {
+				if name, ok := wctx.UserNames[ch.User]; !ok || name == "" {
+					wctx.UnresolvedDMs = append(wctx.UnresolvedDMs, UnresolvedDM{
+						ChannelID: ch.ID,
+						UserID:    ch.User,
+					})
+				}
 			}
 			if cachedUser, err := db.GetUser(ch.User); err == nil && cachedUser.Presence != "" {
 				item.Presence = cachedUser.Presence
@@ -2841,6 +2855,101 @@ func resolveUser(client *slackclient.Client, userID string, userNames map[string
 	return userID, false
 }
 
+// edgeUserDisplayName is the display → real → handle chain used
+// everywhere a user record from edge users/info is shown. Empty means
+// the record resolved nothing and the caller must fall back.
+func edgeUserDisplayName(u edge.User) string {
+	if u.Profile.DisplayName != "" {
+		return u.Profile.DisplayName
+	}
+	if u.Profile.RealName != "" {
+		return u.Profile.RealName
+	}
+	return u.Name
+}
+
+// seedDMDisplayNames batch-resolves IM counterparties that are not yet
+// in wctx.UserNames and writes the results into the in-memory maps
+// buildChannelItem reads. Must run on the connectWorkspace goroutine
+// before the UI is told the workspace is ready — after that,
+// wctx.UserNames has other readers and PatchUserName is the only safe
+// writer.
+func seedDMDisplayNames(wctx *WorkspaceContext, channels []slack.Channel) {
+	if wctx == nil || wctx.UserResolver == nil {
+		return
+	}
+	if wctx.UserNames == nil {
+		wctx.UserNames = make(map[string]string)
+	}
+	if wctx.UserNamesByHandle == nil {
+		wctx.UserNamesByHandle = make(map[string]string)
+	}
+	if wctx.BotUserIDs == nil {
+		wctx.BotUserIDs = make(map[string]bool)
+	}
+	seen := make(map[string]struct{})
+	ids := make([]string, 0)
+	for _, ch := range channels {
+		if !ch.IsIM || ch.User == "" {
+			continue
+		}
+		if _, dup := seen[ch.User]; dup {
+			continue
+		}
+		seen[ch.User] = struct{}{}
+		if name, ok := wctx.UserNames[ch.User]; ok && name != "" {
+			continue
+		}
+		ids = append(ids, ch.User)
+	}
+	if len(ids) == 0 {
+		return
+	}
+	for _, u := range wctx.UserResolver.ResolveNow(ids) {
+		name := edgeUserDisplayName(u)
+		if name == "" {
+			continue
+		}
+		wctx.UserNames[u.ID] = name
+		if u.Name != "" {
+			wctx.UserNamesByHandle[u.Name] = name
+		}
+		if u.IsBot {
+			wctx.BotUserIDs[u.ID] = true
+		}
+	}
+}
+
+// patchWorkspaceDM renames a DM (and re-buckets an app DM) on the
+// workspace's in-memory channel lists so a later workspace switch
+// still shows the resolved name. DMNameResolvedMsg only patches the
+// active sidebar.
+func patchWorkspaceDM(wctx *WorkspaceContext, channelID, name string, isBot bool) {
+	if wctx == nil || channelID == "" || name == "" {
+		return
+	}
+	for i := range wctx.Channels {
+		if wctx.Channels[i].ID != channelID {
+			continue
+		}
+		wctx.Channels[i].Name = name
+		if isBot && wctx.Channels[i].Type == "dm" {
+			wctx.Channels[i].Type = "app"
+		}
+		break
+	}
+	for i := range wctx.FinderItems {
+		if wctx.FinderItems[i].ID != channelID {
+			continue
+		}
+		wctx.FinderItems[i].Name = name
+		if isBot && wctx.FinderItems[i].Type == "dm" {
+			wctx.FinderItems[i].Type = "app"
+		}
+		break
+	}
+}
+
 // resolveDMNames resolves the display names of unresolved DM
 // counterparties, one edge users/info batch for the whole sweep, with
 // the per-user resolveUser loop as the fallback for ids edge did not
@@ -2854,21 +2963,20 @@ func resolveUser(client *slackclient.Client, userID string, userNames map[string
 func resolveDMNames(wctx *WorkspaceContext, db *cache.DB, avatarCache *avatar.Cache, send func(tea.Msg)) {
 	dmIDs := make([]string, 0, len(wctx.UnresolvedDMs))
 	for _, dm := range wctx.UnresolvedDMs {
-		dmIDs = append(dmIDs, dm.UserID)
+		if dm.UserID != "" {
+			dmIDs = append(dmIDs, dm.UserID)
+		}
 	}
 	byEdge := make(map[string]edge.User)
 	for _, u := range wctx.UserResolver.ResolveNow(dmIDs) {
 		byEdge[u.ID] = u
 	}
 	for _, dm := range wctx.UnresolvedDMs {
+		if dm.UserID == "" {
+			continue
+		}
 		if u, ok := byEdge[dm.UserID]; ok {
-			name := u.Profile.DisplayName
-			if name == "" {
-				name = u.Profile.RealName
-			}
-			if name == "" {
-				name = u.Name
-			}
+			name := edgeUserDisplayName(u)
 			if name != "" {
 				// edge users/info carries no is_app_user: a Slack app's DM
 				// resolved here may bucket as "dm" rather than "app" until
@@ -2878,8 +2986,10 @@ func resolveDMNames(wctx *WorkspaceContext, db *cache.DB, avatarCache *avatar.Ca
 				if u.IsBot {
 					wctx.BotUserIDs[dm.UserID] = true
 				}
+				patchWorkspaceDM(wctx, dm.ChannelID, name, u.IsBot)
 				if send != nil {
 					send(ui.DMNameResolvedMsg{
+						TeamID:      wctx.TeamID,
 						ChannelID:   dm.ChannelID,
 						DisplayName: name,
 						IsBot:       u.IsBot,
@@ -2897,12 +3007,16 @@ func resolveDMNames(wctx *WorkspaceContext, db *cache.DB, avatarCache *avatar.Ca
 		if isBot {
 			wctx.BotUserIDs[dm.UserID] = true
 		}
-		if resolved != dm.UserID && send != nil {
-			send(ui.DMNameResolvedMsg{
-				ChannelID:   dm.ChannelID,
-				DisplayName: resolved,
-				IsBot:       isBot,
-			})
+		if resolved != dm.UserID {
+			patchWorkspaceDM(wctx, dm.ChannelID, resolved, isBot)
+			if send != nil {
+				send(ui.DMNameResolvedMsg{
+					TeamID:      wctx.TeamID,
+					ChannelID:   dm.ChannelID,
+					DisplayName: resolved,
+					IsBot:       isBot,
+				})
+			}
 		}
 	}
 }

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -161,6 +161,9 @@ type WorkspaceContext struct {
 	// us the workspace has zero unread threads, we trust that and
 	// suppress the heuristic-derived flags entirely.
 	ThreadsHasUnreads bool
+	// ActivityUnread is client.counts activity_v2 sum for the
+	// sidebar Activity-row badge. Refreshed on boot and reconnect.
+	ActivityUnread int
 	// ThreadSubsGate throttles the workspace's
 	// subscriptions.thread.getView fetches to one per
 	// threadSubsSyncInterval. Fired on workspace-ready, on Threads
@@ -1151,6 +1154,7 @@ func run() error {
 	app.SetSidebarStaleThreshold(time.Duration(cfg.Sidebar.HideInactiveAfterDays) * 24 * time.Hour)
 	app.SetMouseWheelLines(cfg.Appearance.MouseWheelLines)
 	app.SetColoredUsernames(cfg.Appearance.ColoredUsernames)
+	app.SetActivityConfig(cfg.Activity)
 
 	// Wire theme switcher
 	app.SetThemeItems(styles.ThemeNames())
@@ -1696,6 +1700,46 @@ func run() error {
 			}
 		})
 
+		app.SetActivityService(ui.NewActivityService(ui.ActivityServiceFuncs{
+			FetchViews: func(teamID ids.TeamID) tea.Msg {
+				team := string(teamID)
+				wctx := router.ByID(team)
+				if wctx == nil {
+					return ui.ActivityViewsLoadedMsg{TeamID: team, Err: fmt.Errorf("no workspace")}
+				}
+				ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+				defer cancel()
+				views, err := wctx.Client.GetActivityViews(ctx)
+				return ui.ActivityViewsLoadedMsg{TeamID: team, Views: views, Err: err}
+			},
+			FetchFeed: func(teamID ids.TeamID, q ui.ActivityFeedQuery) tea.Msg {
+				team := string(teamID)
+				wctx := router.ByID(team)
+				if wctx == nil {
+					return ui.ActivityFeedLoadedMsg{TeamID: team, Gen: q.Gen, Err: fmt.Errorf("no workspace")}
+				}
+				ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+				defer cancel()
+				items, err := wctx.Client.GetActivityFeed(ctx, slackclient.ActivityFeedOpts{
+					Filter:       q.Filter,
+					Types:        q.Types,
+					Sort:         q.Sort,
+					UnreadOnly:   q.UnreadOnly,
+					PriorityOnly: q.PriorityOnly,
+					Limit:        q.Limit,
+				})
+				return ui.ActivityFeedLoadedMsg{
+					TeamID:     team,
+					Items:      items,
+					Err:        err,
+					Gen:        q.Gen,
+					Filter:     q.Filter,
+					Sort:       q.Sort,
+					UnreadOnly: q.UnreadOnly,
+				}
+			},
+		}))
+
 		app.SetThreadService(ui.NewThreadService(ui.ThreadServiceFuncs{
 			Fetch: func(channelID ids.ChannelID, threadTS ids.ThreadTS) tea.Msg {
 				chIDStr, threadTSStr := string(channelID), string(threadTS)
@@ -1911,6 +1955,7 @@ func run() error {
 			CustomEmoji:      wctx.CustomEmoji,
 			UserGroups:       wctx.UserGroups(),
 			SectionsProvider: sectionsProviderAdapter{store: wctx.SectionStore},
+			ActivityUnread:   wctx.ActivityUnread,
 		}
 	})
 
@@ -2106,6 +2151,7 @@ func run() error {
 				SectionsProvider: sectionsProviderAdapter{store: wctx.SectionStore},
 				InitialActive:    isInitial,
 				LastChannelID:    mostRecentlyVisitedChannel(wctx.LastVisitedByChannel),
+				ActivityUnread:   wctx.ActivityUnread,
 			})
 
 			// Fetch workspace custom emojis in the background. When done,
@@ -2595,6 +2641,7 @@ func connectWorkspace(ctx context.Context, token slackclient.Token, db *cache.DB
 		debuglog.Cache("workspace_unread_bootstrap: team=%s client.counts failed during bootstrap; leaving read state as cached", token.TeamName)
 	}
 	wctx.ThreadsHasUnreads = res.Counts.Threads.HasUnreads
+	wctx.ActivityUnread = res.Counts.ActivityUnread
 	// Boot applies an authoritative FULL snapshot: reset every channel
 	// in the workspace to read, then set the ones client.counts reports
 	// unread. This runs BEFORE the WebSocket goes live (ConnMgr.Run is
@@ -4418,6 +4465,9 @@ func (h *rtmEventHandler) syncOnReconnect(trigger string) bool {
 		program:        h.program,
 		activeChannel:  h.activeChannelID,
 		refreshChannel: h.refreshChannel,
+		onActivity: func(n int) {
+			h.wsCtx.ActivityUnread = n
+		},
 	}
 	go func() {
 		if err := sync.run(context.Background()); err != nil {

--- a/cmd/slk/reconnect_sync.go
+++ b/cmd/slk/reconnect_sync.go
@@ -32,9 +32,9 @@ import (
 // all of it. One method is what "O(1) reconnect" means in code;
 // TestReconnect_ClientSurfaceCannotEnumerate fails if it grows.
 type reconnectClient interface {
-	// GetUnreadCounts is client.counts: one request that returns
-	// unread state for every conversation in the workspace.
-	GetUnreadCounts() ([]slackclient.UnreadInfo, slackclient.ThreadsAggregate, error)
+	// GetCounts is client.counts: one request that returns unread
+	// state for every conversation plus the Activity-tab badge.
+	GetCounts() (slackclient.CountsSnapshot, error)
 }
 
 // teaSender is the subset of *tea.Program the reconnect path uses to
@@ -83,6 +83,11 @@ type reconnectSync struct {
 	// normal open path and pushes the result into the UI. Required;
 	// tests substitute a recorder.
 	refreshChannel func(ctx context.Context, channelID string)
+
+	// onActivity records the activity_v2 badge onto the workspace
+	// context so a later workspace switch still shows the reconnect
+	// value. Optional.
+	onActivity func(unread int)
 }
 
 // run performs one catch-up pass.
@@ -126,16 +131,23 @@ func (r *reconnectSync) run(ctx context.Context) error {
 // Failure is logged and swallowed: unread badges are cosmetic next to
 // the messages themselves, and the next boot refreshes them anyway.
 func (r *reconnectSync) refreshUnreadState() {
-	unreads, _, err := r.client.GetUnreadCounts()
+	snap, err := r.client.GetCounts()
 	if err != nil {
 		debuglog.Backfill("team=%s reconnect-sync counts err=%v (unread badges stay stale)", r.workspaceID, err)
 		return
 	}
-	if len(unreads) == 0 {
+	activityUnread := snap.Activity.Unread()
+	if r.onActivity != nil {
+		r.onActivity(activityUnread)
+	}
+	if r.program != nil {
+		r.program.Send(ui.ActivityCountsMsg{TeamID: r.workspaceID, Unread: activityUnread})
+	}
+	if len(snap.Unreads) == 0 {
 		return
 	}
-	updates := make([]cache.ChannelReadStateUpdate, 0, len(unreads))
-	for _, u := range unreads {
+	updates := make([]cache.ChannelReadStateUpdate, 0, len(snap.Unreads))
+	for _, u := range snap.Unreads {
 		updates = append(updates, cache.ChannelReadStateUpdate{
 			ChannelID:  u.ChannelID,
 			LastReadTS: u.LastRead,

--- a/cmd/slk/reconnect_sync_test.go
+++ b/cmd/slk/reconnect_sync_test.go
@@ -64,20 +64,23 @@ func TestReconnect_DedupeWindow(t *testing.T) {
 // slackhttp.Counter reports, so a count here is comparable with a
 // count from a real session.
 type fakeCounts struct {
-	mu      sync.Mutex
-	calls   []string
-	unreads []slackclient.UnreadInfo
-	err     error
+	mu       sync.Mutex
+	calls    []string
+	unreads  []slackclient.UnreadInfo
+	activity slackclient.ActivityCounts
+	err      error
 }
 
-func (f *fakeCounts) GetUnreadCounts() ([]slackclient.UnreadInfo, slackclient.ThreadsAggregate, error) {
+func (f *fakeCounts) GetCounts() (slackclient.CountsSnapshot, error) {
 	f.mu.Lock()
 	f.calls = append(f.calls, "client.counts")
+	unreads := f.unreads
+	activity := f.activity
 	f.mu.Unlock()
 	if f.err != nil {
-		return nil, slackclient.ThreadsAggregate{}, f.err
+		return slackclient.CountsSnapshot{}, f.err
 	}
-	return f.unreads, slackclient.ThreadsAggregate{}, nil
+	return slackclient.CountsSnapshot{Unreads: unreads, Activity: activity}, nil
 }
 
 func (f *fakeCounts) snapshot() []string {
@@ -181,10 +184,10 @@ func TestReconnect_ClientSurfaceCannotEnumerate(t *testing.T) {
 		for i := 0; i < iface.NumMethod(); i++ {
 			names = append(names, iface.Method(i).Name)
 		}
-		t.Errorf("reconnectClient declares %v; want only GetUnreadCounts — anything per-channel or per-thread here is an O(n) reconnect waiting to happen", names)
+		t.Errorf("reconnectClient declares %v; want only GetCounts — anything per-channel or per-thread here is an O(n) reconnect waiting to happen", names)
 	}
-	if _, ok := iface.MethodByName("GetUnreadCounts"); !ok {
-		t.Error("reconnectClient has no GetUnreadCounts; client.counts is the one call that refreshes unread state for the whole workspace")
+	if _, ok := iface.MethodByName("GetCounts"); !ok {
+		t.Error("reconnectClient has no GetCounts; client.counts is the one call that refreshes unread state for the whole workspace")
 	}
 }
 

--- a/cmd/slk/save_theme.go
+++ b/cmd/slk/save_theme.go
@@ -125,6 +125,55 @@ func sanitizeComment(s string) string {
 	return strings.TrimSpace(b.String())
 }
 
+// findWorkspaceSectionStart returns the line index of the [workspaces.*]
+// header to write into for tomlKey/teamID, or -1 if none exists.
+//
+// Order: the literal tomlKey header, then a legacy [workspaces.<teamID>]
+// header, then any slug-keyed block whose team_id field matches. That
+// last fallback is load-bearing — saveWorkspaceVersionTS used to look
+// only for [workspaces.<tomlKey>], and when tomlKey was the raw team ID
+// it appended a second block next to the slug-keyed one, which Load
+// then rejected as a duplicate workspace.
+func findWorkspaceSectionStart(lines []string, tomlKey, teamID string) int {
+	headers := make([]string, 0, 2)
+	if tomlKey != "" {
+		headers = append(headers, "[workspaces."+tomlKey+"]")
+	}
+	if teamID != "" && teamID != tomlKey {
+		headers = append(headers, "[workspaces."+teamID+"]")
+	}
+	for i, line := range lines {
+		t := strings.TrimSpace(line)
+		for _, h := range headers {
+			if t == h {
+				return i
+			}
+		}
+	}
+	if teamID == "" {
+		return -1
+	}
+	sectionStart := -1
+	for i, line := range lines {
+		t := strings.TrimSpace(line)
+		if strings.HasPrefix(t, "[") {
+			if strings.HasPrefix(t, "[workspaces.") {
+				sectionStart = i
+			} else {
+				sectionStart = -1
+			}
+			continue
+		}
+		if sectionStart < 0 {
+			continue
+		}
+		if strings.HasPrefix(t, "team_id") && strings.Contains(t, teamID) {
+			return sectionStart
+		}
+	}
+	return -1
+}
+
 // saveGlobalTheme rewrites the [appearance] theme line in config.toml.
 // If the file has no theme line, it appends a new [appearance] section.
 // Existing comments and ordering are preserved (textual rewrite, not
@@ -190,15 +239,7 @@ func saveWorkspaceTheme(configPath, tomlKey, teamID, teamName, themeName string)
 	}
 	lines := strings.Split(string(data), "\n")
 
-	header := fmt.Sprintf("[workspaces.%s]", tomlKey)
-
-	sectionStart := -1
-	for i, line := range lines {
-		if strings.TrimSpace(line) == header {
-			sectionStart = i
-			break
-		}
-	}
+	sectionStart := findWorkspaceSectionStart(lines, tomlKey, teamID)
 
 	if sectionStart >= 0 {
 		end := len(lines)

--- a/cmd/slk/save_version_ts.go
+++ b/cmd/slk/save_version_ts.go
@@ -60,15 +60,7 @@ func saveWorkspaceVersionTS(configPath, tomlKey, teamID, teamName, versionTS str
 	}
 	lines := strings.Split(string(data), "\n")
 
-	header := fmt.Sprintf("[workspaces.%s]", tomlKey)
-
-	sectionStart := -1
-	for i, line := range lines {
-		if strings.TrimSpace(line) == header {
-			sectionStart = i
-			break
-		}
-	}
+	sectionStart := findWorkspaceSectionStart(lines, tomlKey, teamID)
 
 	if sectionStart >= 0 {
 		end := len(lines)

--- a/cmd/slk/save_version_ts_test.go
+++ b/cmd/slk/save_version_ts_test.go
@@ -76,6 +76,36 @@ func TestSaveWorkspaceVersionTS_DoesNotTouchOtherWorkspaces(t *testing.T) {
 	}
 }
 
+func TestSaveWorkspaceVersionTS_WritesIntoSlugWhenCalledWithTeamIDKey(t *testing.T) {
+	// workspaceTOMLKey falls back to the raw team ID when the in-memory
+	// config has no matching block. The on-disk file still has the
+	// slug-keyed section from --add-workspace. Writing a second
+	// [workspaces.<teamID>] block is what made Load refuse to start
+	// ("both reference team_id").
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	initial := "# Obvious AI\n[workspaces.obvious-ai]\nteam_id = \"T099JCA82HJ\"\n"
+	if err := os.WriteFile(path, []byte(initial), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := saveWorkspaceVersionTS(path, "T099JCA82HJ", "T099JCA82HJ", "Obvious AI", "1788174451"); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	out := string(mustRead(t, path))
+	if strings.Count(out, "[workspaces.") != 1 {
+		t.Errorf("expected a single workspace section, got:\n%s", out)
+	}
+	if !strings.Contains(out, "[workspaces.obvious-ai]") {
+		t.Errorf("slug section was not the write target:\n%s", out)
+	}
+	if strings.Contains(out, "[workspaces.T099JCA82HJ]") {
+		t.Errorf("appended a leftover team-ID block:\n%s", out)
+	}
+	if !strings.Contains(out, `version_ts = "1788174451"`) {
+		t.Errorf("version_ts missing:\n%s", out)
+	}
+}
+
 func TestSaveWorkspaceVersionTS_CreatesFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "sub", "config.toml")

--- a/cmd/slk/save_width.go
+++ b/cmd/slk/save_width.go
@@ -26,15 +26,7 @@ func saveWorkspaceWidth(configPath, tomlKey, teamID, teamName string, width int)
 	}
 	lines := strings.Split(string(data), "\n")
 
-	header := fmt.Sprintf("[workspaces.%s]", tomlKey)
-
-	sectionStart := -1
-	for i, line := range lines {
-		if strings.TrimSpace(line) == header {
-			sectionStart = i
-			break
-		}
-	}
+	sectionStart := findWorkspaceSectionStart(lines, tomlKey, teamID)
 
 	if sectionStart >= 0 {
 		end := len(lines)

--- a/cmd/slk/user_resolver_test.go
+++ b/cmd/slk/user_resolver_test.go
@@ -15,6 +15,8 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/gammons/slk/internal/slack/edge"
 	"github.com/gammons/slk/internal/ui"
+	"github.com/gammons/slk/internal/ui/sidebar"
+	"github.com/slack-go/slack"
 )
 
 // TestUserResolver_BoundsConcurrentRequests is the second half of the
@@ -446,13 +448,18 @@ func TestResolveDMNames(t *testing.T) {
 		edgeUserRecord("U_APP", "someapp", "Some App", "", "T1", 1, true),
 	}}
 	wctx := &WorkspaceContext{
-		TeamID:       "T1",
-		UserNames:    map[string]string{},
-		BotUserIDs:   map[string]bool{},
-		UserResolver: newUserResolver("T1", nil, db, nil, nil, batcher, nil),
+		TeamID:            "T1",
+		UserNames:         map[string]string{},
+		UserNamesByHandle: map[string]string{},
+		BotUserIDs:        map[string]bool{},
+		UserResolver:      newUserResolver("T1", nil, db, nil, nil, batcher, nil),
 		UnresolvedDMs: []UnresolvedDM{
 			{ChannelID: "D_ALICE", UserID: "U_ALICE"},
 			{ChannelID: "D_APP", UserID: "U_APP"},
+		},
+		Channels: []sidebar.ChannelItem{
+			{ID: "D_ALICE", Name: "U_ALICE", Type: "dm", DMUserID: "U_ALICE"},
+			{ID: "D_APP", Name: "U_APP", Type: "dm", DMUserID: "U_APP"},
 		},
 	}
 	var mu sync.Mutex
@@ -481,6 +488,9 @@ func TestResolveDMNames(t *testing.T) {
 	if alice == nil || alice.DisplayName != "Alice A" {
 		t.Errorf("D_ALICE got %+v; want a DMNameResolvedMsg naming Alice A", alice)
 	}
+	if alice != nil && alice.TeamID != "T1" {
+		t.Errorf("D_ALICE TeamID = %q; want T1 so the UI ignores other workspaces", alice.TeamID)
+	}
 	if app == nil || app.DisplayName != "Some App" || !app.IsBot {
 		t.Errorf("D_APP got %+v; want a DMNameResolvedMsg naming Some App with IsBot true — that flag re-buckets the row into the Apps section", app)
 	}
@@ -489,5 +499,41 @@ func TestResolveDMNames(t *testing.T) {
 	}
 	if n := len(batcher.calls()); n != 1 {
 		t.Errorf("the sweep made %d edge calls; want 1 for any number of DMs", n)
+	}
+	byID := map[string]sidebar.ChannelItem{}
+	for _, ch := range wctx.Channels {
+		byID[ch.ID] = ch
+	}
+	if got := byID["D_ALICE"]; got.Name != "Alice A" {
+		t.Errorf("wctx.Channels D_ALICE Name = %q; want Alice A so a workspace switch still shows the resolved name", got.Name)
+	}
+	if got := byID["D_APP"]; got.Name != "Some App" || got.Type != "app" {
+		t.Errorf("wctx.Channels D_APP = {Name:%q Type:%q}; want Some App / app", got.Name, got.Type)
+	}
+}
+
+func TestSeedDMDisplayNames_FillsUserNamesFromEdge(t *testing.T) {
+	db := newTestDB(t)
+	batcher := &fakeBatcher{res: []edge.User{
+		edgeUserRecord("U1", "alice", "Alice A", "", "T1", 1, false),
+	}}
+	wctx := &WorkspaceContext{
+		TeamID:            "T1",
+		UserNames:         map[string]string{},
+		UserNamesByHandle: map[string]string{},
+		BotUserIDs:        map[string]bool{},
+		UserResolver:      newUserResolver("T1", nil, db, nil, nil, batcher, nil),
+	}
+	channels := []slack.Channel{{
+		GroupConversation: slack.GroupConversation{
+			Conversation: slack.Conversation{ID: "D1", IsIM: true, User: "U1"},
+		},
+	}}
+	seedDMDisplayNames(wctx, channels)
+	if got := wctx.UserNames["U1"]; got != "Alice A" {
+		t.Errorf("UserNames[U1] = %q; want Alice A — sidebar DMs read this map at first paint", got)
+	}
+	if got := wctx.UserNamesByHandle["alice"]; got != "Alice A" {
+		t.Errorf("UserNamesByHandle[alice] = %q; want Alice A", got)
 	}
 }

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -166,6 +166,10 @@ type Threads struct {
 type Counts struct {
 	Unreads []Unread
 	Threads Threads
+	// ActivityUnread is the sum of client.counts activity_v2 type
+	// counts — the Activity-tab badge. Zero when the field is
+	// missing (older snapshots, or a counts body without activity_v2).
+	ActivityUnread int
 }
 
 // History is what a conversations.history fallback returned — a

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	Notifications Notifications                `toml:"notifications"`
 	Cache         CacheConfig                  `toml:"cache"`
 	Sidebar       Sidebar                      `toml:"sidebar"`
+	Activity      Activity                     `toml:"activity"`
 	Sections      map[string]SectionDef        `toml:"sections"`
 	Theme         Theme                        `toml:"theme"`
 	Workspaces    map[string]Workspace         `toml:"workspaces"`
@@ -151,6 +152,181 @@ type Sidebar struct {
 	Width                 int `toml:"width"`
 }
 
+// Activity is the Activity inbox: Slack's activity.feed surface
+// (recents + notifications), with the same filter/sort knobs the
+// official All / DMs / Mentions / Threads tabs send.
+//
+// Config values are the session defaults. The Activity view can
+// cycle them live (f/F filter, s sort, u unread-only); those
+// changes are session-only and do not rewrite this file.
+type Activity struct {
+	// Filter is the Activity tab to open on. Matches an
+	// activity.views name, view_type, or id (All / DMs / Mentions /
+	// Threads, plus any custom view like Unreads / Reactions / VIP).
+	// Empty → "all". Unknown names are kept so a custom tab still
+	// works once views load; if it never appears, the TUI falls
+	// back to All.
+	Filter string `toml:"filter"`
+	// Sort is the feed ranking. "newest" is Slack's chrono_v1
+	// (All tab); "unreads_first" is priority_reads_and_unreads_v1
+	// + sort=vip_unreads_first (the other official tabs).
+	// Clamped on load; empty / unknown → "newest".
+	Sort string `toml:"sort"`
+	// UnreadOnly, when true, sends unread_only=true so Slack
+	// returns only unread items.
+	UnreadOnly bool `toml:"unread_only"`
+	// Density is the Activity list layout. "detailed" is 3-line
+	// cards (Threads-view style); "compact" is one line per item.
+	// Clamped on load; empty / unknown → "detailed".
+	Density string `toml:"density"`
+	// Limit is activity.feed's page size. Clamped to 1..100;
+	// 0 / unset → 50.
+	Limit int `toml:"limit"`
+}
+
+const (
+	ActivityFilterAll       = "all"
+	ActivityFilterDMs       = "dms"
+	ActivityFilterMentions  = "mentions"
+	ActivityFilterThreads   = "threads"
+	ActivityFilterReactions = "reactions"
+
+	ActivitySortNewest       = "newest"
+	ActivitySortUnreadsFirst = "unreads_first"
+
+	ActivityDensityCompact  = "compact"
+	ActivityDensityDetailed = "detailed"
+
+	ActivityLimitDefault = 50
+	ActivityLimitMax     = 100
+)
+
+// ActivityFilters is the cycle order for the Activity view's filter
+// tabs and the f/F keys. Keep in sync with Slack's All / DMs /
+// Mentions / Threads tabs, plus Reactions (a captured feed type).
+var ActivityFilters = []string{
+	ActivityFilterAll,
+	ActivityFilterDMs,
+	ActivityFilterMentions,
+	ActivityFilterThreads,
+	ActivityFilterReactions,
+}
+
+// ActivitySorts is the cycle order for the Activity view's sort chip
+// and the s key.
+var ActivitySorts = []string{
+	ActivitySortNewest,
+	ActivitySortUnreadsFirst,
+}
+
+// ActivityFilterLabel is the tab label shown in the Activity toolbar.
+func ActivityFilterLabel(filter string) string {
+	switch ClampActivityFilter(filter) {
+	case ActivityFilterDMs:
+		return "DMs"
+	case ActivityFilterMentions:
+		return "Mentions"
+	case ActivityFilterThreads:
+		return "Threads"
+	case ActivityFilterReactions:
+		return "Reactions"
+	default:
+		return "All"
+	}
+}
+
+// ActivitySortLabel is the sort-chip label shown in the Activity toolbar.
+func ActivitySortLabel(sort string) string {
+	if ClampActivitySort(sort) == ActivitySortUnreadsFirst {
+		return "unreads first"
+	}
+	return "newest"
+}
+
+func ClampActivityFilter(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ActivityFilterAll
+	}
+	switch strings.ToLower(s) {
+	case ActivityFilterAll, ActivityFilterDMs, ActivityFilterMentions, ActivityFilterThreads, ActivityFilterReactions:
+		return strings.ToLower(s)
+	default:
+		// Custom activity.views name (Unreads, VIP, …) — keep as typed.
+		return s
+	}
+}
+
+func ClampActivitySort(s string) string {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case ActivitySortUnreadsFirst:
+		return ActivitySortUnreadsFirst
+	default:
+		return ActivitySortNewest
+	}
+}
+
+func ClampActivityDensity(s string) string {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case ActivityDensityCompact:
+		return ActivityDensityCompact
+	default:
+		return ActivityDensityDetailed
+	}
+}
+
+func ClampActivityLimit(n int) int {
+	if n < 1 {
+		return ActivityLimitDefault
+	}
+	if n > ActivityLimitMax {
+		return ActivityLimitMax
+	}
+	return n
+}
+
+// Normalized returns a copy with every enum/limit clamped to the
+// documented set. Load applies this so a partial or typo'd [activity]
+// block still starts the TUI on valid knobs.
+func (a Activity) Normalized() Activity {
+	a.Filter = ClampActivityFilter(a.Filter)
+	a.Sort = ClampActivitySort(a.Sort)
+	a.Density = ClampActivityDensity(a.Density)
+	a.Limit = ClampActivityLimit(a.Limit)
+	return a
+}
+
+// NextActivityFilter walks ActivityFilters. dir > 0 advances, dir < 0
+// goes backward, wrapping at both ends.
+func NextActivityFilter(current string, dir int) string {
+	return cycleChoice(ActivityFilters, ClampActivityFilter(current), dir)
+}
+
+// NextActivitySort walks ActivitySorts forward (two values, so this
+// is a toggle).
+func NextActivitySort(current string) string {
+	return cycleChoice(ActivitySorts, ClampActivitySort(current), 1)
+}
+
+func cycleChoice(opts []string, current string, dir int) string {
+	if len(opts) == 0 {
+		return current
+	}
+	i := 0
+	for j, o := range opts {
+		if o == current {
+			i = j
+			break
+		}
+	}
+	n := len(opts)
+	i = (i + dir) % n
+	if i < 0 {
+		i += n
+	}
+	return opts[i]
+}
+
 // Workspace holds per-workspace user preferences. The TOML key for
 // the surrounding map can be either a user-chosen slug (with TeamID
 // set explicitly via team_id) or — for backward compatibility —
@@ -222,6 +398,12 @@ func Default() Config {
 		Sidebar: Sidebar{
 			HideInactiveAfterDays: 30,
 		},
+		Activity: Activity{
+			Filter:  ActivityFilterAll,
+			Sort:    ActivitySortNewest,
+			Density: ActivityDensityDetailed,
+			Limit:   ActivityLimitDefault,
+		},
 	}
 }
 
@@ -264,6 +446,8 @@ func Load(path string) (Config, error) {
 	if cfg.Appearance.EmojiImages != "on" && cfg.Appearance.EmojiImages != "off" {
 		cfg.Appearance.EmojiImages = "on"
 	}
+
+	cfg.Activity = cfg.Activity.Normalized()
 
 	return cfg, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -462,6 +462,48 @@ team_id = "T01ABCDEF"
 	}
 }
 
+func TestLoadWorkspacesMergesLegacyTeamIDKeyIntoSlug(t *testing.T) {
+	// saveWorkspaceVersionTS used to append [workspaces.<teamID>] when
+	// it could not find the slug header, so a real config looks like
+	// this after the first boot. Two slugs for the same team is still
+	// an error (TestLoadWorkspacesDuplicateTeamID); a leftover team-ID
+	// key next to the slug that owns that team is prefs, not a second
+	// workspace.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	data := []byte(`
+[workspaces.work]
+team_id = "T01ABCDEF"
+theme = "dracula"
+
+[workspaces.T01ABCDEF]
+version_ts = "1788174451"
+`)
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if _, ok := cfg.Workspaces["T01ABCDEF"]; ok {
+		t.Fatal("leftover team-ID key should be dropped after merge")
+	}
+	ws, ok := cfg.Workspaces["work"]
+	if !ok {
+		t.Fatalf("expected slug key 'work', got %v", cfg.Workspaces)
+	}
+	if ws.TeamID != "T01ABCDEF" {
+		t.Errorf("TeamID = %q, want T01ABCDEF", ws.TeamID)
+	}
+	if ws.Theme != "dracula" {
+		t.Errorf("Theme = %q, want dracula (slug fields must survive the merge)", ws.Theme)
+	}
+	if ws.VersionTS != "1788174451" {
+		t.Errorf("VersionTS = %q, want the leftover block's 1788174451", ws.VersionTS)
+	}
+}
+
 func TestLoadWorkspacesMixedKeys(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.toml")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -903,3 +903,133 @@ team_id = "T04T4TH8W"
 		t.Errorf("VersionTS = %q; want empty when unset", got)
 	}
 }
+
+func TestActivityDefaults(t *testing.T) {
+	d := Default()
+	if d.Activity.Filter != ActivityFilterAll {
+		t.Errorf("Filter = %q, want all", d.Activity.Filter)
+	}
+	if d.Activity.Sort != ActivitySortNewest {
+		t.Errorf("Sort = %q, want newest", d.Activity.Sort)
+	}
+	if d.Activity.UnreadOnly {
+		t.Error("UnreadOnly should default false")
+	}
+	if d.Activity.Density != ActivityDensityDetailed {
+		t.Errorf("Density = %q, want detailed", d.Activity.Density)
+	}
+	if d.Activity.Limit != ActivityLimitDefault {
+		t.Errorf("Limit = %d, want %d", d.Activity.Limit, ActivityLimitDefault)
+	}
+
+	cfg, err := Load(filepath.Join(t.TempDir(), "missing.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Activity != d.Activity {
+		t.Errorf("missing file Activity = %+v, want %+v", cfg.Activity, d.Activity)
+	}
+}
+
+func TestActivityClampOnLoad(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte(`
+[activity]
+filter = "nope"
+sort = "alphabetical"
+density = "huge"
+limit = 0
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Activity.Filter != "nope" {
+		t.Errorf("unknown filter %q should pass through as a custom view name", cfg.Activity.Filter)
+	}
+	if cfg.Activity.Sort != ActivitySortNewest {
+		t.Errorf("bad sort clamped to %q, want newest", cfg.Activity.Sort)
+	}
+	if cfg.Activity.Density != ActivityDensityDetailed {
+		t.Errorf("bad density clamped to %q, want detailed", cfg.Activity.Density)
+	}
+	if cfg.Activity.Limit != ActivityLimitDefault {
+		t.Errorf("limit 0 clamped to %d, got %d", ActivityLimitDefault, cfg.Activity.Limit)
+	}
+}
+
+func TestActivityValidValuesPassThrough(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte(`
+[activity]
+filter = "mentions"
+sort = "unreads_first"
+unread_only = true
+density = "compact"
+limit = 20
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Activity.Filter != ActivityFilterMentions {
+		t.Errorf("Filter = %q", cfg.Activity.Filter)
+	}
+	if cfg.Activity.Sort != ActivitySortUnreadsFirst {
+		t.Errorf("Sort = %q", cfg.Activity.Sort)
+	}
+	if !cfg.Activity.UnreadOnly {
+		t.Error("UnreadOnly = false, want true")
+	}
+	if cfg.Activity.Density != ActivityDensityCompact {
+		t.Errorf("Density = %q", cfg.Activity.Density)
+	}
+	if cfg.Activity.Limit != 20 {
+		t.Errorf("Limit = %d, want 20", cfg.Activity.Limit)
+	}
+}
+
+func TestActivityLimitClampMax(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte("[activity]\nlimit = 500\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Activity.Limit != ActivityLimitMax {
+		t.Errorf("Limit = %d, want %d", cfg.Activity.Limit, ActivityLimitMax)
+	}
+}
+
+func TestNextActivityFilterWraps(t *testing.T) {
+	if got := NextActivityFilter(ActivityFilterAll, 1); got != ActivityFilterDMs {
+		t.Errorf("all+1 = %q, want dms", got)
+	}
+	if got := NextActivityFilter(ActivityFilterReactions, 1); got != ActivityFilterAll {
+		t.Errorf("reactions+1 = %q, want all", got)
+	}
+	if got := NextActivityFilter(ActivityFilterAll, -1); got != ActivityFilterReactions {
+		t.Errorf("all-1 = %q, want reactions", got)
+	}
+	if got := NextActivityFilter("bogus", 1); got != ActivityFilterDMs {
+		t.Errorf("unknown+1 should start from all → dms, got %q", got)
+	}
+}
+
+func TestNextActivitySortToggles(t *testing.T) {
+	if got := NextActivitySort(ActivitySortNewest); got != ActivitySortUnreadsFirst {
+		t.Errorf("newest → %q", got)
+	}
+	if got := NextActivitySort(ActivitySortUnreadsFirst); got != ActivitySortNewest {
+		t.Errorf("unreads_first → %q", got)
+	}
+}

--- a/internal/config/workspaces.go
+++ b/internal/config/workspaces.go
@@ -48,12 +48,17 @@ func Slugify(s string) string {
 // blocks). Returns an error if a slug-keyed block lacks team_id, if
 // two slugs map to the same team_id, or if a slug-keyed block's
 // team_id field is itself not a Slack-team-ID-shaped string.
+//
+// A leftover [workspaces.<teamID>] block next to a slug-keyed block
+// for the same team is not a duplicate workspace — it is how
+// saveWorkspaceVersionTS used to persist version_ts when it could not
+// find the slug header. Those prefs are merged into the slug block
+// and the leftover key is dropped so Load does not refuse to start.
 func resolveWorkspaceKeys(ws map[string]Workspace) (map[string]Workspace, error) {
 	if len(ws) == 0 {
 		return ws, nil
 	}
-	out := make(map[string]Workspace, len(ws))
-	seenTeamID := make(map[string]string, len(ws)) // teamID -> first slug we saw
+	prepared := make(map[string]Workspace, len(ws))
 	for key, w := range ws {
 		switch {
 		case w.TeamID != "":
@@ -71,13 +76,62 @@ func resolveWorkspaceKeys(ws map[string]Workspace) (map[string]Workspace, error)
 				"workspace %q is missing team_id (the TOML key is a slug, "+
 					"so the block must set team_id explicitly)", key)
 		}
-		if first, dup := seenTeamID[w.TeamID]; dup {
+		prepared[key] = w
+	}
+
+	slugForTeam := make(map[string]string, len(prepared)) // teamID -> slug key
+	for key, w := range prepared {
+		if key == w.TeamID {
+			continue
+		}
+		if first, dup := slugForTeam[w.TeamID]; dup {
 			return nil, fmt.Errorf(
 				"workspaces %q and %q both reference team_id %q",
 				first, key, w.TeamID)
 		}
-		seenTeamID[w.TeamID] = key
+		slugForTeam[w.TeamID] = key
+	}
+
+	out := make(map[string]Workspace, len(prepared))
+	for key, w := range prepared {
+		if key != w.TeamID {
+			continue
+		}
+		if slug, ok := slugForTeam[w.TeamID]; ok {
+			prepared[slug] = mergeWorkspacePrefs(prepared[slug], w)
+			continue
+		}
 		out[key] = w
 	}
+	for _, slug := range slugForTeam {
+		out[slug] = prepared[slug]
+	}
 	return out, nil
+}
+
+// mergeWorkspacePrefs copies unset preference fields from src into dst.
+// Used when a leftover team-ID-keyed block sits beside a slug-keyed
+// block for the same team: the slug keeps identity, the leftover
+// donates version_ts / theme / width / etc. that were saved under
+// the team-ID key. Non-empty dst fields win.
+func mergeWorkspacePrefs(dst, src Workspace) Workspace {
+	if dst.VersionTS == "" {
+		dst.VersionTS = src.VersionTS
+	}
+	if dst.Theme == "" {
+		dst.Theme = src.Theme
+	}
+	if dst.SidebarWidth == 0 {
+		dst.SidebarWidth = src.SidebarWidth
+	}
+	if dst.Order == 0 {
+		dst.Order = src.Order
+	}
+	if dst.UseSlackSections == nil {
+		dst.UseSlackSections = src.UseSlackSections
+	}
+	if len(dst.Sections) == 0 {
+		dst.Sections = src.Sections
+	}
+	return dst
 }

--- a/internal/slack/activity.go
+++ b/internal/slack/activity.go
@@ -1,0 +1,408 @@
+package slackclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// ActivityCounts is client.counts' activity_v2 object: unread Activity
+// items grouped by the same type strings activity.feed uses. Sum is
+// the Activity sidebar badge. Captured 2026-08-31 against Obvious AI
+// (T099JCA82HJ) via the same xoxc session slk already holds.
+type ActivityCounts struct {
+	ByType map[string]int
+}
+
+// Unread returns the sum of all activity_v2 type counts.
+func (a ActivityCounts) Unread() int {
+	n := 0
+	for _, v := range a.ByType {
+		n += v
+	}
+	return n
+}
+
+// ActivityItem is one row in Slack's Activity tab, flattened from
+// activity.feed's per-type payloads so the TUI can render and jump
+// without switching on nested bundle_info shapes.
+//
+// Captured shapes (activity.feed, 2026-08-31):
+//   channel / dm   — bundle_info.payload.{channel,dm}_entry.latest_message
+//   thread_v2      — bundle_info.payload.thread_entry.{channel_id,thread_ts,latest_ts}
+//   message_reaction — message.{channel,ts} + reaction.{user,name}
+//   at_user / at_channel / at_* — message.{channel,ts,author_user_id}
+type ActivityItem struct {
+	Key       string
+	Type      string
+	Unread    bool
+	VIP       bool
+	FeedTS    string
+	ChannelID string
+	MessageTS string
+	ThreadTS  string
+	ActorID   string
+	Reaction  string
+}
+
+// ActivityView is one Activity-tab row from activity.views: Slack's
+// built-in All/DMs/Mentions/Threads plus any user-created custom
+// views (Unreads, Reactions, VIP, …). Captured 2026-08-31.
+//
+// Selecting a view does not send view_id to activity.feed — the
+// official client flattens filters/sort onto the feed form
+// (entry_types → types, unread_only, priority_only).
+type ActivityView struct {
+	ID       string
+	Name     string
+	Type     string // all | dms | mentions | threads | custom
+	Position string
+	Sort     string // newest | vip_unreads_first
+	Density  string // compact | detailed
+	Filters  ActivityViewFilters
+}
+
+// ActivityViewFilters is the subset of a view's filters that
+// activity.feed actually honors.
+type ActivityViewFilters struct {
+	EntryTypes   []string
+	UnreadOnly   bool
+	PriorityOnly bool
+}
+
+// activityFeedTypes is the All-tab `types` field from a 2026-08-31
+// capture of app.slack.com's Activity inbox (activity.feed,
+// _x_reason=fetchActivityFeed). Duplicates are what the official
+// client sent; they are harmless.
+const activityFeedTypes = "at_user,at_user_group,at_channel,at_everyone,keyword,list_record_assigned,list_user_mentioned,list_todo_notification,list_approval_request,list_approval_reviewed,unjoined_channel_mention,at_user,unjoined_channel_mention,at_channel,at_everyone,at_user_group,keyword,thread_v2,message_reaction,bot_dm_bundle,dm,prejoin_dm_welcome_party_alert,internal_channel_invite,external_channel_invite,external_dm_invite,quietly_added_to_channel,channel,saved_reminder,list_record_edited"
+
+// ActivityFeedOpts is the flattened activity.feed request. Prefer
+// FeedOptsFromView so custom tabs (unread_only / priority_only /
+// entry_types) stay in lockstep with activity.views. Filter is the
+// builtin fallback when no view is loaded yet.
+type ActivityFeedOpts struct {
+	Filter       string
+	Types        []string
+	Sort         string
+	UnreadOnly   bool
+	PriorityOnly bool
+	Limit        int
+}
+
+// FeedOptsFromView flattens an activity.views row into the feed
+// params the official client sends when that tab is selected.
+func FeedOptsFromView(v ActivityView) ActivityFeedOpts {
+	sort := "newest"
+	if v.Sort == "vip_unreads_first" {
+		sort = "unreads_first"
+	}
+	return ActivityFeedOpts{
+		Filter:       v.Type,
+		Types:        append([]string(nil), v.Filters.EntryTypes...),
+		Sort:         sort,
+		UnreadOnly:   v.Filters.UnreadOnly,
+		PriorityOnly: v.Filters.PriorityOnly,
+	}
+}
+
+// GetActivityViews fetches the Activity tab list (activity.views),
+// including user-created custom views. Empty / failed responses
+// should fall back to BuiltinActivityViews.
+func (c *Client) GetActivityViews(ctx context.Context) ([]ActivityView, error) {
+	raw, err := c.PostForm(ctx, "activity.views", url.Values{})
+	if err != nil {
+		return nil, fmt.Errorf("activity.views: %w", err)
+	}
+	views, err := parseActivityViews(raw)
+	if err != nil {
+		return nil, err
+	}
+	return views, nil
+}
+
+// BuiltinActivityViews is the All/DMs/Mentions/Threads set the
+// official inbox always shows, used before activity.views lands
+// and if that call fails.
+func BuiltinActivityViews() []ActivityView {
+	return []ActivityView{
+		{ID: "all", Name: "All", Type: "all", Position: "1000000000", Sort: "newest", Density: "compact"},
+		{ID: "dms", Name: "DMs", Type: "dms", Position: "2000000000", Sort: "vip_unreads_first", Filters: ActivityViewFilters{EntryTypes: []string{"dm"}}},
+		{ID: "mentions", Name: "Mentions", Type: "mentions", Position: "3000000000", Sort: "vip_unreads_first", Filters: ActivityViewFilters{EntryTypes: []string{"at_user", "at_user_group", "at_channel", "at_everyone", "keyword", "list_record_assigned", "list_user_mentioned", "list_todo_notification", "unjoined_channel_mention"}}},
+		{ID: "threads", Name: "Threads", Type: "threads", Position: "4000000000", Sort: "vip_unreads_first", Filters: ActivityViewFilters{EntryTypes: []string{"thread_v2"}}},
+	}
+}
+
+// GetActivityFeed fetches Slack's Activity tab (activity.feed).
+//
+// Official All-tab capture (2026-08-31): mode=chrono_v1,
+// is_activity_inbox=true, the types list in activityFeedTypes.
+// DMs/Mentions/Threads tabs send mode=priority_reads_and_unreads_v1
+// and sort=vip_unreads_first. Filter maps onto the captured type
+// groups for those tabs plus Reactions.
+func (c *Client) GetActivityFeed(ctx context.Context, opts ActivityFeedOpts) ([]ActivityItem, error) {
+	raw, err := c.PostForm(ctx, "activity.feed", buildActivityFeedForm(opts))
+	if err != nil {
+		return nil, fmt.Errorf("activity.feed: %w", err)
+	}
+	items, err := parseActivityFeed(raw)
+	if err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+func buildActivityFeedForm(opts ActivityFeedOpts) url.Values {
+	limit := opts.Limit
+	if limit < 1 {
+		limit = 50
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	mode, sort := activityModeForSort(opts.Sort)
+	form := url.Values{
+		"limit":                    {strconv.Itoa(limit)},
+		"types":                    {typesForFeedOpts(opts)},
+		"mode":                     {mode},
+		"archive_only":             {"false"},
+		"unread_only":              {boolForm(opts.UnreadOnly)},
+		"priority_only":            {boolForm(opts.PriorityOnly)},
+		"only_salesforce_channels": {"false"},
+		"exclude_automations":      {"false"},
+		"automations_only":         {"false"},
+		"is_activity_inbox":        {"true"},
+	}
+	if sort != "" {
+		form.Set("sort", sort)
+	}
+	return form
+}
+
+func boolForm(v bool) string {
+	if v {
+		return "true"
+	}
+	return "false"
+}
+
+func typesForFeedOpts(opts ActivityFeedOpts) string {
+	if len(opts.Types) > 0 {
+		return strings.Join(opts.Types, ",")
+	}
+	return activityTypesForFilter(opts.Filter)
+}
+
+func activityTypesForFilter(filter string) string {
+	switch strings.ToLower(strings.TrimSpace(filter)) {
+	case "dms":
+		return "dm"
+	case "mentions":
+		return "at_user,at_user_group,at_channel,at_everyone,keyword,list_record_assigned,list_user_mentioned,list_todo_notification,unjoined_channel_mention"
+	case "threads":
+		return "thread_v2"
+	case "reactions":
+		return "message_reaction"
+	default:
+		return activityFeedTypes
+	}
+}
+
+func activityModeForSort(sort string) (mode, sortField string) {
+	switch strings.ToLower(strings.TrimSpace(sort)) {
+	case "unreads_first", "vip_unreads_first":
+		return "priority_reads_and_unreads_v1", "vip_unreads_first"
+	default:
+		return "chrono_v1", ""
+	}
+}
+
+type activityViewsResponse struct {
+	OK    bool                `json:"ok"`
+	Error string              `json:"error"`
+	Views []activityViewEntry `json:"views"`
+}
+
+type activityViewEntry struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	ViewType string `json:"view_type"`
+	Position string `json:"position"`
+	Sort     string `json:"sort"`
+	Density  string `json:"density"`
+	Filters  struct {
+		EntryTypes   []string `json:"entry_types"`
+		UnreadOnly   bool     `json:"unread_only"`
+		PriorityOnly bool     `json:"priority_only"`
+	} `json:"filters"`
+}
+
+func parseActivityViews(raw []byte) ([]ActivityView, error) {
+	var res activityViewsResponse
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return nil, fmt.Errorf("activity.views: decoding: %w", err)
+	}
+	if !res.OK {
+		errStr := res.Error
+		if errStr == "" {
+			errStr = "ok=false"
+		}
+		return nil, fmt.Errorf("activity.views: %s", errStr)
+	}
+	out := make([]ActivityView, 0, len(res.Views))
+	for _, v := range res.Views {
+		if v.ID == "" && v.Name == "" {
+			continue
+		}
+		out = append(out, ActivityView{
+			ID:       v.ID,
+			Name:     v.Name,
+			Type:     v.ViewType,
+			Position: v.Position,
+			Sort:     v.Sort,
+			Density:  v.Density,
+			Filters: ActivityViewFilters{
+				EntryTypes:   append([]string(nil), v.Filters.EntryTypes...),
+				UnreadOnly:   v.Filters.UnreadOnly,
+				PriorityOnly: v.Filters.PriorityOnly,
+			},
+		})
+	}
+	return out, nil
+}
+
+type activityFeedResponse struct {
+	OK    bool            `json:"ok"`
+	Error string          `json:"error"`
+	Items []activityEntry `json:"items"`
+}
+
+type activityEntry struct {
+	Key      string          `json:"key"`
+	Unread   bool            `json:"is_unread"`
+	FeedTS   string          `json:"feed_ts"`
+	Archived bool            `json:"is_archived"`
+	Item     json.RawMessage `json:"item"`
+	Priority json.RawMessage `json:"priority"`
+}
+
+type activityInner struct {
+	Type       string `json:"type"`
+	BundleInfo struct {
+		Payload struct {
+			ChannelEntry struct {
+				LatestMessage activityMsgRef `json:"latest_message"`
+			} `json:"channel_entry"`
+			DMEntry struct {
+				LatestMessage activityMsgRef `json:"latest_message"`
+			} `json:"dm_entry"`
+			ThreadEntry struct {
+				ChannelID string `json:"channel_id"`
+				ThreadTS  string `json:"thread_ts"`
+				LatestTS  string `json:"latest_ts"`
+			} `json:"thread_entry"`
+		} `json:"payload"`
+	} `json:"bundle_info"`
+	Message struct {
+		TS       string `json:"ts"`
+		Channel  string `json:"channel"`
+		AuthorID string `json:"author_user_id"`
+	} `json:"message"`
+	Reaction struct {
+		User string `json:"user"`
+		Name string `json:"name"`
+	} `json:"reaction"`
+}
+
+type activityMsgRef struct {
+	TS      string `json:"ts"`
+	Channel string `json:"channel"`
+}
+
+func parseActivityFeed(raw []byte) ([]ActivityItem, error) {
+	var res activityFeedResponse
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return nil, fmt.Errorf("activity.feed: decoding: %w", err)
+	}
+	if !res.OK {
+		errStr := res.Error
+		if errStr == "" {
+			errStr = "ok=false"
+		}
+		return nil, fmt.Errorf("activity.feed: %s", errStr)
+	}
+	out := make([]ActivityItem, 0, len(res.Items))
+	for _, e := range res.Items {
+		if e.Archived {
+			continue
+		}
+		item, ok := flattenActivityEntry(e)
+		if !ok {
+			continue
+		}
+		out = append(out, item)
+	}
+	return out, nil
+}
+
+func flattenActivityEntry(e activityEntry) (ActivityItem, bool) {
+	var inner activityInner
+	if err := json.Unmarshal(e.Item, &inner); err != nil {
+		return ActivityItem{}, false
+	}
+	item := ActivityItem{
+		Key:    e.Key,
+		Type:   inner.Type,
+		Unread: e.Unread,
+		VIP:    len(e.Priority) > 2,
+		FeedTS: e.FeedTS,
+	}
+	switch inner.Type {
+	case "channel":
+		item.ChannelID = inner.BundleInfo.Payload.ChannelEntry.LatestMessage.Channel
+		item.MessageTS = inner.BundleInfo.Payload.ChannelEntry.LatestMessage.TS
+	case "dm":
+		item.ChannelID = inner.BundleInfo.Payload.DMEntry.LatestMessage.Channel
+		item.MessageTS = inner.BundleInfo.Payload.DMEntry.LatestMessage.TS
+	case "thread_v2":
+		te := inner.BundleInfo.Payload.ThreadEntry
+		item.ChannelID = te.ChannelID
+		item.ThreadTS = te.ThreadTS
+		item.MessageTS = te.LatestTS
+		if item.MessageTS == "" {
+			item.MessageTS = te.ThreadTS
+		}
+	case "message_reaction":
+		item.ChannelID = inner.Message.Channel
+		item.MessageTS = inner.Message.TS
+		item.ActorID = inner.Reaction.User
+		item.Reaction = inner.Reaction.Name
+	default:
+		// Mentions, keywords, invites, lists: message.{channel,ts}.
+		item.ChannelID = inner.Message.Channel
+		item.MessageTS = inner.Message.TS
+		item.ActorID = inner.Message.AuthorID
+	}
+	if item.ChannelID == "" {
+		return ActivityItem{}, false
+	}
+	return item, true
+}
+
+// parseActivityV2 decodes client.counts' activity_v2 object into
+// ActivityCounts. Unknown keys are kept so a new desktop type still
+// contributes to the badge.
+func parseActivityV2(raw json.RawMessage) ActivityCounts {
+	if len(raw) == 0 {
+		return ActivityCounts{}
+	}
+	var m map[string]int
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return ActivityCounts{}
+	}
+	return ActivityCounts{ByType: m}
+}
+
+

--- a/internal/slack/activity_test.go
+++ b/internal/slack/activity_test.go
@@ -1,0 +1,210 @@
+package slackclient
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestParseActivityFeed_CapturedShapes(t *testing.T) {
+	raw, err := os.ReadFile("testdata/activity-feed.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	items, err := parseActivityFeed(raw)
+	if err != nil {
+		t.Fatalf("parseActivityFeed: %v", err)
+	}
+	if len(items) != 6 {
+		t.Fatalf("len = %d; want 6 (one of each captured type)", len(items))
+	}
+	byType := map[string]ActivityItem{}
+	for _, it := range items {
+		byType[it.Type] = it
+	}
+	ch := byType["channel"]
+	if ch.ChannelID != "C0A95SPDL3B" || ch.MessageTS != "1787955901.383689" || !ch.Unread {
+		t.Errorf("channel = %+v; want C0A95SPDL3B / 1787955901.383689 unread", ch)
+	}
+	th := byType["thread_v2"]
+	if th.ChannelID != "C099JCB0WLC" || th.ThreadTS != "1787859788.452529" || th.MessageTS != "1788181025.052949" {
+		t.Errorf("thread_v2 = %+v", th)
+	}
+	dm := byType["dm"]
+	if dm.ChannelID != "D0ARB1GN6Q5" || dm.MessageTS != "1788133014.963939" {
+		t.Errorf("dm = %+v", dm)
+	}
+	rx := byType["message_reaction"]
+	if rx.ChannelID != "D0ARB1GN6Q5" || rx.ActorID != "U099FC5CXCJ" || rx.Reaction != "eyes" {
+		t.Errorf("reaction = %+v", rx)
+	}
+	at := byType["at_user"]
+	if at.ChannelID != "C0B4EUFSRU3" || at.ActorID != "U09PAK5229E" {
+		t.Errorf("at_user = %+v", at)
+	}
+}
+
+func TestParseActivityFeed_RejectsNotOK(t *testing.T) {
+	_, err := parseActivityFeed([]byte(`{"ok":false,"error":"ratelimited"}`))
+	if err == nil {
+		t.Fatal("want error on ok=false")
+	}
+}
+
+func TestActivityCountsUnread(t *testing.T) {
+	a := parseActivityV2([]byte(`{"channel":30,"dm":2,"at_user":1}`))
+	if got := a.Unread(); got != 33 {
+		t.Errorf("Unread = %d; want 33", got)
+	}
+	if parseActivityV2(nil).Unread() != 0 {
+		t.Error("empty activity_v2 should sum to 0")
+	}
+}
+
+func TestBuildActivityFeedForm_DefaultsMatchAllTab(t *testing.T) {
+	f := buildActivityFeedForm(ActivityFeedOpts{})
+	if f.Get("mode") != "chrono_v1" {
+		t.Errorf("mode = %q; want chrono_v1 (All-tab capture)", f.Get("mode"))
+	}
+	if f.Get("sort") != "" {
+		t.Errorf("sort = %q; All-tab capture omitted sort", f.Get("sort"))
+	}
+	if f.Get("types") != activityFeedTypes {
+		t.Errorf("types = %q; want the captured All-tab list", f.Get("types"))
+	}
+	if f.Get("unread_only") != "false" {
+		t.Errorf("unread_only = %q; want false", f.Get("unread_only"))
+	}
+	if f.Get("is_activity_inbox") != "true" {
+		t.Errorf("is_activity_inbox = %q; want true", f.Get("is_activity_inbox"))
+	}
+	if f.Get("limit") != "50" {
+		t.Errorf("limit = %q; want 50", f.Get("limit"))
+	}
+}
+
+func TestBuildActivityFeedForm_MentionsUnreadsFirst(t *testing.T) {
+	f := buildActivityFeedForm(ActivityFeedOpts{
+		Filter:     "mentions",
+		Sort:       "unreads_first",
+		UnreadOnly: true,
+		Limit:      20,
+	})
+	if f.Get("types") != activityTypesForFilter("mentions") {
+		t.Errorf("types = %q", f.Get("types"))
+	}
+	if !strings.Contains(f.Get("types"), "at_user") || strings.Contains(f.Get("types"), "thread_v2") {
+		t.Errorf("mentions types should include at_user and exclude thread_v2: %q", f.Get("types"))
+	}
+	if f.Get("mode") != "priority_reads_and_unreads_v1" {
+		t.Errorf("mode = %q; want priority_reads_and_unreads_v1", f.Get("mode"))
+	}
+	if f.Get("sort") != "vip_unreads_first" {
+		t.Errorf("sort = %q; want vip_unreads_first", f.Get("sort"))
+	}
+	if f.Get("unread_only") != "true" {
+		t.Errorf("unread_only = %q; want true", f.Get("unread_only"))
+	}
+	if f.Get("limit") != "20" {
+		t.Errorf("limit = %q; want 20", f.Get("limit"))
+	}
+}
+
+func TestBuildActivityFeedForm_ClampsLimit(t *testing.T) {
+	if got := buildActivityFeedForm(ActivityFeedOpts{Limit: 0}).Get("limit"); got != "50" {
+		t.Errorf("limit 0 → %q; want 50", got)
+	}
+	if got := buildActivityFeedForm(ActivityFeedOpts{Limit: 999}).Get("limit"); got != "100" {
+		t.Errorf("limit 999 → %q; want 100", got)
+	}
+}
+
+func TestParseActivityViews_IncludesCustom(t *testing.T) {
+	raw, err := os.ReadFile("testdata/activity-views.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	views, err := parseActivityViews(raw)
+	if err != nil {
+		t.Fatalf("parseActivityViews: %v", err)
+	}
+	if len(views) != 7 {
+		t.Fatalf("len = %d; want 7 (4 builtin + Unreads/Reactions/VIP)", len(views))
+	}
+	byName := map[string]ActivityView{}
+	for _, v := range views {
+		byName[v.Name] = v
+	}
+	if byName["Unreads"].Type != "custom" || !byName["Unreads"].Filters.UnreadOnly {
+		t.Errorf("Unreads = %+v", byName["Unreads"])
+	}
+	if got := byName["Reactions"].Filters.EntryTypes; len(got) != 1 || got[0] != "message_reaction" {
+		t.Errorf("Reactions types = %v", got)
+	}
+	if !byName["VIP"].Filters.PriorityOnly {
+		t.Errorf("VIP missing priority_only: %+v", byName["VIP"])
+	}
+	unreads := FeedOptsFromView(byName["Unreads"])
+	if !unreads.UnreadOnly || unreads.PriorityOnly || unreads.Sort != "newest" {
+		t.Errorf("Unreads feed opts = %+v", unreads)
+	}
+	f := buildActivityFeedForm(unreads)
+	if f.Get("unread_only") != "true" || f.Get("priority_only") != "false" {
+		t.Errorf("Unreads form unread=%s priority=%s", f.Get("unread_only"), f.Get("priority_only"))
+	}
+	if f.Get("types") != activityFeedTypes {
+		t.Error("Unreads tab keeps the full All-tab types list")
+	}
+	vip := buildActivityFeedForm(FeedOptsFromView(byName["VIP"]))
+	if vip.Get("priority_only") != "true" {
+		t.Errorf("VIP form priority_only = %q", vip.Get("priority_only"))
+	}
+	rx := buildActivityFeedForm(FeedOptsFromView(byName["Reactions"]))
+	if rx.Get("types") != "message_reaction" {
+		t.Errorf("Reactions types = %q", rx.Get("types"))
+	}
+}
+
+func TestBuildActivityFeedForm_PriorityOnly(t *testing.T) {
+	f := buildActivityFeedForm(ActivityFeedOpts{PriorityOnly: true, Sort: "newest"})
+	if f.Get("priority_only") != "true" {
+		t.Errorf("priority_only = %q", f.Get("priority_only"))
+	}
+	if f.Get("mode") != "chrono_v1" {
+		t.Errorf("mode = %q", f.Get("mode"))
+	}
+}
+
+func TestActivityTypesForFilter(t *testing.T) {
+	if activityTypesForFilter("threads") != "thread_v2" {
+		t.Errorf("threads types = %q", activityTypesForFilter("threads"))
+	}
+	if activityTypesForFilter("reactions") != "message_reaction" {
+		t.Errorf("reactions types = %q", activityTypesForFilter("reactions"))
+	}
+	if activityTypesForFilter("bogus") != activityFeedTypes {
+		t.Error("unknown filter should fall back to All-tab types")
+	}
+}
+
+func TestFlattenMarksVIP(t *testing.T) {
+	raw := []byte(`{"ok":true,"items":[{"is_unread":false,"feed_ts":"1","key":"t","priority":{"vip":{}},"item":{"type":"thread_v2","bundle_info":{"payload":{"thread_entry":{"channel_id":"C1","thread_ts":"1.0","latest_ts":"2.0"}}}}}]}`)
+	items, err := parseActivityFeed(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 1 || !items[0].VIP {
+		t.Errorf("VIP item = %+v", items)
+	}
+}
+
+func TestFlattenSkipsMissingChannel(t *testing.T) {
+	raw := []byte(`{"ok":true,"items":[{"is_unread":true,"feed_ts":"1","key":"x","item":{"type":"mystery"}}]}`)
+	items, err := parseActivityFeed(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 0 {
+		t.Errorf("got %d items; a type with no channel must be dropped, not shown as a blank row", len(items))
+	}
+}

--- a/internal/slack/client.go
+++ b/internal/slack/client.go
@@ -945,30 +945,41 @@ type ThreadsAggregate struct {
 	MentionCount int
 }
 
-// GetUnreadCounts fetches unread counts for all channels using Slack's
-// internal client.counts API (available with xoxc browser tokens).
-// Also returns the threads aggregate (HasUnreads / counts) for the
-// workspace; the threads block in client.counts is the only place
-// Slack tells us whether per-thread unreads exist without us having to
-// hit subscriptions.thread.* directly.
+// CountsSnapshot is everything one client.counts call learned that slk
+// consumes: per-conversation unreads, the threads rollup, and the
+// Activity-tab badge (activity_v2).
+type CountsSnapshot struct {
+	Unreads  []UnreadInfo
+	Threads  ThreadsAggregate
+	Activity ActivityCounts
+}
+
+// GetUnreadCounts is the historical two-return wrapper around GetCounts.
 func (c *Client) GetUnreadCounts() ([]UnreadInfo, ThreadsAggregate, error) {
+	s, err := c.GetCounts()
+	return s.Unreads, s.Threads, err
+}
+
+// GetCounts fetches unread counts for all channels using Slack's
+// internal client.counts API (available with xoxc browser tokens).
+func (c *Client) GetCounts() (CountsSnapshot, error) {
 	reqURL := c.apiBaseURL + "client.counts"
 	form := url.Values{"token": {c.token}}
 	req, err := http.NewRequest("POST", reqURL, strings.NewReader(form.Encode()))
 	if err != nil {
-		return nil, ThreadsAggregate{}, fmt.Errorf("creating request: %w", err)
+		return CountsSnapshot{}, fmt.Errorf("creating request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	resp, err := c.apiHTTPClient().Do(req)
 	if err != nil {
-		return nil, ThreadsAggregate{}, fmt.Errorf("fetching unread counts: %w", err)
+		return CountsSnapshot{}, fmt.Errorf("fetching unread counts: %w", err)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, ThreadsAggregate{}, fmt.Errorf("reading response: %w", err)
+		return CountsSnapshot{}, fmt.Errorf("reading response: %w", err)
 	}
 
 	var result struct {
@@ -1001,14 +1012,15 @@ func (c *Client) GetUnreadCounts() ([]UnreadInfo, ThreadsAggregate, error) {
 			UnreadCount  int  `json:"unread_count"`
 			MentionCount int  `json:"mention_count"`
 		} `json:"threads"`
+		ActivityV2 json.RawMessage `json:"activity_v2"`
 	}
 
 	if err := json.Unmarshal(body, &result); err != nil {
-		return nil, ThreadsAggregate{}, fmt.Errorf("parsing response: %w", err)
+		return CountsSnapshot{}, fmt.Errorf("parsing response: %w", err)
 	}
 
 	if !result.OK {
-		return nil, ThreadsAggregate{}, fmt.Errorf("client.counts API returned ok=false")
+		return CountsSnapshot{}, fmt.Errorf("client.counts API returned ok=false")
 	}
 
 	var unreads []UnreadInfo
@@ -1054,7 +1066,11 @@ func (c *Client) GetUnreadCounts() ([]UnreadInfo, ThreadsAggregate, error) {
 		UnreadCount:  result.Threads.UnreadCount,
 		MentionCount: result.Threads.MentionCount,
 	}
-	return unreads, threads, nil
+	return CountsSnapshot{
+		Unreads:  unreads,
+		Threads:  threads,
+		Activity: parseActivityV2(result.ActivityV2),
+	}, nil
 }
 
 // SendReply posts a threaded reply to the specified message.

--- a/internal/slack/testdata/activity-feed.json
+++ b/internal/slack/testdata/activity-feed.json
@@ -1,0 +1,91 @@
+{
+  "ok": true,
+  "items": [
+    {
+      "is_unread": true,
+      "feed_ts": "1787955901.383689",
+      "key": "channel-C0A95SPDL3B",
+      "is_archived": false,
+      "item": {
+        "type": "channel",
+        "bundle_info": {
+          "payload": {
+            "channel_entry": {
+              "latest_message": {"ts": "1787955901.383689", "channel": "C0A95SPDL3B"},
+              "unread_msg_count": 1
+            }
+          }
+        }
+      }
+    },
+    {
+      "is_unread": false,
+      "feed_ts": "1788181025.052949",
+      "key": "thread_v2-C099JCB0WLC-1787859788.452529",
+      "item": {
+        "type": "thread_v2",
+        "bundle_info": {
+          "payload": {
+            "thread_entry": {
+              "channel_id": "C099JCB0WLC",
+              "latest_ts": "1788181025.052949",
+              "thread_ts": "1787859788.452529",
+              "unread_msg_count": 0
+            }
+          }
+        }
+      }
+    },
+    {
+      "is_unread": false,
+      "feed_ts": "1788133014.963939",
+      "key": "dm-D0ARB1GN6Q5",
+      "item": {
+        "type": "dm",
+        "bundle_info": {
+          "payload": {
+            "dm_entry": {
+              "latest_message": {"ts": "1788133014.963939", "channel": "D0ARB1GN6Q5"}
+            }
+          }
+        }
+      }
+    },
+    {
+      "is_unread": false,
+      "feed_ts": "1788132798.000000",
+      "key": "message_reaction-D0ARB1GN6Q5-1788132677.527999",
+      "item": {
+        "type": "message_reaction",
+        "message": {"ts": "1788132677.527999", "channel": "D0ARB1GN6Q5"},
+        "reaction": {"user": "U099FC5CXCJ", "name": "eyes"}
+      }
+    },
+    {
+      "is_unread": false,
+      "feed_ts": "1787861003.733819",
+      "key": "at_user-C0B4EUFSRU3-1787861003.733819",
+      "item": {
+        "type": "at_user",
+        "message": {
+          "ts": "1787861003.733819",
+          "channel": "C0B4EUFSRU3",
+          "author_user_id": "U09PAK5229E"
+        }
+      }
+    },
+    {
+      "is_unread": false,
+      "feed_ts": "1787962111.792869",
+      "key": "at_channel-C09THT0TK38-1787962111.792869",
+      "item": {
+        "type": "at_channel",
+        "message": {
+          "ts": "1787962111.792869",
+          "channel": "C09THT0TK38",
+          "author_user_id": "U09DL7X8GG1"
+        }
+      }
+    }
+  ]
+}

--- a/internal/slack/testdata/activity-views.json
+++ b/internal/slack/testdata/activity-views.json
@@ -1,0 +1,83 @@
+{
+  "ok": true,
+  "views": [
+    {
+      "id": "Av0ATWU6QP1Q",
+      "name": "All",
+      "emoji": null,
+      "view_type": "all",
+      "position": "1000000000",
+      "sort": "newest",
+      "density": "compact"
+    },
+    {
+      "id": "Av02",
+      "name": "DMs",
+      "emoji": null,
+      "view_type": "dms",
+      "position": "2000000000",
+      "sort": "vip_unreads_first",
+      "filters": {"entry_types": ["dm"]}
+    },
+    {
+      "id": "Av03",
+      "name": "Mentions",
+      "emoji": null,
+      "view_type": "mentions",
+      "position": "3000000000",
+      "sort": "vip_unreads_first",
+      "filters": {
+        "entry_types": [
+          "at_user",
+          "at_user_group",
+          "at_channel",
+          "at_everyone",
+          "keyword",
+          "list_record_assigned",
+          "list_user_mentioned",
+          "list_todo_notification",
+          "unjoined_channel_mention"
+        ]
+      }
+    },
+    {
+      "id": "Av04",
+      "name": "Threads",
+      "emoji": null,
+      "view_type": "threads",
+      "position": "4000000000",
+      "sort": "vip_unreads_first",
+      "filters": {"entry_types": ["thread_v2"]}
+    },
+    {
+      "id": "Av0BTXFUMSNM",
+      "name": "Unreads",
+      "emoji": null,
+      "view_type": "custom",
+      "position": "5000000000",
+      "sort": "newest",
+      "density": "compact",
+      "filters": {"unread_only": true}
+    },
+    {
+      "id": "Av0BTRHD191B",
+      "name": "Reactions",
+      "emoji": null,
+      "view_type": "custom",
+      "position": "5000000001",
+      "sort": "newest",
+      "density": "compact",
+      "filters": {"entry_types": ["message_reaction"]}
+    },
+    {
+      "id": "Av0BTVL8SCV8",
+      "name": "VIP",
+      "emoji": null,
+      "view_type": "custom",
+      "position": "5000000002",
+      "sort": "newest",
+      "density": "compact",
+      "filters": {"priority_only": true}
+    }
+  ]
+}

--- a/internal/ui/activityview/model.go
+++ b/internal/ui/activityview/model.go
@@ -1,0 +1,991 @@
+// Package activityview is the UI model for the Activity inbox: Slack's
+// activity.feed recents, with filter tabs and sort/unread chips that
+// map onto the official All / DMs / Mentions / Threads request shape.
+//
+// Presentation only. The App layer fetches via ActivityService and
+// pushes items with SetItems; f/F/s/u and toolbar clicks mutate the
+// query held here so the next fetch uses the new knobs.
+package activityview
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"charm.land/lipgloss/v2"
+	"github.com/gammons/slk/internal/config"
+	slackclient "github.com/gammons/slk/internal/slack"
+	"github.com/gammons/slk/internal/ui/styles"
+	"github.com/muesli/reflow/truncate"
+)
+
+const (
+	toolbarLines     = 3 // tabs + hint + blank
+	cardContentLines = 3
+	cardStride       = cardContentLines + 1
+)
+
+func mutedStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(styles.TextMuted)
+}
+
+func unreadDotStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(styles.Primary).Bold(true)
+}
+
+func channelNameStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(styles.Primary).Bold(true)
+}
+
+func tabActiveStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(styles.Primary).Bold(true)
+}
+
+func chipOnStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(styles.Accent).Bold(true)
+}
+
+var thickLeftBorder = lipgloss.Border{Left: "▌"}
+
+func borderInvisStyle() lipgloss.Style {
+	return lipgloss.NewStyle().
+		BorderStyle(thickLeftBorder).BorderLeft(true).
+		BorderForeground(styles.Background).
+		BorderBackground(styles.Background)
+}
+
+func borderSelectStyle(focused bool) lipgloss.Style {
+	return lipgloss.NewStyle().
+		BorderStyle(thickLeftBorder).BorderLeft(true).
+		BorderForeground(styles.SelectionBorderColor(focused)).
+		BorderBackground(styles.SelectionTintColor(focused)).
+		Background(styles.SelectionTintColor(focused))
+}
+
+func borderFillStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Background(styles.Background)
+}
+
+// ClickKind is what a mouse click hit in the Activity panel.
+type ClickKind int
+
+const (
+	ClickNone ClickKind = iota
+	ClickItem
+	ClickControls
+)
+
+type hitKind int
+
+const (
+	hitNone hitKind = iota
+	hitFilter
+	hitSort
+	hitUnread
+	hitDensity
+)
+
+type hitbox struct {
+	x0, x1 int
+	kind   hitKind
+	viewID string
+}
+
+// Item is one flattened activity.feed row plus names resolved by the
+// App layer so the view does not talk to Slack or the cache.
+type Item struct {
+	slackclient.ActivityItem
+	ChannelName string
+	ChannelType string
+	ActorName   string
+}
+
+// Query is the flattened activity.feed request the next fetch should
+// send: the selected activity.views row plus live chip overrides.
+type Query struct {
+	Filter       string
+	Types        []string
+	Sort         string
+	UnreadOnly   bool
+	PriorityOnly bool
+}
+
+// Model holds Activity-list state.
+type Model struct {
+	items        []Item
+	userNames    map[string]string
+	channelNames map[string]string
+	selfUserID   string
+
+	views         []slackclient.ActivityView
+	viewIdx       int
+	filter        string
+	sort          string
+	unreadOnly    bool
+	priorityOnly  bool
+	density       string
+	unreadBadge   int
+
+	selected int
+	yOffset  int
+	focused  bool
+	loading  bool
+	err      string
+
+	snappedSelection int
+	hasSnapped       bool
+
+	tabHits  []hitbox
+	chipHits []hitbox
+	version  int64
+}
+
+// New creates an empty Model seeded from config defaults.
+func New() Model {
+	m := Model{
+		userNames:    map[string]string{},
+		channelNames: map[string]string{},
+		filter:       config.ActivityFilterAll,
+		sort:         config.ActivitySortNewest,
+		density:      config.ActivityDensityDetailed,
+		views:        slackclient.BuiltinActivityViews(),
+	}
+	m.applyView(m.views[0], false)
+	return m
+}
+
+func (m *Model) Version() int64 { return m.version }
+
+func (m *Model) dirty() { m.version++ }
+
+func (m *Model) SetUserNames(names map[string]string) {
+	if names == nil {
+		names = map[string]string{}
+	}
+	if stringMapsEqual(m.userNames, names) {
+		return
+	}
+	m.userNames = names
+	m.dirty()
+}
+
+func (m *Model) SetChannelNames(names map[string]string) {
+	if names == nil {
+		names = map[string]string{}
+	}
+	if stringMapsEqual(m.channelNames, names) {
+		return
+	}
+	m.channelNames = names
+	m.dirty()
+}
+
+func (m *Model) SetSelfUserID(id string) {
+	if m.selfUserID != id {
+		m.selfUserID = id
+		m.dirty()
+	}
+}
+
+func (m *Model) SetFocused(f bool) {
+	if m.focused != f {
+		m.focused = f
+		m.dirty()
+	}
+}
+
+func (m *Model) SetDensity(d string) {
+	d = config.ClampActivityDensity(d)
+	if m.density == d {
+		return
+	}
+	m.density = d
+	m.hasSnapped = false
+	m.dirty()
+}
+
+func (m *Model) SetLoading(loading bool) {
+	if m.loading == loading {
+		return
+	}
+	m.loading = loading
+	m.dirty()
+}
+
+func (m *Model) SetError(err string) {
+	if m.err == err {
+		return
+	}
+	m.err = err
+	m.dirty()
+}
+
+// SetViews replaces the tab list from activity.views. Selection
+// follows the previously selected id/type/name when still present.
+func (m *Model) SetViews(views []slackclient.ActivityView) {
+	if len(views) == 0 {
+		views = slackclient.BuiltinActivityViews()
+	}
+	want := m.filter
+	if v, ok := m.selectedView(); ok {
+		want = v.ID
+	}
+	m.views = views
+	idx := indexView(views, want)
+	if idx < 0 {
+		idx = 0
+	}
+	m.viewIdx = idx
+	m.applyView(views[idx], true)
+}
+
+func (m *Model) Views() []slackclient.ActivityView { return m.views }
+
+func (m *Model) SetUnreadBadge(n int) {
+	if n < 0 {
+		n = 0
+	}
+	if m.unreadBadge == n {
+		return
+	}
+	m.unreadBadge = n
+	m.dirty()
+}
+
+// SetQuery seeds the selected tab and chips from config (or a
+// previous session). filter matches a view id, view_type, or name.
+func (m *Model) SetQuery(filter, sort string, unreadOnly bool) {
+	filter = config.ClampActivityFilter(filter)
+	sort = config.ClampActivitySort(sort)
+	if idx := indexView(m.views, filter); idx >= 0 {
+		m.viewIdx = idx
+		m.applyView(m.views[idx], false)
+	}
+	m.filter = filter
+	m.sort = sort
+	m.unreadOnly = unreadOnly
+	m.dirty()
+}
+
+func (m *Model) Query() Query {
+	var types []string
+	if v, ok := m.selectedView(); ok {
+		types = append([]string(nil), v.Filters.EntryTypes...)
+	}
+	return Query{
+		Filter:       m.filter,
+		Types:        types,
+		Sort:         m.sort,
+		UnreadOnly:   m.unreadOnly,
+		PriorityOnly: m.priorityOnly,
+	}
+}
+
+func (m *Model) Filter() string { return m.filter }
+func (m *Model) Sort() string   { return m.sort }
+func (m *Model) UnreadOnly() bool {
+	return m.unreadOnly
+}
+func (m *Model) Density() string { return m.density }
+
+func (m *Model) selectedView() (slackclient.ActivityView, bool) {
+	if m.viewIdx < 0 || m.viewIdx >= len(m.views) {
+		return slackclient.ActivityView{}, false
+	}
+	return m.views[m.viewIdx], true
+}
+
+func (m *Model) applyView(v slackclient.ActivityView, resetChips bool) {
+	m.filter = v.ID
+	if v.Type != "" && (v.Type != "custom") {
+		m.filter = v.Type
+	}
+	opts := slackclient.FeedOptsFromView(v)
+	if resetChips {
+		m.sort = opts.Sort
+		m.unreadOnly = opts.UnreadOnly
+		m.priorityOnly = opts.PriorityOnly
+		if v.Density != "" {
+			m.density = config.ClampActivityDensity(v.Density)
+		}
+	} else {
+		m.priorityOnly = opts.PriorityOnly
+	}
+	m.dirty()
+}
+
+func (m *Model) selectViewAt(idx int) bool {
+	if idx < 0 || idx >= len(m.views) || idx == m.viewIdx {
+		return false
+	}
+	m.viewIdx = idx
+	m.applyView(m.views[idx], true)
+	return true
+}
+
+// CycleFilter walks activity.views tabs (f / F). dir > 0 advances.
+func (m *Model) CycleFilter(dir int) bool {
+	n := len(m.views)
+	if n == 0 {
+		return false
+	}
+	idx := m.viewIdx + dir
+	idx %= n
+	if idx < 0 {
+		idx += n
+	}
+	return m.selectViewAt(idx)
+}
+
+// CycleSort toggles newest ↔ unreads_first.
+func (m *Model) CycleSort() bool {
+	next := config.NextActivitySort(m.sort)
+	if next == m.sort {
+		return false
+	}
+	m.sort = next
+	m.dirty()
+	return true
+}
+
+// ToggleUnreadOnly flips Slack's Unreads chip on the current tab.
+func (m *Model) ToggleUnreadOnly() bool {
+	m.unreadOnly = !m.unreadOnly
+	m.dirty()
+	return true
+}
+
+// CycleDensity toggles detailed ↔ compact (Slack's Detailed / Dense).
+func (m *Model) CycleDensity() bool {
+	if m.density == config.ActivityDensityCompact {
+		m.density = config.ActivityDensityDetailed
+	} else {
+		m.density = config.ActivityDensityCompact
+	}
+	m.hasSnapped = false
+	m.dirty()
+	return true
+}
+
+func indexView(views []slackclient.ActivityView, key string) int {
+	if key == "" {
+		return -1
+	}
+	lower := strings.ToLower(key)
+	for i, v := range views {
+		if v.ID == key || strings.EqualFold(v.Type, lower) || strings.EqualFold(v.Name, key) {
+			return i
+		}
+	}
+	return -1
+}
+
+// SetItems replaces the list. Selection follows Key when the previous
+// row is still present; otherwise it resets to the top.
+func (m *Model) SetItems(items []Item) {
+	prevKey, hadSel := m.selectedKey()
+	m.items = items
+	m.loading = false
+	m.err = ""
+	newSel := 0
+	if hadSel && prevKey != "" {
+		for i, it := range items {
+			if it.Key == prevKey {
+				newSel = i
+				break
+			}
+		}
+	}
+	m.selected = newSel
+	m.clampSelection()
+	m.hasSnapped = false
+	m.dirty()
+}
+
+func (m *Model) Items() []Item { return m.items }
+
+func (m *Model) SelectedIndex() int { return m.selected }
+
+func (m *Model) SelectedItem() (Item, bool) {
+	if len(m.items) == 0 || m.selected < 0 || m.selected >= len(m.items) {
+		return Item{}, false
+	}
+	return m.items[m.selected], true
+}
+
+func (m *Model) selectedKey() (string, bool) {
+	it, ok := m.SelectedItem()
+	if !ok {
+		return "", false
+	}
+	return it.Key, true
+}
+
+func (m *Model) MoveDown() {
+	if m.selected < len(m.items)-1 {
+		m.selected++
+		m.dirty()
+	}
+}
+
+func (m *Model) MoveUp() {
+	if m.selected > 0 {
+		m.selected--
+		m.dirty()
+	}
+}
+
+func (m *Model) GoToTop() {
+	if m.selected != 0 {
+		m.selected = 0
+		m.dirty()
+	}
+}
+
+func (m *Model) GoToBottom() {
+	if n := len(m.items); n > 0 && m.selected != n-1 {
+		m.selected = n - 1
+		m.dirty()
+	}
+}
+
+func (m *Model) ScrollUp(n int) {
+	if n <= 0 {
+		return
+	}
+	m.yOffset -= n
+	if m.yOffset < 0 {
+		m.yOffset = 0
+	}
+	m.snappedSelection = m.selected
+	m.hasSnapped = true
+	m.dirty()
+}
+
+func (m *Model) ScrollDown(n int) {
+	if n <= 0 {
+		return
+	}
+	m.yOffset += n
+	m.snappedSelection = m.selected
+	m.hasSnapped = true
+	m.dirty()
+}
+
+// ClickAt selects a card or hits a toolbar control. rowY/colX are
+// pane-local content coordinates (border already stripped).
+func (m *Model) ClickAt(rowY, colX int) ClickKind {
+	if rowY < 0 {
+		return ClickNone
+	}
+	if rowY == 0 {
+		return m.clickHits(m.tabHits, colX)
+	}
+	if rowY == 1 {
+		return m.clickHits(m.chipHits, colX)
+	}
+	if rowY < toolbarLines {
+		return ClickNone
+	}
+	bodyY := rowY - toolbarLines
+	absLine := m.yOffset + bodyY
+	if absLine < 0 {
+		return ClickNone
+	}
+	idx := m.indexAtLine(absLine)
+	if idx < 0 || idx >= len(m.items) {
+		return ClickNone
+	}
+	if m.selected != idx {
+		m.selected = idx
+		m.dirty()
+	}
+	return ClickItem
+}
+
+func (m *Model) clickHits(hits []hitbox, colX int) ClickKind {
+	for _, h := range hits {
+		if colX >= h.x0 && colX < h.x1 {
+			switch h.kind {
+			case hitFilter:
+				idx := indexView(m.views, h.viewID)
+				if idx >= 0 && m.selectViewAt(idx) {
+					return ClickControls
+				}
+			case hitSort:
+				if m.CycleSort() {
+					return ClickControls
+				}
+			case hitUnread:
+				if m.ToggleUnreadOnly() {
+					return ClickControls
+				}
+			case hitDensity:
+				m.CycleDensity()
+				return ClickNone
+			}
+			return ClickNone
+		}
+	}
+	return ClickNone
+}
+
+func (m *Model) indexAtLine(absLine int) int {
+	if m.density == config.ActivityDensityCompact {
+		if absLine >= len(m.items) {
+			return -1
+		}
+		return absLine
+	}
+	if absLine%cardStride >= cardContentLines {
+		return -1
+	}
+	return absLine / cardStride
+}
+
+func (m *Model) clampSelection() {
+	if m.selected < 0 {
+		m.selected = 0
+	}
+	if n := len(m.items); n == 0 {
+		m.selected = 0
+	} else if m.selected >= n {
+		m.selected = n - 1
+	}
+}
+
+func (m *Model) View(height, width int) string {
+	if width < 1 {
+		width = 1
+	}
+	if height < 1 {
+		height = 1
+	}
+
+	toolbar := m.renderToolbar(width)
+	bodyHeight := height - toolbarLines
+	if bodyHeight < 0 {
+		bodyHeight = 0
+	}
+
+	var body string
+	switch {
+	case m.loading && len(m.items) == 0:
+		body = placeCenter(width, bodyHeight, mutedStyle().Render("loading activity…"))
+	case m.err != "" && len(m.items) == 0:
+		body = placeCenter(width, bodyHeight, mutedStyle().Render(m.err))
+	case len(m.items) == 0:
+		body = placeCenter(width, bodyHeight, mutedStyle().Render("no activity"))
+	default:
+		lines := m.renderRows(width)
+		if !m.hasSnapped || m.snappedSelection != m.selected {
+			m.snapToSelected(bodyHeight, len(lines))
+			m.snappedSelection = m.selected
+			m.hasSnapped = true
+		}
+		maxOffset := len(lines) - bodyHeight
+		if maxOffset < 0 {
+			maxOffset = 0
+		}
+		if m.yOffset > maxOffset {
+			m.yOffset = maxOffset
+		}
+		if m.yOffset < 0 {
+			m.yOffset = 0
+		}
+		end := m.yOffset + bodyHeight
+		if end > len(lines) {
+			end = len(lines)
+		}
+		visible := lines[m.yOffset:end]
+		if pad := bodyHeight - len(visible); pad > 0 {
+			filler := blankLine(width)
+			out := make([]string, 0, bodyHeight)
+			out = append(out, visible...)
+			for i := 0; i < pad; i++ {
+				out = append(out, filler)
+			}
+			visible = out
+		}
+		body = strings.Join(visible, "\n")
+	}
+
+	if bodyHeight == 0 {
+		return toolbar
+	}
+	return toolbar + "\n" + body
+}
+
+func placeCenter(width, height int, s string) string {
+	if height < 1 {
+		return ""
+	}
+	return lipgloss.Place(width, height, lipgloss.Center, lipgloss.Center, s)
+}
+
+func (m *Model) renderToolbar(width int) string {
+	tabs, boxes := m.renderTabs()
+	tabs = clipToWidth(tabs, width)
+	if pad := width - lipgloss.Width(tabs); pad > 0 {
+		tabs += strings.Repeat(" ", pad)
+	}
+
+	unreadLabel := "unread"
+	sortLabel := config.ActivitySortLabel(m.sort)
+	densityLabel := "detailed"
+	if m.density == config.ActivityDensityCompact {
+		densityLabel = "dense"
+	}
+	unreadStyled := mutedStyle().Render(unreadLabel)
+	if m.unreadOnly {
+		unreadStyled = chipOnStyle().Render(unreadLabel)
+	}
+	sortStyled := mutedStyle().Render(sortLabel)
+	if m.sort == config.ActivitySortUnreadsFirst {
+		sortStyled = chipOnStyle().Render(sortLabel)
+	}
+	densityStyled := mutedStyle().Render(densityLabel)
+	if m.density == config.ActivityDensityCompact {
+		densityStyled = chipOnStyle().Render(densityLabel)
+	}
+	sep := mutedStyle().Render("  ")
+	chips := unreadStyled + sep + sortStyled + sep + densityStyled
+	hint := mutedStyle().Render("  f/F tab  s sort  u unread  enter")
+	line1 := chips + hint
+	line1 = clipToWidth(line1, width)
+	if pad := width - lipgloss.Width(line1); pad > 0 {
+		line1 += strings.Repeat(" ", pad)
+	}
+
+	x := 0
+	chipHits := []hitbox{
+		{x0: x, x1: x + lipgloss.Width(unreadLabel), kind: hitUnread},
+	}
+	x += lipgloss.Width(unreadLabel) + 2
+	chipHits = append(chipHits, hitbox{x0: x, x1: x + lipgloss.Width(sortLabel), kind: hitSort})
+	x += lipgloss.Width(sortLabel) + 2
+	chipHits = append(chipHits, hitbox{x0: x, x1: x + lipgloss.Width(densityLabel), kind: hitDensity})
+	m.tabHits = boxes
+	m.chipHits = chipHits
+
+	return tabs + "\n" + line1 + "\n" + blankLine(width)
+}
+
+func (m *Model) renderTabs() (string, []hitbox) {
+	var b strings.Builder
+	boxes := make([]hitbox, 0, len(m.views))
+	x := 0
+	sel, _ := m.selectedView()
+	for i, v := range m.views {
+		if i > 0 {
+			b.WriteString("  ")
+			x += 2
+		}
+		label := v.Name
+		if label == "" {
+			label = v.Type
+		}
+		if (v.Type == "all" || strings.EqualFold(v.Name, "All")) && m.unreadBadge > 0 {
+			label += " •" + strconv.Itoa(m.unreadBadge)
+		}
+		styled := mutedStyle().Render(label)
+		if v.ID == sel.ID {
+			styled = tabActiveStyle().Render(label)
+		}
+		w := lipgloss.Width(label)
+		boxes = append(boxes, hitbox{x0: x, x1: x + w, kind: hitFilter, viewID: v.ID})
+		b.WriteString(styled)
+		x += w
+	}
+	return b.String(), boxes
+}
+
+func (m *Model) snapToSelected(height, totalLines int) {
+	start, end := m.selectedSpan()
+	if end > m.yOffset+height {
+		m.yOffset = end - height
+	}
+	if start < m.yOffset {
+		m.yOffset = start
+	}
+	if m.yOffset < 0 {
+		m.yOffset = 0
+	}
+	maxOffset := totalLines - height
+	if maxOffset < 0 {
+		maxOffset = 0
+	}
+	if m.yOffset > maxOffset {
+		m.yOffset = maxOffset
+	}
+}
+
+func (m *Model) selectedSpan() (start, end int) {
+	if m.density == config.ActivityDensityCompact {
+		return m.selected, m.selected + 1
+	}
+	start = m.selected * cardStride
+	return start, start + cardContentLines
+}
+
+func (m *Model) renderRows(width int) []string {
+	if m.density == config.ActivityDensityCompact {
+		lines := make([]string, 0, len(m.items))
+		for i, it := range m.items {
+			lines = append(lines, m.renderCompact(it, width, i == m.selected))
+		}
+		return lines
+	}
+	separator := blankLine(width)
+	var lines []string
+	for i, it := range m.items {
+		if i > 0 {
+			lines = append(lines, separator)
+		}
+		lines = append(lines, m.renderCard(it, width, i == m.selected)...)
+	}
+	return lines
+}
+
+func blankLine(width int) string {
+	return lipgloss.NewStyle().Width(width).Render("")
+}
+
+func (m *Model) renderCompact(it Item, width int, selected bool) string {
+	contentWidth := width - 1
+	if contentWidth < 1 {
+		contentWidth = 1
+	}
+	line := m.headerText(it)
+	line = clipToWidth(line, contentWidth)
+	return m.borderFill(line, contentWidth, selected, false)
+}
+
+func (m *Model) renderCard(it Item, width int, selected bool) []string {
+	contentWidth := width - 1
+	if contentWidth < 1 {
+		contentWidth = 1
+	}
+	header := clipToWidth(m.headerText(it), contentWidth)
+	preview := clipToWidth("  "+m.previewText(it), contentWidth)
+	footer := clipToWidth("  "+formatRelTime(it.FeedTS), contentWidth)
+	return []string{
+		m.borderFill(header, contentWidth, selected, false),
+		m.borderFill(preview, contentWidth, selected, false),
+		m.borderFill(footer, contentWidth, selected, true),
+	}
+}
+
+func (m *Model) borderFill(text string, contentWidth int, selected, muted bool) string {
+	borderStyle := borderInvisStyle()
+	fill := borderFillStyle().Width(contentWidth)
+	if selected {
+		borderStyle = borderSelectStyle(m.focused)
+		fill = lipgloss.NewStyle().
+			Background(styles.SelectionTintColor(m.focused)).
+			Width(contentWidth)
+	}
+	if muted {
+		fill = fill.Foreground(styles.TextMuted)
+	}
+	return borderStyle.Render(fill.Render(text))
+}
+
+func (m *Model) headerText(it Item) string {
+	actor := it.ActorName
+	if actor == "" {
+		actor = m.resolveUser(it.ActorID)
+	}
+	title := m.itemTitle(it)
+	var header string
+	if actor != "" {
+		header = actor + "  " + mutedStyle().Render("·") + "  " + title
+	} else {
+		header = title
+	}
+	if it.VIP {
+		header += "  " + chipOnStyle().Render("vip")
+	}
+	if it.Unread {
+		header += "  " + unreadDotStyle().Render("●")
+	}
+	return header
+}
+
+func (m *Model) previewText(it Item) string {
+	actor := it.ActorName
+	if actor == "" {
+		actor = m.resolveUser(it.ActorID)
+	}
+	switch it.Type {
+	case "message_reaction":
+		rx := it.Reaction
+		if rx == "" {
+			rx = "reaction"
+		}
+		if actor != "" {
+			return actor + " reacted :" + rx + ":"
+		}
+		return ":" + rx + ":"
+	case "thread_v2":
+		if actor != "" {
+			return "reply from " + actor
+		}
+		return "thread reply"
+	case "dm":
+		if actor != "" {
+			return actor
+		}
+		return "direct message"
+	default:
+		if actor != "" {
+			return actor
+		}
+		return m.itemTitle(it)
+	}
+}
+
+func (m *Model) channelLabel(it Item) string {
+	if it.ChannelName != "" {
+		return it.ChannelName
+	}
+	if name, ok := m.channelNames[it.ChannelID]; ok && name != "" {
+		return name
+	}
+	return it.ChannelID
+}
+
+func (m *Model) resolveUser(uid string) string {
+	if uid == "" {
+		return ""
+	}
+	if uid == m.selfUserID {
+		return "me"
+	}
+	if name, ok := m.userNames[uid]; ok && name != "" {
+		return name
+	}
+	return uid
+}
+
+func (m *Model) itemTitle(it Item) string {
+	ch := m.channelLabel(it)
+	in := ch
+	if it.ChannelType != "dm" && it.ChannelType != "group_dm" && ch != "" && !strings.HasPrefix(ch, "#") {
+		in = "#" + ch
+	}
+	switch it.Type {
+	case "dm":
+		return "Direct Message"
+	case "channel":
+		if in != "" {
+			return "Post in " + channelNameStyle().Render(in)
+		}
+		return "Post"
+	case "thread_v2":
+		if in != "" {
+			return "Thread in " + channelNameStyle().Render(in)
+		}
+		return "Thread"
+	case "message_reaction":
+		rx := it.Reaction
+		if rx == "" {
+			rx = "reaction"
+		}
+		if it.ChannelType == "dm" || it.ChannelType == "group_dm" {
+			return "Reacted :" + rx + ": in Direct Message"
+		}
+		if in != "" {
+			return "Reacted :" + rx + ": in " + channelNameStyle().Render(in)
+		}
+		return "Reacted :" + rx + ":"
+	case "at_user":
+		if in != "" {
+			return "Mentioned you in " + channelNameStyle().Render(in)
+		}
+		return "Mentioned you"
+	case "at_channel":
+		if in != "" {
+			return "Channel mention in " + channelNameStyle().Render(in)
+		}
+		return "Channel mention"
+	case "at_everyone":
+		if in != "" {
+			return "@everyone in " + channelNameStyle().Render(in)
+		}
+		return "@everyone"
+	case "at_user_group":
+		if in != "" {
+			return "Group mention in " + channelNameStyle().Render(in)
+		}
+		return "Group mention"
+	case "keyword":
+		if in != "" {
+			return "Keyword in " + channelNameStyle().Render(in)
+		}
+		return "Keyword"
+	default:
+		if it.Type == "" {
+			return "Activity"
+		}
+		return it.Type
+	}
+}
+
+func channelGlyph(channelType string) string {
+	switch channelType {
+	case "private":
+		return lipgloss.NewStyle().Foreground(styles.Warning).Render("◆ ")
+	case "dm", "group_dm":
+		return lipgloss.NewStyle().Foreground(styles.TextMuted).Render("● ")
+	default:
+		return "# "
+	}
+}
+
+func formatRelTime(ts string) string {
+	if ts == "" {
+		return ""
+	}
+	secStr := ts
+	if dot := strings.IndexByte(ts, '.'); dot >= 0 {
+		secStr = ts[:dot]
+	}
+	sec, err := strconv.ParseInt(secStr, 10, 64)
+	if err != nil {
+		return ""
+	}
+	d := time.Since(time.Unix(sec, 0))
+	switch {
+	case d < time.Minute:
+		return "now"
+	case d < time.Hour:
+		return strconv.Itoa(int(d/time.Minute)) + "m ago"
+	case d < 24*time.Hour:
+		return strconv.Itoa(int(d/time.Hour)) + "h ago"
+	default:
+		return strconv.Itoa(int(d/(24*time.Hour))) + "d ago"
+	}
+}
+
+func clipToWidth(s string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	if lipgloss.Width(s) <= width {
+		return s
+	}
+	return truncate.StringWithTail(s, uint(width), "…")
+}
+
+func stringMapsEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, va := range a {
+		if vb, ok := b[k]; !ok || vb != va {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/ui/activityview/model_test.go
+++ b/internal/ui/activityview/model_test.go
@@ -1,0 +1,191 @@
+package activityview
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gammons/slk/internal/config"
+	slackclient "github.com/gammons/slk/internal/slack"
+	"github.com/gammons/slk/internal/ui/styles"
+)
+
+func init() {
+	styles.Apply("nord", config.Theme{})
+}
+
+func sampleItems() []Item {
+	return []Item{
+		{ActivityItem: slackclient.ActivityItem{
+			Key: "k1", Type: "channel", Unread: true,
+			ChannelID: "C1", MessageTS: "1.0", FeedTS: "1.0",
+		}, ChannelName: "general", ChannelType: "channel"},
+		{ActivityItem: slackclient.ActivityItem{
+			Key: "k2", Type: "dm", Unread: false,
+			ChannelID: "D1", MessageTS: "2.0", FeedTS: "2.0",
+		}, ChannelName: "alice", ChannelType: "dm"},
+	}
+}
+
+func TestNew_DefaultsMatchConfig(t *testing.T) {
+	m := New()
+	q := m.Query()
+	if q.Filter != config.ActivityFilterAll || q.Sort != config.ActivitySortNewest || q.UnreadOnly {
+		t.Errorf("Query = %+v; want all/newest/false", q)
+	}
+	if m.Density() != config.ActivityDensityDetailed {
+		t.Errorf("Density = %q", m.Density())
+	}
+}
+
+func TestCycleFilterAndSort(t *testing.T) {
+	m := New()
+	if !m.CycleFilter(1) || m.Filter() != config.ActivityFilterDMs {
+		t.Fatalf("f → %q, want dms", m.Filter())
+	}
+	if !m.CycleFilter(-1) || m.Filter() != config.ActivityFilterAll {
+		t.Fatalf("F → %q, want all", m.Filter())
+	}
+	if !m.CycleSort() || m.Sort() != config.ActivitySortUnreadsFirst {
+		t.Fatalf("s → %q", m.Sort())
+	}
+	if !m.ToggleUnreadOnly() || !m.UnreadOnly() {
+		t.Fatal("u should turn unread-only on")
+	}
+}
+
+func TestSetItemsPreservesSelectionByKey(t *testing.T) {
+	m := New()
+	m.SetItems(sampleItems())
+	m.MoveDown()
+	it, _ := m.SelectedItem()
+	if it.Key != "k2" {
+		t.Fatalf("precondition: selected %q", it.Key)
+	}
+	reranked := []Item{sampleItems()[1], sampleItems()[0]}
+	m.SetItems(reranked)
+	got, _ := m.SelectedItem()
+	if got.Key != "k2" {
+		t.Errorf("selection should follow k2, got %q", got.Key)
+	}
+}
+
+func TestView_RendersTabsAndHint(t *testing.T) {
+	m := New()
+	m.SetItems(sampleItems())
+	out := m.View(12, 70)
+	for _, want := range []string{"All", "DMs", "Mentions", "Threads", "unread", "newest", "f/F tab"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("View missing %q:\n%s", want, out)
+		}
+	}
+	if !strings.Contains(out, "general") {
+		t.Errorf("View missing channel name:\n%s", out)
+	}
+}
+
+func TestSetViews_AddsCustomTabs(t *testing.T) {
+	m := New()
+	m.SetViews([]slackclient.ActivityView{
+		{ID: "all", Name: "All", Type: "all", Sort: "newest"},
+		{ID: "custom-unreads", Name: "Unreads", Type: "custom", Sort: "newest", Filters: slackclient.ActivityViewFilters{UnreadOnly: true}},
+		{ID: "custom-vip", Name: "VIP", Type: "custom", Sort: "newest", Filters: slackclient.ActivityViewFilters{PriorityOnly: true}},
+	})
+	out := m.View(8, 70)
+	if !strings.Contains(out, "Unreads") || !strings.Contains(out, "VIP") {
+		t.Errorf("custom tabs missing:\n%s", out)
+	}
+	m.CycleFilter(1)
+	q := m.Query()
+	if !q.UnreadOnly || q.PriorityOnly {
+		t.Errorf("Unreads tab query = %+v", q)
+	}
+	m.CycleFilter(1)
+	q = m.Query()
+	if !q.PriorityOnly {
+		t.Errorf("VIP tab query = %+v", q)
+	}
+}
+
+func TestView_ActiveFilterHighlighted(t *testing.T) {
+	m := New()
+	m.SetQuery(config.ActivityFilterMentions, config.ActivitySortNewest, false)
+	out := m.View(8, 70)
+	if !strings.Contains(out, "Mentions") {
+		t.Fatalf("missing Mentions tab:\n%s", out)
+	}
+}
+
+func TestClickAt_ToolbarFilter(t *testing.T) {
+	m := New()
+	m.SetItems(sampleItems())
+	_ = m.View(12, 70) // populate hitboxes
+	// First tab is "All" at x=0; "DMs" follows two spaces after "All" (3).
+	kind := m.ClickAt(0, 5)
+	if kind != ClickControls {
+		t.Fatalf("click DMs tab = %v, want ClickControls", kind)
+	}
+	if m.Filter() != config.ActivityFilterDMs && m.Filter() != "dms" {
+		t.Errorf("Filter = %q, want dms", m.Filter())
+	}
+}
+
+func TestClickAt_CardSelects(t *testing.T) {
+	m := New()
+	m.SetItems(sampleItems())
+	_ = m.View(16, 50)
+	// toolbarLines=3; detailed card 1 starts at line 3+4=7
+	kind := m.ClickAt(3+cardStride, 2)
+	if kind != ClickItem {
+		t.Fatalf("click card = %v, want ClickItem", kind)
+	}
+	it, ok := m.SelectedItem()
+	if !ok || it.Key != "k2" {
+		t.Errorf("selected %+v ok=%v, want k2", it, ok)
+	}
+}
+
+func TestClickAt_BlankRowIsNone(t *testing.T) {
+	m := New()
+	m.SetItems(sampleItems())
+	_ = m.View(12, 50)
+	if kind := m.ClickAt(2, 2); kind != ClickNone {
+		t.Errorf("blank toolbar row click = %v, want ClickNone", kind)
+	}
+}
+
+func TestCompactDensity_OneLinePerItem(t *testing.T) {
+	m := New()
+	m.SetDensity(config.ActivityDensityCompact)
+	m.SetItems(sampleItems())
+	kind := m.ClickAt(toolbarLines+1, 1)
+	if kind != ClickItem {
+		t.Fatalf("compact click = %v", kind)
+	}
+	it, _ := m.SelectedItem()
+	if it.Key != "k2" {
+		t.Errorf("compact index 1 = %q, want k2", it.Key)
+	}
+}
+
+func TestMoveDownClamps(t *testing.T) {
+	m := New()
+	m.SetItems(sampleItems())
+	m.MoveDown()
+	m.MoveDown()
+	if m.SelectedIndex() != 1 {
+		t.Errorf("SelectedIndex = %d, want 1", m.SelectedIndex())
+	}
+}
+
+func TestEmptyState(t *testing.T) {
+	m := New()
+	out := m.View(10, 40)
+	if !strings.Contains(out, "no activity") {
+		t.Errorf("empty view:\n%s", out)
+	}
+	m.SetLoading(true)
+	out = m.View(10, 40)
+	if !strings.Contains(out, "loading activity") {
+		t.Errorf("loading view:\n%s", out)
+	}
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gammons/slk/internal/ids"
 	imgpkg "github.com/gammons/slk/internal/image"
 	"github.com/gammons/slk/internal/slackurl"
+	"github.com/gammons/slk/internal/ui/activityview"
 	"github.com/gammons/slk/internal/ui/channelfinder"
 	"github.com/gammons/slk/internal/ui/channelpicker"
 	"github.com/gammons/slk/internal/ui/compose"
@@ -72,6 +73,7 @@ type View int
 const (
 	ViewChannels View = iota
 	ViewThreads
+	ViewActivity
 )
 
 const (
@@ -111,6 +113,7 @@ type App struct {
 	threadPanel      *thread.Model
 	threadCompose    compose.Model
 	threadsView      threadsview.Model
+	activityView     activityview.Model
 
 	// State
 	mode           Mode
@@ -201,7 +204,13 @@ type App struct {
 	// unread boundary). See internal/ui/services.go. Defaulted to a
 	// no-op adapter in NewApp so call sites can dispatch without
 	// nil-checks.
-	threads ThreadService
+	threads  ThreadService
+	activity ActivityService
+	// activityCfg is the [activity] config defaults (limit + the
+	// session-start filter/sort/unread_only/density). Live TUI
+	// cycles live on activityView, not here.
+	activityCfg config.Activity
+	activityGen uint64
 
 	threadsDirtyDebounce time.Duration
 	// fetchingOlder tracks in-flight older-history backfills per
@@ -500,6 +509,7 @@ func NewApp() *App {
 		threadPanel:           thread.New(),
 		threadCompose:         compose.New("thread"),
 		threadsView:           threadsview.New(nil, ""),
+		activityView:          activityview.New(),
 		linkPicker:            linkpicker.New(),
 		reactionPicker:        reactionpicker.New(),
 		reactionsView:         reactionsview.New(),
@@ -527,6 +537,7 @@ func NewApp() *App {
 		layout:                newPanelLayout(),
 		reactions:             noopReactionService,
 		threads:               noopThreadService,
+		activity:              noopActivityService,
 		messageSvc:            noopMessageService,
 		channels:              noopChannelService,
 		searchSvc:             noopSearchService,
@@ -558,12 +569,10 @@ func NewApp() *App {
 	// can jump to the threads-list view from the same overlay they use
 	// to switch channels (ctrl+t / ctrl+p). Selecting this row dispatches
 	// ThreadsViewActivatedMsg in handleChannelFinderMode below.
-	app.channelFinder.SetSyntheticItems([]channelfinder.Item{{
-		ID:     channelfinder.ThreadsViewID,
-		Name:   "Threads",
-		Type:   "threads",
-		Joined: true,
-	}})
+	app.channelFinder.SetSyntheticItems([]channelfinder.Item{
+		{ID: channelfinder.ThreadsViewID, Name: "Threads", Type: "threads", Joined: true},
+		{ID: channelfinder.ActivityViewID, Name: "Activity", Type: "activity", Joined: true},
+	})
 	// Seed the statusbar hint with the configured help key label so it
 	// stays accurate if the binding is ever changed.
 	app.statusbar.SetHelpHint(app.defaultHelpHint())
@@ -614,6 +623,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.bootstrap,
 		reduceReactions,
 		reduceThreads,
+		reduceActivity,
 		reduceSend,
 		reduceChannels,
 		reduceLinks,
@@ -1255,6 +1265,10 @@ func (a *App) handleDown() tea.Cmd {
 			// don't fire one conversations.replies call per row.
 			return a.openSelectedThreadCmd(true)
 		}
+		if a.view == ViewActivity {
+			a.activityView.MoveDown()
+			return nil
+		}
 		return a.coalesceContentScroll(+1)
 	case PanelThread:
 		return a.coalesceContentScroll(+1)
@@ -1271,6 +1285,10 @@ func (a *App) handleUp() tea.Cmd {
 			a.threadsView.MoveUp()
 			// k: same debounce as j — see handleDown.
 			return a.openSelectedThreadCmd(true)
+		}
+		if a.view == ViewActivity {
+			a.activityView.MoveUp()
+			return nil
 		}
 		return a.coalesceContentScroll(-1)
 	case PanelThread:
@@ -1382,6 +1400,10 @@ func (a *App) handleGoToBottom() tea.Cmd {
 			// G is a one-shot jump — fire the fetch immediately.
 			return a.openSelectedThreadCmd(false)
 		}
+		if a.view == ViewActivity {
+			a.activityView.GoToBottom()
+			return nil
+		}
 		a.messagepane.GoToBottom()
 	case PanelThread:
 		a.threadPanel.GoToBottom()
@@ -1448,6 +1470,12 @@ func (a *App) scrollFocusedPanel(delta int) tea.Cmd {
 			} else {
 				a.threadsView.ScrollDown(n)
 			}
+		} else if a.view == ViewActivity {
+			if delta < 0 {
+				a.activityView.ScrollUp(n)
+			} else {
+				a.activityView.ScrollDown(n)
+			}
 		} else {
 			if delta < 0 {
 				a.messagepane.ScrollUp(n)
@@ -1507,6 +1535,9 @@ func (a *App) openQuitConfirm() {
 
 func (a *App) handleEnter() tea.Cmd {
 	if a.focusedPanel == PanelSidebar {
+		if a.sidebar.IsActivitySelected() {
+			return func() tea.Msg { return ActivityViewActivatedMsg{} }
+		}
 		if a.sidebar.IsThreadsSelected() {
 			return func() tea.Msg { return ThreadsViewActivatedMsg{} }
 		}
@@ -1536,6 +1567,10 @@ func (a *App) handleEnter() tea.Cmd {
 	// "enter this thread to interact with it"), distinguishing it
 	// from the j/k navigation which preserves PanelMessages focus so
 	// the user can keep walking the list.
+	if a.focusedPanel == PanelMessages && a.view == ViewActivity {
+		return a.openSelectedActivityCmd()
+	}
+
 	if a.focusedPanel == PanelMessages && a.view == ViewThreads {
 		if _, ok := a.threadsView.SelectedSummary(); !ok {
 			return nil
@@ -1923,6 +1958,7 @@ func (a *App) SetChannels(items []sidebar.ChannelItem) {
 	}
 	a.threadPanel.SetChannelNames(names)
 	a.threadsView.SetChannelNames(names)
+	a.activityView.SetChannelNames(names)
 }
 
 // SetChannelService wires the App's ChannelService collaborator
@@ -2010,6 +2046,23 @@ func (a *App) SetThreadService(s ThreadService) {
 		s = noopThreadService
 	}
 	a.threads = s
+}
+
+// SetActivityService wires the App's Activity inbox fetcher.
+func (a *App) SetActivityService(s ActivityService) {
+	if s == nil {
+		s = noopActivityService
+	}
+	a.activity = s
+}
+
+// SetActivityConfig seeds the Activity view from [activity] in
+// config.toml. Live f/F/s/u cycles do not write back here.
+func (a *App) SetActivityConfig(cfg config.Activity) {
+	cfg = cfg.Normalized()
+	a.activityCfg = cfg
+	a.activityView.SetQuery(cfg.Filter, cfg.Sort, cfg.UnreadOnly)
+	a.activityView.SetDensity(cfg.Density)
 }
 
 // SetReadStateReader installs a callback the sidebar (and any future
@@ -2380,6 +2433,7 @@ func (a *App) downloadFileCmd(att messages.Attachment) tea.Cmd {
 func (a *App) SetUserNames(names map[string]string) {
 	a.userNames = names
 	a.threadsView.SetUserNames(names)
+	a.activityView.SetUserNames(names)
 	for _, m := range a.allWinModels() {
 		m.SetUserNames(names)
 	}
@@ -2518,6 +2572,7 @@ func (a *App) SetReactionService(r ReactionService) {
 func (a *App) SetCurrentUserID(userID string) {
 	a.currentUserID = userID
 	a.threadsView.SetSelfUserID(userID)
+	a.activityView.SetSelfUserID(userID)
 	a.messagepane.SetCurrentUser(userID)
 	a.threadPanel.SetCurrentUser(userID)
 }

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -2980,6 +2980,45 @@ func TestThreadMarkedRemoteMsg_ReadClearsRow(t *testing.T) {
 	}
 }
 
+func TestDMNameResolvedMsg_RenamesSidebarDM(t *testing.T) {
+	app := NewApp()
+	app.activeTeamID = "T1"
+	app.SetChannels([]sidebar.ChannelItem{
+		{ID: "D1", Name: "U123", Type: "dm", DMUserID: "U123"},
+	})
+	app.Update(DMNameResolvedMsg{TeamID: "T1", ChannelID: "D1", DisplayName: "Alice"})
+	got := app.sidebar.Items()
+	if len(got) != 1 || got[0].Name != "Alice" {
+		t.Errorf("sidebar DM = %+v; want Name Alice", got)
+	}
+}
+
+func TestDMNameResolvedMsg_IgnoresOtherWorkspace(t *testing.T) {
+	app := NewApp()
+	app.activeTeamID = "T1"
+	app.SetChannels([]sidebar.ChannelItem{
+		{ID: "D1", Name: "U123", Type: "dm", DMUserID: "U123"},
+	})
+	app.Update(DMNameResolvedMsg{TeamID: "T2", ChannelID: "D1", DisplayName: "Alice"})
+	got := app.sidebar.Items()
+	if len(got) != 1 || got[0].Name != "U123" {
+		t.Errorf("inactive-workspace DMNameResolvedMsg mutated the active sidebar: %+v", got)
+	}
+}
+
+func TestUserResolvedMsg_RenamesSidebarDM(t *testing.T) {
+	app := NewApp()
+	app.activeTeamID = "T1"
+	app.SetChannels([]sidebar.ChannelItem{
+		{ID: "D1", Name: "U123", Type: "dm", DMUserID: "U123"},
+	})
+	app.Update(UserResolvedMsg{TeamID: "T1", UserID: "U123", DisplayName: "Alice", IsBot: false})
+	got := app.sidebar.Items()
+	if len(got) != 1 || got[0].Name != "Alice" {
+		t.Errorf("sidebar DM = %+v; want Name Alice from UserResolvedMsg", got)
+	}
+}
+
 func TestConversationOpenedMsg_SidebarReceivesItemAndUnread(t *testing.T) {
 	app := NewApp()
 	app.activeTeamID = "T1"

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -15,7 +15,9 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/gammons/slk/internal/cache"
+	"github.com/gammons/slk/internal/config"
 	"github.com/gammons/slk/internal/ids"
+	slackclient "github.com/gammons/slk/internal/slack"
 	imgpkg "github.com/gammons/slk/internal/image"
 	"github.com/gammons/slk/internal/ui/compose"
 	"github.com/gammons/slk/internal/ui/messages"
@@ -691,12 +693,115 @@ func TestApp_ThreadsListLoadedIgnoredForOtherWorkspace(t *testing.T) {
 	}
 }
 
+func TestApp_ActivityViewActivation(t *testing.T) {
+	app := NewApp()
+	app.activeTeamID = "T1"
+	_, _ = app.Update(ActivityViewActivatedMsg{})
+	if app.view != ViewActivity {
+		t.Fatalf("after activation view = %v, want ViewActivity", app.view)
+	}
+	_, _ = app.Update(ChannelSelectedMsg{ID: "C1", Name: "general"})
+	if app.view != ViewChannels {
+		t.Errorf("after ChannelSelectedMsg view = %v, want ViewChannels", app.view)
+	}
+}
+
+func TestApp_ActivityCountsUpdatesBadge(t *testing.T) {
+	app := NewApp()
+	app.activeTeamID = "T1"
+	_, _ = app.Update(ActivityCountsMsg{TeamID: "T1", Unread: 7})
+	if app.sidebar.ActivityUnreadCount() != 7 {
+		t.Errorf("ActivityUnreadCount = %d, want 7", app.sidebar.ActivityUnreadCount())
+	}
+	_, _ = app.Update(ActivityCountsMsg{TeamID: "T2", Unread: 99})
+	if app.sidebar.ActivityUnreadCount() != 7 {
+		t.Errorf("other-team counts should be ignored; got %d", app.sidebar.ActivityUnreadCount())
+	}
+}
+
+func TestApp_HandleEnterOnActivityRowActivatesView(t *testing.T) {
+	app := NewApp()
+	app.activeTeamID = "T1"
+	if !app.sidebar.IsActivitySelected() {
+		t.Fatal("precondition: Activity row is the default top slot")
+	}
+	cmd := app.handleEnter()
+	if cmd == nil {
+		t.Fatal("expected a tea.Cmd, got nil")
+	}
+	msg := cmd()
+	if _, ok := msg.(ActivityViewActivatedMsg); !ok {
+		t.Errorf("expected ActivityViewActivatedMsg, got %T", msg)
+	}
+}
+
+func TestApp_ActivityFeedLoadedDecoratesAndSelects(t *testing.T) {
+	app := NewApp()
+	app.activeTeamID = "T1"
+	app.channelNames = map[string]string{"C1": "general"}
+	app.SetUserNames(map[string]string{"U1": "alice"})
+	app.view = ViewActivity
+	app.activityGen = 3
+	_, _ = app.Update(ActivityFeedLoadedMsg{
+		TeamID: "T1",
+		Gen:    3,
+		Items: []slackclient.ActivityItem{{
+			Key: "k1", Type: "at_user", ChannelID: "C1", MessageTS: "1.0", ActorID: "U1",
+		}},
+	})
+	it, ok := app.activityView.SelectedItem()
+	if !ok {
+		t.Fatal("expected a selected activity item")
+	}
+	if it.ChannelName != "general" {
+		t.Errorf("ChannelName = %q, want general", it.ChannelName)
+	}
+	if it.ActorName != "alice" {
+		t.Errorf("ActorName = %q, want alice", it.ActorName)
+	}
+}
+
+func TestApp_ActivityFeedLoadedDropsStaleGen(t *testing.T) {
+	app := NewApp()
+	app.activeTeamID = "T1"
+	app.activityGen = 5
+	_, _ = app.Update(ActivityFeedLoadedMsg{
+		TeamID: "T1",
+		Gen:    4,
+		Items:  []slackclient.ActivityItem{{Key: "stale", ChannelID: "C1"}},
+	})
+	if _, ok := app.activityView.SelectedItem(); ok {
+		t.Error("stale gen should not populate the view")
+	}
+}
+
+func TestApp_SetActivityConfigSeedsQuery(t *testing.T) {
+	app := NewApp()
+	app.SetActivityConfig(config.Activity{
+		Filter:     "mentions",
+		Sort:       "unreads_first",
+		UnreadOnly: true,
+		Density:    "compact",
+		Limit:      20,
+	})
+	q := app.activityView.Query()
+	if q.Filter != "mentions" || q.Sort != "unreads_first" || !q.UnreadOnly {
+		t.Errorf("Query = %+v", q)
+	}
+	if app.activityView.Density() != "compact" {
+		t.Errorf("Density = %q", app.activityView.Density())
+	}
+	if app.activityCfg.Limit != 20 {
+		t.Errorf("Limit = %d", app.activityCfg.Limit)
+	}
+}
+
 func TestApp_HandleEnterOnThreadsRowActivatesView(t *testing.T) {
 	app := NewApp()
 	app.activeTeamID = "T1"
-	// Sidebar default-selects the Threads row.
+	app.sidebar.SelectThreadsRow()
 	if !app.sidebar.IsThreadsSelected() {
-		t.Fatalf("precondition: sidebar should default-select Threads row")
+		t.Fatalf("precondition: Threads row selected")
 	}
 	cmd := app.handleEnter()
 	if cmd == nil {
@@ -1164,11 +1269,11 @@ func TestApp_BackgroundWorkspaceReadyDoesNotClobberActiveState(t *testing.T) {
 
 func TestApp_WorkspaceSwitchedTriggersThreadsListFetchAndSelectsThreadsRow(t *testing.T) {
 	app := NewApp()
-	// Move sidebar selection off the Threads row first to verify the reset.
+	// Move sidebar selection off the synthetic rows first to verify the reset.
 	app.sidebar.SetItems([]sidebar.ChannelItem{{ID: "C1", Name: "general", Type: "channel"}})
-	app.sidebar.MoveDown()
-	if app.sidebar.IsThreadsSelected() {
-		t.Fatal("precondition: should be off Threads row")
+	app.sidebar.SelectByID("C1")
+	if app.sidebar.IsThreadsSelected() || app.sidebar.IsActivitySelected() {
+		t.Fatal("precondition: should be off synthetic rows")
 	}
 
 	fetched := make(chan string, 1)

--- a/internal/ui/channelfinder/model.go
+++ b/internal/ui/channelfinder/model.go
@@ -23,11 +23,14 @@ var nonJoinedColor = lipgloss.Color("#5a5a5a")
 // threads-list view instead of switching channels.
 const ThreadsViewID = "__slk_view_threads"
 
+// ActivityViewID is the sentinel ID used for the synthetic "Activity" entry.
+const ActivityViewID = "__slk_view_activity"
+
 // ChannelResult is returned when the user selects a channel.
 type ChannelResult struct {
 	ID     string
 	Name   string
-	Type   string // channel, dm, group_dm, private, threads
+	Type   string // channel, dm, group_dm, private, threads, activity
 	Joined bool   // false => caller should join the channel before opening it
 }
 
@@ -35,7 +38,7 @@ type ChannelResult struct {
 type Item struct {
 	ID       string
 	Name     string
-	Type     string // channel, dm, group_dm, private, threads
+	Type     string // channel, dm, group_dm, private, threads, activity
 	Presence string // for DMs: active, away
 	Joined   bool   // true if the user is already a member; false for browseable public channels
 	// LastVisited is the unix timestamp (seconds) of the user's most
@@ -477,6 +480,9 @@ func (m *Model) lessNoQuery(ai, bi int) bool {
 	a, b := m.items[ai], m.items[bi]
 	if a.Synthetic != b.Synthetic {
 		return a.Synthetic
+	}
+	if a.Synthetic && b.Synthetic {
+		return ai < bi
 	}
 	if a.Joined != b.Joined {
 		return a.Joined

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -62,6 +62,10 @@ type KeyMap struct {
 	WinCycle            key.Binding
 	WinClose            key.Binding
 	WinOnly             key.Binding
+	ActivityFilter      key.Binding
+	ActivityFilterPrev  key.Binding
+	ActivitySort        key.Binding
+	ActivityUnreadOnly  key.Binding
 }
 
 func DefaultKeyMap() KeyMap {
@@ -132,5 +136,9 @@ func DefaultKeyMap() KeyMap {
 		WinCycle:     key.NewBinding(key.WithHelp("ctrl+w w", "cycle windows")),
 		WinClose:     key.NewBinding(key.WithHelp("ctrl+w q / :q", "close window")),
 		WinOnly:      key.NewBinding(key.WithHelp("ctrl+w o / :only", "close other windows")),
+		ActivityFilter:     key.NewBinding(key.WithKeys("f"), key.WithHelp("f", "next activity tab")),
+		ActivityFilterPrev: key.NewBinding(key.WithKeys("F"), key.WithHelp("F", "prev activity tab")),
+		ActivitySort:       key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "cycle activity sort")),
+		ActivityUnreadOnly: key.NewBinding(key.WithKeys("u"), key.WithHelp("u", "toggle activity unread-only")),
 	}
 }

--- a/internal/ui/mode_channel_finder.go
+++ b/internal/ui/mode_channel_finder.go
@@ -31,6 +31,9 @@ func handleChannelFinderMode(a *App, msg tea.KeyMsg) tea.Cmd {
 		if result.Type == "threads" {
 			return func() tea.Msg { return ThreadsViewActivatedMsg{} }
 		}
+		if result.Type == "activity" {
+			return func() tea.Msg { return ActivityViewActivatedMsg{} }
+		}
 		// Already-joined: switch immediately. Not joined: kick off
 		// a join command; ChannelJoinedMsg will fold the channel
 		// into the sidebar and switch to it.

--- a/internal/ui/mode_normal.go
+++ b/internal/ui/mode_normal.go
@@ -60,7 +60,7 @@ func handleNormalMode(a *App, msg tea.KeyMsg) tea.Cmd {
 		// only way to type is into the right-side thread panel's
 		// compose. Force focus there even when the threads list
 		// itself was the focused panel.
-		if a.focusedPanel == PanelThread || (a.view == ViewThreads && a.threadVisible) {
+		if a.focusedPanel == PanelThread || ((a.view == ViewThreads || a.view == ViewActivity) && a.threadVisible) {
 			a.focusedPanel = PanelThread
 			return a.threadCompose.Focus()
 		}
@@ -97,7 +97,7 @@ func handleNormalMode(a *App, msg tea.KeyMsg) tea.Cmd {
 	case key.Matches(msg, a.keys.SearchMode):
 		// Spec scopes `/` to the channel message pane in v1: no-op
 		// while the thread panel has focus.
-		if a.focusedPanel == PanelThread {
+		if a.focusedPanel == PanelThread || a.view == ViewThreads || a.view == ViewActivity {
 			return nil
 		}
 		a.searchInput = ""
@@ -170,6 +170,23 @@ func handleNormalMode(a *App, msg tea.KeyMsg) tea.Cmd {
 
 	case key.Matches(msg, a.keys.Enter):
 		return a.handleEnter()
+
+	case a.focusedPanel == PanelMessages && a.view == ViewActivity && key.Matches(msg, a.keys.ActivityFilter):
+		if a.activityView.CycleFilter(1) {
+			return a.fetchActivityCmd()
+		}
+	case a.focusedPanel == PanelMessages && a.view == ViewActivity && key.Matches(msg, a.keys.ActivityFilterPrev):
+		if a.activityView.CycleFilter(-1) {
+			return a.fetchActivityCmd()
+		}
+	case a.focusedPanel == PanelMessages && a.view == ViewActivity && key.Matches(msg, a.keys.ActivitySort):
+		if a.activityView.CycleSort() {
+			return a.fetchActivityCmd()
+		}
+	case a.focusedPanel == PanelMessages && a.view == ViewActivity && key.Matches(msg, a.keys.ActivityUnreadOnly):
+		if a.activityView.ToggleUnreadOnly() {
+			return a.fetchActivityCmd()
+		}
 
 	case key.Matches(msg, a.keys.ToggleSection):
 		// Space on a sidebar section header toggles its collapsed

--- a/internal/ui/msgs.go
+++ b/internal/ui/msgs.go
@@ -199,6 +199,7 @@ type (
 		ChannelID string
 	}
 	DMNameResolvedMsg struct {
+		TeamID      string
 		ChannelID   string
 		DisplayName string
 		// IsBot is true when the resolved peer is a Slack app or bot.

--- a/internal/ui/msgs.go
+++ b/internal/ui/msgs.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/gammons/slk/internal/cache"
 	emojiutil "github.com/gammons/slk/internal/emoji"
+	slackclient "github.com/gammons/slk/internal/slack"
 	"github.com/gammons/slk/internal/ui/channelfinder"
 	"github.com/gammons/slk/internal/ui/messages"
 	"github.com/gammons/slk/internal/ui/searchresults"
@@ -169,6 +170,34 @@ type (
 	ThreadsListDirtyMsg struct {
 		TeamID string
 	}
+	// ActivityViewActivatedMsg is dispatched when the user picks the
+	// synthetic Activity sidebar row (or the finder shortcut). The App
+	// switches the message pane to the Activity inbox and refetches.
+	ActivityViewActivatedMsg struct{}
+	// ActivityViewsLoadedMsg carries activity.views (builtin + custom
+	// tabs). Ignored if TeamID doesn't match the active workspace.
+	ActivityViewsLoadedMsg struct {
+		TeamID string
+		Views  []slackclient.ActivityView
+		Err    error
+	}
+	// ActivityFeedLoadedMsg carries a freshly fetched activity.feed
+	// page. Ignored if TeamID/Gen don't match the in-flight request.
+	ActivityFeedLoadedMsg struct {
+		TeamID     string
+		Items      []slackclient.ActivityItem
+		Err        error
+		Gen        uint64
+		Filter     string
+		Sort       string
+		UnreadOnly bool
+	}
+	// ActivityCountsMsg updates the sidebar Activity badge from
+	// client.counts activity_v2. Ignored if TeamID is not active.
+	ActivityCountsMsg struct {
+		TeamID string
+		Unread int
+	}
 	ConnectionStateMsg struct {
 		State int // 0=connecting, 1=connected, 2=disconnected
 	}
@@ -255,6 +284,7 @@ type (
 		// workspace. Nil means "use config-glob behavior" (the App's
 		// sidebar reverts to its existing name-keyed buckets).
 		SectionsProvider sidebar.SectionsProvider
+		ActivityUnread   int
 	}
 	// ReadStateChangedMsg is sent whenever the persistent read state changes,
 	// so panels that read from cache.GetWorkspaceReadState re-render.
@@ -333,6 +363,9 @@ type (
 		// sidebar's first entry, so a restart lands the user back where
 		// they were. Empty (e.g. first ever run) falls back to Channels[0].
 		LastChannelID string
+		// ActivityUnread is client.counts activity_v2 sum, used for
+		// the sidebar Activity-row badge on the initial workspace.
+		ActivityUnread int
 	}
 	// CustomEmojisLoadedMsg is sent when a workspace's custom emoji list
 	// finishes loading in the background, after WorkspaceReadyMsg has

--- a/internal/ui/reducer_activity.go
+++ b/internal/ui/reducer_activity.go
@@ -1,0 +1,145 @@
+// internal/ui/reducer_activity.go
+//
+// Activity-inbox reducer for App.Update.
+//
+//   ActivityViewActivatedMsg — user opened the Activity list:
+//     switch view + focus, kick a feed fetch.
+//   ActivityFeedLoadedMsg    — activity.feed returned: push items,
+//     drop stale generations / other workspaces.
+//   ActivityCountsMsg        — client.counts activity_v2 badge.
+package ui
+
+import (
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/gammons/slk/internal/ids"
+	slackclient "github.com/gammons/slk/internal/slack"
+	"github.com/gammons/slk/internal/ui/activityview"
+)
+
+var reduceActivity reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
+	switch m := msg.(type) {
+	case ActivityViewActivatedMsg:
+		_ = m
+		a.view = ViewActivity
+		a.sidebar.SetActivityActive(true)
+		a.sidebar.SetThreadsActive(false)
+		a.focusedPanel = PanelMessages
+		a.activityView.SetUnreadBadge(a.sidebar.ActivityUnreadCount())
+		var batch []tea.Cmd
+		if a.activeTeamID != "" {
+			activity := a.activity
+			team := ids.TeamID(a.activeTeamID)
+			batch = append(batch, func() tea.Msg { return activity.FetchViews(team) })
+		}
+		if cmd := a.fetchActivityCmd(); cmd != nil {
+			batch = append(batch, cmd)
+		}
+		return tea.Batch(batch...), true
+
+	case ActivityViewsLoadedMsg:
+		if m.TeamID != a.activeTeamID {
+			return nil, true
+		}
+		if m.Err != nil || len(m.Views) == 0 {
+			return nil, true
+		}
+		a.activityView.SetViews(m.Views)
+		return a.fetchActivityCmd(), true
+
+	case ActivityFeedLoadedMsg:
+		if m.TeamID != a.activeTeamID || m.Gen != a.activityGen {
+			return nil, true
+		}
+		if m.Err != nil {
+			a.activityView.SetLoading(false)
+			a.activityView.SetError("activity.feed failed — " + m.Err.Error())
+			return nil, true
+		}
+		a.activityView.SetItems(a.decorateActivityItems(m.Items))
+		return nil, true
+
+	case ActivityCountsMsg:
+		if m.TeamID != "" && m.TeamID != a.activeTeamID {
+			return nil, true
+		}
+		a.sidebar.SetActivityUnreadCount(m.Unread)
+		a.activityView.SetUnreadBadge(m.Unread)
+		return nil, true
+	}
+	return nil, false
+}
+
+func (a *App) fetchActivityCmd() tea.Cmd {
+	if a.activeTeamID == "" {
+		return nil
+	}
+	a.activityGen++
+	gen := a.activityGen
+	q := a.activityView.Query()
+	limit := a.activityCfg.Limit
+	if limit < 1 {
+		limit = 50
+	}
+	a.activityView.SetLoading(true)
+	a.activityView.SetError("")
+	activity := a.activity
+	team := ids.TeamID(a.activeTeamID)
+	return func() tea.Msg {
+		return activity.FetchFeed(team, ActivityFeedQuery{
+			Filter:       q.Filter,
+			Types:        q.Types,
+			Sort:         q.Sort,
+			UnreadOnly:   q.UnreadOnly,
+			PriorityOnly: q.PriorityOnly,
+			Limit:        limit,
+			Gen:          gen,
+		})
+	}
+}
+
+func (a *App) decorateActivityItems(in []slackclient.ActivityItem) []activityview.Item {
+	out := make([]activityview.Item, len(in))
+	for i, it := range in {
+		item := activityview.Item{ActivityItem: it}
+		if name, ok := a.channelNames[it.ChannelID]; ok {
+			item.ChannelName = name
+		}
+		if _, t, ok := a.channels.Lookup(ids.ChannelID(it.ChannelID)); ok {
+			item.ChannelType = t
+		}
+		if it.ActorID != "" {
+			if it.ActorID == a.currentUserID {
+				item.ActorName = "me"
+			} else if name, ok := a.userNames[it.ActorID]; ok && name != "" {
+				item.ActorName = name
+			}
+		}
+		out[i] = item
+	}
+	return out
+}
+
+func (a *App) openSelectedActivityCmd() tea.Cmd {
+	it, ok := a.activityView.SelectedItem()
+	if !ok || it.ChannelID == "" {
+		return nil
+	}
+	name, chType, found := a.channels.Lookup(ids.ChannelID(it.ChannelID))
+	if !found {
+		name = it.ChannelName
+		chType = it.ChannelType
+		if name == "" {
+			name = it.ChannelID
+		}
+	}
+	a.pendingLinkNav = &pendingLinkNav{
+		channelID: it.ChannelID,
+		messageTS: it.MessageTS,
+		threadTS:  it.ThreadTS,
+	}
+	id := it.ChannelID
+	return func() tea.Msg {
+		return ChannelSelectedMsg{ID: id, Name: name, Type: chType}
+	}
+}

--- a/internal/ui/reducer_channels.go
+++ b/internal/ui/reducer_channels.go
@@ -334,6 +334,7 @@ func reduceChannelSelected(a *App, m ChannelSelectedMsg) (tea.Cmd, bool) {
 	// Picking a channel always exits the Threads view.
 	a.view = ViewChannels
 	a.sidebar.SetThreadsActive(false)
+	a.sidebar.SetActivityActive(false)
 	a.lastOpenedChannelID = ""
 	a.lastOpenedThreadTS = ""
 	// Close thread panel when switching channels.

--- a/internal/ui/reducer_modal_click_test.go
+++ b/internal/ui/reducer_modal_click_test.go
@@ -50,9 +50,10 @@ func TestModalClick_OnRowActivates(t *testing.T) {
 	app := openChannelFinder(t)
 	startX, startY := channelFinderOrigin(app)
 
-	// Row offset 2 from the first list row. NewApp pins a synthetic
-	// "Threads" row at the top, so offset 0=Threads, 1=C1, 2=C2.
-	clickY := startY + 5 + 2
+	// Row offset from the first list row. NewApp pins synthetic
+	// Threads then Activity at the top, so 0=Threads, 1=Activity,
+	// 2=C1, 3=C2.
+	clickY := startY + 5 + 3
 	clickX := startX + 3
 
 	cmd := reduceMouseClick(app, tea.MouseClickMsg{Button: tea.MouseLeft, X: clickX, Y: clickY})

--- a/internal/ui/reducer_mouse.go
+++ b/internal/ui/reducer_mouse.go
@@ -33,6 +33,7 @@ package ui
 import (
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/gammons/slk/internal/ui/activityview"
 	"github.com/gammons/slk/internal/ui/messages"
 )
 
@@ -113,6 +114,14 @@ func reduceMouseWheel(a *App, m tea.MouseWheelMsg) tea.Cmd {
 			}
 			// No openSelectedThreadCmd here: pure viewport scroll
 			// does not change the highlighted thread card.
+			return nil
+		}
+		if a.view == ViewActivity {
+			if up {
+				a.activityView.ScrollUp(wheelLinesPerNotch)
+			} else {
+				a.activityView.ScrollDown(wheelLinesPerNotch)
+			}
 			return nil
 		}
 		if up {
@@ -220,6 +229,9 @@ func reduceMouseClick(a *App, m tea.MouseClickMsg) tea.Cmd {
 		// ClickAt returns ok=false for the synthetic Threads row;
 		// if the click landed there (sidebar updates its own
 		// selection state), activate the threads view.
+		if a.sidebar.IsActivitySelected() {
+			return func() tea.Msg { return ActivityViewActivatedMsg{} }
+		}
 		if a.sidebar.IsThreadsSelected() {
 			return func() tea.Msg { return ThreadsViewActivatedMsg{} }
 		}
@@ -249,6 +261,19 @@ func reduceMouseClick(a *App, m tea.MouseClickMsg) tea.Cmd {
 			panel, _, py, ok := a.panelAt(m.X, m.Y)
 			if ok && panel == PanelMessages && py >= 0 && a.threadsView.ClickAt(py) {
 				return a.openSelectedThreadCmd(false)
+			}
+			return nil
+		}
+		if a.view == ViewActivity {
+			panel, px, py, ok := a.panelAt(m.X, m.Y)
+			if !ok || panel != PanelMessages || py < 0 {
+				return nil
+			}
+			switch a.activityView.ClickAt(py, px) {
+			case activityview.ClickItem:
+				return a.openSelectedActivityCmd()
+			case activityview.ClickControls:
+				return a.fetchActivityCmd()
 			}
 			return nil
 		}

--- a/internal/ui/reducer_threads.go
+++ b/internal/ui/reducer_threads.go
@@ -140,6 +140,7 @@ var reduceThreads reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
 		_ = m
 		a.view = ViewThreads
 		a.sidebar.SetThreadsActive(true)
+		a.sidebar.SetActivityActive(false)
 		a.focusedPanel = PanelMessages
 		var batch []tea.Cmd
 		if a.activeTeamID != "" {

--- a/internal/ui/reducer_workspace.go
+++ b/internal/ui/reducer_workspace.go
@@ -28,8 +28,8 @@
 //	                          roundtrip): patch the sidebar entry
 //	                          and re-render.
 //	UserResolvedMsg         - per-user display-name resolved:
-//	                          patch any in-history references in
-//	                          both messages pane and thread panel.
+//	                          patch in-history references and any
+//	                          sidebar DM whose peer is this user.
 //	UserExternalMsg         - per-user external/internal flag
 //	                          resolved: update the cache + re-push
 //	                          SetUserNames so styling refreshes.
@@ -90,6 +90,9 @@ var reduceWorkspace reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
 		return nil, true
 
 	case DMNameResolvedMsg:
+		if m.TeamID != "" && m.TeamID != a.activeTeamID {
+			return nil, true
+		}
 		items := a.sidebar.Items()
 		for i := range items {
 			if items[i].ID != m.ChannelID {
@@ -112,10 +115,32 @@ var reduceWorkspace reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
 			mp.PatchUserName(m.UserID, m.DisplayName)
 		}
 		a.threadPanel.PatchUserName(m.UserID, m.DisplayName)
-		// IsBot affects DM channel-type classification, but that's
-		// orchestrated by DMNameResolvedMsg; this handler is only
-		// the in-history name patch. IsBot is carried for forward
-		// compatibility but not consumed here.
+		// Also rename any sidebar DM whose peer is this user. The
+		// unresolved-DM sweep sends DMNameResolvedMsg for the same
+		// purpose, but UserResolvedMsg is what the batched edge path
+		// emits, and a DM that was painted as its user ID would
+		// otherwise stay that way until a workspace switch rebuilt
+		// the sidebar from wctx.Channels.
+		if m.DisplayName != "" {
+			items := a.sidebar.Items()
+			changed := false
+			for i := range items {
+				if items[i].DMUserID != m.UserID {
+					continue
+				}
+				if items[i].Name != m.DisplayName {
+					items[i].Name = m.DisplayName
+					changed = true
+				}
+				if m.IsBot && items[i].Type == "dm" {
+					items[i].Type = "app"
+					changed = true
+				}
+			}
+			if changed {
+				a.SetChannels(items)
+			}
+		}
 		return nil, true
 
 	case UserExternalMsg:

--- a/internal/ui/reducer_workspace.go
+++ b/internal/ui/reducer_workspace.go
@@ -199,8 +199,11 @@ func reduceWorkspaceReady(a *App, m WorkspaceReadyMsg) tea.Cmd {
 	if m.InitialActive && a.bootstrap.ClaimInitialActive() {
 		a.view = ViewChannels
 		a.sidebar.SetThreadsActive(false)
+		a.sidebar.SetActivityActive(false)
 		a.threadsView.SetSummaries(nil)
+		a.activityView.SetItems(nil)
 		a.sidebar.SetThreadsUnreadCount(0)
+		a.sidebar.SetActivityUnreadCount(m.ActivityUnread)
 		a.lastOpenedChannelID = ""
 		a.lastOpenedThreadTS = ""
 		// Apply the resolved theme for the initial active
@@ -305,8 +308,11 @@ func reduceWorkspaceSwitched(a *App, m WorkspaceSwitchedMsg) tea.Cmd {
 	// has no channels at all.
 	a.view = ViewChannels
 	a.sidebar.SetThreadsActive(false)
+	a.sidebar.SetActivityActive(false)
 	a.threadsView.SetSummaries(nil)
+	a.activityView.SetItems(nil)
 	a.sidebar.SetThreadsUnreadCount(0)
+	a.sidebar.SetActivityUnreadCount(m.ActivityUnread)
 	a.lastOpenedChannelID = ""
 	a.lastOpenedThreadTS = ""
 	a.CloseThread()

--- a/internal/ui/services.go
+++ b/internal/ui/services.go
@@ -255,6 +255,56 @@ func (t threadAdapter) ChannelLastRead(channelID ids.ChannelID) string {
 	return t.fns.ChannelLastRead(channelID)
 }
 
+// ActivityFeedQuery is the flattened activity.feed request: the
+// selected activity.views tab plus live unread/sort chips.
+type ActivityFeedQuery struct {
+	Filter       string
+	Types        []string
+	Sort         string
+	UnreadOnly   bool
+	PriorityOnly bool
+	Limit        int
+	Gen          uint64
+}
+
+// ActivityServiceFuncs is the closure bundle for NewActivityService.
+type ActivityServiceFuncs struct {
+	FetchViews func(teamID ids.TeamID) tea.Msg
+	FetchFeed  func(teamID ids.TeamID, q ActivityFeedQuery) tea.Msg
+}
+
+// ActivityService fetches Slack's Activity inbox (activity.views +
+// activity.feed). Wired by cmd/slk/main.go.
+type ActivityService interface {
+	FetchViews(teamID ids.TeamID) tea.Msg
+	FetchFeed(teamID ids.TeamID, q ActivityFeedQuery) tea.Msg
+}
+
+// NewActivityService builds an ActivityService from named closures.
+func NewActivityService(fns ActivityServiceFuncs) ActivityService {
+	return activityAdapter{fns: fns}
+}
+
+var noopActivityService ActivityService = activityAdapter{}
+
+type activityAdapter struct {
+	fns ActivityServiceFuncs
+}
+
+func (a activityAdapter) FetchViews(teamID ids.TeamID) tea.Msg {
+	if a.fns.FetchViews == nil {
+		return ActivityViewsLoadedMsg{TeamID: string(teamID)}
+	}
+	return a.fns.FetchViews(teamID)
+}
+
+func (a activityAdapter) FetchFeed(teamID ids.TeamID, q ActivityFeedQuery) tea.Msg {
+	if a.fns.FetchFeed == nil {
+		return ActivityFeedLoadedMsg{TeamID: string(teamID), Gen: q.Gen}
+	}
+	return a.fns.FetchFeed(teamID, q)
+}
+
 // MessageService is the App's interface to Slack's per-message
 // operations: send, edit, delete, mark-unread, and permalink lookup.
 // Implementations are wired by cmd/slk/main.go.

--- a/internal/ui/sidebar/collapse_test.go
+++ b/internal/ui/sidebar/collapse_test.go
@@ -32,7 +32,8 @@ func TestToggleCollapse_OnSelectedHeader(t *testing.T) {
 		{ID: "C1", Name: "general", Type: "channel"},
 		{ID: "D1", Name: "alice", Type: "dm"},
 	})
-	// Cursor: Threads → Direct Messages header. Toggle it: should collapse.
+	// Cursor: Activity → Threads → Direct Messages header.
+	m.MoveDown()
 	m.MoveDown()
 	name, ok := m.IsSectionHeaderSelected()
 	if !ok || name != "Direct Messages" {
@@ -61,12 +62,12 @@ func TestToggleCollapse_OnSelectedHeader(t *testing.T) {
 
 func TestToggleCollapse_NotOnHeader_IsNoop(t *testing.T) {
 	m := New([]ChannelItem{{ID: "D1", Name: "alice", Type: "dm"}})
-	// Cursor on Threads row.
-	if !m.IsThreadsSelected() {
-		t.Fatal("precondition: Threads should be selected")
+	// Cursor on the top synthetic row (Activity).
+	if !m.IsActivitySelected() {
+		t.Fatal("precondition: Activity should be selected")
 	}
 	if m.ToggleCollapseSelected() {
-		t.Errorf("ToggleCollapseSelected on the Threads row should report false")
+		t.Errorf("ToggleCollapseSelected on the Activity row should report false")
 	}
 }
 
@@ -176,6 +177,7 @@ func TestToggleCollapse_PreservesCursorOnHeader(t *testing.T) {
 		{ID: "C1", Name: "general", Type: "channel"},
 		{ID: "D1", Name: "alice", Type: "dm"},
 	})
+	m.MoveDown() // Threads
 	m.MoveDown() // onto DM header
 	if name, _ := m.IsSectionHeaderSelected(); name != "Direct Messages" {
 		t.Fatalf("precondition: expected DM header, got %q", name)
@@ -193,7 +195,8 @@ func TestToggleCollapse_PreservesCursorOnHeader(t *testing.T) {
 
 func TestIsThreadsSelected_FalseOnSectionHeader(t *testing.T) {
 	m := New([]ChannelItem{{ID: "D1", Name: "alice", Type: "dm"}})
-	m.MoveDown()
+	m.MoveDown() // Threads
+	m.MoveDown() // DM header
 	if m.IsThreadsSelected() {
 		t.Errorf("Threads should not be reported selected when cursor is on a section header")
 	}

--- a/internal/ui/sidebar/model.go
+++ b/internal/ui/sidebar/model.go
@@ -23,7 +23,7 @@ const (
 	defaultDMSection       = "Direct Messages"
 	// defaultAppsSection groups DMs whose peer is a Slack app or bot,
 	// matching the behavior of the official Slack desktop client. Falls
-	// between "Direct Messages" (humans) and "Channels" (firehose).
+	// after custom sections and before "Channels" (the firehose).
 	defaultAppsSection = "Apps"
 )
 
@@ -95,12 +95,11 @@ func orderedSections(items []ChannelItem, filtered []int) []string {
 }
 
 // orderedSectionsLegacy returns the section names in display order given the
-// currently filtered items. Custom (user-defined) sections come first,
-// sorted by SectionOrder ascending then by first-appearance for ties.
-// The three built-in fallback sections are appended at the end in this
-// order: "Direct Messages" (humans you talk to one-on-one), "Apps"
-// (Slack apps and bots), then "Channels" (the firehose). Anything the
-// user pinned to a custom section still wins the top spots.
+// currently filtered items. Direct Messages sit at the top (after the
+// Threads row), then custom (user-defined) sections sorted by
+// SectionOrder ascending then by first-appearance for ties, then Apps,
+// then Channels. DMs lead because they are the daily-driver
+// conversations; custom groupings and the channel firehose follow.
 func orderedSectionsLegacy(items []ChannelItem, filtered []int) []string {
 	type customInfo struct {
 		name      string
@@ -148,11 +147,11 @@ func orderedSectionsLegacy(items []ChannelItem, filtered []int) []string {
 	})
 
 	out := make([]string, 0, len(customs)+3)
-	for _, c := range customs {
-		out = append(out, c.name)
-	}
 	if hasDMs {
 		out = append(out, defaultDMSection)
+	}
+	for _, c := range customs {
+		out = append(out, c.name)
 	}
 	if hasApps {
 		out = append(out, defaultAppsSection)
@@ -216,8 +215,9 @@ type Model struct {
 
 	// sectionsProvider is the Slack-native sections data source. Nil
 	// means "use config-glob behavior". When non-nil and Ready, the
-	// orderedSections function returns the provider's verbatim order
-	// and headers are keyed by section ID instead of name.
+	// section order is the provider's linked list with direct_messages
+	// hoisted to the top, and headers are keyed by section ID instead
+	// of name.
 	sectionsProvider SectionsProvider
 	// readStateReader returns the per-channel read state map for the
 	// active workspace, keyed by channel ID. Set by App via
@@ -444,9 +444,12 @@ func (m *Model) sectionFor(item ChannelItem) string {
 }
 
 // modelOrderedSections returns the section keys in display order for
-// the current model state. Slack mode: provider's verbatim list,
-// returning IDs of sections that have at least one filtered item OR
-// are standard-typed. Config mode: legacy algorithm.
+// the current model state. Slack mode: provider's linked-list order,
+// with direct_messages hoisted to the top so DMs sit under Threads
+// instead of at the bottom of the rail. Sections with at least one
+// filtered item, or of type standard, are included. Config mode:
+// legacy algorithm (DMs, then custom sections, then Apps, then
+// Channels).
 func (m *Model) modelOrderedSections(filtered []int) []string {
 	if !m.useSlackSections() {
 		return orderedSectionsLegacy(m.items, filtered)
@@ -456,13 +459,18 @@ func (m *Model) modelOrderedSections(filtered []int) []string {
 	for _, idx := range filtered {
 		hasItem[m.sectionFor(m.items[idx])] = true
 	}
-	out := make([]string, 0, len(metas))
+	var dms, rest []string
 	for _, meta := range metas {
-		if meta.Type == "standard" || hasItem[meta.ID] {
-			out = append(out, meta.ID)
+		if meta.Type != "standard" && !hasItem[meta.ID] {
+			continue
 		}
+		if meta.Type == "direct_messages" {
+			dms = append(dms, meta.ID)
+			continue
+		}
+		rest = append(rest, meta.ID)
 	}
-	return out
+	return append(dms, rest...)
 }
 
 // SetFocused records whether the sidebar currently holds user focus and

--- a/internal/ui/sidebar/model.go
+++ b/internal/ui/sidebar/model.go
@@ -169,6 +169,7 @@ type navKind int
 
 const (
 	navThreads navKind = iota
+	navActivity
 	navHeader
 	navChannel
 )
@@ -243,6 +244,8 @@ type Model struct {
 	// is on a different row), the synthetic Threads row renders with
 	// the same orange "active" indicator used for active channels.
 	threadsActive bool
+	// activityActive is the same indicator for the Activity inbox row.
+	activityActive bool
 	nowFn         func() time.Time
 
 	// snappedSelection lets View() avoid snapping yOffset back to the
@@ -267,12 +270,13 @@ type Model struct {
 	cacheWidth  int
 	cacheFiller string // pre-rendered empty row for vertical padding
 
-	// Synthetic "Threads" row state. The Threads row is rendered at the
-	// very top of the sidebar and is the first entry in nav. It is
-	// selectable via j/k like a channel, but it is NOT a channel — when
-	// the cursor sits on it, SelectedItem/SelectedID return zero / empty
-	// and the App layer activates the threads view instead.
-	threadsUnread int
+	// Synthetic Activity (inbox) then Threads sit at the top of the
+	// sidebar. They are selectable via j/k like a channel, but they
+	// are NOT channels — when the cursor sits on one, SelectedItem /
+	// SelectedID return zero / empty and the App layer activates the
+	// matching view instead.
+	threadsUnread  int
+	activityUnread int
 
 	// focused tracks whether this panel currently has user focus. When
 	// false, the cursor "▌" glyph dims from Accent to TextMuted (via
@@ -445,8 +449,8 @@ func (m *Model) sectionFor(item ChannelItem) string {
 
 // modelOrderedSections returns the section keys in display order for
 // the current model state. Slack mode: provider's linked-list order,
-// with direct_messages hoisted to the top so DMs sit under Threads
-// instead of at the bottom of the rail. Sections with at least one
+// with direct_messages hoisted to the top so DMs sit under Activity
+// and Threads instead of at the bottom of the rail. Sections with at least one
 // filtered item, or of type standard, are included. Config mode:
 // legacy algorithm (DMs, then custom sections, then Apps, then
 // Channels).
@@ -555,6 +559,16 @@ func (m *Model) SetThreadsActive(active bool) {
 	m.dirty()
 }
 
+// SetActivityActive marks the synthetic "Activity" row as the active
+// destination in the message pane. Mirrors SetThreadsActive.
+func (m *Model) SetActivityActive(active bool) {
+	if m.activityActive == active {
+		return
+	}
+	m.activityActive = active
+	m.dirty()
+}
+
 // Version returns a counter that increments any time the View() output could
 // change. Callers can compare against a previously-seen version to know
 // whether to recompute downstream layout / wrapping.
@@ -576,7 +590,8 @@ func New(items []ChannelItem) Model {
 	}
 	m.rebuildFilter()
 	m.rebuildNav()
-	// Default selection is the synthetic Threads row at the top.
+	// Default selection is the synthetic Activity row at the top
+	// (Threads sits under it, then sections).
 	m.cursor = 0
 	return m
 }
@@ -594,6 +609,28 @@ func (m *Model) IsThreadsSelected() bool {
 func (m *Model) SelectThreadsRow() {
 	for i, n := range m.nav {
 		if n.kind == navThreads {
+			if m.cursor != i {
+				m.cursor = i
+				m.dirty()
+			}
+			return
+		}
+	}
+}
+
+// IsActivitySelected reports whether the synthetic "Activity" row is
+// the selected entry.
+func (m *Model) IsActivitySelected() bool {
+	if m.cursor < 0 || m.cursor >= len(m.nav) {
+		return false
+	}
+	return m.nav[m.cursor].kind == navActivity
+}
+
+// SelectActivityRow moves the cursor to the synthetic Activity row.
+func (m *Model) SelectActivityRow() {
+	for i, n := range m.nav {
+		if n.kind == navActivity {
 			if m.cursor != i {
 				m.cursor = i
 				m.dirty()
@@ -685,11 +722,28 @@ func (m *Model) SetThreadsUnreadCount(n int) {
 // ThreadsUnreadCount returns the current Threads-row unread badge count.
 func (m *Model) ThreadsUnreadCount() int { return m.threadsUnread }
 
+// SetActivityUnreadCount updates the badge count shown next to the
+// Activity row (client.counts activity_v2 sum). Invalidates the
+// render cache when the count changes.
+func (m *Model) SetActivityUnreadCount(n int) {
+	if n < 0 {
+		n = 0
+	}
+	if m.activityUnread != n {
+		m.activityUnread = n
+		m.cacheValid = false
+		m.dirty()
+	}
+}
+
+// ActivityUnreadCount returns the current Activity-row unread badge.
+func (m *Model) ActivityUnreadCount() int { return m.activityUnread }
+
 // SetItems replaces the sidebar's channel list. It does NOT reset the
 // cursor to the Threads row — SetItems is called on every routine
 // refresh (presence updates, unread changes, channel-list resync, etc.)
 // and clobbering selection on those refreshes would be wrong. Callers
-// that want to reset selection to the default Threads row on a major
+// that want to reset selection to the default Activity row on a major
 // context change (e.g. workspace switch) should explicitly call
 // SelectThreadsRow() after SetItems.
 func (m *Model) SetItems(items []ChannelItem) {
@@ -1048,6 +1102,8 @@ func (m *Model) currentCursorKey() (cursorKey, bool) {
 	switch n.kind {
 	case navThreads:
 		return cursorKey{kind: navThreads}, true
+	case navActivity:
+		return cursorKey{kind: navActivity}, true
 	case navHeader:
 		return cursorKey{kind: navHeader, header: n.header}, true
 	case navChannel:
@@ -1073,8 +1129,8 @@ func (m *Model) rebuildNav() {
 		bucket[key] = append(bucket[key], fi)
 	}
 
-	nav := make([]navItem, 0, 1+len(sectionOrder))
-	nav = append(nav, navItem{kind: navThreads})
+	nav := make([]navItem, 0, 2+len(sectionOrder))
+	nav = append(nav, navItem{kind: navActivity}, navItem{kind: navThreads})
 	for _, name := range sectionOrder {
 		nav = append(nav, navItem{kind: navHeader, header: name})
 		if m.IsCollapsed(name) {
@@ -1105,6 +1161,9 @@ func (m *Model) rebuildNavPreserveCursor() {
 		case key.kind == navThreads && n.kind == navThreads:
 			m.cursor = i
 			return
+		case key.kind == navActivity && n.kind == navActivity:
+			m.cursor = i
+			return
 		case key.kind == navHeader && n.kind == navHeader && n.header == key.header:
 			m.cursor = i
 			return
@@ -1116,7 +1175,8 @@ func (m *Model) rebuildNavPreserveCursor() {
 		}
 	}
 	// Previous target gone (e.g. the channel was filtered out, or its
-	// section now collapsed). Fall back to the Threads row.
+	// section now collapsed). Fall back to the top synthetic row
+	// (Activity).
 	m.cursor = 0
 }
 
@@ -1173,6 +1233,8 @@ type renderRow struct {
 	// the `active` variant whenever m.threadsActive is true (mirroring
 	// the channelID-based check used for channels).
 	isThreadsRow bool
+	// isActivityRow is the same flag for the Activity inbox row.
+	isActivityRow bool
 }
 
 // buildCache rebuilds m.cacheRows for the given width. Expensive; runs only
@@ -1216,10 +1278,13 @@ func (m *Model) buildCache(width int) {
 	headerNavIdx := map[string]int{}
 	channelNavIdx := map[int]int{} // filter idx -> nav idx
 	threadsIdx := -1
+	activityIdx := -1
 	for i, n := range m.nav {
 		switch n.kind {
 		case navThreads:
 			threadsIdx = i
+		case navActivity:
+			activityIdx = i
 		case navHeader:
 			headerNavIdx[n.header] = i
 		case navChannel:
@@ -1265,45 +1330,11 @@ func (m *Model) buildCache(width int) {
 	appPrefixMuted := "▣ "
 	groupDMPrefix := styles.PresenceAway.Render("● ")
 
-	// Synthetic "Threads" row, always rendered at the very top of the sidebar
-	// (before any section). Selectable like a channel; the App layer activates
-	// the threads view when IsThreadsSelected() is true.
-	threadsLabel := " ⚑ Threads"
-	threadsCursor := cursorSelected + "⚑ Threads"
-	threadsActiveLabel := activeBorder + "⚑ Threads"
-	if m.threadsUnread > 0 {
-		// Render "•N" as a single styled span so the dot glyph and the digits
-		// stay adjacent in the output (no ANSI reset splits them). Tests rely
-		// on the literal substring "•N" being searchable in View() output.
-		badge := " " + dotStyle.Render("•"+fmt.Sprintf("%d", m.threadsUnread))
-		threadsLabel += badge
-		threadsCursor += badge
-		threadsActiveLabel += badge
-	}
-	threadsAttrs := bgAnsi
-	if m.threadsUnread > 0 {
-		threadsAttrs += "\x1b[1m"
-	}
-	threadsLabel = messages.ReapplyBgAfterResets(threadsLabel, threadsAttrs)
-	threadsCursor = messages.ReapplyBgAfterResets(threadsCursor, threadsAttrs)
-	threadsActiveLabel = messages.ReapplyBgAfterResets(threadsActiveLabel, threadsAttrs)
-	threadsBaseStyle := styles.ChannelNormal
-	if m.threadsUnread > 0 {
-		threadsBaseStyle = styles.ChannelUnread
-	}
-	threadsNormal := threadsBaseStyle.Width(width - 2).Render(threadsLabel)
-	threadsSelectedRow := styles.ChannelSelected.Width(width - 2).Render(threadsCursor)
-	threadsActiveRow := styles.ChannelSelected.Width(width - 2).Render(threadsActiveLabel)
-	m.cacheRows = append(m.cacheRows, renderRow{
-		normal:       threadsNormal,
-		selected:     threadsSelectedRow,
-		active:       threadsActiveRow,
-		height:       1,
-		navIdx:       threadsIdx,
-		isThreadsRow: true,
-	})
-	// Blank separator between the Threads row and the first section (or below
-	// the Threads row when there are no channels at all).
+	// Activity sits above Threads so new inbox rows displace Threads
+	// rather than stacking under it. Then a blank, then sections.
+	m.cacheRows = append(m.cacheRows, m.synthRow("◎ Activity", m.activityUnread, activityIdx, width, cursorSelected, activeBorder, bgAnsi, dotStyle, false, true))
+	m.cacheRows = append(m.cacheRows, m.synthRow("⚑ Threads", m.threadsUnread, threadsIdx, width, cursorSelected, activeBorder, bgAnsi, dotStyle, true, false))
+	// Blank separator between the synthetic rows and the first section.
 	m.cacheRows = append(m.cacheRows, renderRow{height: 1, navIdx: -1})
 
 	// Pre-build the per-section channel rows so we can flatten with
@@ -1648,6 +1679,8 @@ func (m *Model) View(height, width int) string {
 			// Threads view is the currently displayed view; mark the
 			// Threads row as active with the same orange indicator.
 			visible = append(visible, r.active)
+		case r.isActivityRow && m.activityActive && r.active != "":
+			visible = append(visible, r.active)
 		case r.normal == "":
 			// Inter-section blank row -- emit a width-sized themed blank so
 			// the panel background remains continuous.
@@ -1666,9 +1699,10 @@ func (m *Model) View(height, width int) string {
 // ClickAt handles a mouse click at the given y-coordinate (relative to
 // sidebar content top). Updates the cursor to whatever sits at that
 // position. Returns the channel item and true ONLY when the click
-// landed on a channel row; section-header / threads-row / blank clicks
-// return (zero, false). Callers consult IsThreadsSelected /
-// IsSectionHeaderSelected after this call when ok == false.
+// landed on a channel row; section-header / threads-row / activity-row
+// / blank clicks return (zero, false). Callers consult
+// IsThreadsSelected / IsActivitySelected / IsSectionHeaderSelected
+// after this call when ok == false.
 func (m *Model) ClickAt(y int) (ChannelItem, bool) {
 	absoluteY := y + m.yOffset
 	if absoluteY < 0 || absoluteY >= len(m.cacheRows) {
@@ -1685,14 +1719,52 @@ func (m *Model) ClickAt(y int) (ChannelItem, bool) {
 	}
 	n := m.nav[r.navIdx]
 	if n.kind != navChannel {
-		// Threads row or section header — nothing to return; caller
-		// inspects IsThreadsSelected / IsSectionHeaderSelected.
+		// Threads / Activity row or section header — nothing to
+		// return; caller inspects IsThreadsSelected /
+		// IsActivitySelected / IsSectionHeaderSelected.
 		return ChannelItem{}, false
 	}
 	if n.fi < 0 || n.fi >= len(m.filtered) {
 		return ChannelItem{}, false
 	}
 	return m.items[m.filtered[n.fi]], true
+}
+
+// synthRow renders one synthetic sidebar destination (Threads, Activity)
+// with the same cursor / active / unread-badge treatment as a channel.
+func (m *Model) synthRow(core string, unread, navIdx, width int, cursorSelected, activeBorder, bgAnsi string, dotStyle lipgloss.Style, isThreads, isActivity bool) renderRow {
+	label := " " + core
+	cursor := cursorSelected + core
+	active := activeBorder + core
+	if unread > 0 {
+		// Render "•N" as a single styled span so the dot glyph and the digits
+		// stay adjacent in the output (no ANSI reset splits them). Tests rely
+		// on the literal substring "•N" being searchable in View() output.
+		badge := " " + dotStyle.Render("•"+fmt.Sprintf("%d", unread))
+		label += badge
+		cursor += badge
+		active += badge
+	}
+	attrs := bgAnsi
+	if unread > 0 {
+		attrs += "\x1b[1m"
+	}
+	label = messages.ReapplyBgAfterResets(label, attrs)
+	cursor = messages.ReapplyBgAfterResets(cursor, attrs)
+	active = messages.ReapplyBgAfterResets(active, attrs)
+	baseStyle := styles.ChannelNormal
+	if unread > 0 {
+		baseStyle = styles.ChannelUnread
+	}
+	return renderRow{
+		normal:        baseStyle.Width(width - 2).Render(label),
+		selected:      styles.ChannelSelected.Width(width - 2).Render(cursor),
+		active:        styles.ChannelSelected.Width(width - 2).Render(active),
+		height:        1,
+		navIdx:        navIdx,
+		isThreadsRow:  isThreads,
+		isActivityRow: isActivity,
+	}
 }
 
 const (

--- a/internal/ui/sidebar/model_test.go
+++ b/internal/ui/sidebar/model_test.go
@@ -40,7 +40,8 @@ func TestSidebarNavigation(t *testing.T) {
 	// Expand the Channels section so j/k can reach the channel rows.
 	m.ToggleCollapse("Channels")
 
-	// Nav order: Threads → "Channels" header → C1 → C2 → C3.
+	// Nav order: Activity → Threads → "Channels" header → C1 → C2 → C3.
+	m.MoveDown() // Threads
 	m.MoveDown() // onto the "Channels" section header
 	if name, ok := m.IsSectionHeaderSelected(); !ok || name != "Channels" {
 		t.Errorf("expected Channels header selected, got name=%q ok=%v", name, ok)
@@ -68,13 +69,16 @@ func TestSidebarNavigation(t *testing.T) {
 	}
 }
 
-func TestThreadsItem_DefaultSelected(t *testing.T) {
+func TestActivityItem_DefaultSelected(t *testing.T) {
 	m := New([]ChannelItem{
 		{ID: "C1", Name: "general", Type: "channel"},
 		{ID: "C2", Name: "design", Type: "channel"},
 	})
-	if !m.IsThreadsSelected() {
-		t.Errorf("expected Threads entry to be selected by default (top of list)")
+	if !m.IsActivitySelected() {
+		t.Errorf("expected Activity entry to be selected by default (top of list)")
+	}
+	if m.IsThreadsSelected() {
+		t.Errorf("Threads should sit under Activity, not keep the top slot")
 	}
 }
 
@@ -84,10 +88,11 @@ func TestThreadsItem_MoveDownLeavesIt(t *testing.T) {
 		{ID: "C2", Name: "design", Type: "channel"},
 	})
 	m.ToggleCollapse("Channels")
+	m.MoveDown() // Threads
 	m.MoveDown() // header
 	m.MoveDown() // first channel
-	if m.IsThreadsSelected() {
-		t.Errorf("MoveDown should leave the Threads entry")
+	if m.IsThreadsSelected() || m.IsActivitySelected() {
+		t.Errorf("MoveDown should leave the synthetic rows")
 	}
 	item, ok := m.SelectedItem()
 	if !ok || item.ID != "C1" {
@@ -100,15 +105,20 @@ func TestThreadsItem_MoveUpReturnsToIt(t *testing.T) {
 		{ID: "C1", Name: "general", Type: "channel"},
 	})
 	m.ToggleCollapse("Channels")
+	m.MoveDown() // Threads
 	m.MoveDown() // header
 	m.MoveDown() // C1
 	if m.IsThreadsSelected() {
 		t.Fatalf("precondition: should be on a channel")
 	}
 	m.MoveUp() // back to header
-	m.MoveUp() // back to Threads
+	m.MoveUp() // Threads
 	if !m.IsThreadsSelected() {
-		t.Errorf("MoveUp from first channel should land on Threads entry")
+		t.Errorf("MoveUp from first channel should land on Threads (under Activity)")
+	}
+	m.MoveUp() // Activity
+	if !m.IsActivitySelected() {
+		t.Errorf("MoveUp from Threads should land on Activity at the top")
 	}
 }
 
@@ -142,8 +152,8 @@ func TestThreadsItem_VisibleWhenNoChannels(t *testing.T) {
 	if !strings.Contains(out, "Threads") {
 		t.Errorf("View should contain 'Threads' even when there are no channels: %q", out)
 	}
-	if !m.IsThreadsSelected() {
-		t.Errorf("Threads row should still be selected when there are no channels")
+	if !m.IsActivitySelected() {
+		t.Errorf("Activity row should be selected when there are no channels")
 	}
 }
 
@@ -183,12 +193,60 @@ func TestSetThreadsUnreadCount_ZeroRemovesBadge(t *testing.T) {
 func TestThreadsItem_SelectedItemFalseWhenOnThreadsRow(t *testing.T) {
 	m := New([]ChannelItem{{ID: "C1", Name: "general", Type: "channel"}})
 	if _, ok := m.SelectedItem(); ok {
+		t.Errorf("SelectedItem should return ok=false on the top synthetic row")
+	}
+	m.MoveDown() // Threads
+	if _, ok := m.SelectedItem(); ok {
 		t.Errorf("SelectedItem should return ok=false when Threads row is selected")
+	}
+}
+
+func TestActivityItem_SitsAboveThreads(t *testing.T) {
+	m := New([]ChannelItem{{ID: "C1", Name: "general", Type: "channel"}})
+	if !m.IsActivitySelected() {
+		t.Fatal("Activity should own the top slot")
+	}
+	m.MoveDown()
+	if !m.IsThreadsSelected() {
+		t.Error("MoveDown from Activity should land on Threads")
+	}
+	if _, ok := m.SelectedItem(); ok {
+		t.Error("SelectedItem should be false on the Threads row")
+	}
+}
+
+func TestActivityItem_UnreadBadgeRenders(t *testing.T) {
+	m := New([]ChannelItem{{ID: "C1", Name: "general", Type: "channel"}})
+	m.SetActivityUnreadCount(12)
+	out := m.View(10, 30)
+	var line string
+	for _, l := range strings.Split(out, "\n") {
+		if strings.Contains(l, "Activity") {
+			line = l
+			break
+		}
+	}
+	if line == "" {
+		t.Fatalf("no Activity line in view: %q", out)
+	}
+	if !strings.Contains(line, "•12") {
+		t.Errorf("Activity line should contain badge '•12', got %q", line)
+	}
+}
+
+func TestSetActivityUnreadCount_NoChangeNoVersionBump(t *testing.T) {
+	m := New([]ChannelItem{{ID: "C1", Name: "general", Type: "channel"}})
+	m.SetActivityUnreadCount(3)
+	v1 := m.Version()
+	m.SetActivityUnreadCount(3)
+	if m.Version() != v1 {
+		t.Error("identical SetActivityUnreadCount should not bump version")
 	}
 }
 
 func TestThreadsItem_SelectByIDClearsThreadsSelection(t *testing.T) {
 	m := New([]ChannelItem{{ID: "C1", Name: "general", Type: "channel"}})
+	m.SelectThreadsRow()
 	if !m.IsThreadsSelected() {
 		t.Fatal("precondition")
 	}
@@ -323,17 +381,24 @@ func TestRender_UnreadThreadsRow_KeepsBoldAfterPrefixReset(t *testing.T) {
 	m.SetThreadsUnreadCount(3)
 	out := m.View(20, 40)
 
-	threadsIdx := strings.Index(out, "Threads")
-	if threadsIdx < 0 {
+	var threadsLine string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "Threads") {
+			threadsLine = line
+			break
+		}
+	}
+	if threadsLine == "" {
 		t.Fatalf("output missing Threads label; got: %q", out)
 	}
-	prefix := out[:threadsIdx]
+	threadsIdx := strings.Index(threadsLine, "Threads")
+	prefix := threadsLine[:threadsIdx]
 	lastResetIdx := strings.LastIndex(prefix, "\x1b[m")
 	if lastResetIdx == -1 {
 		t.Skip("no mid-label reset found before Threads; render path changed")
 	}
 	afterReset := prefix[lastResetIdx:]
-	if !strings.Contains(afterReset, "\x1b[1m") {
+	if !strings.Contains(afterReset, "\x1b[1") {
 		t.Errorf("bold attribute not re-emitted after ⚑ reset for unread Threads row\nafterReset=%q", afterReset)
 	}
 }
@@ -346,11 +411,18 @@ func TestRender_ReadThreadsRow_DoesNotEmitBoldAfterReset(t *testing.T) {
 	m.SetThreadsUnreadCount(0)
 	out := m.View(20, 40)
 
-	threadsIdx := strings.Index(out, "Threads")
-	if threadsIdx < 0 {
+	var threadsLine string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "Threads") {
+			threadsLine = line
+			break
+		}
+	}
+	if threadsLine == "" {
 		t.Fatalf("output missing Threads label")
 	}
-	prefix := out[:threadsIdx]
+	threadsIdx := strings.Index(threadsLine, "Threads")
+	prefix := threadsLine[:threadsIdx]
 	lastResetIdx := strings.LastIndex(prefix, "\x1b[m")
 	if lastResetIdx == -1 {
 		return

--- a/internal/ui/sidebar/model_test.go
+++ b/internal/ui/sidebar/model_test.go
@@ -484,7 +484,7 @@ type fakeProvider struct {
 func (f *fakeProvider) Ready() bool                         { return f.ready }
 func (f *fakeProvider) OrderedSlackSections() []SectionMeta { return f.sections }
 
-func TestOrderedSections_SlackMode_HonorsLinkedListOrder(t *testing.T) {
+func TestOrderedSections_SlackMode_HoistsDirectMessages(t *testing.T) {
 	items := []ChannelItem{
 		{ID: "C1", Name: "ch1", Type: "channel", Section: "B"},
 		{ID: "C2", Name: "ch2", Type: "channel", Section: "A"},
@@ -501,7 +501,9 @@ func TestOrderedSections_SlackMode_HonorsLinkedListOrder(t *testing.T) {
 	m := New(items)
 	m.SetSectionsProvider(provider)
 	got := slackModeNavHeaders(&m)
-	want := []string{"A", "B", "DMS"}
+	// Direct Messages is hoisted above Slack's linked-list order so
+	// DMs sit under Threads instead of at the bottom of the rail.
+	want := []string{"DMS", "A", "B"}
 	if len(got) != len(want) {
 		t.Fatalf("len = %d, want %d (%v)", len(got), len(want), got)
 	}
@@ -566,8 +568,8 @@ func TestOrderedSections_ConfigMode_UnchangedWhenNoProvider(t *testing.T) {
 	}
 	m := New(items)
 	got := orderedSections(m.items, m.filtered)
-	// Custom first, then DMs, then Channels.
-	want := []string{"Custom", "Direct Messages", "Channels"}
+	// DMs first, then custom sections, then Channels.
+	want := []string{"Direct Messages", "Custom", "Channels"}
 	if len(got) != len(want) {
 		t.Fatalf("len = %d, want %d (%v)", len(got), len(want), got)
 	}
@@ -660,8 +662,8 @@ func TestCollapseByID_IndependentFromConfigMode(t *testing.T) {
 	}
 	m := New(items)
 	m.SetSectionsProvider(p)
-	m.ToggleCollapse("A")        // collapse via ID
-	m.SetSectionsProvider(nil)   // back to config mode
+	m.ToggleCollapse("A")      // collapse via ID
+	m.SetSectionsProvider(nil) // back to config mode
 	// Now "A" is just a string in config mode; whether it's collapsed
 	// depends on the name-keyed `collapsed` map (which is the default
 	// state set in New). The ID-mode collapse must NOT bleed into

--- a/internal/ui/sidebar/section_nav_test.go
+++ b/internal/ui/sidebar/section_nav_test.go
@@ -30,13 +30,13 @@ func TestRenderedSelectionMatchesNavigation(t *testing.T) {
 	// cursor lands on a line containing each name in order. Headers
 	// share names with the visible section titles ("Engineering",
 	// "Alerts", "Direct Messages", "Channels") so we list them too.
-	// Custom sections are ordered by SectionOrder ascending, so Alerts
-	// (order=1) precedes Engineering (order=2). Then DMs, then the
-	// catch-all Channels section.
+	// DMs lead, then custom sections by SectionOrder ascending (Alerts
+	// order=1 before Engineering order=2), then the catch-all Channels
+	// section.
 	expectedOrder := []string{
+		"Direct Messages", "alice", "bob",
 		"Alerts", "alerts", "ops",
 		"Engineering", "deploys",
-		"Direct Messages", "alice", "bob",
 		"Channels", "general",
 	}
 	for i, name := range expectedOrder {
@@ -60,8 +60,8 @@ func TestRenderedSelectionMatchesNavigation(t *testing.T) {
 
 func TestNavigationFollowsSectionOrder(t *testing.T) {
 	// Items in Slack-response order: a default channel, then two custom-section
-	// channels, then a DM. Expected display order: custom section first, then
-	// "Direct Messages", then "Channels".
+	// channels, then a DM. Expected display order: Direct Messages first, then
+	// the custom section, then Channels.
 	items := []ChannelItem{
 		{ID: "C1", Name: "general", Type: "channel"},
 		{ID: "C2", Name: "alerts", Type: "channel", Section: "Alerts", SectionOrder: 1},
@@ -73,9 +73,9 @@ func TestNavigationFollowsSectionOrder(t *testing.T) {
 	m.ToggleCollapse("Channels")
 
 	// Walk through every channel ID, advancing j past section headers
-	// as needed. Selection-by-channel-ID order: C2, C3 (Alerts), D1
-	// (Direct Messages), C1 (Channels).
-	want := []string{"C2", "C3", "D1", "C1"}
+	// as needed. Selection-by-channel-ID order: D1 (Direct Messages),
+	// C2, C3 (Alerts), C1 (Channels).
+	want := []string{"D1", "C2", "C3", "C1"}
 	stepDownToID := func(t *testing.T, want string) {
 		t.Helper()
 		for i := 0; i < 50; i++ {
@@ -104,7 +104,7 @@ func TestNavigationFollowsSectionOrder(t *testing.T) {
 	}
 }
 
-func TestOrderedSectionsCustomFirstDMsLast(t *testing.T) {
+func TestOrderedSectionsDMsFirstThenCustom(t *testing.T) {
 	items := []ChannelItem{
 		{ID: "C1", Name: "general", Type: "channel"},
 		{ID: "D1", Name: "bob", Type: "dm"},
@@ -113,7 +113,7 @@ func TestOrderedSectionsCustomFirstDMsLast(t *testing.T) {
 	}
 	filtered := []int{0, 1, 2, 3}
 	got := orderedSections(items, filtered)
-	want := []string{"Engineering", "Alerts", "Direct Messages", "Channels"}
+	want := []string{"Direct Messages", "Engineering", "Alerts", "Channels"}
 	if len(got) != len(want) {
 		t.Fatalf("got %v, want %v", got, want)
 	}

--- a/internal/ui/sidebar/section_nav_test.go
+++ b/internal/ui/sidebar/section_nav_test.go
@@ -23,7 +23,8 @@ func TestRenderedSelectionMatchesNavigation(t *testing.T) {
 	// default-collapsed "Channels" section would otherwise hide
 	// "general" from the rendered output.
 	m.ToggleCollapse("Channels")
-	// Step off the synthetic Threads row.
+	// Step off the synthetic Threads and Activity rows.
+	m.MoveDown()
 	m.MoveDown()
 
 	// Expected nav stops include section headers; the test asserts the

--- a/internal/ui/view_messages.go
+++ b/internal/ui/view_messages.go
@@ -9,6 +9,8 @@
 //   ViewThreads  -> threads-list panel (no compose, no typing
 //                   line). Whole bordered panel is cached on
 //                   threadsView.Version + layout key.
+//   ViewActivity -> Activity inbox (same chrome as threads:
+//                   no compose). Cached on activityView.Version.
 //   ViewChannels -> message pane + typing row + compose box, with
 //                   a split-cache pattern: bordered top region
 //                   (messages + top edge + sides only, no bottom
@@ -84,9 +86,16 @@ func (a *App) renderMessagesRegion(frame panelLayoutFrame, themeVer int64, previ
 	// would take 2^13 theme switches, and bit 32 would take 2^29),
 	// composeHeight bits 16+ (terminal rows, < 2^10), window id
 	// bits 32+ (wintree.LeafID increments per split; tiny).
+	viewN := int64(0)
+	switch a.view {
+	case ViewThreads:
+		viewN = 1
+	case ViewActivity:
+		viewN = 2
+	}
 	msgLayoutKey := int64(a.focusedWin)<<32 |
-		themeVer<<3 |
-		boolToInt(a.view == ViewThreads)<<2 |
+		themeVer<<4 |
+		viewN<<2 |
 		boolToInt(msgFocused)<<1
 	a.compose.SetWidth(msgWidth - 2)
 
@@ -97,6 +106,9 @@ func (a *App) renderMessagesRegion(frame panelLayoutFrame, themeVer int64, previ
 	}
 	if a.view == ViewThreads {
 		return a.renderThreadsViewPanel(msgWidth, msgBorder, contentHeight, msgFocused, msgLayoutKey)
+	}
+	if a.view == ViewActivity {
+		return a.renderActivityViewPanel(msgWidth, msgBorder, contentHeight, msgFocused, msgLayoutKey)
 	}
 	return a.renderChannelMessagesPanel(msgWidth, msgBorder, contentHeight, msgFocused, composeFocused, msgLayoutKey)
 }
@@ -142,6 +154,34 @@ func (a *App) renderThreadsViewPanel(msgWidth, msgBorder, contentHeight int, msg
 		msgWidth+msgBorder, contentHeight,
 	)
 	c.store(out, tvVersion, msgWidth, contentHeight, msgLayoutKey)
+	return out
+}
+
+func (a *App) renderActivityViewPanel(msgWidth, msgBorder, contentHeight int, msgFocused bool, msgLayoutKey int64) string {
+	a.activityView.SetUserNames(a.userNames)
+	a.activityView.SetSelfUserID(a.currentUserID)
+	a.activityView.SetFocused(msgFocused)
+	avVersion := a.activityView.Version()
+	c := &a.renderCache.msgPanel
+	if c.hit(avVersion, msgWidth, contentHeight, msgLayoutKey) {
+		return c.output
+	}
+	msgBorderStyle := styles.UnfocusedBorder.Width(msgWidth)
+	if msgFocused {
+		msgBorderStyle = styles.FocusedBorder.Width(msgWidth)
+	}
+	msgContentHeight := contentHeight - 2
+	a.layout.SetMsgHeight(msgContentHeight)
+	if msgContentHeight < 3 {
+		msgContentHeight = 3
+	}
+	avView := a.activityView.View(msgContentHeight, msgWidth-2)
+	avView = messages.ReapplyBgAfterResets(avView, messages.BgANSI())
+	out := exactSize(
+		msgBorderStyle.Render(avView),
+		msgWidth+msgBorder, contentHeight,
+	)
+	c.store(out, avVersion, msgWidth, contentHeight, msgLayoutKey)
 	return out
 }
 

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -63,6 +63,17 @@ message_retention_days = 30
 max_db_size_mb = 500
 max_image_cache_mb = 200
 
+# Activity inbox (Slack's Activity tab). These are the session defaults;
+# f / F / s / u in the Activity view cycle them live without rewriting
+# this file.
+[activity]
+filter = "all"            # All / DMs / Mentions / Threads, or a custom
+                          # activity.views name (Unreads, Reactions, VIP, …)
+sort = "newest"           # newest | unreads_first
+unread_only = false
+density = "detailed"      # detailed | compact (Slack Detailed / Dense)
+limit = 50                # activity.feed page size, 1–100
+
 # Glob-based channel sections — only consulted when use_slack_sections
 # is false (globally or per-workspace), or when Slack's section API is
 # unreachable. Otherwise slk reads the user's actual Slack sections.
@@ -173,6 +184,24 @@ regardless of network timing, even without an explicit `order` set.
 
 Legacy configs that key the block by raw team ID
 (`[workspaces.T01ABCDEF]`) keep working unchanged.
+
+## Activity inbox
+
+`[activity]` sets the defaults for the Activity sidebar row (Slack's
+Activity tab). Unknown values clamp on load.
+
+| Key | Values | Default | Maps to |
+|---|---|---|---|
+| `filter` | view name / type / id (`all`, `Unreads`, `VIP`, …) | `all` | selected `activity.views` tab |
+| `sort` | `newest`, `unreads_first` | `newest` | `chrono_v1` vs `priority_reads_and_unreads_v1` + `vip_unreads_first` |
+| `unread_only` | bool | `false` | `unread_only` |
+| `density` | `detailed`, `compact` | `detailed` | 3-line cards vs one line |
+| `limit` | 1–100 | `50` | `activity.feed` page size |
+
+In the Activity view, `f`/`F`, `s`, and `u` cycle filter / sort /
+unread-only for the rest of the session without rewriting
+`config.toml`. Click the tabs and chips in the toolbar for the same
+controls.
 
 ## Terminal-palette themes (`ANSI Dark`, `ANSI Light`)
 

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -51,6 +51,28 @@ See [[Terminal Compatibility|Terminal-Compatibility]] for which protocol your te
   v1 is computed from the local SQLite cache, so threads from channels
   you have not yet opened in slk will not appear until they are seen.
 
+## Activity
+
+- **Activity inbox** (`◎ Activity` above Threads in the sidebar): Slack's
+  Activity tab — recents and notifications, read and unread — via
+  `activity.feed`. The sidebar badge is `client.counts` `activity_v2`.
+- Tabs come from `activity.views`, so built-in All / DMs / Mentions /
+  Threads plus **any custom view you created in Slack** (Unreads,
+  Reactions, VIP, …) show up automatically. Selecting a tab flattens
+  that view's `entry_types` / `unread_only` / `priority_only` onto
+  `activity.feed`, matching the official client.
+- Cards follow Slack's copy: "Post in #channel", "Thread in #channel",
+  "Direct Message", "Mentioned you", "Reacted :eyes:", with a `vip`
+  marker when the item is priority.
+- Sort is newest (`chrono_v1`) or unreads-first
+  (`priority_reads_and_unreads_v1` + `vip_unreads_first`). The unread
+  chip is Slack's Unreads button on the current tab.
+- Defaults live in `[activity]` in `config.toml`. In the view: `f`/`F`
+  cycle tabs, `s` cycles sort, `u` toggles unread-only (session-only;
+  config is the next-launch default). Click the tabs/chips too.
+- `Enter` on a row opens the message (or thread) through the same
+  in-app permalink path search results use.
+
 ## Reactions
 
 - Search-first picker overlay (`r`) with frecent emoji

--- a/wiki/Keybindings.md
+++ b/wiki/Keybindings.md
@@ -5,7 +5,11 @@
 | `j` / `k` | Normal | Move down/up in channel list or messages |
 | `h` / `l` | Normal | Switch focus between panels |
 | `Tab` / `Shift+Tab` | Normal | Cycle focus |
-| `Enter` | Normal (sidebar) | Open selected channel, or toggle a section header |
+| `Enter` | Normal (sidebar) | Open selected channel, Threads, or Activity, or toggle a section header |
+| `f` / `F` | Normal (Activity) | Next / previous Activity tab (Slack views, including custom Unreads / Reactions / VIP) |
+| `s` | Normal (Activity) | Cycle Activity sort (newest ↔ unreads first) |
+| `u` | Normal (Activity) | Toggle Activity unread-only |
+| `Enter` | Normal (Activity) | Open the selected Activity item in its channel / thread |
 | `Space` | Normal (sidebar) | Toggle the selected section header (collapse/expand) |
 | `Enter` | Normal (message) | Open thread |
 | `i` | Normal | Enter insert mode |


### PR DESCRIPTION
## Why

Slack's Activity inbox (mentions, DMs, reactions, …) is the other half of "what needs my attention" next to Threads. slk had no view for it.

## What

- New `activity.feed` / `activity.views` client (unofficial Slack protocol, same class as the rest of slk — it can change without notice).
- Synthetic **Activity** row above Threads with an `activity_v2` unread badge from `client.counts`.
- Message pane: filter / sort / unread-only, compact and detailed density, jump-to-message.
- Prefs in `[activity]` in config.toml.
- Docs: README, wiki Features / Configuration / Keybindings.

## Test plan

- [x] `go test ./internal/config/ ./internal/slack/ ./internal/bootstrap/ ./internal/ui/ ./internal/ui/sidebar/ ./internal/ui/activityview/ ./cmd/slk/`
- [ ] Open Activity from the sidebar; feed loads; unread badge matches Slack.
- [ ] Cycle filters, toggle unread-only, jump to a mention/DM.
- [ ] Reconnect: badge refreshes from `client.counts`.

**Merge after #168** (stack 4/4). Contains the full stack. Testdata is sanitized API JSON (no tokens).