### PR TITLE
test(resolver): fix flaky edge-batch test that raced the cache write

### DIFF
--- a/cmd/slk/user_resolver_test.go
+++ b/cmd/slk/user_resolver_test.go
@@ -104,6 +104,25 @@ func TestUserResolver_RequestDoesNotBlockTheCaller(t *testing.T) {
 	}
 }
 
+// waitUntil polls cond until it holds or the deadline passes.
+//
+// Use this rather than waiting on fakeBatcher.calls() whenever the
+// assertion is about resolver *output* (cache rows, sent messages).
+// fakeBatcher records a batch on entry and returns immediately, while
+// the resolver applies the records afterwards — so a call count is not
+// a barrier for anything applyEdgeUser writes.
+func waitUntil(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
 // fakeBatcher implements userBatcher and records each batch it was
 // asked for.
 type fakeBatcher struct {
@@ -166,10 +185,34 @@ func TestUserResolver_BatchesMissesThroughEdge(t *testing.T) {
 	r.Request("U001")
 	r.Request("U002")
 
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) && len(batcher.calls()) == 0 {
-		time.Sleep(10 * time.Millisecond)
-	}
+	// Wait for the cache rows, not for the batch call.
+	//
+	// fakeBatcher records the call and returns; the resolver only then
+	// loops applyEdgeUser, which is what writes the row
+	// (UpsertUserFromEdge). Waiting on batcher.calls() therefore
+	// returns *before* the state asserted below exists, and the
+	// GetUser calls race the write — an intermittent "U001 was not
+	// cached from the edge batch: sql: no rows in result set".
+	// applyEdgeUser writes the row and *then* sends UserResolvedMsg,
+	// per user, so waiting for both messages implies every write has
+	// landed.
+	waitUntil(t, "the edge batch to be applied to the cache", func() bool {
+		for _, id := range []string{"U001", "U002"} {
+			if _, err := db.GetUser(id); err != nil {
+				return false
+			}
+		}
+		sentMu.Lock()
+		defer sentMu.Unlock()
+		n := 0
+		for _, m := range sent {
+			if _, ok := m.(ui.UserResolvedMsg); ok {
+				n++
+			}
+		}
+		return n == 2
+	})
+
 	calls := batcher.calls()
 	if len(calls) != 1 {
 		t.Fatalf("edge batches = %d; want 1 — misses inside the window coalesce (sent: %v)", len(calls), calls)


### PR DESCRIPTION
Second flaky test, same root cause as the one fixed in #171. This one just failed CI on #128, which is otherwise ready to merge.

## Symptom

```
--- FAIL: TestUserResolver_BatchesMissesThroughEdge
    user_resolver_test.go:189: U001 was not cached from the edge batch:
    getting user: sql: no rows in result set
```

Reproduces locally ~2 times per 20 runs. Confirmed **pre-existing** — it fails at c782404 (before #171) as well, so the gofmt/formatter work didn't cause it. It had simply been hiding behind the fact that CI often got lucky.

## Root cause

Identical shape to the membership flake: the test waits on a barrier that doesn't gate the state it asserts on.

`fakeBatcher.UsersInfo` records the batch and returns immediately. The resolver only *then* loops `applyEdgeUser`, which is what calls `UpsertUserFromEdge` (`cmd/slk/main.go:584`). So:

```go
for time.Now().Before(deadline) && len(batcher.calls()) == 0 {
```

returned before any row existed, and the `db.GetUser` assertions below raced the write.

## Fix

Wait for the applied *result* instead — both cache rows present and both `UserResolvedMsg` sent. `applyEdgeUser` writes the row and then sends, per user, so the message count is the later signal and implies every write has landed.

Adds a `waitUntil` helper to the package with a comment explaining why a batcher call count must never be used as a barrier, so the next test in this file doesn't repeat it.

I checked the sibling tests: `TestUserResolver_ResolveNowBatchesAndApplies` and friends are safe, because `ResolveNow` is synchronous and applies before returning. Only the `Request`-driven batch-window path had the race.

## Verification

- **40/40** passes under `-race` (previously ~2 failures per 20)
- Still **fails as intended** when `UpsertUserFromEdge` is stubbed out — so it hasn't been weakened into a no-op:
  ```
  user_resolver_test.go:199: timed out waiting for the edge batch to be applied to the cache
  ```
- `go build ./...`, `go vet ./...`, `gofmt -l` clean
- `go test ./... -race` — 54 packages, 0 failures