### PR TITLE
chore(release): exclude scoped chore/test/docs commits from the changelog

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -100,10 +100,17 @@ changelog:
     - title: Other
       order: 999
   filters:
+    # Scoped prefixes must be matched explicitly: "^chore:" does NOT
+    # match "chore(ci): ...", so scoped internal commits were leaking
+    # into user-facing notes (v0.16.0 shipped with "chore(ci): bump
+    # golangci-lint" under Other). The (\(.*\))? makes the scope
+    # optional so both spellings are excluded.
     exclude:
-      - "^docs:"
-      - "^test:"
-      - "^chore:"
+      - "^docs(\\(.*\\))?:"
+      - "^test(\\(.*\\))?:"
+      - "^chore(\\(.*\\))?:"
+      - "^style(\\(.*\\))?:"
+      - "^ci(\\(.*\\))?:"
       - "Merge pull request"
       - "Merge branch"
 


### PR DESCRIPTION
Release prep for v0.16.1.

## Problem

`.goreleaser.yaml` filters the changelog on bare prefixes:

```yaml
exclude:
  - "^docs:"
  - "^test:"
  - "^chore:"
```

But this repo writes *scoped* conventional commits — `chore(ci):`, `test(membership):`, `docs(readme):` — and `^chore:` does not match `chore(ci):`. So internal commits leak into user-facing release notes. It already happened in v0.16.0:

```
### Other
* 6d39fe5e73c8485f96e7da282f9f4e5337e64b52: chore(ci): bump golangci-lint to v2.13.1 for go1.27 support (@gammons)
```

Without this, v0.16.1's notes would list all three of our CI-hygiene commits.

## Fix

Make the scope optional via `(\(.*\))?`, and add `style` / `ci` while here.

## Verification

Ran the actual regexes (Go `regexp`, same engine goreleaser uses) against real subjects from this repo's history:

```
chore(ci): bump golangci-lint to v2.13.1 for go1.27 support              EXCLUDED
chore(lint): enforce gofmt in CI and reformat the tree                   EXCLUDED
test(membership): fix flaky backoff-expiry test...                       EXCLUDED
test(resolver): fix flaky edge-batch test that raced the cache write     EXCLUDED
docs(readme): slim README; move tmux details to the wiki                 EXCLUDED
fix(slackdesktop): detect flatpak and snap Slack config dirs on Linux    -> Bug fixes
fix(slackdesktop): distinguish missing Slack keyring entry...            -> Bug fixes
fix: clicking a sidebar section header did nothing                       -> Bug fixes
fix(kitty): encode image payloads at the terminal's real cell size       -> Bug fixes
feat(ui): add y/c keybinding to copy message text                        -> Features
```

Config-only change; no code paths affected.