### PR TITLE
perf(reactionpicker): fold candidate names once

### DIFF
--- a/internal/ui/reactionpicker/bench_test.go
+++ b/internal/ui/reactionpicker/bench_test.go
@@ -1,0 +1,24 @@
+package reactionpicker
+
+import (
+	"fmt"
+	"testing"
+)
+
+func BenchmarkFilterByQuery(b *testing.B) {
+	customs := make(map[string]string, 10_000)
+	for i := 0; i < 10_000; i++ {
+		name := fmt.Sprintf("candidate_%05d", i)
+		customs[name] = "https://emoji.example.com/" + name + ".gif"
+	}
+
+	m := New()
+	m.SetCustomEmoji(customs)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.Open("C123", "1234.5678", nil)
+		m.HandleKey("~")
+	}
+}

--- a/internal/ui/reactionpicker/model.go
+++ b/internal/ui/reactionpicker/model.go
@@ -251,9 +251,10 @@ func (m *Model) filter() {
 
 	var substringMatches []EmojiEntry
 	for _, e := range m.allEmoji {
-		if strings.HasPrefix(text.Fold(e.Name), q) {
+		name := text.Fold(e.Name)
+		if strings.HasPrefix(name, q) {
 			m.filtered = append(m.filtered, e)
-		} else if strings.Contains(text.Fold(e.Name), q) {
+		} else if strings.Contains(name, q) {
 			substringMatches = append(substringMatches, e)
 		}
 		if len(m.filtered)+len(substringMatches) >= 50 {

--- a/internal/ui/reactionpicker/model_test.go
+++ b/internal/ui/reactionpicker/model_test.go
@@ -197,6 +197,26 @@ func TestCustomEmojiAppearsInSearch(t *testing.T) {
 	}
 }
 
+func TestSubstringSearchSelectsCustomEmoji(t *testing.T) {
+	m := New()
+	m.SetCustomEmoji(map[string]string{
+		"custom_needle": "https://emoji.example.com/custom_needle.gif",
+	})
+	m.Open("C123", "1234.5678", nil)
+
+	for _, ch := range "needle" {
+		m.HandleKey(string(ch))
+	}
+
+	result := m.HandleKey("enter")
+	if result == nil {
+		t.Fatal("expected substring search to produce a selectable result")
+	}
+	if result.Emoji != "custom_needle" {
+		t.Fatalf("selected emoji = %q, want %q", result.Emoji, "custom_needle")
+	}
+}
+
 func TestCustomEmojiOverridesBuiltin(t *testing.T) {
 	m := New()
 	m.SetCustomEmoji(map[string]string{


### PR DESCRIPTION
## Summary

- fold each reaction-picker candidate name once and reuse it for prefix and substring checks
- cover substring selection through the exported `SetCustomEmoji`, `Open`, and `HandleKey` seam, observing the selected `ReactionResult`
- benchmark a full-scan query over 10,000 custom emoji through the same input seam

This is the first of two independent performance follow-ups requested after PR #174 / issue #165.

## Benchmark

Apple M3 Max, darwin/arm64:

```console
go test ./internal/ui/reactionpicker -run '^$' -bench '^BenchmarkFilterByQuery$' -benchmem -count=6 -benchtime=500ms
```

Observed median: **604,271 -> 341,907 ns/op** (**43.4% lower**). Memory remained **0 B/op, 0 allocs/op** before and after.

## Testing

- `go test ./internal/ui/reactionpicker -run 'TestSubstringSearchSelectsCustomEmoji|TestFilterByQuery'`
- `go test -race ./internal/ui/reactionpicker`
- benchmark command above

Refs #165