### PR TITLE
perf(text): add ASCII fast path to Fold

### DIFF
--- a/internal/text/fold.go
+++ b/internal/text/fold.go
@@ -4,6 +4,7 @@ package text
 import (
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
 	"golang.org/x/text/runes"
 	"golang.org/x/text/transform"
@@ -27,10 +28,45 @@ import (
 // in-memory strings with this chain), Fold falls back to strings.ToLower(s)
 // so matching degrades gracefully instead of panicking.
 func Fold(s string) string {
+	// ASCII fast path.
+	//
+	// ASCII code points have no canonical decomposition and carry no
+	// combining marks, so NFD -> remove Mn -> NFC is the identity on
+	// them; only the lowercasing is load-bearing. foldSlow is the
+	// reference implementation and TestFoldFastPathMatchesSlow (plus
+	// FuzzFold) pin the two to identical output, so this cannot drift.
+	//
+	// This matters because Fold is called once per candidate inside the
+	// filter loop of ten pickers -- channelfinder, channelpicker,
+	// sidebar, emojipicker, reactionpicker, mentionpicker,
+	// workspacefinder, themeswitcher, presencemenu, help -- and the
+	// transform chain allocates on every single call. Measured on 62k
+	// emoji entries with a rare query (full scan, no early exit):
+	//
+	//	compose picker    135 ms / 542 MB / 372k allocs
+	//	              ->  1.59 ms / 0 B   / 0 allocs
+	//	reaction picker   271 ms / 1.12 GB / 768k allocs
+	//	              ->  2.96 ms / 611 B  / 1 alloc
+	//
+	// Allocations reach zero because strings.ToLower returns its input
+	// unchanged when there is nothing to lower, which is the common
+	// case for already-lowercase names.
+	//
+	// See issue #165 for the full measurements and methodology.
+	if isASCII(s) {
+		return strings.ToLower(s)
+	}
+	return foldSlow(s)
+}
+
+// foldSlow is the general Unicode implementation: the reference
+// behaviour Fold's ASCII fast path must match exactly.
+func foldSlow(s string) string {
 	// Build the chain per call: transform.Chain returns a *chain with
 	// internal buffers and cursor state that transform.String mutates,
 	// so it is NOT safe to share across goroutines. Per-call allocation
-	// is fine at this volume (a TUI re-filters O(items) per keystroke).
+	// is acceptable here now that the ASCII fast path keeps this off
+	// the hot filter loops.
 	chain := transform.Chain(
 		norm.NFD,
 		runes.Remove(runes.In(unicode.Mn)),
@@ -41,4 +77,14 @@ func Fold(s string) string {
 		return strings.ToLower(s)
 	}
 	return strings.ToLower(out)
+}
+
+// isASCII reports whether s is entirely ASCII.
+func isASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= utf8.RuneSelf {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/text/fold_test.go
+++ b/internal/text/fold_test.go
@@ -53,3 +53,114 @@ func TestFoldDoesNotPanicOnSingleCombiningMark(t *testing.T) {
 	// U+0301 COMBINING ACUTE ACCENT, in isolation.
 	_ = Fold("\u0301")
 }
+
+// foldInputs is shared by the fast-path equivalence test and the fuzz
+// seed corpus: every ASCII shape that could plausibly reach a picker
+// filter, plus the non-ASCII cases that must still take the slow path.
+var foldInputs = []string{
+	"",
+	"a",
+	"A",
+	"Z",
+	"cafe",
+	"Foo Bar",
+	"CUSTOM_00042",
+	"custom_00042",
+	"tada",
+	"+1",
+	"-1",
+	"white_check_mark",
+	"party-parrot",
+	"0123456789",
+	"~!@#$%^&*()_+{}|:\"<>?[]\\;',./",
+	"\t\n\r ",
+	"\x00\x01\x7f",
+	"MiXeD_CaSe-42",
+	// Non-ASCII: must route to foldSlow and fold identically.
+	"Mélanie",
+	"MÉLANIE",
+	"François",
+	"año",
+	"São",
+	"Müller",
+	"Việt",
+	"東京 Tōkyō",
+	"ß",
+	"ﬃ",
+	"\u0301",
+	"a\u0301",
+	"🎉",
+	"👍🏽",
+	"e\u0301chec",
+}
+
+// TestFoldFastPathMatchesSlow pins Fold's ASCII fast path to foldSlow,
+// the reference implementation. The fast path is only sound because
+// NFD -> remove Mn -> NFC is the identity on ASCII; if that assumption
+// is ever wrong, or the chain changes, this fails instead of silently
+// returning different results for ASCII than for everything else.
+func TestFoldFastPathMatchesSlow(t *testing.T) {
+	for _, in := range foldInputs {
+		if got, want := Fold(in), foldSlow(in); got != want {
+			t.Errorf("Fold(%q) = %q, but foldSlow(%q) = %q", in, got, in, want)
+		}
+	}
+}
+
+// TestIsASCII covers the boundary between the two paths.
+func TestIsASCII(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"", true},
+		{"abc", true},
+		{"\x7f", true},          // last ASCII byte
+		{"\u0080", false},       // first non-ASCII rune
+		{"caf\u00e9", false},    // é
+		{"abc\u00e9def", false}, // non-ASCII in the middle
+		{"🎉", false},
+	}
+	for _, tc := range cases {
+		if got := isASCII(tc.in); got != tc.want {
+			t.Errorf("isASCII(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+// FuzzFold asserts the same equivalence on arbitrary input. The seed
+// corpus alone runs during a normal `go test`, so this guards the
+// invariant even without -fuzz.
+func FuzzFold(f *testing.F) {
+	for _, in := range foldInputs {
+		f.Add(in)
+	}
+	f.Fuzz(func(t *testing.T, s string) {
+		if got, want := Fold(s), foldSlow(s); got != want {
+			t.Errorf("Fold(%q) = %q, but foldSlow(%q) = %q", s, got, s, want)
+		}
+	})
+}
+
+func BenchmarkFold(b *testing.B) {
+	// The realistic hot-loop input: a lowercase ASCII emoji or channel
+	// name, folded once per candidate per keystroke.
+	b.Run("ascii_lower", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = Fold("white_check_mark")
+		}
+	})
+	b.Run("ascii_mixed_case", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = Fold("White_Check_Mark")
+		}
+	})
+	b.Run("non_ascii", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = Fold("Mélanie")
+		}
+	})
+}


### PR DESCRIPTION
Fixes #165. Co-authored with @YousefHadder, whose report, benchmarks and reproduction this is built on.

## Problem

`text.Fold` builds a fresh `NFD -> remove-marks -> NFC` transform chain on **every call**, and it's called once per candidate inside the filter loop of ten pickers:

`channelfinder:363` · `channelpicker:127` · `sidebar:978` · `emojipicker:139` · `reactionpicker:254,256` · `mentionpicker/match.go:55` · `workspacefinder:196` · `themeswitcher:212` · `presencemenu:221` · `help:191-192`

With a large custom-emoji catalog loaded, typing in either emoji picker visibly stalls. Result caps don't help — a rare or no-match query scans the entire list.

Reproduced independently of the reporter, 62k entries, rare query:

| | ns/op | B/op | allocs/op |
|---|---:|---:|---:|
| compose picker | 135 ms | 542 MB | 372,012 |
| reaction picker | 271 ms | 1.12 GB | 767,674 |

His figures were 563 MB / 386k and 1.13 GB / 773k — within a couple percent, on different hardware.

Worth noting `messages/highlight.go:134` already carries a hand-rolled per-rune ASCII fast path with a comment pointing at `fold.go`. This problem was found once before and worked around locally.

## Fix

ASCII fast path inside `Fold` itself. No picker changes.

| | ns/op | B/op | allocs/op | |
|---|---:|---:|---:|---|
| compose picker | 135 ms → **1.59 ms** | 542 MB → **0 B** | 372k → **0** | 85× |
| reaction picker | 271 ms → **2.96 ms** | 1.12 GB → **611 B** | 768k → **1** | 92× |
| `Fold` per call | 2173 ns → **25 ns** | 9344 B → **0 B** | 9 → **0** | 86× |

Allocations reach zero because `strings.ToLower` returns its input unchanged when there's nothing to lower — the common case for already-lowercase names.

## Why this is exact, not an approximation

ASCII code points have no canonical decomposition and carry no combining marks, so `NFD -> remove Mn -> NFC` is the identity on them; only the lowercasing is load-bearing.

Rather than assert that, the PR pins it:

- The general implementation stays as **`foldSlow`**, unchanged.
- **`TestFoldFastPathMatchesSlow`** requires `Fold(s) == foldSlow(s)` across a table covering ASCII shapes (control bytes, punctuation, mixed case, `+1`, `party-parrot`) and non-ASCII (accents, CJK, `ß`, `ﬃ`, lone combining marks, emoji, skin-tone sequences).
- **`FuzzFold`** asserts the same on arbitrary input. The seed corpus runs during a normal `go test`; I also ran it properly: **45s, 311,357 executions, zero mismatches.**
- **`TestIsASCII`** covers the `\x7f` / `\u0080` boundary.

If the assumption is ever wrong, or the chain changes, these fail loudly instead of silently diverging for ASCII.

## Why here instead of caching folded keys in the pickers

The issue proposed precomputing folded search keys in the two emoji pickers. That works and is ~10× faster still (~0.15 ms vs 1.59 ms), but:

- It fixes 2 of the 10 call sites.
- 1.59 ms and 2.96 ms are already far inside a frame budget; the perceptible bug is the 135 ms.
- It needs parallel slices kept index-aligned with `entries` / `allEmoji` across `SetEntries`, `SetCustomEmoji` and `buildEmojiList`. A desync doesn't panic — it silently returns the wrong emoji.
- It retains ~64k extra strings.

If we ever want that last millisecond, it can be added later and measured against this baseline instead of today's.

## Sequencing

This matters most once #160 lands, since that's what actually fetches the full workspace `emoji.list`. It's independent though, and better in before that flips on.

## Follow-ups, deliberately not in this PR

- `reactionpicker/model.go:254-256` folds the same name twice per prefix miss (`HasPrefix` then `Contains`). Nearly free now, but still worth collapsing.
- `messages/highlight.go:126-143` can drop its per-rune ASCII workaround now that `Fold` is fast. That's hot render code, so it deserves its own before/after.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l` clean
- `go test ./... -race` — 54 packages, 0 failures
- All pre-existing accent tests (`french_acute`, `vietnamese_tones`, `german_umlaut`, `mixed_script_cjk`) pass unchanged; non-ASCII still routes through `foldSlow`