### PR TITLE
chore(release): exclude every merge commit from the changelog

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -111,8 +111,12 @@ changelog:
       - "^chore(\\(.*\\))?:"
       - "^style(\\(.*\\))?:"
       - "^ci(\\(.*\\))?:"
-      - "Merge pull request"
-      - "Merge branch"
+      # Every merge commit, not just the two spellings we happened to
+      # hit first. "Merge pull request" and "Merge branch" both missed
+      # "Merge remote-tracking branch ...", which is what git writes
+      # when a PR branch is brought up to date with main -- so that
+      # leaked into the notes as if it were a change.
+      - "^Merge "
 
 nfpms:
   - id: slk


### PR DESCRIPTION
Release prep for v0.16.2, and a follow-on to #173.

## Problem

The changelog filters named two specific merge spellings:

```yaml
- "Merge pull request"
- "Merge branch"
```

Neither matches **`Merge remote-tracking branch 'origin/main' into HEAD`** — which is exactly what git writes when a PR branch is brought up to date with `main`. One of those is sitting in `v0.16.1..main` right now (from updating #160's branch), so without this it would appear in the v0.16.2 notes as if it were a change.

## Fix

Replace both with `^Merge `, which covers every form.

## Verification

Ran the real regexes against real subjects:

| subject | result |
|---|---|
| `Merge pull request #160 from rfist/fix/custom-emoji-workspace-list` | excluded |
| `Merge remote-tracking branch 'origin/main' into HEAD` | excluded |
| `Merge branch 'main' into feature` | excluded |
| `perf(text): add ASCII fast path to Fold` | kept |
| `fix: fetch the workspace emoji list again instead of the boot channel's subset` | kept |

Config-only; no code paths affected.