### PR TITLE
chore(ci): fix flaky membership test and enforce gofmt

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,3 +24,12 @@ linters:
         text: "ST1023:" # should omit type from declaration; it will be inferred
       - linters: [staticcheck]
         text: "QF1011:" # could omit type from declaration; it will be inferred
+
+# Formatting is checked in CI, not just linted. Without this, `gofmt`
+# drift accumulates silently: contributors' editors reformat whatever
+# they touch, so unrelated alignment churn lands in feature diffs and
+# review has to separate signal from noise every time. Keeping the tree
+# gofmt-clean makes that churn impossible to introduce.
+formatters:
+  enable:
+    - gofmt

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -108,7 +108,7 @@ type WorkspaceContext struct {
 	// Edge is the edgeapi client for this workspace: the
 	// conditional-revalidation and server-side-search endpoints. Nil
 	// only if construction failed, and every caller nil-checks.
-	Edge       *edge.Client
+	Edge *edge.Client
 	// EdgeHealth records whether edge resolution is working for this
 	// workspace this session. bootstrap marks it degraded on a
 	// wholesale failure; the user resolver reads it to skip batch

--- a/cmd/slk/onboarding.go
+++ b/cmd/slk/onboarding.go
@@ -67,7 +67,7 @@ func addWorkspace() error {
 				Description("All selected by default; space to toggle, enter to confirm.").
 				Options(opts...).
 				Value(&chosen).
-				Height(visibleRows+4),
+				Height(visibleRows + 4),
 		),
 	).WithTheme(huh.ThemeFunc(huh.ThemeDracula))
 	if err := form.Run(); err != nil {

--- a/cmd/slk/onboarding_core_test.go
+++ b/cmd/slk/onboarding_core_test.go
@@ -27,4 +27,3 @@ func TestBuildWorkspaceTokens(t *testing.T) {
 		t.Fatalf("unexpected token fields: %+v", toks[0])
 	}
 }
-

--- a/internal/cache/messages_test.go
+++ b/internal/cache/messages_test.go
@@ -275,7 +275,7 @@ func TestGetThreadReplies(t *testing.T) {
 // TestGetMessages_IncludesThreadParents guards against the regression
 // where thread parents (top-level messages whose thread_ts equals
 // their own ts because they have replies) were excluded from
-// GetMessages by the original `thread_ts = ''` filter. Slack's
+// GetMessages by the original `thread_ts = ”` filter. Slack's
 // conversations.history returns parents with thread_ts == ts, so an
 // active channel quickly accumulates parents that the cache view
 // silently dropped until the next network refresh masked the bug.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,15 +13,15 @@ import (
 )
 
 type Config struct {
-	General       General                      `toml:"general"`
-	Appearance    Appearance                   `toml:"appearance"`
-	Animations    Animations                   `toml:"animations"`
-	Notifications Notifications                `toml:"notifications"`
-	Cache         CacheConfig                  `toml:"cache"`
-	Sidebar       Sidebar                      `toml:"sidebar"`
-	Sections      map[string]SectionDef        `toml:"sections"`
-	Theme         Theme                        `toml:"theme"`
-	Workspaces    map[string]Workspace         `toml:"workspaces"`
+	General       General               `toml:"general"`
+	Appearance    Appearance            `toml:"appearance"`
+	Animations    Animations            `toml:"animations"`
+	Notifications Notifications         `toml:"notifications"`
+	Cache         CacheConfig           `toml:"cache"`
+	Sidebar       Sidebar               `toml:"sidebar"`
+	Sections      map[string]SectionDef `toml:"sections"`
+	Theme         Theme                 `toml:"theme"`
+	Workspaces    map[string]Workspace  `toml:"workspaces"`
 }
 
 // SectionDef defines a sidebar section with channel name patterns.

--- a/internal/emoji/fuse_test.go
+++ b/internal/emoji/fuse_test.go
@@ -26,8 +26,8 @@ func TestStripSkinTone(t *testing.T) {
 		{"empty", "", ""},
 
 		// Custom emoji names that happen to look similar — must not strip.
-		{"custom_emoji_named_tone6", "anything_tone6", "anything_tone6"},   // tone6 doesn't match 1-5
-		{"custom my_tonemate", "my_tonemate", "my_tonemate"},                // doesn't match _toneN pattern exactly
+		{"custom_emoji_named_tone6", "anything_tone6", "anything_tone6"},        // tone6 doesn't match 1-5
+		{"custom my_tonemate", "my_tonemate", "my_tonemate"},                    // doesn't match _toneN pattern exactly
 		{"name with skin-tone in middle", "skin-tone-thing", "skin-tone-thing"}, // no "::" prefix
 
 		// Edge: very short names.

--- a/internal/emoji/tokens_test.go
+++ b/internal/emoji/tokens_test.go
@@ -38,7 +38,7 @@ func TestResolveEmojiToTokens_Shortcodes(t *testing.T) {
 	rocketURL := CDNBaseURL + "1f680.png"    // :rocket:
 	customParrot := "https://emoji.slack-edge.com/T01/party_parrot/abc.gif"
 	customs := map[string]string{
-		"party_parrot": customParrot,
+		"party_parrot":     customParrot,
 		"alias_for_rocket": "alias:rocket",
 	}
 
@@ -104,10 +104,10 @@ func TestResolveEmojiToTokens_Shortcodes(t *testing.T) {
 }
 
 func TestResolveEmojiToTokens_UnicodeClusters(t *testing.T) {
-	thumbURL := CDNBaseURL + "1f44d.png"                  // 👍
-	astronautURL := CDNBaseURL + "1f468-200d-1f680.png"   // 👨‍🚀 (ZWJ kept)
-	heartURL := CDNBaseURL + "2764-fe0f.png"              // ❤️ (VS16 preserved)
-	flagUSURL := CDNBaseURL + "1f1fa-1f1f8.png"           // 🇺🇸 (regional indicators)
+	thumbURL := CDNBaseURL + "1f44d.png"                   // 👍
+	astronautURL := CDNBaseURL + "1f468-200d-1f680.png"    // 👨‍🚀 (ZWJ kept)
+	heartURL := CDNBaseURL + "2764-fe0f.png"               // ❤️ (VS16 preserved)
+	flagUSURL := CDNBaseURL + "1f1fa-1f1f8.png"            // 🇺🇸 (regional indicators)
 	rainbowURL := CDNBaseURL + "1f3f3-fe0f-200d-1f308.png" // 🏳️‍🌈 (VS16 preserved mid-sequence)
 
 	cases := []struct {

--- a/internal/notify/status_test.go
+++ b/internal/notify/status_test.go
@@ -38,7 +38,7 @@ func TestStatusReporter_NilReportIsNoop(t *testing.T) {
 }
 
 func TestStatusReporter_NilEnqueueIsNoop(t *testing.T) {
-	var sr *StatusReporter // nil
+	var sr *StatusReporter          // nil
 	sr.Enqueue(1, 0, "ws", "title") // must not panic or block
 }
 

--- a/internal/slack/connection_test.go
+++ b/internal/slack/connection_test.go
@@ -26,4 +26,3 @@ func TestBackoffSequence(t *testing.T) {
 		backoff = nextBackoff(backoff, maxBackoff)
 	}
 }
-

--- a/internal/slack/membership/manager_test.go
+++ b/internal/slack/membership/manager_test.go
@@ -11,18 +11,30 @@ import (
 )
 
 // fakeMemberAPI implements ConversationMemberAPI for tests.
+//
+// delay is slept *after* the call is recorded and the lock released, so
+// a test can hold the Manager's post-call bookkeeping (lastFailed /
+// lastFetched, which backgroundFetch writes only once the API returns)
+// open for a deterministic window. Tests that assert on that
+// bookkeeping must therefore never treat callCount as a barrier for it
+// — see waitUntil.
 type fakeMemberAPI struct {
 	mu     sync.Mutex
 	calls  int
 	result []string
 	err    error
+	delay  time.Duration
 }
 
 func (f *fakeMemberAPI) GetUsersInConversation(ctx context.Context, channelID string) ([]string, error) {
 	f.mu.Lock()
-	defer f.mu.Unlock()
 	f.calls++
-	return f.result, f.err
+	result, err, delay := f.result, f.err, f.delay
+	f.mu.Unlock()
+	if delay > 0 {
+		time.Sleep(delay)
+	}
+	return result, err
 }
 
 func (f *fakeMemberAPI) callCount() int {
@@ -157,6 +169,36 @@ func waitForCallCount(t *testing.T, api *fakeMemberAPI, n int) {
 		time.Sleep(5 * time.Millisecond)
 	}
 	t.Fatalf("timed out waiting for %d API calls", n)
+}
+
+// waitUntil polls cond until it holds or the deadline passes.
+//
+// Prefer this over waitForCallCount/waitForPush when asserting on
+// Manager bookkeeping. Neither of those is a barrier for it:
+// fakeMemberAPI records a call on *entry* while backgroundFetch writes
+// lastFailed/lastFetched only after the call returns (manager.go), and
+// EnsureFresh pushes synchronously on the caller's goroutine
+// (manager.go, pushSnapshot) so a push can be the caller's own rather
+// than the background fetch's.
+func waitUntil(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+// failureRecordedAt reports the manager's lastFailed entry for a
+// channel under the manager's own lock.
+func failureRecordedAt(mgr *Manager, channelID string) (time.Time, bool) {
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+	ts, ok := mgr.lastFailed[channelID]
+	return ts, ok
 }
 
 func TestApplyJoinPersistsAndPushes(t *testing.T) {
@@ -373,10 +415,19 @@ func TestBackgroundFetchRetriesAfterBackoffExpiry(t *testing.T) {
 	mgr, api, sink, db := newManagerForTest(t)
 	defer db.Close()
 	api.err = fmt.Errorf("channel_not_found")
+	api.delay = 50 * time.Millisecond
 
 	mgr.EnsureFresh(context.Background(), "C1")
-	waitForPush(t, sink, 1)
-	waitForCallCount(t, api, 1)
+
+	// Wait for the failure to be *recorded*, not merely for the API to
+	// be entered. backgroundFetch writes lastFailed after the call
+	// returns, so backdating it below on a callCount barrier alone
+	// races the write and gets clobbered — leaving the backoff live and
+	// suppressing the retry this test exists to prove.
+	waitUntil(t, "the failed fetch to be recorded", func() bool {
+		_, ok := failureRecordedAt(mgr, "C1")
+		return ok
+	})
 
 	// Simulate a failure far enough in the past that the backoff has
 	// expired, then recover.
@@ -388,16 +439,27 @@ func TestBackgroundFetchRetriesAfterBackoffExpiry(t *testing.T) {
 
 	mgr.EnsureFresh(context.Background(), "C1")
 	waitForCallCount(t, api, 2)
-	waitForPush(t, sink, 2)
 
 	// A successful fetch clears the failure record, so the next
 	// EnsureFresh is governed by the normal TTL, not the backoff.
-	mgr.mu.Lock()
-	_, stillMarked := mgr.lastFailed["C1"]
-	mgr.mu.Unlock()
-	if stillMarked {
-		t.Error("lastFailed not cleared by a successful fetch; a recovered channel would stay throttled")
-	}
+	//
+	// Poll rather than assert once: EnsureFresh above pushed
+	// synchronously, so waiting on a push count would return before the
+	// background fetch had cleared anything.
+	waitUntil(t, "lastFailed to be cleared by the successful fetch", func() bool {
+		_, stillMarked := failureRecordedAt(mgr, "C1")
+		return !stillMarked
+	})
+
+	// And the recovered members actually landed.
+	waitUntil(t, "the recovered member set to be pushed", func() bool {
+		for _, p := range sink.snapshot() {
+			if p.channelID == "C1" && len(p.memberIDs) == 1 && p.memberIDs[0] == "U1" {
+				return true
+			}
+		}
+		return false
+	})
 }
 
 func TestEnsureFreshConcurrentDoesNotDuplicate(t *testing.T) {

--- a/internal/slackdesktop/decrypt_test.go
+++ b/internal/slackdesktop/decrypt_test.go
@@ -6,8 +6,8 @@ import (
 	"crypto/cipher"
 	"testing"
 
-	"golang.org/x/crypto/pbkdf2"
 	"crypto/sha1"
+	"golang.org/x/crypto/pbkdf2"
 )
 
 func cbcEncrypt(t *testing.T, plaintext, password []byte, rounds int) []byte {

--- a/internal/slackfmt/mpdm_test.go
+++ b/internal/slackfmt/mpdm_test.go
@@ -6,11 +6,11 @@ func TestFormatMPDMName(t *testing.T) {
 	// Lookup table mapping handles to display names. Anything missing
 	// returns "" so the formatter falls back to the handle itself.
 	display := map[string]string{
-		"grant":  "Grant Ammons",
-		"myles":  "Myles Williamson",
-		"ray":    "Ray Bradbury",
-		"alice":  "Alice A.",
-		"bob.r":  "Bob R.",
+		"grant": "Grant Ammons",
+		"myles": "Myles Williamson",
+		"ray":   "Ray Bradbury",
+		"alice": "Alice A.",
+		"bob.r": "Bob R.",
 	}
 	lookup := func(handle string) string { return display[handle] }
 
@@ -65,10 +65,10 @@ func TestFormatMPDMName(t *testing.T) {
 func TestFormatMPDMName_FallsBackOnUnparseable(t *testing.T) {
 	lookup := func(string) string { return "" }
 	cases := []string{
-		"general",         // not an mpdm name
-		"mpdm-",           // empty body
-		"mpdm",            // missing prefix dash
-		"",                // empty
+		"general",             // not an mpdm name
+		"mpdm-",               // empty body
+		"mpdm",                // missing prefix dash
+		"",                    // empty
 		"mpim-grant--myles-1", // wrong prefix
 	}
 	for _, in := range cases {

--- a/internal/ui/app_panelat_test.go
+++ b/internal/ui/app_panelat_test.go
@@ -9,15 +9,15 @@
 // rail | sidebar | messages | thread, with the 1-row status bar at
 // y == height-1.
 //
-//   x < layout.railWidth                                   → PanelWorkspace, ok=false
-//   sidebarVisible && x < layout.sidebarEnd                → PanelSidebar, ok=false
-//   x < layout.msgEnd                                      → PanelMessages
-//                                                            paneX = x - layout.sidebarEnd - 1
-//                                                            paneY = y - 1, ok=true
-//   threadVisible && x < layout.threadEnd                  → PanelThread
-//                                                            paneX = x - layout.msgEnd - 1
-//                                                            paneY = y - 1, ok=true
-//   y >= height-1                                          → PanelWorkspace, ok=false
+//	x < layout.railWidth                                   → PanelWorkspace, ok=false
+//	sidebarVisible && x < layout.sidebarEnd                → PanelSidebar, ok=false
+//	x < layout.msgEnd                                      → PanelMessages
+//	                                                         paneX = x - layout.sidebarEnd - 1
+//	                                                         paneY = y - 1, ok=true
+//	threadVisible && x < layout.threadEnd                  → PanelThread
+//	                                                         paneX = x - layout.msgEnd - 1
+//	                                                         paneY = y - 1, ok=true
+//	y >= height-1                                          → PanelWorkspace, ok=false
 package ui
 
 import "testing"

--- a/internal/ui/app_panelcache_test.go
+++ b/internal/ui/app_panelcache_test.go
@@ -30,9 +30,9 @@ func TestPanelCacheHitAfterStore(t *testing.T) {
 
 func TestPanelCacheMissOnAnyKeyChange(t *testing.T) {
 	cases := []struct {
-		name                            string
+		name                           string
 		version, width, height, layout int64
-		w, h                            int
+		w, h                           int
 	}{
 		{"different version", 9, 80, 24, 42, 80, 24},
 		{"different width", 7, 81, 24, 42, 81, 24},

--- a/internal/ui/messages/render_test.go
+++ b/internal/ui/messages/render_test.go
@@ -783,12 +783,13 @@ func TestBgFgANSIForBasicColorOutOfRange(t *testing.T) {
 
 // TestSubstituteBgSGR exercises the grammar-aware bg-parameter
 // substitution. The helper must:
-//   (1) substitute the param when it stands alone (\x1b[40m)
-//   (2) substitute the param within a bundled SGR (\x1b[1;31;40m)
-//   (3) NOT corrupt literal digits in non-SGR content
-//   (4) NOT match the param value inside a 256-color sub-argument
-//       (\x1b[38;5;40m is an FG index 40, not a bg basic 40)
-//   (5) leave the string unchanged when from == to
+//
+//	(1) substitute the param when it stands alone (\x1b[40m)
+//	(2) substitute the param within a bundled SGR (\x1b[1;31;40m)
+//	(3) NOT corrupt literal digits in non-SGR content
+//	(4) NOT match the param value inside a 256-color sub-argument
+//	    (\x1b[38;5;40m is an FG index 40, not a bg basic 40)
+//	(5) leave the string unchanged when from == to
 func TestSubstituteBgSGR(t *testing.T) {
 	const to = "48;2;100;100;200"
 

--- a/internal/ui/mode_insert.go
+++ b/internal/ui/mode_insert.go
@@ -7,23 +7,23 @@
 // visibility). It also owns:
 //
 //   - Esc with active upload     -> "Upload in progress" toast (Esc
-//                                   doesn't cancel an in-flight
-//                                   upload).
+//     doesn't cancel an in-flight
+//     upload).
 //   - Esc with active edit       -> close any open compose picker
-//                                   first, else cancel the edit.
+//     first, else cancel the edit.
 //   - Esc otherwise              -> close any open compose picker
-//                                   first, else exit insert mode.
+//     first, else exit insert mode.
 //   - Ctrl+V                     -> smartPaste (clipboard image /
-//                                   file path / verbatim text).
+//     file path / verbatim text).
 //   - Ctrl+U                     -> clear compose (text +
-//                                   attachments + uploading flag).
+//     attachments + uploading flag).
 //   - Up / Down on first/last line -> jump to start/end of textarea.
 //   - Plain Enter                -> send (or commit edit, or upload-
-//                                   then-send if attachments present).
+//     then-send if attachments present).
 //   - Shift+Enter / Ctrl+J       -> insert literal newline.
 //   - Other keys                 -> forward to compose; throttled
-//                                   typing-indicator emit on every
-//                                   text keystroke.
+//     typing-indicator emit on every
+//     text keystroke.
 //
 // Compose-overlay pickers (emoji / @mention / #channel) get
 // priority on Up/Down/Enter: when a picker is active, those keys

--- a/internal/ui/newmessagepicker/model_test.go
+++ b/internal/ui/newmessagepicker/model_test.go
@@ -134,7 +134,7 @@ func TestFilter_PrefixBeatsSubstring(t *testing.T) {
 
 func TestFilter_SubstringBeatsSubsequence(t *testing.T) {
 	users := []User{
-		{ID: "U1", DisplayName: "Stephanie", Username: "steph", Recency: 100},   // contains "eph"
+		{ID: "U1", DisplayName: "Stephanie", Username: "steph", Recency: 100},    // contains "eph"
 		{ID: "U2", DisplayName: "Edward Phillips", Username: "ep", Recency: 999}, // subseq e-p-h
 	}
 	m := New()
@@ -437,7 +437,7 @@ func TestHandleKey_EnterWithEmptyFilteredButPillsStillSubmits(t *testing.T) {
 	m := New()
 	m.SetUsers(testUsers())
 	m.Open()
-	m.HandleKey(" ")     // select Alice
+	m.HandleKey(" ")    // select Alice
 	m.setQuery("xyzqq") // filter to nothing
 	res := m.HandleKey("enter")
 	if res == nil || len(res.UserIDs) != 1 || res.UserIDs[0] != "U1" {

--- a/internal/ui/panellayout.go
+++ b/internal/ui/panellayout.go
@@ -9,15 +9,15 @@
 //
 // Layout is a two-step dance with View():
 //
-//	1. View calls Compute(...) at frame start. Compute resolves the
-//	   per-pane widths/borders for the current terminal size and
-//	   visibility flags, stores the resulting horizontal bands for
-//	   subsequent PanelAt calls, and returns a panelLayoutFrame the
-//	   caller uses to drive rendering.
+//  1. View calls Compute(...) at frame start. Compute resolves the
+//     per-pane widths/borders for the current terminal size and
+//     visibility flags, stores the resulting horizontal bands for
+//     subsequent PanelAt calls, and returns a panelLayoutFrame the
+//     caller uses to drive rendering.
 //
-//	2. As each pane renders, it calls SetSidebarHeight / SetMsgHeight /
-//	   SetThreadHeight with the chrome-stripped content height. These
-//	   feed PageHeight() which pageSize / halfPageSize consult.
+//  2. As each pane renders, it calls SetSidebarHeight / SetMsgHeight /
+//     SetThreadHeight with the chrome-stripped content height. These
+//     feed PageHeight() which pageSize / halfPageSize consult.
 //
 // Auto-hide: if there isn't room for both the messages pane (≥40 cols)
 // AND the thread pane (≥30 cols), Compute returns ThreadAutoHidden=true.

--- a/internal/ui/reducer_channels.go
+++ b/internal/ui/reducer_channels.go
@@ -5,35 +5,35 @@
 // Owns the nine Update arms that drive the channel-selection
 // lifecycle and channel-list mutations:
 //
-//   ChannelSelectedMsg            - user picked a channel: reset
-//                                   view state, mark visit,
-//                                   dispatch by cache freshness
-//                                   tier (fresh / verify-in-bg /
-//                                   spinner).
-//   MessagesLoadedMsg             - initial messages fetch landed:
-//                                   replace pane contents (nil =
-//                                   network failure, keep cache).
-//   OlderMessagesLoadedMsg        - history backfill landed:
-//                                   prepend (anchor-validated: dropped
-//                                   if the buffer was replaced
-//                                   mid-flight).
-//   ChannelMarkedRemoteMsg        - WS echo of a remote mark:
-//                                   apply locally.
-//   ChannelMarkedReadMsg          - optimistic mark-read echo:
-//                                   refresh sidebar read state.
-//   ChannelMembershipMsg          - membership fetch landed:
-//                                   push to the cache used by
-//                                   mention picker / DM resolution.
-//   ChannelJoinedMsg              - finder-driven join succeeded:
-//                                   add to sidebar + open it.
-//   ChannelJoinFailedMsg          - finder-driven join failed:
-//                                   log warning (toast TBD).
-//   channelSearchDebounceMsg      - finder typing paused: issue one
-//                                   channels/search for the query
-//                                   the user stopped on.
-//   RemoteChannelsFoundMsg        - that search answered: merge the
-//                                   non-joined matches into the
-//                                   finder, unless superseded.
+//	ChannelSelectedMsg            - user picked a channel: reset
+//	                                view state, mark visit,
+//	                                dispatch by cache freshness
+//	                                tier (fresh / verify-in-bg /
+//	                                spinner).
+//	MessagesLoadedMsg             - initial messages fetch landed:
+//	                                replace pane contents (nil =
+//	                                network failure, keep cache).
+//	OlderMessagesLoadedMsg        - history backfill landed:
+//	                                prepend (anchor-validated: dropped
+//	                                if the buffer was replaced
+//	                                mid-flight).
+//	ChannelMarkedRemoteMsg        - WS echo of a remote mark:
+//	                                apply locally.
+//	ChannelMarkedReadMsg          - optimistic mark-read echo:
+//	                                refresh sidebar read state.
+//	ChannelMembershipMsg          - membership fetch landed:
+//	                                push to the cache used by
+//	                                mention picker / DM resolution.
+//	ChannelJoinedMsg              - finder-driven join succeeded:
+//	                                add to sidebar + open it.
+//	ChannelJoinFailedMsg          - finder-driven join failed:
+//	                                log warning (toast TBD).
+//	channelSearchDebounceMsg      - finder typing paused: issue one
+//	                                channels/search for the query
+//	                                the user stopped on.
+//	RemoteChannelsFoundMsg        - that search answered: merge the
+//	                                non-joined matches into the
+//	                                finder, unless superseded.
 //
 // Free reducer (not controller-absorbed): these arms cooperate on
 // the sidebar, messagepane, statusbar, channelFinder, navHistory,

--- a/internal/ui/reducer_modal_click.go
+++ b/internal/ui/reducer_modal_click.go
@@ -7,15 +7,15 @@
 // than the main-tab panels behind it:
 //
 //   - Click OUTSIDE the box        -> dismiss the modal (synthesised Esc,
-//                                     reusing each mode handler's esc path:
-//                                     close + restore mode + any cleanup).
+//     reusing each mode handler's esc path:
+//     close + restore mode + any cleanup).
 //   - Click ON a list row          -> move the modal's selection there and
-//                                     synthesise the modal's activation key
-//                                     (Enter to choose, Space to toggle for
-//                                     the multi-select new-message picker;
-//                                     help has no activation).
+//     synthesise the modal's activation key
+//     (Enter to choose, Space to toggle for
+//     the multi-select new-message picker;
+//     help has no activation).
 //   - Click INSIDE but not a row   -> consumed, no-op (never leaks to the
-//                                     main tab).
+//     main tab).
 //
 // Geometry comes from each modal's BoxSize, mirroring the centering done
 // by overlay.DimmedOverlay so the hit-test lines up with what was drawn.

--- a/internal/ui/reducer_mouse.go
+++ b/internal/ui/reducer_mouse.go
@@ -5,18 +5,18 @@
 // Owns the two remaining mouse Update arms that act as multi-panel
 // routers:
 //
-//   tea.MouseWheelMsg  - viewport scroll for the panel under the
-//                        cursor (sidebar, messages pane / threads
-//                        view, thread panel). Decoupled from j/k
-//                        selection. Triggers maybeFetchOlderHistory
-//                        on the messages pane when the viewport
-//                        hits the top.
-//   tea.MouseClickMsg  - panel-router: workspace rail (switch
-//                        workspace), sidebar (channel select /
-//                        threads view), messages pane (threads
-//                        click / reaction hit-test / image hit-test
-//                        / drag begin), thread panel (reaction
-//                        hit-test / drag begin).
+//	tea.MouseWheelMsg  - viewport scroll for the panel under the
+//	                     cursor (sidebar, messages pane / threads
+//	                     view, thread panel). Decoupled from j/k
+//	                     selection. Triggers maybeFetchOlderHistory
+//	                     on the messages pane when the viewport
+//	                     hits the top.
+//	tea.MouseClickMsg  - panel-router: workspace rail (switch
+//	                     workspace), sidebar (channel select /
+//	                     threads view), messages pane (threads
+//	                     click / reaction hit-test / image hit-test
+//	                     / drag begin), thread panel (reaction
+//	                     hit-test / drag begin).
 //
 // Free reducer (not controller-absorbed) because both arms route
 // across multiple sub-models: the sidebar, messagepane, threadPanel,

--- a/internal/ui/reducer_new_message.go
+++ b/internal/ui/reducer_new_message.go
@@ -2,18 +2,18 @@
 //
 // Reducer for the new-message picker lifecycle:
 //
-//   EnterNewMessageMsg     - user pressed Ctrl+N: seed the picker
-//                            with current workspace users, open it,
-//                            enter ModeNewMessage.
-//   NewMessageOpenedMsg    - conversations.open succeeded: validate
-//                            RequestID against the in-flight counter
-//                            and the cancelled flag, then close the
-//                            modal, switch to the opened channel,
-//                            and enter ModeInsert (so the cursor
-//                            lands in compose ready to type).
-//   NewMessageFailedMsg    - conversations.open failed: log and
-//                            keep the modal open so the user can
-//                            retry or cancel.
+//	EnterNewMessageMsg     - user pressed Ctrl+N: seed the picker
+//	                         with current workspace users, open it,
+//	                         enter ModeNewMessage.
+//	NewMessageOpenedMsg    - conversations.open succeeded: validate
+//	                         RequestID against the in-flight counter
+//	                         and the cancelled flag, then close the
+//	                         modal, switch to the opened channel,
+//	                         and enter ModeInsert (so the cursor
+//	                         lands in compose ready to type).
+//	NewMessageFailedMsg    - conversations.open failed: log and
+//	                         keep the modal open so the user can
+//	                         retry or cancel.
 //
 // Cache hydration for AlreadyOpen=false is implemented in Task 12;
 // this task emits ChannelSelectedMsg directly without inserting a

--- a/internal/ui/reducer_send.go
+++ b/internal/ui/reducer_send.go
@@ -6,34 +6,34 @@
 // message lifecycle for channel messages (thread-reply lifecycle
 // lives in reducer_threads.go):
 //
-//   NewMessageMsg            - inbound WS event for any channel:
-//                              edit-echo update, self-send dedup
-//                              (recorded + early-arrival in-flight
-//                              guards), append-to-pane or
-//                              mark-channel-unread, and threads-list
-//                              dirty-bump for replies.
-//   SendMessageMsg           - user send: optimistic placeholder +
-//                              chat.postMessage call.
-//   MessageSentMsg           - send landed: swap placeholder for
-//                              authoritative message.
-//   MessageSendFailedMsg     - send failed: roll back placeholder
-//                              + fire SendFailed toast.
-//   EditMessageMsg           - user edit: chat.update call.
-//   MessageEditedMsg         - edit result: leave edit mode + on
-//                              failure fire EditFailed toast.
-//   DeleteMessageMsg         - user delete: chat.delete call.
-//   MessageDeletedMsg        - delete result: on failure fire
-//                              DeleteFailed toast.
-//   MarkUnreadMsg            - user mark-unread: subscriptions
-//                              mark call.
-//   MessageMarkedUnreadMsg   - mark-unread result: apply local
-//                              read-state mark + fire success or
-//                              failure toast.
-//   WSMessageDeletedMsg      - inbound WS delete echo: remove from
-//                              both panes, cancel any in-flight
-//                              edit of this message, close the
-//                              thread panel if the deleted message
-//                              is the open thread's parent.
+//	NewMessageMsg            - inbound WS event for any channel:
+//	                           edit-echo update, self-send dedup
+//	                           (recorded + early-arrival in-flight
+//	                           guards), append-to-pane or
+//	                           mark-channel-unread, and threads-list
+//	                           dirty-bump for replies.
+//	SendMessageMsg           - user send: optimistic placeholder +
+//	                           chat.postMessage call.
+//	MessageSentMsg           - send landed: swap placeholder for
+//	                           authoritative message.
+//	MessageSendFailedMsg     - send failed: roll back placeholder
+//	                           + fire SendFailed toast.
+//	EditMessageMsg           - user edit: chat.update call.
+//	MessageEditedMsg         - edit result: leave edit mode + on
+//	                           failure fire EditFailed toast.
+//	DeleteMessageMsg         - user delete: chat.delete call.
+//	MessageDeletedMsg        - delete result: on failure fire
+//	                           DeleteFailed toast.
+//	MarkUnreadMsg            - user mark-unread: subscriptions
+//	                           mark call.
+//	MessageMarkedUnreadMsg   - mark-unread result: apply local
+//	                           read-state mark + fire success or
+//	                           failure toast.
+//	WSMessageDeletedMsg      - inbound WS delete echo: remove from
+//	                           both panes, cancel any in-flight
+//	                           edit of this message, close the
+//	                           thread panel if the deleted message
+//	                           is the open thread's parent.
 //
 // Free reducer (not controller-absorbed): these arms cooperate on
 // the messagepane, threadPanel, selfSend, editController, sidebar

--- a/internal/ui/reducer_threads.go
+++ b/internal/ui/reducer_threads.go
@@ -5,29 +5,29 @@
 // Owns the nine Update arms that drive the thread panel, the
 // threads-list view, and the thread-reply send path:
 //
-//   ThreadMarkedRemoteMsg       - apply a remote subscriptions.thread.mark
-//                                 echo to the local read state.
-//   threadFetchDebounceMsg      - debounced j/k stop: fire the actual
-//                                 thread fetch (drops stale generations
-//                                 and post-navigation ticks).
-//   ThreadRepliesLoadedMsg      - replies fetch returned: refresh the
-//                                 panel, mark the thread as read, and
-//                                 refresh the sidebar badge.
-//   ThreadsViewActivatedMsg     - user opened the threads-list view:
-//                                 switch view + focus, kick a list
-//                                 fetch, open the highlighted thread.
-//   ThreadsListLoadedMsg        - threads-list fetch returned: push
-//                                 summaries + refresh badge, re-open
-//                                 the highlighted thread if visible.
-//   ThreadsListDirtyMsg         - a debounced "list might be stale"
-//                                 trigger: kick a refresh fetch.
-//   SendThreadReplyMsg          - user sent a reply: optimistic
-//                                 placeholder + chat.postMessage call.
-//   ThreadReplySentMsg          - reply landed: swap placeholder for
-//                                 authoritative message, bump parent
-//                                 reply count, mark threads list dirty.
-//   ThreadReplySendFailedMsg    - reply failed: roll back the
-//                                 placeholder + fire SendFailed toast.
+//	ThreadMarkedRemoteMsg       - apply a remote subscriptions.thread.mark
+//	                              echo to the local read state.
+//	threadFetchDebounceMsg      - debounced j/k stop: fire the actual
+//	                              thread fetch (drops stale generations
+//	                              and post-navigation ticks).
+//	ThreadRepliesLoadedMsg      - replies fetch returned: refresh the
+//	                              panel, mark the thread as read, and
+//	                              refresh the sidebar badge.
+//	ThreadsViewActivatedMsg     - user opened the threads-list view:
+//	                              switch view + focus, kick a list
+//	                              fetch, open the highlighted thread.
+//	ThreadsListLoadedMsg        - threads-list fetch returned: push
+//	                              summaries + refresh badge, re-open
+//	                              the highlighted thread if visible.
+//	ThreadsListDirtyMsg         - a debounced "list might be stale"
+//	                              trigger: kick a refresh fetch.
+//	SendThreadReplyMsg          - user sent a reply: optimistic
+//	                              placeholder + chat.postMessage call.
+//	ThreadReplySentMsg          - reply landed: swap placeholder for
+//	                              authoritative message, bump parent
+//	                              reply count, mark threads list dirty.
+//	ThreadReplySendFailedMsg    - reply failed: roll back the
+//	                              placeholder + fire SendFailed toast.
 //
 // Free reducer (not controller-absorbed): these arms cooperate on
 // the thread panel, the threads-list view, the sidebar's threads

--- a/internal/ui/selfsend.go
+++ b/internal/ui/selfsend.go
@@ -11,16 +11,16 @@
 //
 // Two dedup windows cooperate:
 //
-//   1. InFlight(channelID) — channel-level, time-based: covers the
-//      gap between SendMessageMsg dispatch (we call MarkInFlight) and
-//      the matching chat.postMessage HTTP response landing. Drops
-//      self-user WS echoes that arrive before we know the
-//      authoritative TS.
+//  1. InFlight(channelID) — channel-level, time-based: covers the
+//     gap between SendMessageMsg dispatch (we call MarkInFlight) and
+//     the matching chat.postMessage HTTP response landing. Drops
+//     self-user WS echoes that arrive before we know the
+//     authoritative TS.
 //
-//   2. IsSelfSent(ts) — TS-level, exact match: applies after we know
-//      the authoritative TS (RecordSent has been called from
-//      MessageSentMsg / ThreadReplySentMsg). Drops any late WS echo
-//      that carries that TS.
+//  2. IsSelfSent(ts) — TS-level, exact match: applies after we know
+//     the authoritative TS (RecordSent has been called from
+//     MessageSentMsg / ThreadReplySentMsg). Drops any late WS echo
+//     that carries that TS.
 //
 // NextLocalTS mints unique "local:<counter>" placeholder IDs for the
 // optimistic rows added at send time, before chat.postMessage returns.

--- a/internal/ui/services_helpers_test.go
+++ b/internal/ui/services_helpers_test.go
@@ -99,5 +99,3 @@ func (a *App) setChannelMembershipFetcherForTest(fn func(channelID ids.ChannelID
 	fns.MembershipFetch = fn
 	a.SetChannelService(NewChannelService(fns))
 }
-
-

--- a/internal/ui/sidebar/model_test.go
+++ b/internal/ui/sidebar/model_test.go
@@ -660,8 +660,8 @@ func TestCollapseByID_IndependentFromConfigMode(t *testing.T) {
 	}
 	m := New(items)
 	m.SetSectionsProvider(p)
-	m.ToggleCollapse("A")        // collapse via ID
-	m.SetSectionsProvider(nil)   // back to config mode
+	m.ToggleCollapse("A")      // collapse via ID
+	m.SetSectionsProvider(nil) // back to config mode
 	// Now "A" is just a string in config mode; whether it's collapsed
 	// depends on the name-keyed `collapsed` map (which is the default
 	// state set in New). The ID-mode collapse must NOT bleed into

--- a/internal/ui/typing.go
+++ b/internal/ui/typing.go
@@ -14,14 +14,14 @@
 //
 // Two cohesive types live here:
 //
-//   typingTracker      Inbound state: per-channel "who is typing now"
-//                      map, the global enabled flag, and the ticker-
-//                      alive bookkeeping (one tea.Tick chain at a time
-//                      regardless of how many UserTypingMsg's arrive).
+//	typingTracker      Inbound state: per-channel "who is typing now"
+//	                   map, the global enabled flag, and the ticker-
+//	                   alive bookkeeping (one tea.Tick chain at a time
+//	                   regardless of how many UserTypingMsg's arrive).
 //
-//   typingBroadcaster  Outbound throttle: holds the TypingSendFunc and
-//                      the wall clock of the last self-emit. Refuses
-//                      to send more than once per 3 seconds.
+//	typingBroadcaster  Outbound throttle: holds the TypingSendFunc and
+//	                   the wall clock of the last self-emit. Refuses
+//	                   to send more than once per 3 seconds.
 //
 // The broadcaster holds a *typingTracker reference so it can consult
 // the shared Enabled() flag without forcing the App to re-check it at

--- a/internal/ui/view_messages.go
+++ b/internal/ui/view_messages.go
@@ -6,19 +6,19 @@
 // sidebar, MESSAGES, thread). It has two top-level branches
 // depending on a.view:
 //
-//   ViewThreads  -> threads-list panel (no compose, no typing
-//                   line). Whole bordered panel is cached on
-//                   threadsView.Version + layout key.
-//   ViewChannels -> message pane + typing row + compose box, with
-//                   a split-cache pattern: bordered top region
-//                   (messages + top edge + sides only, no bottom
-//                   edge) cached on messagepane.Version only;
-//                   bottom region (typing + compose + bottom
-//                   edge + sides) re-rendered fresh each frame.
-//                   The two stack into a continuous bordered
-//                   panel because BorderBottom(false) on the top
-//                   + BorderTop(false) on the bottom lines up the
-//                   border glyphs.
+//	ViewThreads  -> threads-list panel (no compose, no typing
+//	                line). Whole bordered panel is cached on
+//	                threadsView.Version + layout key.
+//	ViewChannels -> message pane + typing row + compose box, with
+//	                a split-cache pattern: bordered top region
+//	                (messages + top edge + sides only, no bottom
+//	                edge) cached on messagepane.Version only;
+//	                bottom region (typing + compose + bottom
+//	                edge + sides) re-rendered fresh each frame.
+//	                The two stack into a continuous bordered
+//	                panel because BorderBottom(false) on the top
+//	                + BorderTop(false) on the bottom lines up the
+//	                border glyphs.
 //
 // PERF (see Phase 2g render-cache discussion + the split-rendering
 // note in the channels branch): caching the entire bordered panel

--- a/internal/ui/wintree/layout.go
+++ b/internal/ui/wintree/layout.go
@@ -78,4 +78,3 @@ func (t *Tree) ComputeRects(bounds Rect) map[LeafID]Rect {
 	walk(t.Layout(bounds))
 	return out
 }
-


### PR DESCRIPTION
Two CI-hygiene fixes found while triaging the open PR queue. Both were producing false signals that cost review time on unrelated PRs.

## 1. Flaky `TestBackgroundFetchRetriesAfterBackoffExpiry`

This test was failing intermittently in CI on PRs that don't touch `internal/slack/membership` — currently red on #163, #166 and #169, all of which are innocent.

It used two barriers that don't gate the state it asserts on:

- **`waitForCallCount`** — `fakeMemberAPI` records a call on *entry*, but `backgroundFetch` writes `lastFailed` only after the API call returns (`manager.go:183-185`). So backdating `lastFailed` after `waitForCallCount(1)` raced the manager's own write and got clobbered, leaving the backoff live so the retry never fired → `timed out waiting for 2 API calls`.
- **`waitForPush`** — `EnsureFresh` calls `pushSnapshot` synchronously on the caller's goroutine (`manager.go:91-92`), so `waitForPush(sink, 2)` was satisfied by the test's *own* second `EnsureFresh`, not by the background fetch. The assertion then ran while that fetch was still in flight → `lastFailed not cleared by a successful fetch`.

Replaced both with a `waitUntil` helper that polls manager state under its own lock, and added an optional post-call delay to `fakeMemberAPI` so the slow-API interleaving that used to be a rare race is now this test's default path.

**The product code was correct** — `delete(m.lastFailed, channelID)` at `manager.go:222` is properly locked. This was purely a test bug.

Verified:
- With the 50ms delay, the old test failed **5/5**.
- The new test passes **20/20** under `-race`.
- It still fails as intended when `delete(m.lastFailed, channelID)` is removed from `manager.go`, so it hasn't been weakened into a no-op.

## 2. gofmt enforcement

`.golangci.yml` enabled no formatter, so drift accumulated silently — **29 files were unformatted on main**.

The cost shows up in review: contributors' editors reformat whatever they touch, so alignment churn rides along inside feature diffs. The same `Edge *edge.Client` realignment currently appears in four separate open PRs (#161, #162, #167, #170) for exactly this reason, and two open PRs introduce *new* gofmt failures that CI can't currently see.

Enables the `gofmt` formatter and reformats the tree in one pass, so the next diff touching these files is only the actual change.

## Verification

- `go build ./...` — pass
- `go vet ./...` — pass
- `go test ./... -race` — pass, 54 packages, 0 failures

Recommend merging this **first**, so the rest of the PR queue rebases onto a tree where CI tells the truth.