### PR TITLE
perf(messages): fold ASCII highlight segments once

### DIFF
--- a/internal/ui/messages/highlight.go
+++ b/internal/ui/messages/highlight.go
@@ -129,16 +129,17 @@ func HighlightSearchTerms(s string, terms []string, hlStart, hlEnd string) strin
 		}
 		runes := []rune(sg.text)
 		folded := make([]string, len(runes))
-		for i, r := range runes {
-			if r < utf8.RuneSelf {
-				// ASCII fast path: text.Fold allocates a transform
-				// chain per call (see fold.go); for ASCII, folding is
-				// just lowercasing.
-				if r >= 'A' && r <= 'Z' {
-					r += 'a' - 'A'
-				}
-				folded[i] = string(r)
-			} else {
+		if len(runes) == len(sg.text) && utf8.ValidString(sg.text) {
+			// ASCII is one byte per rune, so folding the segment once keeps
+			// each byte aligned with the corresponding original rune.
+			foldedText := text.Fold(sg.text)
+			for i := range folded {
+				folded[i] = foldedText[i : i+1]
+			}
+		} else {
+			// Preserve one entry per original rune when folding can change
+			// byte or rune counts, as with decomposed combining marks.
+			for i, r := range runes {
 				folded[i] = text.Fold(string(r))
 			}
 		}

--- a/internal/ui/messages/highlight_test.go
+++ b/internal/ui/messages/highlight_test.go
@@ -36,6 +36,13 @@ func TestHighlightSearchTerms_CaseAndAccentInsensitive(t *testing.T) {
 	}
 }
 
+func TestHighlightSearchTerms_DecomposedAccentPreservesRuneMapping(t *testing.T) {
+	got := HighlightSearchTerms("Cafe\u0301 open", []string{"cafe"}, "[", "]")
+	if got != "[Cafe]\u0301 open" {
+		t.Errorf("fold: %q", got)
+	}
+}
+
 func TestHighlightSearchTerms_SkipsANSISequences(t *testing.T) {
 	in := "\x1b[31mdeploy\x1b[0m fine"
 	got := HighlightSearchTerms(in, []string{"deploy"}, "[", "]")


### PR DESCRIPTION
## Summary

- Replace the private hand-rolled ASCII lowering path with segment-level `internal/text.Fold` now that PR #174 centralizes the ASCII fast path.
- Fold valid ASCII segments once, then split the result back into the existing one-entry-per-rune mapping.
- Keep the per-rune `text.Fold` fallback for non-ASCII and invalid UTF-8 so highlight indices and behavior remain unchanged.

## Behavior coverage

Behavior-level tests exercise the `HighlightSearchTerms` package seam, including decomposed combining-mark mapping (`Cafe\u0301`) to preserve the original rune-to-highlight relationship.

## Observed benchmark

Environment: Apple M3 Max, darwin/arm64.

Protocol:

```sh
go test ./internal/ui/messages -run '^$' -bench '^BenchmarkHighlightSearchTerms_ASCII$' -benchmem -count=6 -benchtime=500ms
```

| Implementation | Median ns/op | Observed range ns/op | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: |
| Original hand-rolled baseline | 2,789 | 2,755-3,318 | 5,008 | 185 |
| Final coarse `text.Fold` path | 1,855 | 1,837-1,921 | 4,304 | 9 |

In these measurements, the median was 33.5% lower and allocations decreased from 185 to 9 per operation. These are observed results on the environment above, not universal performance claims.

## Context

This is the independent message-highlighting follow-up requested after PR #174 / issue #165. It is separate from the reaction-picker follow-up in PR #177.

Refs #165