### PR TITLE
Add 'also send to channel' broadcast for thread replies

### DIFF
--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -1797,7 +1797,7 @@ func run() error {
 					}
 				}
 			},
-			SendReply: func(channelID ids.ChannelID, threadTS ids.ThreadTS, text string) tea.Msg {
+			SendReply: func(channelID ids.ChannelID, threadTS ids.ThreadTS, text string, broadcast bool) tea.Msg {
 				chIDStr, threadTSStr := string(channelID), string(threadTS)
 				wctx := router.Active()
 				if wctx == nil {
@@ -1806,7 +1806,7 @@ func run() error {
 				client := wctx.Client
 				userNames := wctx.UserNames
 				ctx := context.Background()
-				ts, sentMrkdwn, err := client.SendReply(ctx, chIDStr, threadTSStr, text)
+				ts, sentMrkdwn, err := client.SendReply(ctx, chIDStr, threadTSStr, text, broadcast)
 				if err != nil {
 					log.Printf("Warning: failed to send thread reply: %v", err)
 					return ui.ThreadReplySendFailedMsg{ChannelID: chIDStr, ThreadTS: threadTSStr, Reason: err.Error()}
@@ -1815,9 +1815,18 @@ func run() error {
 				if resolved, ok := userNames[client.UserID()]; ok {
 					userName = resolved
 				}
+				// Broadcast replies surface in the parent channel feed as
+				// thread_broadcast rows; flag the authoritative copy so the
+				// reducer's channel-pane swap renders the same label the WS
+				// echo would have carried.
+				subtype := ""
+				if broadcast {
+					subtype = "thread_broadcast"
+				}
 				return ui.ThreadReplySentMsg{
 					ChannelID: chIDStr,
 					ThreadTS:  threadTSStr,
+					Broadcast: broadcast,
 					Message: messages.MessageItem{
 						TS:        ts,
 						UserID:    client.UserID(),
@@ -1825,6 +1834,7 @@ func run() error {
 						Text:      sentMrkdwn,
 						Timestamp: formatTimestamp(ts, tsFormat),
 						ThreadTS:  threadTSStr,
+						Subtype:   subtype,
 					},
 				}
 			},

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -77,6 +77,8 @@ Last updated: 2026-05-03
 - [x] Thread reply compose with Shift+Enter for newlines
 - [x] Real-time thread reply routing via WebSocket
 - [x] Thread reply sending via Slack API
+- [x] Also send to channel (`Ctrl+O` in thread compose toggles Slack's
+  reply-broadcast checkbox; optimistic thread_broadcast row in the channel feed)
 - [x] Channel switch closes thread panel
 - [x] Threads view (top-of-sidebar `⚑ Threads` entry): list of threads the
   user authored, replied to, or was @-mentioned in for the active workspace,

--- a/internal/slack/client.go
+++ b/internal/slack/client.go
@@ -1070,9 +1070,13 @@ func (c *Client) GetUnreadCounts() ([]UnreadInfo, ThreadsAggregate, error) {
 	return unreads, threads, nil
 }
 
-// SendReply posts a threaded reply to the specified message.
-// Returns the timestamp and the converted mrkdwn text actually sent.
-func (c *Client) SendReply(ctx context.Context, channelID, threadTS, text string) (string, string, error) {
+// SendReply posts a threaded reply to the specified message. When
+// broadcast is true, the reply is also posted to the parent channel
+// feed (chat.postMessage reply_broadcast=true, Slack's "Also send to
+// #channel" checkbox); Slack surfaces such replies with the
+// thread_broadcast subtype. Returns the timestamp and the converted
+// mrkdwn text actually sent.
+func (c *Client) SendReply(ctx context.Context, channelID, threadTS, text string, broadcast bool) (string, string, error) {
 	mr, block := mrkdwn.Convert(text)
 	opts := []slack.MsgOption{
 		slack.MsgOptionText(mr, false),
@@ -1080,6 +1084,9 @@ func (c *Client) SendReply(ctx context.Context, channelID, threadTS, text string
 	}
 	if block != nil {
 		opts = append(opts, slack.MsgOptionBlocks(block))
+	}
+	if broadcast {
+		opts = append(opts, slack.MsgOptionBroadcast())
 	}
 	_, ts, err := c.api.PostMessage(channelID, opts...)
 	if err != nil {

--- a/internal/slack/client_test.go
+++ b/internal/slack/client_test.go
@@ -1670,7 +1670,7 @@ func TestSendReply_BuildsRichTextBlock(t *testing.T) {
 	defer closeFn()
 	c := &Client{api: api}
 
-	ts, sentMrkdwn, err := c.SendReply(context.Background(), "C1", "1700000000.000100", "see [docs](https://x.com)")
+	ts, sentMrkdwn, err := c.SendReply(context.Background(), "C1", "1700000000.000100", "see [docs](https://x.com)", false)
 	if err != nil {
 		t.Fatalf("SendReply: %v", err)
 	}
@@ -1686,6 +1686,30 @@ func TestSendReply_BuildsRichTextBlock(t *testing.T) {
 	}
 	if form.Get("blocks") == "" {
 		t.Error("blocks form value empty; expected rich_text block")
+	}
+	if form.Get("thread_ts") != "1700000000.000100" {
+		t.Errorf("thread_ts = %q, want parent ts", form.Get("thread_ts"))
+	}
+	if form.Get("reply_broadcast") != "" {
+		t.Errorf("reply_broadcast = %q, want unset for plain reply", form.Get("reply_broadcast"))
+	}
+}
+
+func TestSendReply_BroadcastSetsReplyBroadcast(t *testing.T) {
+	// A broadcast reply (Slack's "Also send to #channel") must carry
+	// reply_broadcast=true on the wire so Slack surfaces it in the
+	// parent channel feed with the thread_broadcast subtype.
+	api, getForm, closeFn := newTestSlackAPI(t, `{"ok":true,"ts":"1700000000.000300","channel":"C1"}`)
+	defer closeFn()
+	c := &Client{api: api}
+
+	_, _, err := c.SendReply(context.Background(), "C1", "1700000000.000100", "heads up", true)
+	if err != nil {
+		t.Fatalf("SendReply(broadcast): %v", err)
+	}
+	form := getForm()
+	if got := form.Get("reply_broadcast"); got != "true" {
+		t.Errorf("reply_broadcast = %q, want %q", got, "true")
 	}
 	if form.Get("thread_ts") != "1700000000.000100" {
 		t.Errorf("thread_ts = %q, want parent ts", form.Get("thread_ts"))

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1871,6 +1871,18 @@ func (a *App) openThreadForSelectedMessage() tea.Cmd {
 	return a.openThreadPanel(msg, a.activeChannelID, threadTS)
 }
 
+// threadComposeChannelName resolves the display name for the thread's
+// parent channel so the thread compose's placeholder and the
+// "also send to #channel" broadcast hint show the real channel.
+// Falls back to the generic "channel" when the ID isn't in the
+// mention-resolution map (e.g. DM/MPIM edge cases).
+func (a *App) threadComposeChannelName(channelID string) string {
+	if name, ok := a.channelNames[channelID]; ok && name != "" {
+		return name
+	}
+	return "channel"
+}
+
 // openThreadPanel makes the thread panel visible for (channelID,
 // threadTS) with the given parent row, primes replies from the thread
 // cache, and returns a cmd that fetches authoritative replies. Shared
@@ -1881,7 +1893,10 @@ func (a *App) openThreadPanel(parent messages.MessageItem, channelID, threadTS s
 	a.statusbar.SetInThread(true)
 	a.focusedPanel = PanelThread
 	a.threadPanel.SetThread(parent, nil, channelID, threadTS)
-	a.threadCompose.SetChannel("thread")
+	a.threadCompose.SetChannel(a.threadComposeChannelName(channelID))
+	// A fresh thread must not inherit the previous thread's
+	// "also send to channel" toggle.
+	a.threadCompose.SetBroadcast(false)
 	a.applyThreadUnreadBoundary(channelID, threadTS)
 
 	threads := a.threads
@@ -2069,7 +2084,10 @@ func (a *App) openSelectedThreadCmd(debounce bool) tea.Cmd {
 		ThreadTS: sum.ThreadTS,
 	}
 	a.threadPanel.SetThread(parent, nil, sum.ChannelID, sum.ThreadTS)
-	a.threadCompose.SetChannel("thread")
+	a.threadCompose.SetChannel(a.threadComposeChannelName(sum.ChannelID))
+	// A fresh thread must not inherit the previous thread's
+	// "also send to channel" toggle.
+	a.threadCompose.SetBroadcast(false)
 	// Snapshot the thread's own last-read cursor BEFORE the local mark-
 	// read flips below, so the "── new ──" landmark in the thread panel
 	// reflects what the user had actually seen prior to opening this

--- a/internal/ui/app_thread_broadcast_test.go
+++ b/internal/ui/app_thread_broadcast_test.go
@@ -1,0 +1,293 @@
+// internal/ui/app_thread_broadcast_test.go
+//
+// Tests for Slack's "Also send to #channel" thread-reply broadcast:
+// ctrl+o toggle in the thread compose, the optimistic thread_broadcast
+// row in the channel feed, the authoritative swap on success, and the
+// rollback on failure.
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/gammons/slk/internal/ui/messages"
+)
+
+func newThreadBroadcastApp(t *testing.T) *App {
+	t.Helper()
+	app := NewApp()
+	app.SetCurrentUserID("USELF")
+	app.activeChannelID = "C1"
+	app.threadPanel.SetThread(messages.MessageItem{TS: "1700000000.000100"}, nil, "C1", "1700000000.000100")
+	app.threadVisible = true
+	app.focusedPanel = PanelThread
+	app.SetMode(ModeInsert)
+	return app
+}
+
+// TestHandleInsertMode_CtrlOTogglesThreadBroadcast pins the ctrl+o
+// toggle: it flips the thread compose's broadcast flag on and off, and
+// the next Enter dispatches SendThreadReplyMsg with Broadcast=true.
+func TestHandleInsertMode_CtrlOTogglesThreadBroadcast(t *testing.T) {
+	app := newThreadBroadcastApp(t)
+
+	app.handleInsertMode(tea.KeyPressMsg{Code: 'o', Mod: tea.ModCtrl})
+	if !app.threadCompose.Broadcast() {
+		t.Fatal("ctrl+o should turn the thread broadcast toggle on")
+	}
+
+	// The toggle must survive typing (ctrl+o is intercepted before the
+	// textarea sees it).
+	app.threadCompose.SetValue("heads up")
+	if !app.threadCompose.Broadcast() {
+		t.Fatal("plain typing should not clear the broadcast toggle")
+	}
+
+	app.handleInsertMode(tea.KeyPressMsg{Code: 'o', Mod: tea.ModCtrl})
+	if app.threadCompose.Broadcast() {
+		t.Fatal("second ctrl+o should turn the toggle off")
+	}
+
+	// Toggle back on and send; the dispatched msg must carry Broadcast.
+	app.handleInsertMode(tea.KeyPressMsg{Code: 'o', Mod: tea.ModCtrl})
+	cmd := app.handleInsertMode(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("Enter with text should return a send cmd")
+	}
+	msg, ok := cmd().(SendThreadReplyMsg)
+	if !ok {
+		t.Fatalf("expected SendThreadReplyMsg, got %T", msg)
+	}
+	if !msg.Broadcast {
+		t.Error("SendThreadReplyMsg.Broadcast = false, want true after ctrl+o toggle")
+	}
+
+	// Non-sticky: the toggle must reset to false after send so it does
+	// not silently broadcast subsequent replies.
+	if app.threadCompose.Broadcast() {
+		t.Error("broadcast toggle should be cleared after send (non-sticky)")
+	}
+}
+
+// TestHandleInsertMode_AltEnterSendsThreadBroadcast asserts that Alt+Enter
+// in the thread compose sends with broadcast immediately as a one-shot,
+// without requiring the Ctrl+O toggle first.
+func TestHandleInsertMode_AltEnterSendsThreadBroadcast(t *testing.T) {
+	app := newThreadBroadcastApp(t)
+	app.threadCompose.SetValue("quick broadcast")
+
+	if app.threadCompose.Broadcast() {
+		t.Fatal("setup: broadcast should be off initially")
+	}
+
+	cmd := app.handleInsertMode(tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModAlt})
+	if cmd == nil {
+		t.Fatal("Alt+Enter with text should return a send cmd")
+	}
+	msg, ok := cmd().(SendThreadReplyMsg)
+	if !ok {
+		t.Fatalf("expected SendThreadReplyMsg, got %T", msg)
+	}
+	if !msg.Broadcast {
+		t.Error("SendThreadReplyMsg.Broadcast = false, want true after Alt+Enter")
+	}
+	if app.threadCompose.Broadcast() {
+		t.Error("broadcast toggle should be false after Alt+Enter send")
+	}
+}
+
+// TestHandleInsertMode_CtrlOInactiveOnChannelCompose guards the
+// thread-compose-only scope: ctrl+o while composing a channel message
+// must be forwarded to the textarea, not flip any broadcast state.
+func TestHandleInsertMode_CtrlOInactiveOnChannelCompose(t *testing.T) {
+	app := NewApp()
+	app.activeChannelID = "C1"
+	app.focusedPanel = PanelMessages
+	app.SetMode(ModeInsert)
+
+	app.handleInsertMode(tea.KeyPressMsg{Code: 'o', Mod: tea.ModCtrl})
+	if app.compose.Broadcast() {
+		t.Error("channel compose must never expose a broadcast toggle")
+	}
+}
+
+// TestSendThreadReply_BroadcastOptimisticChannelRowAndSwap covers the
+// feed path: a broadcast reply optimistically lands in the channel
+// pane as a thread_broadcast row (with the local placeholder TS), and
+// ThreadReplySentMsg swaps it for the authoritative message.
+func TestSendThreadReply_BroadcastOptimisticChannelRowAndSwap(t *testing.T) {
+	app := newThreadBroadcastApp(t)
+
+	app.Update(SendThreadReplyMsg{
+		ChannelID: "C1",
+		ThreadTS:  "1700000000.000100",
+		Text:      "heads up",
+		Broadcast: true,
+	})
+
+	// Thread pane got the optimistic reply...
+	if got := app.threadPanel.ReplyCount(); got != 1 {
+		t.Fatalf("thread panel replies = %d, want 1", got)
+	}
+	// ...and the channel feed got a thread_broadcast placeholder.
+	paneMsgs := app.messagepane.Messages()
+	if len(paneMsgs) != 1 {
+		t.Fatalf("channel pane messages = %d, want 1 optimistic broadcast row", len(paneMsgs))
+	}
+	localTS := paneMsgs[0].TS
+	if !strings.HasPrefix(localTS, "local:") {
+		t.Fatalf("channel row TS = %q, want local:... placeholder", localTS)
+	}
+	if paneMsgs[0].Subtype != "thread_broadcast" {
+		t.Errorf("channel row Subtype = %q, want thread_broadcast", paneMsgs[0].Subtype)
+	}
+	if paneMsgs[0].ThreadTS != "1700000000.000100" {
+		t.Errorf("channel row ThreadTS = %q, want parent thread ts", paneMsgs[0].ThreadTS)
+	}
+
+	// Non-broadcast send must NOT touch the channel feed.
+	app.Update(SendThreadReplyMsg{
+		ChannelID: "C1",
+		ThreadTS:  "1700000000.000100",
+		Text:      "quiet reply",
+	})
+	if got := len(app.messagepane.Messages()); got != 1 {
+		t.Fatalf("non-broadcast reply added a channel row: %d rows, want 1", got)
+	}
+
+	app.Update(ThreadReplySentMsg{
+		ChannelID: "C1",
+		ThreadTS:  "1700000000.000100",
+		LocalTS:   localTS,
+		Broadcast: true,
+		Message: messages.MessageItem{
+			TS: "1700000050.000400", UserID: "USELF", UserName: "you",
+			Text: "heads up", ThreadTS: "1700000000.000100",
+			Subtype: "thread_broadcast",
+		},
+	})
+
+	paneMsgs = app.messagepane.Messages()
+	if len(paneMsgs) != 1 {
+		t.Fatalf("post-swap channel rows = %d, want 1", len(paneMsgs))
+	}
+	if paneMsgs[0].TS != "1700000050.000400" {
+		t.Errorf("post-swap TS = %q, want authoritative Slack ts", paneMsgs[0].TS)
+	}
+	if paneMsgs[0].Subtype != "thread_broadcast" {
+		t.Errorf("post-swap Subtype = %q, want thread_broadcast", paneMsgs[0].Subtype)
+	}
+}
+
+// TestSendThreadReply_BroadcastFailureRollsBackChannelRow ensures a
+// failed broadcast send removes the optimistic row from BOTH the
+// thread panel and the channel feed.
+func TestSendThreadReply_BroadcastFailureRollsBackChannelRow(t *testing.T) {
+	app := newThreadBroadcastApp(t)
+
+	app.Update(SendThreadReplyMsg{
+		ChannelID: "C1",
+		ThreadTS:  "1700000000.000100",
+		Text:      "heads up",
+		Broadcast: true,
+	})
+	localTS := app.messagepane.Messages()[0].TS
+
+	app.Update(ThreadReplySendFailedMsg{
+		ChannelID: "C1",
+		ThreadTS:  "1700000000.000100",
+		LocalTS:   localTS,
+		Broadcast: true,
+		Reason:    "network error",
+	})
+
+	if got := len(app.messagepane.Messages()); got != 0 {
+		t.Errorf("channel rows after failure = %d, want 0", got)
+	}
+	if got := app.threadPanel.ReplyCount(); got != 0 {
+		t.Errorf("thread replies after failure = %d, want 0", got)
+	}
+}
+
+// TestOpenThread_ClearsBroadcastToggle locks in the per-thread scope
+// of the toggle: opening a (different) thread resets "also send to
+// channel" so it can't silently leak into the next thread.
+func TestOpenThread_ClearsBroadcastToggle(t *testing.T) {
+	app := newThreadBroadcastApp(t)
+	app.threadCompose.SetBroadcast(true)
+	app.channelNames = map[string]string{"C1": "general"}
+
+	cmd := app.openThreadPanel(messages.MessageItem{TS: "1700000099.000001"}, "C1", "1700000099.000001")
+	_ = cmd
+
+	if app.threadCompose.Broadcast() {
+		t.Error("opening a thread must clear the broadcast toggle")
+	}
+	if got := app.threadCompose.Value(); got != "" {
+		t.Errorf("compose should be empty on thread open, got %q", got)
+	}
+	// The thread compose must learn the real channel name so the hint
+	// and placeholder read "#general", not a synthetic label.
+	app.threadCompose.SetBroadcast(true)
+	view := app.threadCompose.View(60, true)
+	if !strings.Contains(view, "also send to #general") {
+		t.Errorf("hint should use the resolved channel name, got:\n%s", view)
+	}
+}
+
+// TestNewMessage_InboundThreadBroadcastRendersInChannelFeed tests an
+// inbound WebSocket message from another user with subtype thread_broadcast:
+// 1. It must append to the parent channel's message feed as a thread_broadcast row.
+// 2. It must increment the parent thread's reply count in the channel feed.
+// 3. If the thread panel is open for that thread, it must also append to the thread replies.
+func TestNewMessage_InboundThreadBroadcastRendersInChannelFeed(t *testing.T) {
+	app := NewApp()
+	app.SetCurrentUserID("USELF")
+	app.activeChannelID = "C1"
+
+	parent := messages.MessageItem{
+		TS:   "1700000000.000100",
+		Text: "parent discussion",
+	}
+	app.messagepane.AppendMessage(parent)
+	app.threadPanel.SetThread(parent, nil, "C1", "1700000000.000100")
+	app.threadVisible = true
+
+	// Inbound WS message from another user with subtype="thread_broadcast"
+	app.Update(NewMessageMsg{
+		ChannelID: "C1",
+		Message: messages.MessageItem{
+			TS:        "1700000050.000200",
+			UserID:    "UOTHER",
+			Text:      "broadcast from another user",
+			ThreadTS:  "1700000000.000100",
+			Subtype:   "thread_broadcast",
+			Timestamp: "12:05",
+		},
+	})
+
+	// 1. Channel feed must now have 2 messages: parent + broadcast reply
+	feedMsgs := app.messagepane.Messages()
+	if len(feedMsgs) != 2 {
+		t.Fatalf("channel feed messages = %d, want 2 (parent + broadcast)", len(feedMsgs))
+	}
+	if feedMsgs[0].ReplyCount != 1 {
+		t.Errorf("parent reply count = %d, want 1", feedMsgs[0].ReplyCount)
+	}
+	if feedMsgs[1].TS != "1700000050.000200" {
+		t.Errorf("broadcast row TS = %q, want 1700000050.000200", feedMsgs[1].TS)
+	}
+	if feedMsgs[1].Subtype != "thread_broadcast" {
+		t.Errorf("broadcast row Subtype = %q, want thread_broadcast", feedMsgs[1].Subtype)
+	}
+
+	// 2. Thread panel must have received the reply as well
+	if got := app.threadPanel.ReplyCount(); got != 1 {
+		t.Errorf("thread panel reply count = %d, want 1", got)
+	}
+	if got := app.threadPanel.Replies()[0].TS; got != "1700000050.000200" {
+		t.Errorf("thread reply TS = %q, want 1700000050.000200", got)
+	}
+}

--- a/internal/ui/app_thread_broadcast_test.go
+++ b/internal/ui/app_thread_broadcast_test.go
@@ -11,8 +11,11 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	lipgloss "charm.land/lipgloss/v2"
 
+	"github.com/gammons/slk/internal/config"
 	"github.com/gammons/slk/internal/ui/messages"
+	"github.com/gammons/slk/internal/ui/styles"
 )
 
 func newThreadBroadcastApp(t *testing.T) *App {
@@ -54,20 +57,47 @@ func TestHandleInsertMode_CtrlOTogglesThreadBroadcast(t *testing.T) {
 	app.handleInsertMode(tea.KeyPressMsg{Code: 'o', Mod: tea.ModCtrl})
 	cmd := app.handleInsertMode(tea.KeyPressMsg{Code: tea.KeyEnter})
 	if cmd == nil {
-		t.Fatal("Enter with text should return a send cmd")
+		t.Fatal("Enter in insert mode should produce a send command")
 	}
-	msg, ok := cmd().(SendThreadReplyMsg)
+	msg := cmd()
+	sendMsg, ok := msg.(SendThreadReplyMsg)
 	if !ok {
 		t.Fatalf("expected SendThreadReplyMsg, got %T", msg)
 	}
-	if !msg.Broadcast {
-		t.Error("SendThreadReplyMsg.Broadcast = false, want true after ctrl+o toggle")
+	if !sendMsg.Broadcast {
+		t.Errorf("SendThreadReplyMsg.Broadcast = false, want true")
+	}
+}
+
+func TestThreadComposeBroadcastRender(t *testing.T) {
+	styles.Apply("default", config.Theme{})
+	app := newThreadBroadcastApp(t)
+	app.channelNames = map[string]string{"C1": "newsroom"}
+	app.threadCompose.SetChannel("newsroom")
+	app.threadCompose.SetBroadcast(true)
+	app.threadCompose.SetValue("draft reply")
+
+	raw := app.threadCompose.View(40, true)
+	for i, l := range strings.Split(raw, "\n") {
+		if w := lipgloss.Width(l); w != 39 {
+			t.Errorf("threadCompose line %d visual width = %d, want 39 (line: %q)", i, w, l)
+		}
+		if !strings.Contains(l, "▌") {
+			t.Errorf("threadCompose line %d missing border ▌ (line: %q)", i, l)
+		}
 	}
 
-	// Non-sticky: the toggle must reset to false after send so it does
-	// not silently broadcast subsequent replies.
-	if app.threadCompose.Broadcast() {
-		t.Error("broadcast toggle should be cleared after send (non-sticky)")
+	frame := panelLayoutFrame{
+		ContentHeight: 30,
+		ThreadWidth:   42,
+		ThreadBorder:  1,
+	}
+	out := app.renderThreadRegion(frame, 0)
+	wantWidth := frame.ThreadWidth + frame.ThreadBorder
+	for i, l := range strings.Split(out, "\n") {
+		if w := lipgloss.Width(l); w != wantWidth {
+			t.Errorf("thread region line %d visual width = %d, want %d", i, w, wantWidth)
+		}
 	}
 }
 

--- a/internal/ui/callbacks.go
+++ b/internal/ui/callbacks.go
@@ -82,7 +82,8 @@ type ThreadCacheReadFunc func(channelID ids.ChannelID, threadTS ids.ThreadTS) []
 type ThreadMarkFunc func(channelID ids.ChannelID, threadTS ids.ThreadTS, ts ids.MessageTS) tea.Cmd
 
 // ThreadReplySendFunc is called when the user sends a thread reply.
-type ThreadReplySendFunc func(channelID ids.ChannelID, threadTS ids.ThreadTS, text string) tea.Msg
+// broadcast is Slack's "Also send to #channel" (reply_broadcast=true).
+type ThreadReplySendFunc func(channelID ids.ChannelID, threadTS ids.ThreadTS, text string, broadcast bool) tea.Msg
 
 // ThreadsListFetchFunc loads the involved-threads list for a workspace.
 // Returns the resulting tea.Msg (typically ThreadsListLoadedMsg).

--- a/internal/ui/compose/model.go
+++ b/internal/ui/compose/model.go
@@ -1284,20 +1284,19 @@ func (m Model) renderChips(width int) string {
 	return lipgloss.NewStyle().MaxWidth(width).Render(row)
 }
 
-// renderBroadcastHint returns the one-line "also send to channel"
-// indicator shown under the input while the broadcast toggle is on,
-// or "" when it is off. innerBG must match the background used by the
-// input box so the hint row reads as part of the compose area.
+// renderBroadcastHint returns the "also send to channel" indicator
+// shown under the input while the broadcast toggle is on, or "" when
+// it is off. innerBG must match the background used by the input box
+// so the hint row reads as part of the compose area.
 func (m Model) renderBroadcastHint(width int, innerBG color.Color) string {
 	if !m.broadcast {
 		return ""
 	}
-	hint := lipgloss.NewStyle().
+	return lipgloss.NewStyle().
 		Foreground(styles.Accent).
 		Background(innerBG).
 		Width(width).
 		Render(fmt.Sprintf("↪ also send to #%s  (ctrl+o to cancel)", m.channelName))
-	return lipgloss.NewStyle().MaxWidth(width).Render(hint)
 }
 
 func (m Model) View(width int, focused bool) string {
@@ -1307,6 +1306,9 @@ func (m Model) View(width int, focused bool) string {
 	// lipgloss Width includes padding but excludes border.
 	// Total rendered = Width + border = (width-1) + 1 = width.
 	innerWidth := width - 3 // content area: width - border(1) - padding(2)
+	if innerWidth < 1 {
+		innerWidth = 1
+	}
 
 	var style = styles.ComposeBox.Width(width - 1)
 	if focused {
@@ -1322,38 +1324,34 @@ func (m Model) View(width int, focused bool) string {
 		innerBG = styles.ComposeInsertBG
 	}
 
-	var box string
+	var content string
 	// If empty and unfocused, render placeholder manually with correct background.
 	// When focused, show an empty compose box with cursor (no placeholder).
 	if m.input.Value() == "" && !focused {
-		placeholder := lipgloss.NewStyle().
+		content = lipgloss.NewStyle().
 			Foreground(styles.TextMuted).
 			Background(innerBG).
 			Width(innerWidth).
 			Render(m.input.Placeholder)
-		box = style.Render(placeholder)
 	} else {
 		// Wrap textarea output with full-width tinted background.
 		// The textarea's internal styles use Inline(true) which only covers text,
 		// not the full line width. This wrapper ensures consistent background.
-		content := lipgloss.NewStyle().
+		content = lipgloss.NewStyle().
 			Background(innerBG).
 			Foreground(styles.TextPrimary).
 			Width(innerWidth).
 			Render(m.input.View())
-		box = style.Render(content)
 	}
 
-	hint := m.renderBroadcastHint(width-3, innerBG)
+	hint := m.renderBroadcastHint(innerWidth, innerBG)
+	if hint != "" {
+		content = content + "\n" + hint
+	}
+	box := style.Render(content)
 
 	if chips == "" {
-		if hint == "" {
-			return box
-		}
-		return lipgloss.JoinVertical(lipgloss.Left, box, hint)
+		return box
 	}
-	if hint == "" {
-		return lipgloss.JoinVertical(lipgloss.Left, chips, box)
-	}
-	return lipgloss.JoinVertical(lipgloss.Left, chips, box, hint)
+	return lipgloss.JoinVertical(lipgloss.Left, chips, box)
 }

--- a/internal/ui/compose/model.go
+++ b/internal/ui/compose/model.go
@@ -3,6 +3,7 @@ package compose
 
 import (
 	"fmt"
+	"image/color"
 	"sort"
 	"strings"
 
@@ -89,6 +90,14 @@ type Model struct {
 	// chip row to render in muted style and the Update() to refuse
 	// Esc / Backspace-clear.
 	uploading bool
+
+	// broadcast is Slack's "Also send to #channel" toggle for thread
+	// replies: when true, the next send posts the reply to the parent
+	// channel feed as well (reply_broadcast=true). Only meaningful for
+	// the thread compose; the channel compose never exposes the toggle.
+	// Non-sticky: cleared on send / Reset() and when a different thread
+	// opens, so a high-visibility broadcast never silently repeats.
+	broadcast bool
 
 	// version increments on every Update / state mutation. Used by App's
 	// panel-cache layer so the wrapped compose panel only re-renders when
@@ -278,6 +287,29 @@ func (m *Model) SetUploading(on bool) {
 // Uploading reports whether an upload is currently in flight.
 func (m *Model) Uploading() bool { return m.uploading }
 
+// ToggleBroadcast flips the "also send to channel" flag and reports
+// the new value. Bound to ctrl+o while composing a thread reply.
+func (m *Model) ToggleBroadcast() bool {
+	m.broadcast = !m.broadcast
+	m.dirty()
+	return m.broadcast
+}
+
+// SetBroadcast explicitly sets the "also send to channel" flag. The
+// host clears it when a different thread opens so the toggle never
+// silently carries over between threads.
+func (m *Model) SetBroadcast(on bool) {
+	if m.broadcast == on {
+		return
+	}
+	m.broadcast = on
+	m.dirty()
+}
+
+// Broadcast reports whether the next send will also post to the
+// parent channel.
+func (m Model) Broadcast() bool { return m.broadcast }
+
 // CursorAtFirstLine reports whether the textarea cursor is on the
 // first (topmost) line.
 func (m *Model) CursorAtFirstLine() bool {
@@ -320,6 +352,7 @@ func (m *Model) Reset() {
 	m.emojiPicker.Close()
 	m.pending = nil
 	m.uploading = false
+	m.broadcast = false
 	m.dirty()
 }
 
@@ -1251,6 +1284,22 @@ func (m Model) renderChips(width int) string {
 	return lipgloss.NewStyle().MaxWidth(width).Render(row)
 }
 
+// renderBroadcastHint returns the one-line "also send to channel"
+// indicator shown under the input while the broadcast toggle is on,
+// or "" when it is off. innerBG must match the background used by the
+// input box so the hint row reads as part of the compose area.
+func (m Model) renderBroadcastHint(width int, innerBG color.Color) string {
+	if !m.broadcast {
+		return ""
+	}
+	hint := lipgloss.NewStyle().
+		Foreground(styles.Accent).
+		Background(innerBG).
+		Width(width).
+		Render(fmt.Sprintf("↪ also send to #%s  (ctrl+o to cancel)", m.channelName))
+	return lipgloss.NewStyle().MaxWidth(width).Render(hint)
+}
+
 func (m Model) View(width int, focused bool) string {
 	chips := m.renderChips(width)
 
@@ -1295,8 +1344,16 @@ func (m Model) View(width int, focused bool) string {
 		box = style.Render(content)
 	}
 
+	hint := m.renderBroadcastHint(width-3, innerBG)
+
 	if chips == "" {
-		return box
+		if hint == "" {
+			return box
+		}
+		return lipgloss.JoinVertical(lipgloss.Left, box, hint)
 	}
-	return lipgloss.JoinVertical(lipgloss.Left, chips, box)
+	if hint == "" {
+		return lipgloss.JoinVertical(lipgloss.Left, chips, box)
+	}
+	return lipgloss.JoinVertical(lipgloss.Left, chips, box, hint)
 }

--- a/internal/ui/compose/model_test.go
+++ b/internal/ui/compose/model_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	lipgloss "charm.land/lipgloss/v2"
 	"github.com/gammons/slk/internal/config"
 	"github.com/gammons/slk/internal/emoji"
 	"github.com/gammons/slk/internal/ui/mentionpicker"
@@ -1188,5 +1189,40 @@ func TestResetClearsBroadcast(t *testing.T) {
 	m.Reset()
 	if m.Broadcast() {
 		t.Error("Reset() must clear broadcast flag (non-sticky across sends)")
+	}
+}
+
+func TestBroadcastHintWrapping(t *testing.T) {
+	styles.Apply("default", config.Theme{})
+	m := New("newsroom")
+	m.ToggleBroadcast()
+
+	// With width=40, the compose box style has Width(39). The hint
+	// "↪ also send to #newsroom  (ctrl+o to cancel)" is 44 display columns
+	// wide, so it must wrap into 2 lines.
+	view := m.View(40, true)
+	lines := strings.Split(view, "\n")
+	if len(lines) < 4 {
+		t.Fatalf("expected at least 4 lines (top pad, input, wrapped hint lines, bottom pad), got %d:\n%s", len(lines), view)
+	}
+
+	wantWidth := 39 // style.Width(width - 1)
+	for i, l := range lines {
+		w := lipgloss.Width(l)
+		if w != wantWidth {
+			t.Errorf("line %d visual width = %d, want %d (line: %q)", i, w, wantWidth, l)
+		}
+		if !strings.Contains(l, "▌") {
+			t.Errorf("line %d missing left border ▌ (line: %q)", i, l)
+		}
+	}
+
+	// Verify unfocused view also maintains uniform width and border.
+	viewUnfocused := m.View(40, false)
+	for i, l := range strings.Split(viewUnfocused, "\n") {
+		w := lipgloss.Width(l)
+		if w != wantWidth {
+			t.Errorf("unfocused line %d visual width = %d, want %d", i, w, wantWidth)
+		}
 	}
 }

--- a/internal/ui/compose/model_test.go
+++ b/internal/ui/compose/model_test.go
@@ -1120,3 +1120,73 @@ func TestSetChannelMembershipAfterLoadingFlipsInChannel(t *testing.T) {
 		}
 	}
 }
+
+func TestBroadcastToggle(t *testing.T) {
+	m := New("general")
+	if m.Broadcast() {
+		t.Fatal("broadcast should default to off")
+	}
+	if m.ToggleBroadcast() != true || !m.Broadcast() {
+		t.Fatal("ToggleBroadcast should turn the flag on")
+	}
+	if m.ToggleBroadcast() != false || m.Broadcast() {
+		t.Fatal("second ToggleBroadcast should turn the flag off")
+	}
+	m.ToggleBroadcast()
+	m.SetBroadcast(false)
+	if m.Broadcast() {
+		t.Fatal("SetBroadcast(false) should clear the flag")
+	}
+	// Idempotent SetBroadcast must not dirty an already-cleared model.
+	v := m.Version()
+	m.SetBroadcast(false)
+	if m.Version() != v {
+		t.Error("no-op SetBroadcast should not bump Version")
+	}
+}
+
+func TestComposeViewBroadcastHint(t *testing.T) {
+	m := New("general")
+	m.SetValue("draft text")
+
+	off := m.View(40, true)
+	if strings.Contains(off, "also send to") {
+		t.Errorf("hint must be hidden while broadcast is off, got:\n%s", off)
+	}
+
+	m.ToggleBroadcast()
+	on := m.View(40, true)
+	if !strings.Contains(on, "also send to #general") {
+		t.Errorf("hint with channel name missing while broadcast is on, got:\n%s", on)
+	}
+	if !strings.Contains(on, "ctrl+o") {
+		t.Errorf("hint should name the toggle key, got:\n%s", on)
+	}
+	if strings.Contains(on, "draft text") == false {
+		t.Errorf("hint render must not drop compose content, got:\n%s", on)
+	}
+}
+
+func TestComposeViewBroadcastHintUnfocused(t *testing.T) {
+	// The hint must render even when the compose is blurred (e.g. the
+	// user toggled and Esc'd out), otherwise the pending broadcast is
+	// invisible until the next send.
+	m := New("ops")
+	m.ToggleBroadcast()
+	view := m.View(40, false)
+	if !strings.Contains(view, "also send to #ops") {
+		t.Errorf("hint missing in unfocused view, got:\n%s", view)
+	}
+}
+
+func TestResetClearsBroadcast(t *testing.T) {
+	m := New("general")
+	m.ToggleBroadcast()
+	if !m.Broadcast() {
+		t.Fatal("expected broadcast to be on")
+	}
+	m.Reset()
+	if m.Broadcast() {
+		t.Error("Reset() must clear broadcast flag (non-sticky across sends)")
+	}
+}

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -63,6 +63,7 @@ type KeyMap struct {
 	WinCycle            key.Binding
 	WinClose            key.Binding
 	WinOnly             key.Binding
+	ToggleBroadcast     key.Binding
 }
 
 func DefaultKeyMap() KeyMap {
@@ -134,5 +135,9 @@ func DefaultKeyMap() KeyMap {
 		WinCycle:     key.NewBinding(key.WithHelp("ctrl+w w", "cycle windows")),
 		WinClose:     key.NewBinding(key.WithHelp("ctrl+w q / :q", "close window")),
 		WinOnly:      key.NewBinding(key.WithHelp("ctrl+w o / :only", "close other windows")),
+		// Insert mode, thread compose only: toggles Slack's
+		// "Also send to #channel" checkbox for the next reply.
+		// Alt+Enter sends and broadcasts in a single keystroke.
+		ToggleBroadcast: key.NewBinding(key.WithKeys("ctrl+o"), key.WithHelp("ctrl+o / alt+enter", "also send reply to channel")),
 	}
 }

--- a/internal/ui/mode_insert.go
+++ b/internal/ui/mode_insert.go
@@ -17,6 +17,8 @@
 //     file path / verbatim text).
 //   - Ctrl+U                     -> clear compose (text +
 //     attachments + uploading flag).
+//   - Ctrl+O (thread compose)    -> toggle "also send to channel" for
+//     the next thread reply.
 //   - Up / Down on first/last line -> jump to start/end of textarea.
 //   - Plain Enter                -> send (or commit edit, or upload-
 //     then-send if attachments present).
@@ -134,6 +136,14 @@ func handleInsertMode(a *App, msg tea.KeyMsg) tea.Cmd {
 	// shortcuts below swallow the arrow keys before the picker
 	// ever sees them.
 	pickerActive := target.IsEmojiActive() || target.IsMentionActive() || target.IsChannelActive()
+	// Ctrl+O toggles Slack's "Also send to #channel" for the next
+	// thread reply. Thread compose only -- the channel compose has no
+	// broadcast concept. Skipped while a picker is active so picker
+	// navigation keys keep precedence.
+	if target == &a.threadCompose && !pickerActive && code == 'o' && mod == tea.ModCtrl {
+		a.threadCompose.ToggleBroadcast()
+		return nil
+	}
 	if !pickerActive {
 		if code == tea.KeyUp && mod == 0 && target.CursorAtFirstLine() {
 			target.MoveCursorToStart()
@@ -146,7 +156,9 @@ func handleInsertMode(a *App, msg tea.KeyMsg) tea.Cmd {
 	}
 	// Plain Enter sends; Shift+Enter (and Ctrl+J as a fallback
 	// for terminals that don't disambiguate modifiers) inserts a
-	// newline.
+	// newline. Alt+Enter sends with broadcast in thread compose
+	// (one-shot send-with-broadcast without needing the Ctrl+O toggle).
+	isAltEnter := code == tea.KeyEnter && mod.Contains(tea.ModAlt)
 	isSend := code == tea.KeyEnter && !mod.Contains(tea.ModShift)
 	isNewline := (code == tea.KeyEnter && mod.Contains(tea.ModShift)) ||
 		(code == 'j' && mod == tea.ModCtrl)
@@ -181,6 +193,7 @@ func handleInsertMode(a *App, msg tea.KeyMsg) tea.Cmd {
 			text := a.threadCompose.Value()
 			if text != "" {
 				text = a.threadCompose.TranslateMentionsForSend(text)
+				broadcast := a.threadCompose.Broadcast() || isAltEnter
 				a.threadCompose.Reset()
 				threadTS := a.threadPanel.ThreadTS()
 				channelID := a.threadPanel.ChannelID()
@@ -190,6 +203,7 @@ func handleInsertMode(a *App, msg tea.KeyMsg) tea.Cmd {
 						ChannelID: channelID,
 						ThreadTS:  threadTS,
 						Text:      text,
+						Broadcast: broadcast,
 					}
 				}
 			}

--- a/internal/ui/mode_normal.go
+++ b/internal/ui/mode_normal.go
@@ -7,7 +7,7 @@
 //     prompt), Ctrl-Y (theme switcher), ? (help),
 //     S (presence menu), R (reaction picker)
 //   - navigation: j/k (selection), Ctrl-D/U (half-page), C-f/b
-//     (page), G (bottom), Tab/h/l (focus next/prev), Ctrl-o/i
+//     (page), G (bottom), Tab/h/l (focus next/prev), Ctrl-h/k
 //     (nav back/forward through visited channels)
 //   - layout toggles: s (sidebar), t (thread)
 //   - message ops: y (copy message), Y/C (copy permalink), E (edit), D (delete),

--- a/internal/ui/msgs.go
+++ b/internal/ui/msgs.go
@@ -141,12 +141,21 @@ type (
 		ChannelID string
 		ThreadTS  string
 		Text      string
+		// Broadcast is Slack's "Also send to #channel": the reply is
+		// additionally posted to the parent channel feed
+		// (reply_broadcast=true; Slack echoes it with the
+		// thread_broadcast subtype).
+		Broadcast bool
 	}
 	ThreadReplySentMsg struct {
 		ChannelID string
 		ThreadTS  string
 		LocalTS   string // optimistic-placeholder id; see MessageSentMsg.LocalTS
 		Message   messages.MessageItem
+		// Broadcast mirrors SendThreadReplyMsg.Broadcast; when true the
+		// reducer also lands the message in the channel pane as a
+		// thread_broadcast row.
+		Broadcast bool
 	}
 	// ThreadReplySendFailedMsg is returned when chat.postMessage for a
 	// thread reply fails. Mirrors MessageSendFailedMsg.
@@ -155,6 +164,10 @@ type (
 		ThreadTS  string
 		LocalTS   string
 		Reason    string
+		// Broadcast mirrors SendThreadReplyMsg.Broadcast so the failure
+		// handler can also roll back the optimistic thread_broadcast
+		// row in the channel feed.
+		Broadcast bool
 	}
 	// ThreadsViewActivatedMsg is dispatched when the user picks the
 	// synthetic Threads sidebar row. The App switches the message pane to

--- a/internal/ui/reducer_send.go
+++ b/internal/ui/reducer_send.go
@@ -264,15 +264,17 @@ func reduceNewMessage(a *App, m NewMessageMsg) tea.Cmd {
 	// realtime traffic too.
 	for _, mm := range a.modelsForChannel(m.ChannelID) {
 		// Always add to the pane if it's a top-level message (no
-		// ThreadTS or is the parent); update the parent's reply
-		// count when a thread reply arrives. cloneMessageItem: fresh
-		// WS messages carry no reactions today, but a shared
-		// Reactions array across sibling models would corrupt on the
-		// first in-place UpdateReaction — clone is the cheap
-		// insurance.
-		if m.Message.ThreadTS == "" || m.Message.ThreadTS == m.Message.TS {
+		// ThreadTS or is the parent) or a thread_broadcast reply;
+		// update the parent's reply count when a thread reply
+		// arrives. cloneMessageItem: fresh WS messages carry no
+		// reactions today, but a shared Reactions array across
+		// sibling models would corrupt on the first in-place
+		// UpdateReaction — clone is the cheap insurance.
+		isBroadcast := m.Message.Subtype == "thread_broadcast"
+		if m.Message.ThreadTS == "" || m.Message.ThreadTS == m.Message.TS || isBroadcast {
 			mm.AppendMessage(cloneMessageItem(m.Message))
-		} else {
+		}
+		if m.Message.ThreadTS != "" && m.Message.ThreadTS != m.Message.TS {
 			mm.IncrementReplyCount(m.Message.ThreadTS, m.Message.TS)
 		}
 	}

--- a/internal/ui/reducer_threads.go
+++ b/internal/ui/reducer_threads.go
@@ -300,18 +300,39 @@ var reduceThreads reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
 				ThreadTS:  m.ThreadTS,
 			})
 		}
+		// Broadcast ("Also send to #channel"): the reply will also
+		// land in the parent channel feed as a thread_broadcast row.
+		// The self-send dedup (selfSend.RecordSent in
+		// ThreadReplySentMsg) suppresses the WS echo, so the only
+		// way the feed shows the row promptly is this optimistic
+		// add + the swap in ThreadReplySentMsg below.
+		if m.Broadcast {
+			for _, mm := range a.modelsForChannel(m.ChannelID) {
+				mm.AppendMessage(messages.MessageItem{
+					TS:        localTS,
+					UserID:    a.currentUserID,
+					UserName:  a.userNameFor(a.currentUserID),
+					Text:      optimisticText,
+					Timestamp: a.nowFormatted(),
+					ThreadTS:  m.ThreadTS,
+					Subtype:   "thread_broadcast",
+				})
+			}
+		}
 		threads := a.threads
 		chID := ids.ChannelID(m.ChannelID)
 		ts := ids.ThreadTS(m.ThreadTS)
 		text := m.Text
+		broadcast := m.Broadcast
 		return func() tea.Msg {
-			result := threads.SendReply(chID, ts, text)
+			result := threads.SendReply(chID, ts, text, broadcast)
 			switch r := result.(type) {
 			case ThreadReplySentMsg:
 				r.LocalTS = localTS
 				return r
 			case ThreadReplySendFailedMsg:
 				r.LocalTS = localTS
+				r.Broadcast = broadcast
 				return r
 			}
 			return result
@@ -345,6 +366,18 @@ var reduceThreads reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
 				a.threadPanel.UpsertSelfSentReply(m.Message)
 			}
 		}
+		// Broadcast: also land the authoritative message in the
+		// channel feed, swapping the optimistic thread_broadcast
+		// placeholder added in SendThreadReplyMsg. Mirrors
+		// MessageSentMsg's swap-or-upsert contract.
+		if m.Broadcast {
+			for _, mm := range a.modelsForChannel(m.ChannelID) {
+				item := cloneMessageItem(m.Message)
+				if !mm.SwapLocalSent(m.LocalTS, item) {
+					mm.UpsertSelfSent(item)
+				}
+			}
+		}
 		for _, mm := range a.modelsForChannel(m.ChannelID) {
 			mm.IncrementReplyCount(m.ThreadTS, m.Message.TS)
 		}
@@ -356,8 +389,15 @@ var reduceThreads reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
 	case ThreadReplySendFailedMsg:
 		// chat.postMessage for the thread reply failed; roll back
 		// the optimistic placeholder. Mirrors MessageSendFailedMsg.
+		// For broadcasts, also roll back the thread_broadcast row
+		// optimistically added to the channel feed.
 		if a.threadVisible && m.ThreadTS == a.threadPanel.ThreadTS() && m.ChannelID == a.threadPanel.ChannelID() && m.LocalTS != "" {
 			a.threadPanel.RemoveLocalSentReply(m.LocalTS)
+		}
+		if m.Broadcast && m.LocalTS != "" {
+			for _, mm := range a.modelsForChannel(m.ChannelID) {
+				mm.RemoveLocalSent(m.LocalTS)
+			}
 		}
 		reason := m.Reason
 		return func() tea.Msg {

--- a/internal/ui/services.go
+++ b/internal/ui/services.go
@@ -149,9 +149,11 @@ type ThreadService interface {
 	// user has now seen. Returns a tea.Cmd yielding ThreadMarkedLocalMsg.
 	Mark(channelID ids.ChannelID, threadTS ids.ThreadTS, ts ids.MessageTS) tea.Cmd
 
-	// SendReply posts a reply to threadTS in channelID. Returns a
-	// tea.Msg (typically ThreadReplySentMsg or ThreadReplySendFailedMsg).
-	SendReply(channelID ids.ChannelID, threadTS ids.ThreadTS, text string) tea.Msg
+	// SendReply posts a reply to threadTS in channelID. When broadcast
+	// is true the reply is also posted to the parent channel feed
+	// (reply_broadcast=true). Returns a tea.Msg (typically
+	// ThreadReplySentMsg or ThreadReplySendFailedMsg).
+	SendReply(channelID ids.ChannelID, threadTS ids.ThreadTS, text string, broadcast bool) tea.Msg
 
 	// ListFetch loads the involved-threads list for the workspace
 	// (Slack subscriptions.list). Returns a tea.Msg (typically
@@ -229,11 +231,11 @@ func (t threadAdapter) Mark(channelID ids.ChannelID, threadTS ids.ThreadTS, ts i
 	return t.fns.Mark(channelID, threadTS, ts)
 }
 
-func (t threadAdapter) SendReply(channelID ids.ChannelID, threadTS ids.ThreadTS, text string) tea.Msg {
+func (t threadAdapter) SendReply(channelID ids.ChannelID, threadTS ids.ThreadTS, text string, broadcast bool) tea.Msg {
 	if t.fns.SendReply == nil {
 		return nil
 	}
-	return t.fns.SendReply(channelID, threadTS, text)
+	return t.fns.SendReply(channelID, threadTS, text, broadcast)
 }
 
 func (t threadAdapter) ListFetch(teamID ids.TeamID) tea.Msg {

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -44,6 +44,11 @@ See [[Terminal Compatibility|Terminal-Compatibility]] for which protocol your te
 
 - Side panel (35% width), opened with `Enter`, toggled with `Ctrl+]`
 - Live thread reply routing, real-time updates
+- Also send to channel: `Ctrl+O` while composing a thread reply toggles Slack's
+  "Also send to #channel" broadcast (`reply_broadcast=true`), and `Alt+Enter`
+  sends with broadcast in a single keystroke. An accent-colored
+  `↪ also send to #channel` line under the input shows when it's armed; the
+  toggle is non-sticky (cleared after send or when opening another thread).
 - Auto-closes on channel switch or narrow terminals
 - **Threads view** (`⚑ Threads` at top of sidebar): scrollable list of every
   thread you authored, replied to, or were @-mentioned in for the active

--- a/wiki/Keybindings.md
+++ b/wiki/Keybindings.md
@@ -14,6 +14,8 @@
 | `Shift+Enter` | Insert | Newline |
 | `Ctrl+V` | Insert | Smart paste — image / file path / text (use `Ctrl+V`, not the terminal's `Ctrl+Shift+V`) |
 | `Ctrl+U` | Insert | Clear compose (text + pending attachments) |
+| `Ctrl+O` | Insert (thread) | Toggle "also send to channel" for the next thread reply |
+| `Alt+Enter` | Insert (thread) | Send thread reply and broadcast to channel (one-shot) |
 | `Ctrl+U` / `Ctrl+D` | Normal | Half-page up / down |
 | `Up` | Insert | Previous line; on the first line, jump to start of message |
 | `Down` | Insert | Next line; on the last line, jump to end of message |

--- a/wiki/Terminal-Compatibility.md
+++ b/wiki/Terminal-Compatibility.md
@@ -142,6 +142,10 @@ You can override slk's image-protocol pick via the `[appearance] image_protocol`
 config key (`auto` / `kitty` / `sixel` / `halfblock` / `off`). See
 [[Configuration]] for details.
 
+## Keybindings and terminal quirks
+
+- `Ctrl+O` in insert mode is the primary binding to toggle "also send to channel" for thread replies. Some terminals or outer shell configurations intercept `Ctrl+O` (readline's `operate-and-get-next`). In slk's raw terminal mode this is delivered cleanly, but `Alt+Enter` is also available as a one-shot send-with-broadcast without needing the toggle. Note that on macOS, Terminal.app and default iTerm2 profiles do not send Meta for the Option key by default; `Alt+Enter` requires enabling "Use Option as Meta key" (or Esc+) in your terminal preferences.
+
 ## Related
 
 - [[Clipboard and OSC 52|Clipboard-and-OSC-52]] — getting copy/paste to land


### PR DESCRIPTION
## Summary
- Adds Slack's "Also send to #channel" to thread replies: `Ctrl+O` in the thread compose toggles the broadcast flag (`reply_broadcast=true` on the wire via `slack.MsgOptionBroadcast()`), and `Alt+Enter` sends with broadcast in a single keystroke
- Accent-colored `↪ also send to #channel  (ctrl+o to cancel)` hint row renders under the thread input while armed
- Non-sticky: the toggle clears immediately upon send (`Reset()`), on compose clear (`Ctrl+U`), and when opening another thread, preventing accidental repeated broadcasts
- Broadcast replies optimistically land in the channel feed as `thread_broadcast` rows, swap for the authoritative message on success, and roll back on failure — mirroring the existing `SendMessageMsg` placeholder contract
- Inbound WebSocket `thread_broadcast` echoes from other users now append to the parent channel's message feed (previously dropped due to `ThreadTS != ""`) while also incrementing the parent thread reply count
- Drive-by fix: `threadComposeChannelName` resolves the parent channel's real name for the thread compose hint and placeholder instead of the synthetic literal string `"thread"` (with a sane `"channel"` fallback for DM/MPIM)
- Cleaned up stale comment at `mode_normal.go:10` referring to `ctrl+o`/`ctrl+i` for channel nav (actual bindings are `ctrl+h`/`ctrl+k`)
- Documented terminal readline behavior for `Ctrl+O` in `wiki/Terminal-Compatibility.md`

## Test plan
- [x] `go build ./...`, `go vet`, `gofmt -l .` (all clean)
- [x] All 55 packages pass in `go test ./...` (including `cmd/slk`)
- [x] New tests: wire-form `reply_broadcast=true`, compose toggle/hint/reset, `Ctrl+O` dispatch, `Alt+Enter` one-shot dispatch, optimistic/swap/rollback, per-thread reset, and inbound WS `thread_broadcast` echo feed appending
- [x] Manual: toggle on (`Ctrl+O`), send a thread reply, verify it appears in the channel as "↳ replied to a thread" in another client
- [x] Manual: send via `Alt+Enter` and verify one-shot broadcast
- [x] Manual: verify toggle is non-sticky (subsequent reply is plain thread reply)
- [x] Manual: verify toggle resets when opening a different thread