### PR TITLE
fix(mrkdwn): treat a single asterisk pair as bold, matching Slack's own mrkdwn

### DIFF
--- a/internal/slack/mrkdwn/convert_test.go
+++ b/internal/slack/mrkdwn/convert_test.go
@@ -186,29 +186,25 @@ func TestConvert_ItalicUnderscore(t *testing.T) {
 	}
 }
 
-func TestConvert_AsteriskPreservedAsLiteral(t *testing.T) {
-	// *x* in CommonMark is italic, but in Slack mrkdwn it's bold.
-	// We preserve the asterisks as literal characters so users who
-	// type Slack-style *bold* don't get it converted to _italic_.
+func TestConvert_SingleAsteriskIsBold(t *testing.T) {
+	// *x* in CommonMark is italic, but Slack's own mrkdwn treats a
+	// single asterisk pair as bold. slk treats it as bold (same as
+	// **x**) so a message that renders bold in slk's own compose/
+	// message view also renders bold in real Slack.
 	mr, blk := Convert("*hello*")
 	if mr != "*hello*" {
 		t.Errorf("mrkdwn = %q, want %q", mr, "*hello*")
 	}
-	// Block side: text elements concatenate to "*hello*", no italic.
 	sec := blk.Elements[0].(*slack.RichTextSection)
-	var got string
-	for _, el := range sec.Elements {
-		te, ok := el.(*slack.RichTextSectionTextElement)
-		if !ok {
-			t.Fatalf("element is %T, want only text elements", el)
-		}
-		if te.Style != nil && (te.Style.Italic || te.Style.Bold) {
-			t.Errorf("element %+v has style %+v, want no italic/bold for literal asterisks", te, te.Style)
-		}
-		got += te.Text
+	if len(sec.Elements) != 1 {
+		t.Fatalf("elements = %d, want 1: %s", len(sec.Elements), blockJSON(blk))
 	}
-	if got != "*hello*" {
-		t.Errorf("concatenated text = %q, want %q", got, "*hello*")
+	te := sec.Elements[0].(*slack.RichTextSectionTextElement)
+	if te.Text != "hello" {
+		t.Errorf("text = %q, want %q", te.Text, "hello")
+	}
+	if te.Style == nil || !te.Style.Bold {
+		t.Errorf("expected Style.Bold = true, got %+v", te.Style)
 	}
 }
 
@@ -225,65 +221,46 @@ func TestConvert_AsteriskRoundTripStable(t *testing.T) {
 	}
 }
 
-func TestConvert_NestedItalicAroundAsteriskLiteral(t *testing.T) {
-	// _*both*_ : outer italic, inner literal asterisks. The outer
-	// underscore-italic must apply, and the inner asterisks must be
-	// preserved as literal text inside the italic run.
+func TestConvert_NestedItalicAroundBold(t *testing.T) {
+	// _*both*_ : outer italic (underscore), inner bold (single
+	// asterisk pair, Slack's native bold syntax). Both styles apply
+	// to "both".
 	mr, blk := Convert("_*both*_")
 	want := "_*both*_"
 	if mr != want {
 		t.Errorf("mrkdwn = %q, want %q", mr, want)
 	}
-	// Block side: italic should be set on text elements inside the
-	// outer wrapper. The literal asterisks inherit italic from the
-	// surrounding inheritedStyle.
 	sec := blk.Elements[0].(*slack.RichTextSection)
-	for i, el := range sec.Elements {
-		te, ok := el.(*slack.RichTextSectionTextElement)
-		if !ok {
-			t.Fatalf("element[%d] is %T, want text", i, el)
-		}
-		if te.Style == nil || !te.Style.Italic {
-			t.Errorf("element[%d] %q style = %+v, want italic", i, te.Text, te.Style)
-		}
-		if te.Style != nil && te.Style.Bold {
-			t.Errorf("element[%d] %q has bold style, want italic only", i, te.Text)
-		}
+	if len(sec.Elements) != 1 {
+		t.Fatalf("elements = %d, want 1: %s", len(sec.Elements), blockJSON(blk))
+	}
+	te := sec.Elements[0].(*slack.RichTextSectionTextElement)
+	if te.Text != "both" {
+		t.Errorf("text = %q, want %q", te.Text, "both")
+	}
+	if te.Style == nil || !te.Style.Italic || !te.Style.Bold {
+		t.Errorf("style = %+v, want italic+bold", te.Style)
 	}
 }
 
-func TestConvert_NestedAsteriskLiteralAroundItalic(t *testing.T) {
-	// *_both_* : outer literal asterisks, inner underscore-italic.
-	// The outer asterisks must be preserved as literal text, and
-	// the inner italic must apply to "both".
+func TestConvert_NestedBoldAroundItalic(t *testing.T) {
+	// *_both_* : outer bold (single asterisk pair), inner italic
+	// (underscore). Both styles apply to "both".
 	mr, blk := Convert("*_both_*")
 	want := "*_both_*"
 	if mr != want {
 		t.Errorf("mrkdwn = %q, want %q", mr, want)
 	}
-	// Block side: walk the elements and verify "both" carries italic
-	// while the surrounding asterisks do not.
 	sec := blk.Elements[0].(*slack.RichTextSection)
-	var got string
-	sawItalicBoth := false
-	for _, el := range sec.Elements {
-		te, ok := el.(*slack.RichTextSectionTextElement)
-		if !ok {
-			t.Fatalf("element is %T, want text", el)
-		}
-		got += te.Text
-		if te.Text == "both" {
-			if te.Style == nil || !te.Style.Italic {
-				t.Errorf("'both' element style = %+v, want italic", te.Style)
-			}
-			sawItalicBoth = true
-		}
+	if len(sec.Elements) != 1 {
+		t.Fatalf("elements = %d, want 1: %s", len(sec.Elements), blockJSON(blk))
 	}
-	if got != "*both*" {
-		t.Errorf("concatenated visible text = %q, want %q", got, "*both*")
+	te := sec.Elements[0].(*slack.RichTextSectionTextElement)
+	if te.Text != "both" {
+		t.Errorf("text = %q, want %q", te.Text, "both")
 	}
-	if !sawItalicBoth {
-		t.Error("did not find a 'both' text element with italic style")
+	if te.Style == nil || !te.Style.Italic || !te.Style.Bold {
+		t.Errorf("style = %+v, want italic+bold", te.Style)
 	}
 }
 

--- a/internal/slack/mrkdwn/walk.go
+++ b/internal/slack/mrkdwn/walk.go
@@ -125,11 +125,16 @@ func (w *walker) walkInline(n ast.Node) {
 		// Level 1: distinguish _italic_ from *italic*. Goldmark's
 		// emphasis node doesn't expose the delimiter byte directly,
 		// so we look at the byte immediately before the first child
-		// text segment.
+		// text segment. Underscore is CommonMark italic; a single
+		// asterisk pair is Slack's own native bold syntax, so treat
+		// it as bold (same as walkBold) rather than reinterpreting
+		// it as CommonMark italic — that keeps outgoing messages
+		// consistent with both real Slack's rendering and slk's own
+		// message view, which already displays "*word*" as bold.
 		if w.emphasisDelimiter(n) == '_' {
 			w.walkItalic(n)
 		} else {
-			w.walkAsteriskLiteral(n)
+			w.walkBold(n)
 		}
 	case *ast.CodeSpan:
 		w.mrkdwn.WriteString("`")
@@ -236,19 +241,6 @@ func (w *walker) walkItalic(n *ast.Emphasis) {
 	w.walkInlineChildren(n)
 	w.inheritedStyle = prev
 	w.mrkdwn.WriteString("_")
-}
-
-// walkAsteriskLiteral preserves *x* as literal text in both outputs.
-// The asterisks become text elements (no italic style of their own)
-// in the rich text block; if an enclosing emphasis is in scope, they
-// inherit ITS style via inheritedStyle so they visually flow with the
-// surrounding text. Inline formatting inside the run (e.g. *hello
-// **bold***) is still processed via walkInlineChildren — only the
-// outer asterisk pair is treated as literal text.
-func (w *walker) walkAsteriskLiteral(n *ast.Emphasis) {
-	w.appendText("*")
-	w.walkInlineChildren(n)
-	w.appendText("*")
 }
 
 // handleLink emits a CommonMark [label](url) as Slack mrkdwn

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -25,7 +25,7 @@
 - Special mentions: `@here`, `@channel`, `@everyone`
 - Bracketed paste — paste multi-line text from the system clipboard without it being interpreted as keystrokes
 - Smart paste (`Ctrl+V`) — pastes a clipboard image as an attachment, or a copied file path as an attached file, or falls through to text. Multiple attachments + caption send together via Slack's V2 file-upload API. Note: use `Ctrl+V` (not your terminal's `Ctrl+Shift+V` paste shortcut) — terminal-initiated paste only delivers text, never image bytes.
-- CommonMark in compose: type `**bold**`, `~~strike~~`, `[label](url)`, `- list items`, `1. numbered`, or fenced ```code blocks``` and slk converts them on send to Slack's mrkdwn + rich_text format. Already-mrkdwn syntax (`*bold*`, `_italic_`, `~strike~`) passes through unchanged. Single-asterisk emphasis (`*x*`) is preserved as literal text since it conflicts with Slack mrkdwn bold.
+- CommonMark in compose: type `**bold**`, `~~strike~~`, `[label](url)`, `- list items`, `1. numbered`, or fenced ```code blocks``` and slk converts them on send to Slack's mrkdwn + rich_text format. Already-mrkdwn syntax (`*bold*`, `_italic_`, `~strike~`) passes through unchanged and receives the corresponding rich-text styling.
 
 ## Images
 


### PR DESCRIPTION
## Problem

Typing `*bold*` in the composer sent literal, unstyled asterisks to Slack.

slk renders `*bold*` as bold in its own compose box and message view, because that is what Slack's mrkdwn means — a single asterisk pair is Slack's native bold syntax. But the outgoing converter treated the same input as *literal text*: `walkAsteriskLiteral` emitted `*`, the inner run, and `*` as plain text elements with no style of their own. So a message that looked bold while you were writing it arrived in real Slack with the asterisks showing.

The cause is a CommonMark/mrkdwn mismatch. Goldmark parses `*x*` as `ast.Emphasis` — CommonMark *italic* — and the walker only distinguished the delimiter to avoid emitting `_x_` for it:

```go
if w.emphasisDelimiter(n) == '_' {
    w.walkItalic(n)
} else {
    w.walkAsteriskLiteral(n)   // preserved the asterisks as text
}
```

## Fix

One line: the asterisk branch calls `walkBold` instead, so a single asterisk pair produces the same `rich_text` styling as `**x**`.

```go
if w.emphasisDelimiter(n) == '_' {
    w.walkItalic(n)
} else {
    w.walkBold(n)
}
```

`walkAsteriskLiteral` is deleted along with it — nothing else called it.

Scope is deliberately narrow. Only single-asterisk emphasis changes: `_italic_` still emits italic, `**bold**` and `__bold__` are untouched, and the mrkdwn string output is unchanged in every case (`*hello*` still round-trips to `*hello*`). Only the block side gains the style it should always have had.

## About the test diff

**This removes 74 test lines, and none of it is lost coverage.** Three tests asserted the *old* behaviour on purpose and had to be inverted rather than deleted:

| Before | After |
|---|---|
| `TestConvert_AsteriskPreservedAsLiteral` | `TestConvert_SingleAsteriskIsBold` |
| `TestConvert_NestedItalicAroundAsteriskLiteral` | `TestConvert_NestedItalicAroundBold` |
| `TestConvert_NestedAsteriskLiteralAroundItalic` | `TestConvert_NestedBoldAroundItalic` |

Each got shorter because the assertion got simpler. The old ones had to walk a variable number of text elements, concatenate them, and check that the asterisks carried no style of their own while inheriting any enclosing one. The new ones assert a single element with the expected style — `*hello*` is one bold element, `_*both*_` and `*_both_*` are each one element carrying italic and bold.

Worth noting that the old test's own comment argued for this change:

> `*x*` in CommonMark is italic, but in Slack mrkdwn it's bold. We preserve the asterisks as literal characters so users who type Slack-style `*bold*` don't get it converted to `_italic_`.

The goal was already right — stop `*bold*` becoming `_italic_`. Making the asterisks literal stopped the wrong conversion without doing the right one. This finishes the job.

Untouched and still passing: `TestConvert_BoldDoubleAsterisk`, `TestConvert_BoldDoubleUnderscore`, `TestConvert_ItalicUnderscore`, `TestConvert_ItalicContainingBold`, `TestConvert_AsteriskRoundTripStable`, and the link/mention/strikethrough style-inheritance tests.

## Documentation

`wiki/Features.md` documented the old behaviour explicitly — "Single-asterisk emphasis (`*x*`) is preserved as literal text since it conflicts with Slack mrkdwn bold" — so it is corrected in the same commit. The preceding sentence already said that already-mrkdwn syntax passes through unchanged; it now also says that it receives the corresponding rich-text styling, which I verified holds for `*bold*`, `_italic_` and `~strike~` alike.

The `docs/superpowers/` references to literal asterisks are left alone: those are the dated design plan and spec from the original CommonMark-compose work, i.e. a record of what was decided then, not current user documentation.

## Test plan

- Confirmed the tests fail against the old code: reverting `walk.go` to main fails exactly `TestConvert_SingleAsteriskIsBold`, `TestConvert_NestedItalicAroundBold` and `TestConvert_NestedBoldAroundItalic`, and nothing else.
- `go test ./...`, `go vet ./...`, `gofmt -l .` clean, `go build ./...`.
- Rebased onto current main.
