### PR TITLE
fix: advance Slack's read cursor for messages seen in a focused terminal (#159)

### DIFF
--- a/cmd/slk/event_handler_marked_test.go
+++ b/cmd/slk/event_handler_marked_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/gammons/slk/internal/cache"
@@ -126,14 +128,54 @@ func TestOnChannelMarked_ZeroUnreadCount_ClearsHasUnread(t *testing.T) {
 	}
 }
 
-func TestMarkChannelReadAsync_UpdatesReadState(t *testing.T) {
-	// markChannelReadAsync runs its work in a goroutine and calls
-	// client.MarkChannel on a *slackclient.Client, which requires real
-	// HTTP/Slack wiring (or a fake) to construct. The function body is
-	// otherwise a thin wrapper over db.UpdateChannelReadState (covered by
-	// cache-level tests) plus a tea.Program send. Wiring a fake Client
-	// would require introducing an interface seam we don't otherwise need.
-	// The reconnect-backfill integration test in Task 20 exercises this
-	// path end-to-end.
-	t.Skip("markChannelReadAsync requires a real *slackclient.Client; covered by Task 20 integration test")
+type fakeChannelMarker struct {
+	err   error
+	calls []string // "channelID/ts" per call
+}
+
+func (f *fakeChannelMarker) MarkChannel(_ context.Context, channelID, ts string) error {
+	f.calls = append(f.calls, channelID+"/"+ts)
+	return f.err
+}
+
+func TestMarkChannelRead_SuccessPersistsReadState(t *testing.T) {
+	db := newTestDB(t)
+	_ = db.UpsertChannel(cache.Channel{ID: "C1", WorkspaceID: "T1", Name: "general", Type: "channel"})
+	if err := db.UpdateChannelReadState("C1", "", true); err != nil {
+		t.Fatalf("seed has_unread: %v", err)
+	}
+	marker := &fakeChannelMarker{}
+
+	if err := markChannelRead(context.Background(), marker, db, "C1", "1700000000.000100"); err != nil {
+		t.Fatalf("markChannelRead: %v", err)
+	}
+
+	if len(marker.calls) != 1 || marker.calls[0] != "C1/1700000000.000100" {
+		t.Fatalf("unexpected MarkChannel calls: %v", marker.calls)
+	}
+	s, _ := db.GetChannelReadState("C1")
+	if s.LastReadTS != "1700000000.000100" || s.HasUnread {
+		t.Errorf("read state = %+v, want LastReadTS advanced and HasUnread=false", s)
+	}
+}
+
+func TestMarkChannelRead_FailureLeavesChannelUnread(t *testing.T) {
+	db := newTestDB(t)
+	_ = db.UpsertChannel(cache.Channel{ID: "C1", WorkspaceID: "T1", Name: "general", Type: "channel"})
+	if err := db.UpdateChannelReadState("C1", "", true); err != nil {
+		t.Fatalf("seed has_unread: %v", err)
+	}
+	marker := &fakeChannelMarker{err: errors.New("conversations.mark: invalid_auth")}
+
+	if err := markChannelRead(context.Background(), marker, db, "C1", "1700000000.000100"); err == nil {
+		t.Fatal("markChannelRead: want error, got nil")
+	}
+
+	s, _ := db.GetChannelReadState("C1")
+	if s.LastReadTS != "" {
+		t.Errorf("LastReadTS = %q, want unchanged after a rejected mark", s.LastReadTS)
+	}
+	if !s.HasUnread {
+		t.Error("HasUnread must stay true so the state can be reconciled later")
+	}
 }

--- a/cmd/slk/event_handler_marked_test.go
+++ b/cmd/slk/event_handler_marked_test.go
@@ -285,3 +285,27 @@ func TestMarkThreadRead_FailureLeavesTheCursorAlone(t *testing.T) {
 		t.Errorf("last_read = %q, want it unchanged after a rejected mark", got)
 	}
 }
+
+// The local mark path fires for every thread the user opens, including
+// threads from the messages pane they never subscribed to. Persisting
+// the cursor must not fabricate an active=1 subscription row, or the
+// Threads list gains a phantom entry until the next getView reconcile.
+func TestMarkThreadRead_UnsubscribedThreadDoesNotFabricateASubscription(t *testing.T) {
+	db := newTestDB(t)
+	marker := &fakeThreadMarker{}
+
+	if err := markThreadRead(context.Background(), marker, db, "T1", "C1", "1700000000.000100", "1700000000.000500"); err != nil {
+		t.Fatalf("markThreadRead: %v", err)
+	}
+
+	if len(marker.calls) != 1 {
+		t.Fatalf("unexpected MarkThread calls: %v", marker.calls)
+	}
+	active, err := db.ListActiveThreadSubscriptions("T1")
+	if err != nil {
+		t.Fatalf("ListActiveThreadSubscriptions: %v", err)
+	}
+	if len(active) != 0 {
+		t.Fatalf("marking an unsubscribed thread read created %d subscription row(s): %+v", len(active), active)
+	}
+}

--- a/cmd/slk/event_handler_marked_test.go
+++ b/cmd/slk/event_handler_marked_test.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/gammons/slk/internal/cache"
+	"github.com/gammons/slk/internal/ui"
 )
 
 func TestOnChannelMarked_WritesReadState(t *testing.T) {
@@ -177,5 +179,56 @@ func TestMarkChannelRead_FailureLeavesChannelUnread(t *testing.T) {
 	}
 	if !s.HasUnread {
 		t.Error("HasUnread must stay true so the state can be reconciled later")
+	}
+}
+
+func TestMarkChannelReadAndNotify_FailureDoesNotNotify(t *testing.T) {
+	// The UI must not optimistically clear an unread state that Slack
+	// rejected: a ChannelMarkedReadMsg would blank the sidebar's unread
+	// badge for a channel Slack still considers unread, which is the
+	// cross-client divergence #159 is about.
+	db := newTestDB(t)
+	_ = db.UpsertChannel(cache.Channel{ID: "C1", WorkspaceID: "T1", Name: "general", Type: "channel"})
+	if err := db.UpdateChannelReadState("C1", "", true); err != nil {
+		t.Fatalf("seed has_unread: %v", err)
+	}
+	marker := &fakeChannelMarker{err: errors.New("conversations.mark: invalid_auth")}
+	var sent []tea.Msg
+
+	markChannelReadAndNotify(context.Background(), marker, db, func(m tea.Msg) {
+		sent = append(sent, m)
+	}, "C1", "1700000000.000100")
+
+	if len(sent) != 0 {
+		t.Errorf("notify called %d time(s) with %v; want no notification after a rejected mark", len(sent), sent)
+	}
+	s, _ := db.GetChannelReadState("C1")
+	if s.LastReadTS != "" || !s.HasUnread {
+		t.Errorf("read state = %+v, want untouched after a rejected mark", s)
+	}
+}
+
+func TestMarkChannelReadAndNotify_SuccessNotifiesOnce(t *testing.T) {
+	db := newTestDB(t)
+	_ = db.UpsertChannel(cache.Channel{ID: "C1", WorkspaceID: "T1", Name: "general", Type: "channel"})
+	if err := db.UpdateChannelReadState("C1", "", true); err != nil {
+		t.Fatalf("seed has_unread: %v", err)
+	}
+	marker := &fakeChannelMarker{}
+	var sent []tea.Msg
+
+	markChannelReadAndNotify(context.Background(), marker, db, func(m tea.Msg) {
+		sent = append(sent, m)
+	}, "C1", "1700000000.000100")
+
+	if len(sent) != 1 {
+		t.Fatalf("notify called %d time(s), want exactly 1", len(sent))
+	}
+	got, ok := sent[0].(ui.ChannelMarkedReadMsg)
+	if !ok {
+		t.Fatalf("notified with %T, want ui.ChannelMarkedReadMsg", sent[0])
+	}
+	if got != (ui.ChannelMarkedReadMsg{ChannelID: "C1"}) {
+		t.Errorf("notified with %+v, want ChannelID C1", got)
 	}
 }

--- a/cmd/slk/event_handler_marked_test.go
+++ b/cmd/slk/event_handler_marked_test.go
@@ -232,3 +232,56 @@ func TestMarkChannelReadAndNotify_SuccessNotifiesOnce(t *testing.T) {
 		t.Errorf("notified with %+v, want ChannelID C1", got)
 	}
 }
+
+type fakeThreadMarker struct {
+	err   error
+	calls []string // "channelID/threadTS/ts" per call
+}
+
+func (f *fakeThreadMarker) MarkThread(_ context.Context, channelID, threadTS, ts string) error {
+	f.calls = append(f.calls, channelID+"/"+threadTS+"/"+ts)
+	return f.err
+}
+
+func TestMarkThreadRead_SuccessAdvancesTheCursor(t *testing.T) {
+	db := newTestDB(t)
+	if err := db.UpsertThreadSubscription("T1", "C1", "1700000000.000100", "1700000000.000100", true); err != nil {
+		t.Fatalf("seed subscription: %v", err)
+	}
+	marker := &fakeThreadMarker{}
+
+	if err := markThreadRead(context.Background(), marker, db, "T1", "C1", "1700000000.000100", "1700000000.000500"); err != nil {
+		t.Fatalf("markThreadRead: %v", err)
+	}
+
+	if len(marker.calls) != 1 || marker.calls[0] != "C1/1700000000.000100/1700000000.000500" {
+		t.Fatalf("unexpected MarkThread calls: %v", marker.calls)
+	}
+	got, err := db.GetThreadLastRead("T1", "C1", "1700000000.000100")
+	if err != nil {
+		t.Fatalf("GetThreadLastRead: %v", err)
+	}
+	if got != "1700000000.000500" {
+		t.Errorf("last_read = %q, want it advanced to 1700000000.000500; the WS echo may never arrive", got)
+	}
+}
+
+func TestMarkThreadRead_FailureLeavesTheCursorAlone(t *testing.T) {
+	db := newTestDB(t)
+	if err := db.UpsertThreadSubscription("T1", "C1", "1700000000.000100", "1700000000.000100", true); err != nil {
+		t.Fatalf("seed subscription: %v", err)
+	}
+	marker := &fakeThreadMarker{err: errors.New("subscriptions.thread.mark: thread_not_found")}
+
+	if err := markThreadRead(context.Background(), marker, db, "T1", "C1", "1700000000.000100", "1700000000.000500"); err == nil {
+		t.Fatal("markThreadRead: want error, got nil")
+	}
+
+	got, err := db.GetThreadLastRead("T1", "C1", "1700000000.000100")
+	if err != nil {
+		t.Fatalf("GetThreadLastRead: %v", err)
+	}
+	if got != "1700000000.000100" {
+		t.Errorf("last_read = %q, want it unchanged after a rejected mark", got)
+	}
+}

--- a/cmd/slk/event_handler_test.go
+++ b/cmd/slk/event_handler_test.go
@@ -232,7 +232,7 @@ func TestOnMessage_ThreadBroadcast_SetsHasUnread(t *testing.T) {
 	}
 }
 
-func TestOnThreadMarked_UpsertsSubscription(t *testing.T) {
+func TestOnThreadMarked_AdvancesCursorWithoutTombstoning(t *testing.T) {
 	db := newTestDB(t)
 	h := &rtmEventHandler{
 		db:          db,
@@ -240,9 +240,7 @@ func TestOnThreadMarked_UpsertsSubscription(t *testing.T) {
 		isActive:    func() bool { return true },
 	}
 
-	// read=false means the thread is now unread, which corresponds to
-	// active=true in thread_subscriptions.
-	h.OnThreadMarked("C1", "1700000100.000000", "1700000150.000000", false)
+	h.OnThreadMarked("C1", "1700000100.000000", "1700000150.000000")
 
 	got, err := db.ListActiveThreadSubscriptions("T1")
 	if err != nil {
@@ -256,11 +254,46 @@ func TestOnThreadMarked_UpsertsSubscription(t *testing.T) {
 		t.Fatalf("subscription row mismatch: %+v", got[0])
 	}
 
-	// Marking read flips the row to inactive (tombstone-style).
-	h.OnThreadMarked("C1", "1700000100.000000", "1700000150.000000", true)
-	got, _ = db.ListActiveThreadSubscriptions("T1")
-	if len(got) != 0 {
-		t.Fatalf("expected 0 active after read=true, got %d", len(got))
+	// A later cursor move must advance last_read and leave the row
+	// active. Writing `active` here used to tombstone the row, making
+	// the thread disappear from the Threads list.
+	h.OnThreadMarked("C1", "1700000100.000000", "1700000200.000000")
+	got, err = db.ListActiveThreadSubscriptions("T1")
+	if err != nil {
+		t.Fatalf("ListActiveThreadSubscriptions: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("thread must stay in the list after being read, got %d active", len(got))
+	}
+	if got[0].LastRead != "1700000200.000000" {
+		t.Errorf("LastRead = %q, want 1700000200.000000", got[0].LastRead)
+	}
+}
+
+// An empty last_read would erase the read cursor and make the whole
+// thread render unread. UpdateThreadLastRead does not reject it, so the
+// handler must drop the event outright rather than persist or dispatch.
+func TestOnThreadMarked_EmptyLastReadIsIgnored(t *testing.T) {
+	db := newTestDB(t)
+	if err := db.UpdateThreadLastRead("T1", "C1", "1700000100.000000", "1700000150.000000"); err != nil {
+		t.Fatalf("UpdateThreadLastRead: %v", err)
+	}
+	h := &rtmEventHandler{
+		db:          db,
+		workspaceID: "T1",
+		isActive:    func() bool { return true },
+		// program intentionally nil: a UI dispatch here would panic,
+		// pinning that the handler returns before touching it.
+	}
+
+	h.OnThreadMarked("C1", "1700000100.000000", "")
+
+	lastRead, err := db.GetThreadLastRead("T1", "C1", "1700000100.000000")
+	if err != nil {
+		t.Fatalf("GetThreadLastRead: %v", err)
+	}
+	if lastRead != "1700000150.000000" {
+		t.Errorf("LastRead = %q, want the cursor left untouched at 1700000150.000000", lastRead)
 	}
 }
 
@@ -327,8 +360,7 @@ func TestOnThreadMarked_PersistsOnInactiveWorkspace(t *testing.T) {
 		// persist the DB row.
 	}
 
-	// read=false → thread is now unread → row should be active=true.
-	h.OnThreadMarked("C1", "1700000100.000000", "1700000150.000000", false)
+	h.OnThreadMarked("C1", "1700000100.000000", "1700000150.000000")
 
 	got, err := db.ListActiveThreadSubscriptions("T1")
 	if err != nil {

--- a/cmd/slk/event_handler_test.go
+++ b/cmd/slk/event_handler_test.go
@@ -185,6 +185,74 @@ func TestOnMessage_ActiveChannel_StillSetsHasUnread(t *testing.T) {
 	}
 }
 
+// Your own send comes back over the WS like any other message. Nothing
+// downstream would ever clear a has_unread set for it -- reduceNewMessage
+// returns at its IsSelfSent arm before the read-state tail -- so the dot
+// would appear on the channel you just posted in and stick until the
+// next channel entry.
+func TestOnMessage_SelfMessage_DoesNotSetHasUnread(t *testing.T) {
+	db := newTestDB(t)
+	_ = db.UpsertChannel(cache.Channel{ID: "C1", WorkspaceID: "T1", Name: "general", Type: "channel"})
+	h := &rtmEventHandler{
+		db:              db,
+		wsCtx:           &WorkspaceContext{},
+		isActive:        func() bool { return true },
+		activeChannelID: func() string { return "C1" },
+		currentUserID:   "USELF",
+	}
+	h.OnMessage("C1", "USELF", "1.001", "hi", "", "", false, nil, slack.Blocks{}, nil, "", "")
+
+	s, _ := db.GetChannelReadState("C1")
+	if s.HasUnread {
+		t.Error("HasUnread = true, want false: your own message never makes a channel unread")
+	}
+}
+
+// The author comparison must not treat "no human sender" as "it was me".
+// A bot message carries userID == "", and currentUserID is also "" until
+// workspace bootstrap wires it -- an unguarded equality would exempt
+// every bot message from marking its channel unread.
+func TestOnMessage_BotMessage_WithUnsetCurrentUser_SetsHasUnread(t *testing.T) {
+	db := newTestDB(t)
+	_ = db.UpsertChannel(cache.Channel{ID: "C1", WorkspaceID: "T1", Name: "general", Type: "channel"})
+	h := &rtmEventHandler{
+		db:              db,
+		wsCtx:           &WorkspaceContext{},
+		isActive:        func() bool { return true },
+		activeChannelID: func() string { return "C2" },
+		// currentUserID deliberately left empty, as it is pre-bootstrap
+	}
+	h.OnMessage("C1", "", "1.001", "beep", "", "", false, nil, slack.Blocks{}, nil, "B1", "buildbot")
+
+	s, _ := db.GetChannelReadState("C1")
+	if !s.HasUnread {
+		t.Error("HasUnread = false, want true: an empty userID is a bot, not the current user")
+	}
+}
+
+// An edit echo (message_changed) re-delivers a message the channel has
+// already accounted for. reduceNewMessage returns at its IsEdited arm
+// before the read-state tail, so a flag set here would never clear.
+func TestOnMessage_EditEcho_DoesNotSetHasUnread(t *testing.T) {
+	db := newTestDB(t)
+	_ = db.UpsertChannel(cache.Channel{ID: "C1", WorkspaceID: "T1", Name: "general", Type: "channel"})
+	h := &rtmEventHandler{
+		db:              db,
+		wsCtx:           &WorkspaceContext{},
+		isActive:        func() bool { return true },
+		activeChannelID: func() string { return "C2" },
+		currentUserID:   "USELF",
+	}
+	// edited=true, and from someone else, so only the edit gate can
+	// suppress the write.
+	h.OnMessage("C1", "U1", "1.001", "hi (edited)", "", "", true, nil, slack.Blocks{}, nil, "", "")
+
+	s, _ := db.GetChannelReadState("C1")
+	if s.HasUnread {
+		t.Error("HasUnread = true, want false: editing a message does not make a channel unread")
+	}
+}
+
 func TestOnMessage_InactiveWorkspace_StillSetsHasUnread(t *testing.T) {
 	db := newTestDB(t)
 	_ = db.UpsertChannel(cache.Channel{ID: "C1", WorkspaceID: "T1", Name: "general", Type: "channel"})

--- a/cmd/slk/event_handler_test.go
+++ b/cmd/slk/event_handler_test.go
@@ -281,9 +281,14 @@ func TestOnThreadMarked_EmptyLastReadIsIgnored(t *testing.T) {
 	h := &rtmEventHandler{
 		db:          db,
 		workspaceID: "T1",
-		isActive:    func() bool { return true },
-		// program intentionally nil: a UI dispatch here would panic,
-		// pinning that the handler returns before touching it.
+		// The guard returns before the isActive check, which is the
+		// first thing on the dispatch path. Failing here pins the
+		// "skip the UI dispatch" half of the requirement; a nil
+		// program would not, since OnThreadMarked nil-checks it.
+		isActive: func() bool {
+			t.Fatal("handler must return before reaching the dispatch path")
+			return true
+		},
 	}
 
 	h.OnThreadMarked("C1", "1700000100.000000", "")

--- a/cmd/slk/event_handler_test.go
+++ b/cmd/slk/event_handler_test.go
@@ -142,8 +142,10 @@ func TestOnConversationOpened_InactiveWorkspace_PersistsContext(t *testing.T) {
 // (InactiveWorkspace_BumpsChannelUnreadCount, ...ThreadReplyDoesNotBumpChannel,
 // ...ThreadBroadcastBumpsChannel), which asserted against the now-removed
 // wctx.Channels[i].UnreadCount in-memory bump. The DB-backed assertions
-// here exercise the actual contract (UpdateChannelReadState writes) and
-// also cover the new active-channel suppression dimension.
+// here exercise the actual contract (UpdateChannelReadState writes).
+// The active/inactive channel dimension is kept as a pair because the
+// write used to be gated on it; it now runs unconditionally, and the
+// focus-gated clear lives in internal/ui (reduceNewMessage).
 
 func TestOnMessage_InactiveChannel_SetsHasUnread(t *testing.T) {
 	db := newTestDB(t)
@@ -162,20 +164,24 @@ func TestOnMessage_InactiveChannel_SetsHasUnread(t *testing.T) {
 	}
 }
 
-func TestOnMessage_ActiveChannel_DoesNotSetHasUnread(t *testing.T) {
+// The active channel is no longer exempt: whether the user can see it
+// depends on terminal focus, which only the UI goroutine knows. The WS
+// handler always flags, and reduceNewMessage clears it by marking read
+// when focused.
+func TestOnMessage_ActiveChannel_StillSetsHasUnread(t *testing.T) {
 	db := newTestDB(t)
 	_ = db.UpsertChannel(cache.Channel{ID: "C1", WorkspaceID: "T1", Name: "general", Type: "channel"})
 	h := &rtmEventHandler{
 		db:              db,
 		wsCtx:           &WorkspaceContext{},
 		isActive:        func() bool { return true },
-		activeChannelID: func() string { return "C1" }, // viewing the same channel
+		activeChannelID: func() string { return "C1" },
 	}
 	h.OnMessage("C1", "U1", "1.001", "hi", "", "", false, nil, slack.Blocks{}, nil, "", "")
 
 	s, _ := db.GetChannelReadState("C1")
-	if s.HasUnread {
-		t.Errorf("HasUnread = true, want false (active-channel suppression)")
+	if !s.HasUnread {
+		t.Error("HasUnread = false, want true: the UI layer owns the focus-gated clear")
 	}
 }
 

--- a/cmd/slk/event_handler_test.go
+++ b/cmd/slk/event_handler_test.go
@@ -306,6 +306,9 @@ func TestOnMessage_ThreadBroadcast_SetsHasUnread(t *testing.T) {
 	}
 }
 
+// subscribed=true is the case where reconstructing a missing row is
+// legitimate: Slack says the user is subscribed, so a row the local
+// cache has never seen is a gap in the cache, not a phantom.
 func TestOnThreadMarked_AdvancesCursorWithoutTombstoning(t *testing.T) {
 	db := newTestDB(t)
 	h := &rtmEventHandler{
@@ -314,7 +317,7 @@ func TestOnThreadMarked_AdvancesCursorWithoutTombstoning(t *testing.T) {
 		isActive:    func() bool { return true },
 	}
 
-	h.OnThreadMarked("C1", "1700000100.000000", "1700000150.000000")
+	h.OnThreadMarked("C1", "1700000100.000000", "1700000150.000000", true)
 
 	got, err := db.ListActiveThreadSubscriptions("T1")
 	if err != nil {
@@ -331,7 +334,7 @@ func TestOnThreadMarked_AdvancesCursorWithoutTombstoning(t *testing.T) {
 	// A later cursor move must advance last_read and leave the row
 	// active. Writing `active` here used to tombstone the row, making
 	// the thread disappear from the Threads list.
-	h.OnThreadMarked("C1", "1700000100.000000", "1700000200.000000")
+	h.OnThreadMarked("C1", "1700000100.000000", "1700000200.000000", true)
 	got, err = db.ListActiveThreadSubscriptions("T1")
 	if err != nil {
 		t.Fatalf("ListActiveThreadSubscriptions: %v", err)
@@ -365,7 +368,7 @@ func TestOnThreadMarked_EmptyLastReadIsIgnored(t *testing.T) {
 		},
 	}
 
-	h.OnThreadMarked("C1", "1700000100.000000", "")
+	h.OnThreadMarked("C1", "1700000100.000000", "", true)
 
 	lastRead, err := db.GetThreadLastRead("T1", "C1", "1700000100.000000")
 	if err != nil {
@@ -373,6 +376,102 @@ func TestOnThreadMarked_EmptyLastReadIsIgnored(t *testing.T) {
 	}
 	if lastRead != "1700000150.000000" {
 		t.Errorf("LastRead = %q, want the cursor left untouched at 1700000150.000000", lastRead)
+	}
+}
+
+// slk's own subscriptions.thread.mark comes back as a thread_marked
+// echo, so opening an unsubscribed thread from the messages pane
+// reaches this handler. markThreadRead deliberately writes nothing for
+// such a thread; inserting a row here would fabricate the active=1 row
+// it refused to create and put a phantom entry in the Threads list.
+// `subscribed` (Slack's subscription.active) is the signal that says
+// which case this is.
+func TestOnThreadMarked_UnsubscribedDoesNotCreateRow(t *testing.T) {
+	db := newTestDB(t)
+	h := &rtmEventHandler{
+		db:          db,
+		workspaceID: "T1",
+		isActive:    func() bool { return true },
+	}
+
+	h.OnThreadMarked("C1", "1700000100.000000", "1700000150.000000", false)
+
+	got, err := db.ListActiveThreadSubscriptions("T1")
+	if err != nil {
+		t.Fatalf("ListActiveThreadSubscriptions: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("want no active subscription rows for an unsubscribed thread, got %d: %+v", len(got), got)
+	}
+	// ListActiveThreadSubscriptions filters on active=1, so it would
+	// also report 0 for a fabricated row that happened to be
+	// tombstoned. Assert on the row itself: no cursor means no row.
+	lastRead, err := db.GetThreadLastRead("T1", "C1", "1700000100.000000")
+	if err != nil {
+		t.Fatalf("GetThreadLastRead: %v", err)
+	}
+	if lastRead != "" {
+		t.Errorf("GetThreadLastRead = %q, want \"\" — no row should have been created at all", lastRead)
+	}
+}
+
+// The cursor is still the cursor: an existing row advances whether or
+// not the event reports the user as subscribed. Only the missing-row
+// case turns on `subscribed`.
+func TestOnThreadMarked_UnsubscribedAdvancesExistingRow(t *testing.T) {
+	db := newTestDB(t)
+	if err := db.UpsertThreadSubscription("T1", "C1", "1700000100.000000", "1700000150.000000", true); err != nil {
+		t.Fatalf("UpsertThreadSubscription: %v", err)
+	}
+	h := &rtmEventHandler{
+		db:          db,
+		workspaceID: "T1",
+		isActive:    func() bool { return true },
+	}
+
+	h.OnThreadMarked("C1", "1700000100.000000", "1700000200.000000", false)
+
+	got, err := db.ListActiveThreadSubscriptions("T1")
+	if err != nil {
+		t.Fatalf("ListActiveThreadSubscriptions: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want the existing row still active, got %d rows", len(got))
+	}
+	if got[0].LastRead != "1700000200.000000" {
+		t.Errorf("LastRead = %q, want 1700000200.000000", got[0].LastRead)
+	}
+}
+
+// `active` is owned by thread_subscribed / thread_unsubscribed / the
+// getView reconcile. Neither cursor writer may resurrect a tombstoned
+// row, including the inserting one taken when subscribed=true.
+func TestOnThreadMarked_SubscribedLeavesTombstonedRowTombstoned(t *testing.T) {
+	db := newTestDB(t)
+	if err := db.UpsertThreadSubscription("T1", "C1", "1700000100.000000", "1700000150.000000", false); err != nil {
+		t.Fatalf("UpsertThreadSubscription: %v", err)
+	}
+	h := &rtmEventHandler{
+		db:          db,
+		workspaceID: "T1",
+		isActive:    func() bool { return true },
+	}
+
+	h.OnThreadMarked("C1", "1700000100.000000", "1700000200.000000", true)
+
+	got, err := db.ListActiveThreadSubscriptions("T1")
+	if err != nil {
+		t.Fatalf("ListActiveThreadSubscriptions: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("a tombstoned row must stay tombstoned, got %d active: %+v", len(got), got)
+	}
+	lastRead, err := db.GetThreadLastRead("T1", "C1", "1700000100.000000")
+	if err != nil {
+		t.Fatalf("GetThreadLastRead: %v", err)
+	}
+	if lastRead != "1700000200.000000" {
+		t.Errorf("LastRead = %q, want the cursor advanced to 1700000200.000000", lastRead)
 	}
 }
 
@@ -439,7 +538,7 @@ func TestOnThreadMarked_PersistsOnInactiveWorkspace(t *testing.T) {
 		// persist the DB row.
 	}
 
-	h.OnThreadMarked("C1", "1700000100.000000", "1700000150.000000")
+	h.OnThreadMarked("C1", "1700000100.000000", "1700000150.000000", true)
 
 	got, err := db.ListActiveThreadSubscriptions("T1")
 	if err != nil {

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -4577,8 +4577,11 @@ func (h *rtmEventHandler) OnChannelMarked(channelID, ts string, unreadCount int)
 //     undo that guard one hop later and surface a phantom entry in the
 //     Threads list, which filters on active=1.
 //
-// Neither writer touches `active`, so a tombstoned row stays
-// tombstoned either way.
+// Neither writer touches `active` on a row that already exists, so a
+// tombstoned row stays tombstoned either way — it takes
+// UpdateThreadLastRead's ON CONFLICT path, which sets last_read and
+// updated_at only. The subscribed branch's INSERT does create a
+// missing row with active=1, which is the whole point of choosing it.
 func (h *rtmEventHandler) OnThreadMarked(channelID, threadTS, lastRead string, subscribed slackclient.Subscribed) {
 	// An empty cursor would erase the thread's read position and make
 	// every reply render unread. UpdateThreadLastRead does not reject

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -3130,8 +3130,13 @@ func markThreadRead(ctx context.Context, client threadMarker, db *cache.DB, team
 		return err
 	}
 	if db != nil {
-		if err := db.UpdateThreadLastRead(teamID, channelID, threadTS, ts); err != nil {
-			debuglog.Cache("markThreadRead: UpdateThreadLastRead %s/%s: %v",
+		// ...IfExists, not UpdateThreadLastRead: this path fires for
+		// ANY thread the user opens, including ones opened from the
+		// messages pane that they never subscribed to. The inserting
+		// variant would fabricate an active=1 row and put a phantom
+		// entry in the Threads list.
+		if err := db.UpdateThreadLastReadIfExists(teamID, channelID, threadTS, ts); err != nil {
+			debuglog.Cache("markThreadRead: UpdateThreadLastReadIfExists %s/%s: %v",
 				channelID, threadTS, err)
 		}
 	}

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -4121,26 +4121,25 @@ func (h *rtmEventHandler) OnMessage(channelID, userID, ts, text, threadTS, subty
 		}
 	}
 
-	// Read-state: mark the channel has_unread=true when a message
-	// arrives in a channel the user is NOT actively viewing. Mirrors
-	// Slack's channel-unread semantics — non-broadcast thread replies
-	// do not mark the parent channel unread (only top-level messages
-	// and thread_broadcast subtypes do). See internal/ui/app.go's
-	// thread-reply guard for the matching active-path treatment.
+	// Read-state: mark the channel has_unread=true for every eligible
+	// message. Mirrors Slack's channel-unread semantics — non-broadcast
+	// thread replies do not mark the parent channel unread (only
+	// top-level messages and thread_broadcast subtypes do).
+	//
+	// There is deliberately NO active-channel exemption here. Whether
+	// the user can actually see the active channel depends on terminal
+	// focus, which is only known on the UI goroutine. reduceNewMessage
+	// owns that decision and clears this flag by marking read when the
+	// terminal is focused; if the mark fails, or the terminal is
+	// blurred, the flag correctly stands.
 	//
 	// This write runs for BOTH active and inactive workspaces; the
 	// active/inactive split below only governs the UI dispatch path,
-	// not durable read state. Task 10 of the read-state-sync plan
-	// consolidated the previously duplicated paths into this single
-	// gated write.
+	// not durable read state.
 	isThreadReply := threadTS != "" && threadTS != ts
 	isBroadcast := subtype == "thread_broadcast"
 	shouldMarkChannel := !isThreadReply || isBroadcast
-	activeChIDForRead := ""
-	if h.activeChannelID != nil {
-		activeChIDForRead = h.activeChannelID()
-	}
-	if h.db != nil && shouldMarkChannel && activeChIDForRead != channelID {
+	if h.db != nil && shouldMarkChannel {
 		if err := h.db.UpdateChannelReadState(channelID, "", true); err != nil {
 			log.Printf("Warning: failed to set has_unread for %s: %v", channelID, err)
 		}

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -1485,15 +1485,20 @@ func run() error {
 				lastReadTS := state.LastReadTS
 
 				// Mark channel as read up to the latest message
+				markedTS := ""
 				if len(msgItems) > 0 {
-					latestTS := msgItems[len(msgItems)-1].TS
-					markChannelReadAsync(ctx, wctx.Client, db, p, chIDStr, latestTS)
+					markedTS = msgItems[len(msgItems)-1].TS
+					markChannelReadAsync(ctx, wctx.Client, db, p, chIDStr, markedTS)
 				}
 
 				return ui.MessagesLoadedMsg{
 					ChannelID:  chIDStr,
 					Messages:   msgItems,
 					LastReadTS: lastReadTS,
+					// Reported so the reducer can record it on the
+					// Update goroutine and suppress the echo of this
+					// mark; see ui.MessagesLoadedMsg.MarkedTS.
+					MarkedTS: markedTS,
 				}
 			},
 			MarkRead: func(channelID ids.ChannelID, ts ids.MessageTS) tea.Msg {

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -4149,12 +4149,18 @@ func (h *rtmEventHandler) OnMessage(channelID, userID, ts, text, threadTS, subty
 	//
 	// Your own message never makes a channel unread on Slack, whichever
 	// client sent it, so the exclusion is global rather than scoped to
-	// the active channel. It compares the raw userID rather than the
-	// derived authorID: a bot message carries userID == "" (and
-	// authorID == botID), and h.currentUserID is also "" before
-	// workspace bootstrap wires it (main.go:2076), so an unguarded
-	// equality would exempt every bot message from marking its channel
-	// unread.
+	// the active channel.
+	//
+	// The userID != "" guard is load-bearing, not defensive: a bot
+	// message carries userID == "", and h.currentUserID is also ""
+	// until workspace bootstrap wires it (main.go:2076), so a bare
+	// equality would classify every bot message arriving in that window
+	// as self-authored and never flag its channel. Keyed on the raw
+	// userID for the same reason the notification block above is: "did
+	// I write this" is a question about the human sender. (authorID
+	// would behave identically today, since it only diverges for bot
+	// messages and a B-prefixed bot ID cannot equal a U-prefixed user
+	// ID — the choice is about intent, not a behavioral difference.)
 	isSelfMessage := userID != "" && userID == h.currentUserID
 	// edited is true only for message_changed
 	// (internal/slack/events.go:307): a re-delivery of a message the

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -4579,7 +4579,7 @@ func (h *rtmEventHandler) OnChannelMarked(channelID, ts string, unreadCount int)
 //
 // Neither writer touches `active`, so a tombstoned row stays
 // tombstoned either way.
-func (h *rtmEventHandler) OnThreadMarked(channelID, threadTS, lastRead string, subscribed bool) {
+func (h *rtmEventHandler) OnThreadMarked(channelID, threadTS, lastRead string, subscribed slackclient.Subscribed) {
 	// An empty cursor would erase the thread's read position and make
 	// every reply render unread. UpdateThreadLastRead does not reject
 	// it, so drop the event here instead of corrupting the row.

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -4619,8 +4619,13 @@ func (h *rtmEventHandler) OnThreadMarked(channelID, threadTS, lastRead string, s
 		ThreadTS:  threadTS,
 		LastRead:  lastRead,
 	})
-	// Optimistic flag updates above are in-memory only; this schedules
-	// the authoritative recompute from cache.ListSubscribedThreads.
+	// The message above carries this thread's cursor only, and its
+	// reducer applies it to the open panel and to that one list row.
+	// This asks for the authoritative recompute of the whole list,
+	// from the cache rows the write above just updated. Sent per
+	// event with no deduplication here: the reducer coalesces dirty
+	// messages on receipt, so an echo landing inside an open refresh
+	// window costs no additional ListSubscribedThreads query.
 	h.program.Send(ui.ThreadsListDirtyMsg{TeamID: h.workspaceID})
 }
 

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -4620,7 +4620,12 @@ func (h *rtmEventHandler) OnThreadMarked(channelID, threadTS, lastRead string, s
 		LastRead:  lastRead,
 	})
 	// The message above carries this thread's cursor only, and its
-	// reducer applies it to the open panel and to that one list row.
+	// reducer applies it to that one list row — and to the open
+	// panel's landmark, but only when the mark came from another
+	// client. Every mark slk issues itself is broadcast back here too,
+	// and applyThreadMarkEcho deliberately holds the landmark for
+	// those rather than dragging it off what the user was reading.
+	//
 	// This asks for the authoritative recompute of the whole list,
 	// from the cache rows the write above just updated. Sent per
 	// event with no deduplication here: the reducer coalesces dirty

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -1840,18 +1840,17 @@ func run() error {
 				}
 				ensureWorkspaceThreadSubs(ctx, wctx, db, p.Send)
 			},
-			ChannelLastRead: func(channelID ids.ChannelID) string {
+			ThreadLastRead: func(channelID ids.ChannelID, threadTS ids.ThreadTS) string {
 				wctx := router.Active()
 				if wctx == nil {
 					return ""
 				}
-				chIDStr := string(channelID)
-				state, err := db.GetChannelReadState(chIDStr)
+				lastRead, err := db.GetThreadLastRead(wctx.TeamID, string(channelID), string(threadTS))
 				if err != nil {
-					log.Printf("Warning: GetChannelReadState for %s: %v", chIDStr, err)
+					debuglog.Cache("ThreadLastRead: %s/%s: %v", channelID, threadTS, err)
 					return ""
 				}
-				return state.LastReadTS
+				return lastRead
 			},
 		}))
 

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -4151,16 +4151,25 @@ func (h *rtmEventHandler) OnMessage(channelID, userID, ts, text, threadTS, subty
 	// client sent it, so the exclusion is global rather than scoped to
 	// the active channel.
 	//
-	// The userID != "" guard is load-bearing, not defensive: a bot
-	// message carries userID == "", and h.currentUserID is also ""
-	// until workspace bootstrap wires it (main.go:2076), so a bare
-	// equality would classify every bot message arriving in that window
-	// as self-authored and never flag its channel. Keyed on the raw
-	// userID for the same reason the notification block above is: "did
-	// I write this" is a question about the human sender. (authorID
-	// would behave identically today, since it only diverges for bot
-	// messages and a B-prefixed bot ID cannot equal a U-prefixed user
-	// ID — the choice is about intent, not a behavioral difference.)
+	// The userID != "" guard is defensive, not load-bearing. A bot
+	// message carries userID == "", so a bare equality would treat
+	// every one of them as self-authored — and silently stop flagging
+	// their channels — the moment h.currentUserID were empty. That
+	// cannot happen today: currentUserID is assigned once in the
+	// handler's struct literal (main.go:2076) from wctx.UserID and is
+	// never reassigned, so no message can reach this handler before it
+	// is populated. The adjacent notification path ships the unguarded
+	// form (internal/notify/notifier.go:68) without incident, which
+	// corroborates that. The guard is kept anyway because the failure
+	// it prevents is silent, it costs one comparison, and it matches
+	// App.isOwnMessage (internal/ui/app.go:3082).
+	//
+	// Keyed on the raw userID for the same reason the notification
+	// block above is: "did I write this" is a question about the human
+	// sender. authorID would behave identically today, since it only
+	// diverges for bot messages and a B-prefixed bot ID cannot equal a
+	// U-prefixed user ID — the choice is about intent, not a
+	// behavioral difference.
 	isSelfMessage := userID != "" && userID == h.currentUserID
 	// edited is true only for message_changed
 	// (internal/slack/events.go:307): a re-delivery of a message the

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -4124,7 +4124,9 @@ func (h *rtmEventHandler) OnMessage(channelID, userID, ts, text, threadTS, subty
 	// Read-state: mark the channel has_unread=true for every eligible
 	// message. Mirrors Slack's channel-unread semantics — non-broadcast
 	// thread replies do not mark the parent channel unread (only
-	// top-level messages and thread_broadcast subtypes do).
+	// top-level messages and thread_broadcast subtypes do), and neither
+	// your own sends nor edits of existing messages do (see the two
+	// exclusions below).
 	//
 	// There is deliberately NO active-channel exemption here. Whether
 	// the user can actually see the active channel depends on terminal
@@ -4138,7 +4140,27 @@ func (h *rtmEventHandler) OnMessage(channelID, userID, ts, text, threadTS, subty
 	// not durable read state.
 	isThreadReply := threadTS != "" && threadTS != ts
 	isBroadcast := subtype == "thread_broadcast"
-	shouldMarkChannel := !isThreadReply || isBroadcast
+	channelEligible := !isThreadReply || isBroadcast
+	// Self-sends and edit echoes are excluded because reduceNewMessage
+	// returns BEFORE its read-state tail for both (reducer_send.go, the
+	// IsEdited and IsSelfSent arms). Nothing on the UI side would ever
+	// clear a flag set here, so it would stick until the next channel
+	// entry — the dot would appear on the channel you just posted in.
+	//
+	// Your own message never makes a channel unread on Slack, whichever
+	// client sent it, so the exclusion is global rather than scoped to
+	// the active channel. It compares the raw userID rather than the
+	// derived authorID: a bot message carries userID == "" (and
+	// authorID == botID), and h.currentUserID is also "" before
+	// workspace bootstrap wires it (main.go:2076), so an unguarded
+	// equality would exempt every bot message from marking its channel
+	// unread.
+	isSelfMessage := userID != "" && userID == h.currentUserID
+	// edited is true only for message_changed
+	// (internal/slack/events.go:307): a re-delivery of a message the
+	// channel already accounted for. Editing it does not make the
+	// channel unread on Slack.
+	shouldMarkChannel := channelEligible && !isSelfMessage && !edited
 	if h.db != nil && shouldMarkChannel {
 		if err := h.db.UpdateChannelReadState(channelID, "", true); err != nil {
 			log.Printf("Warning: failed to set has_unread for %s: %v", channelID, err)
@@ -4146,16 +4168,21 @@ func (h *rtmEventHandler) OnMessage(channelID, userID, ts, text, threadTS, subty
 	}
 
 	if h.isActive != nil && !h.isActive() {
-		// Inactive workspace — read state was already persisted above.
-		// Fire a ReadStateChangedMsg so the workspace rail refreshes
-		// its dot from db.WorkspacesWithUnreads(). The sidebar's
-		// Invalidate is a no-op here because the active workspace's
-		// sidebar isn't showing this channel anyway.
-		if shouldMarkChannel {
+		// Inactive workspace — durable read state is already settled
+		// above (written, or deliberately skipped). Fire a
+		// ReadStateChangedMsg so the workspace rail refreshes its dot
+		// from db.WorkspacesWithUnreads(). The sidebar's Invalidate is
+		// a no-op here because the active workspace's sidebar isn't
+		// showing this channel anyway.
+		switch {
+		case shouldMarkChannel:
 			debuglog.Cache("OnMessage: team=%s channel=%s ts=%s subtype=%q thread_ts=%s decision=inactive_workspace_persisted",
 				h.workspaceID, channelID, ts, subtype, threadTS)
-		} else {
+		case !channelEligible:
 			debuglog.Cache("OnMessage: team=%s channel=%s ts=%s subtype=%q thread_ts=%s decision=skipped_thread_reply_inactive",
+				h.workspaceID, channelID, ts, subtype, threadTS)
+		default:
+			debuglog.Cache("OnMessage: team=%s channel=%s ts=%s subtype=%q thread_ts=%s decision=skipped_self_or_edit_inactive",
 				h.workspaceID, channelID, ts, subtype, threadTS)
 		}
 		if h.program != nil {

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -1487,7 +1487,7 @@ func run() error {
 				// Mark channel as read up to the latest message
 				if len(msgItems) > 0 {
 					latestTS := msgItems[len(msgItems)-1].TS
-					markChannelReadAsync(ctx, wctx, db, p, chIDStr, latestTS)
+					markChannelReadAsync(ctx, wctx.Client, db, p, chIDStr, latestTS)
 				}
 
 				return ui.MessagesLoadedMsg{
@@ -1498,7 +1498,10 @@ func run() error {
 			},
 			MarkRead: func(channelID ids.ChannelID, ts ids.MessageTS) tea.Msg {
 				wctx := router.Active()
-				markChannelReadAsync(ctx, wctx, db, p, string(channelID), string(ts))
+				if wctx == nil {
+					return nil
+				}
+				markChannelReadAsync(ctx, wctx.Client, db, p, string(channelID), string(ts))
 				return nil // ChannelMarkedReadMsg is emitted from inside the goroutine
 			},
 			FetchOlder: func(channelID ids.ChannelID, oldestTS ids.MessageTS) tea.Msg {
@@ -3095,24 +3098,48 @@ func summarizeCachedRows(rows []cache.Message) string {
 		len(rows), rows[0].TS, rows[len(rows)-1].TS)
 }
 
-// markChannelReadAsync fires Slack's conversations.mark plus the local
-// LastReadTS persistence in a background goroutine. Returns
-// immediately. wctx may be nil (returns silently in that case).
+// channelMarker is the single Slack operation the mark-read path needs.
+// Narrowing it to an interface (rather than taking *WorkspaceContext and
+// reaching through to a concrete *slackclient.Client) is what makes the
+// failure path testable without real HTTP wiring.
+type channelMarker interface {
+	MarkChannel(ctx context.Context, channelID, ts string) error
+}
+
+// markChannelRead calls conversations.mark and, ONLY if Slack accepts
+// it, persists the local read state. On failure the channel stays
+// unread locally, which is the honest state: it reconciles on the next
+// channel entry or reconnect sync. Synchronous so the failure path is
+// deterministically testable; markChannelReadAsync is the goroutine
+// wrapper.
+func markChannelRead(ctx context.Context, client channelMarker, db *cache.DB, channelID, ts string) error {
+	if err := client.MarkChannel(ctx, channelID, ts); err != nil {
+		return err
+	}
+	if db != nil {
+		if err := db.UpdateChannelReadState(channelID, ts, false); err != nil {
+			log.Printf("Warning: failed to update read state in markChannelRead %s/%s: %v", channelID, ts, err)
+		}
+	}
+	return nil
+}
+
+// markChannelReadAsync fires markChannelRead in a background goroutine
+// and returns immediately. client may be nil (returns silently).
 func markChannelReadAsync(
 	ctx context.Context,
-	wctx *WorkspaceContext,
+	client channelMarker,
 	db *cache.DB,
 	p *tea.Program,
 	channelID, ts string,
 ) {
-	if wctx == nil || ts == "" {
+	if client == nil || ts == "" {
 		return
 	}
-	client := wctx.Client
 	go func() {
-		_ = client.MarkChannel(ctx, channelID, ts)
-		if err := db.UpdateChannelReadState(channelID, ts, false); err != nil {
-			log.Printf("Warning: failed to update read state in markChannelReadAsync %s/%s: %v", channelID, ts, err)
+		if err := markChannelRead(ctx, client, db, channelID, ts); err != nil {
+			log.Printf("Warning: conversations.mark %s/%s failed, leaving channel unread: %v", channelID, ts, err)
+			return
 		}
 		if p != nil {
 			p.Send(ui.ChannelMarkedReadMsg{ChannelID: channelID})

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -3139,6 +3139,10 @@ func markThreadRead(ctx context.Context, client threadMarker, db *cache.DB, team
 		// messages pane that they never subscribed to. The inserting
 		// variant would fabricate an active=1 row and put a phantom
 		// entry in the Threads list.
+		//
+		// Slack echoes this very mark back as thread_marked, so the
+		// guard only holds because OnThreadMarked applies the same
+		// rule to the echo, using the event's own subscription flag.
 		if err := db.UpdateThreadLastReadIfExists(teamID, channelID, threadTS, ts); err != nil {
 			debuglog.Cache("markThreadRead: UpdateThreadLastReadIfExists %s/%s: %v",
 				channelID, threadTS, err)
@@ -4556,7 +4560,26 @@ func (h *rtmEventHandler) OnChannelMarked(channelID, ts string, unreadCount int)
 // thread_subscribed / thread_unsubscribed / the getView reconcile.
 // Writing `active` here used to tombstone the row on every read, which
 // made the thread vanish from the Threads list until the next sweep.
-func (h *rtmEventHandler) OnThreadMarked(channelID, threadTS, lastRead string) {
+//
+// subscribed (Slack's subscription.active) chooses the cursor writer,
+// and does nothing else. It is a subscription signal, never a
+// read/unread one: whether the thread is unread stays a comparison of
+// last_read against the newest known reply, computed downstream.
+//
+//   - subscribed: UpdateThreadLastRead, which inserts a missing row.
+//     Slack says the user is subscribed, so a row the local cache lacks
+//     is a gap to reconstruct rather than a phantom to invent.
+//   - not subscribed: UpdateThreadLastReadIfExists, which never
+//     inserts. slk's own subscriptions.thread.mark echoes back here, so
+//     this handler sees marks for threads the user merely opened from
+//     the messages pane and never subscribed to. markThreadRead
+//     deliberately writes no row for those; inserting one here would
+//     undo that guard one hop later and surface a phantom entry in the
+//     Threads list, which filters on active=1.
+//
+// Neither writer touches `active`, so a tombstoned row stays
+// tombstoned either way.
+func (h *rtmEventHandler) OnThreadMarked(channelID, threadTS, lastRead string, subscribed bool) {
 	// An empty cursor would erase the thread's read position and make
 	// every reply render unread. UpdateThreadLastRead does not reject
 	// it, so drop the event here instead of corrupting the row.
@@ -4570,9 +4593,15 @@ func (h *rtmEventHandler) OnThreadMarked(channelID, threadTS, lastRead string) {
 	// and OnChannelMarked: dropping the write on inactive workspaces
 	// leaves stale read state behind on the next switch.
 	if h.db != nil {
-		if err := h.db.UpdateThreadLastRead(h.workspaceID, channelID, threadTS, lastRead); err != nil {
-			debuglog.Cache("OnThreadMarked: UpdateThreadLastRead %s/%s: %v",
-				channelID, threadTS, err)
+		write := h.db.UpdateThreadLastReadIfExists
+		writer := "UpdateThreadLastReadIfExists"
+		if subscribed {
+			write = h.db.UpdateThreadLastRead
+			writer = "UpdateThreadLastRead"
+		}
+		if err := write(h.workspaceID, channelID, threadTS, lastRead); err != nil {
+			debuglog.Cache("OnThreadMarked: %s %s/%s: %v",
+				writer, channelID, threadTS, err)
 		}
 	}
 

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -1741,20 +1741,29 @@ func run() error {
 				}
 				return loadCachedThreadReplies(db, wctx.Client.UserID(), string(channelID), string(threadTS), wctx.UserNames, tsFormat, router)
 			},
-			Mark: func(channelID ids.ChannelID, threadTS ids.ThreadTS, ts ids.MessageTS) {
+			Mark: func(channelID ids.ChannelID, threadTS ids.ThreadTS, ts ids.MessageTS) tea.Cmd {
 				chIDStr, threadTSStr, tsStr := string(channelID), string(threadTS), string(ts)
 				wctx := router.Active()
 				if wctx == nil {
-					return
+					return nil
 				}
 				client := wctx.Client
-				go func() {
+				teamID := wctx.TeamID
+				return func() tea.Msg {
 					ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 					defer cancel()
-					if err := client.MarkThread(ctx, chIDStr, threadTSStr, tsStr); err != nil {
+					// markThreadRead persists the cursor only after
+					// Slack accepts; see its doc comment.
+					if err := markThreadRead(ctx, client, db, teamID, chIDStr, threadTSStr, tsStr); err != nil {
 						log.Printf("Warning: MarkThread(%s, %s): %v", chIDStr, threadTSStr, err)
+						return ui.ThreadMarkedLocalMsg{
+							ChannelID: chIDStr, ThreadTS: threadTSStr, TS: tsStr, Err: err,
+						}
 					}
-				}()
+					return ui.ThreadMarkedLocalMsg{
+						ChannelID: chIDStr, ThreadTS: threadTSStr, TS: tsStr,
+					}
+				}
 			},
 			SendReply: func(channelID ids.ChannelID, threadTS ids.ThreadTS, text string) tea.Msg {
 				chIDStr, threadTSStr := string(channelID), string(threadTS)
@@ -3096,6 +3105,37 @@ func summarizeCachedRows(rows []cache.Message) string {
 	}
 	return fmt.Sprintf("count=%d oldest=%s newest=%s",
 		len(rows), rows[0].TS, rows[len(rows)-1].TS)
+}
+
+// threadMarker is the single Slack operation the thread mark-read path
+// needs. Narrowed to an interface for the same reason as channelMarker
+// below: it makes the "did Slack accept?" branch testable without real
+// HTTP wiring.
+type threadMarker interface {
+	MarkThread(ctx context.Context, channelID, threadTS, ts string) error
+}
+
+// markThreadRead calls subscriptions.thread.mark and, ONLY if Slack
+// accepts it, advances the local thread_subscriptions cursor. Before
+// this gate existed the cursor advanced solely via the thread_marked WS
+// echo, and a lost echo left last_read stale enough to flip the thread
+// back to unread on the next threads-list refresh.
+//
+// A failed local write is logged, not returned: Slack accepted the mark,
+// so the thread genuinely is read and the cache heals on the next
+// getView reconcile. Only a rejected mark is an error, because that is
+// the case where the UI must not clear the unread flag.
+func markThreadRead(ctx context.Context, client threadMarker, db *cache.DB, teamID, channelID, threadTS, ts string) error {
+	if err := client.MarkThread(ctx, channelID, threadTS, ts); err != nil {
+		return err
+	}
+	if db != nil {
+		if err := db.UpdateThreadLastRead(teamID, channelID, threadTS, ts); err != nil {
+			debuglog.Cache("markThreadRead: UpdateThreadLastRead %s/%s: %v",
+				channelID, threadTS, err)
+		}
+	}
+	return nil
 }
 
 // channelMarker is the single Slack operation the mark-read path needs.

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -1476,7 +1476,7 @@ func run() error {
 			Fetch: func(channelID ids.ChannelID, channelName string) tea.Msg {
 				chIDStr := string(channelID)
 				wctx := router.Active()
-				if wctx == nil {
+				if wctx == nil || wctx.Client == nil {
 					return nil
 				}
 				msgItems := fetchChannelMessages(wctx.Client, chIDStr, db, wctx.UserNames, tsFormat, avatarCache, router)
@@ -1498,7 +1498,7 @@ func run() error {
 			},
 			MarkRead: func(channelID ids.ChannelID, ts ids.MessageTS) tea.Msg {
 				wctx := router.Active()
-				if wctx == nil {
+				if wctx == nil || wctx.Client == nil {
 					return nil
 				}
 				markChannelReadAsync(ctx, wctx.Client, db, p, string(channelID), string(ts))
@@ -3124,8 +3124,40 @@ func markChannelRead(ctx context.Context, client channelMarker, db *cache.DB, ch
 	return nil
 }
 
-// markChannelReadAsync fires markChannelRead in a background goroutine
-// and returns immediately. client may be nil (returns silently).
+// markChannelReadAndNotify marks the channel read and, only on success,
+// hands ChannelMarkedReadMsg to notify. A rejected mark must not notify:
+// the UI would optimistically clear an unread badge that Slack still
+// considers unread.
+//
+// notify is a plain func rather than a *tea.Program so this whole
+// decision stays synchronous and testable. Taking the program here
+// would push the send decision back into the goroutine and make
+// "did not notify" assertable only with a sleep.
+func markChannelReadAndNotify(
+	ctx context.Context,
+	client channelMarker,
+	db *cache.DB,
+	notify func(tea.Msg),
+	channelID, ts string,
+) {
+	if err := markChannelRead(ctx, client, db, channelID, ts); err != nil {
+		log.Printf("Warning: conversations.mark %s/%s failed, leaving channel unread: %v", channelID, ts, err)
+		return
+	}
+	if notify != nil {
+		notify(ui.ChannelMarkedReadMsg{ChannelID: channelID})
+	}
+}
+
+// markChannelReadAsync runs markChannelReadAndNotify in a background
+// goroutine and returns immediately. The goroutine is required: p.Send
+// blocks until the Update goroutine receives (bubbletea v2's program
+// channel is unbuffered), so this must never run on Update.
+//
+// client must be non-nil and non-typed-nil: the guard below catches only
+// an untyped nil interface, so a nil *slackclient.Client boxed into a
+// channelMarker would pass it and panic inside the goroutine. Callers
+// check wctx.Client themselves.
 func markChannelReadAsync(
 	ctx context.Context,
 	client channelMarker,
@@ -3136,15 +3168,11 @@ func markChannelReadAsync(
 	if client == nil || ts == "" {
 		return
 	}
-	go func() {
-		if err := markChannelRead(ctx, client, db, channelID, ts); err != nil {
-			log.Printf("Warning: conversations.mark %s/%s failed, leaving channel unread: %v", channelID, ts, err)
-			return
-		}
-		if p != nil {
-			p.Send(ui.ChannelMarkedReadMsg{ChannelID: channelID})
-		}
-	}()
+	var notify func(tea.Msg)
+	if p != nil {
+		notify = func(m tea.Msg) { p.Send(m) }
+	}
+	go markChannelReadAndNotify(ctx, client, db, notify, channelID, ts)
 }
 
 // loadCachedMessages reads up to 50 cached messages for a channel from

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -1658,7 +1658,7 @@ func run() error {
 					// thread_subscriptions row's last_read is the
 					// source of truth and gets updated when Slack
 					// echoes back a thread_marked event. The UI
-					// updates immediately via applyThreadMark; on
+					// updates immediately via applyThreadMarkUnread; on
 					// next refresh cache.ListSubscribedThreads will
 					// reconcile from the persisted subscription row.
 				}
@@ -4406,18 +4406,27 @@ func (h *rtmEventHandler) OnChannelMarked(channelID, ts string, unreadCount int)
 	})
 }
 
-func (h *rtmEventHandler) OnThreadMarked(channelID, threadTS, ts string, read bool) {
-	// Persist subscription state regardless of active-workspace state.
-	// Mirrors OnChannelMarked / OnMessage: durable cache must reflect
-	// every WS event, otherwise switching to an inactive workspace
-	// would surface stale read state and (worse) miss newly-unread
-	// threads until the next reconnect-driven reconcile. active =
-	// !read per the dispatch in internal/slack/events.go: WS `active`
-	// means "subscribed for unread updates", which corresponds to
-	// active=1 in our table.
+// OnThreadMarked persists a thread read-cursor move from Slack's
+// thread_marked event. It writes last_read ONLY: `active` is owned by
+// thread_subscribed / thread_unsubscribed / the getView reconcile.
+// Writing `active` here used to tombstone the row on every read, which
+// made the thread vanish from the Threads list until the next sweep.
+func (h *rtmEventHandler) OnThreadMarked(channelID, threadTS, lastRead string) {
+	// An empty cursor would erase the thread's read position and make
+	// every reply render unread. UpdateThreadLastRead does not reject
+	// it, so drop the event here instead of corrupting the row.
+	if lastRead == "" {
+		debuglog.Cache("OnThreadMarked: empty last_read for %s/%s, ignoring",
+			channelID, threadTS)
+		return
+	}
+
+	// Persist regardless of active-workspace state, matching OnMessage
+	// and OnChannelMarked: dropping the write on inactive workspaces
+	// leaves stale read state behind on the next switch.
 	if h.db != nil {
-		if err := h.db.UpsertThreadSubscription(h.workspaceID, channelID, threadTS, ts, !read); err != nil {
-			debuglog.Cache("OnThreadMarked: UpsertThreadSubscription %s/%s: %v",
+		if err := h.db.UpdateThreadLastRead(h.workspaceID, channelID, threadTS, lastRead); err != nil {
+			debuglog.Cache("OnThreadMarked: UpdateThreadLastRead %s/%s: %v",
 				channelID, threadTS, err)
 		}
 	}
@@ -4434,9 +4443,11 @@ func (h *rtmEventHandler) OnThreadMarked(channelID, threadTS, ts string, read bo
 	h.program.Send(ui.ThreadMarkedRemoteMsg{
 		ChannelID: channelID,
 		ThreadTS:  threadTS,
-		TS:        ts,
-		Read:      read,
+		LastRead:  lastRead,
 	})
+	// Optimistic flag updates above are in-memory only; this schedules
+	// the authoritative recompute from cache.ListSubscribedThreads.
+	h.program.Send(ui.ThreadsListDirtyMsg{TeamID: h.workspaceID})
 }
 
 // OnThreadSubscriptionChanged persists a subscribe/unsubscribe event

--- a/docs/superpowers/plans/2026-09-04-focus-gated-read-marking.md
+++ b/docs/superpowers/plans/2026-09-04-focus-gated-read-marking.md
@@ -126,6 +126,23 @@ Expected: FAIL — all four report `want error ..., got nil`, because the curren
 Replace `internal/slack/client.go:1215-1278` in full with:
 
 ```go
+// parseOKResponse checks a Slack Web API response envelope. Slack
+// answers HTTP 200 even for failures, so the {"ok":false,"error":...}
+// body is the only signal that a call was rejected.
+func parseOKResponse(method string, raw []byte) error {
+	var resp struct {
+		OK    bool   `json:"ok"`
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return fmt.Errorf("parsing %s: %w (body=%s)", method, err, truncateForLog(raw))
+	}
+	if !resp.OK {
+		return fmt.Errorf("%s: %s (body=%s)", method, resp.Error, truncateForLog(raw))
+	}
+	return nil
+}
+
 // markChannel posts to conversations.mark. Used by both MarkChannel
 // (read up to ts) and MarkChannelUnread (roll the watermark backward to
 // ts). Routed through postForm so HTTP status, 429, and the Slack
@@ -139,17 +156,7 @@ func (c *Client) markChannel(ctx context.Context, channelID, ts string) error {
 	if err != nil {
 		return err
 	}
-	var resp struct {
-		OK    bool   `json:"ok"`
-		Error string `json:"error"`
-	}
-	if err := json.Unmarshal(raw, &resp); err != nil {
-		return fmt.Errorf("parsing conversations.mark: %w (body=%s)", err, truncateForLog(raw))
-	}
-	if !resp.OK {
-		return fmt.Errorf("conversations.mark: %s (body=%s)", resp.Error, truncateForLog(raw))
-	}
-	return nil
+	return parseOKResponse("conversations.mark", raw)
 }
 
 // markThread posts to subscriptions.thread.mark. Used by both MarkThread
@@ -176,19 +183,11 @@ func (c *Client) markThread(ctx context.Context, channelID, threadTS, ts string,
 	if err != nil {
 		return err
 	}
-	var resp struct {
-		OK    bool   `json:"ok"`
-		Error string `json:"error"`
-	}
-	if err := json.Unmarshal(raw, &resp); err != nil {
-		return fmt.Errorf("parsing subscriptions.thread.mark: %w (body=%s)", err, truncateForLog(raw))
-	}
-	if !resp.OK {
-		return fmt.Errorf("subscriptions.thread.mark: %s (body=%s)", resp.Error, truncateForLog(raw))
-	}
-	return nil
+	return parseOKResponse("subscriptions.thread.mark", raw)
 }
 ```
+
+`parseOKResponse` is a package-level function, not a method — it needs no `Client` state. If `internal/slack` already has an equivalent envelope-checking helper, use that one instead of adding a second.
 
 Leave `MarkChannel`, `MarkThread`, `MarkChannelUnread`, and `MarkThreadUnread` (`client.go:1280-1314`) untouched.
 
@@ -400,7 +399,7 @@ git commit -m "feat(cache): add thread read-cursor accessors that preserve activ
 - Consumes: `cache.ThreadSummary` fields `ChannelID`, `ThreadTS`, `LastReplyTS`, `Unread` (`internal/cache/threads.go:12-24`); the private `m.summaries []cache.ThreadSummary` and `m.dirty()`.
 - Produces: `func (m *Model) MarkByThreadTSReadAt(channelID, threadTS, lastRead string) bool` — sets `Unread = LastReplyTS > lastRead` on the matching row. Returns true only when the flag actually changed.
 
-`MarkByThreadTSRead` and `MarkByThreadTSUnread` stay: the explicit user-initiated mark-unread flow still needs to force a row unread (Task 4 keeps it on a separate path).
+`MarkByThreadTSUnread` stays: the user-initiated mark-unread flow still needs to force a row unread, and Task 4 keeps it on a separate path. `MarkByThreadTSRead` is left alone for now but loses both its callers across Tasks 4 and 6; Task 6 deletes it.
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -1238,15 +1237,29 @@ Add a new arm to the same switch, immediately after the `ThreadMarkedRemoteMsg` 
 
 Add `"github.com/gammons/slk/internal/debuglog"` to that file's imports if it is not already present.
 
-- [ ] **Step 6: Run the full suite**
+- [ ] **Step 6: Delete the now-dead MarkByThreadTSRead**
+
+That edit removed the last caller of `threadsview.MarkByThreadTSRead` — Task 4 already replaced the other one, in `applyThreadMark`. Delete the method from `internal/ui/threadsview/model.go` (it sits between `MarkSelectedRead` and `MarkByThreadTSUnread`) along with its tests in `internal/ui/threadsview/model_test.go` (`TestMarkByThreadTSRead_*`).
+
+Keep `MarkSelectedRead` and `MarkByThreadTSUnread`: `openSelectedThreadCmd` still calls the former, and `applyThreadMarkUnread` still calls the latter.
+
+Confirm nothing references it before deleting:
+
+```bash
+grep -rn "MarkByThreadTSRead\b" --include='*.go' internal/ cmd/
+```
+
+Expected: no matches (`MarkByThreadTSReadAt` will not match because of the `\b`).
+
+- [ ] **Step 7: Run the full suite**
 
 Run: `make test`
 Expected: PASS. Any test that supplied a `Mark` closure with the old void signature must be updated to return `tea.Cmd` (return `nil`).
 
-- [ ] **Step 7: Commit**
+- [ ] **Step 8: Commit**
 
 ```bash
-git add internal/ui/callbacks.go internal/ui/services.go internal/ui/msgs.go internal/ui/reducer_threads.go internal/ui/reducer_threads_test.go cmd/slk/main.go
+git add internal/ui/callbacks.go internal/ui/services.go internal/ui/msgs.go internal/ui/reducer_threads.go internal/ui/reducer_threads_test.go internal/ui/threadsview/model.go internal/ui/threadsview/model_test.go cmd/slk/main.go
 git commit -m "feat(threads): persist the thread read cursor after a successful mark"
 ```
 
@@ -1756,6 +1769,10 @@ func TestInactiveChannelArrivalDoesNotMark(t *testing.T) {
 func TestFocusedArrivalLeavesDividerInPlace(t *testing.T) {
 	app, _ := markCapture(t)
 	app.activeChannelID = "C1"
+	// Bind the pane to C1 first. Without this the pane is not in
+	// modelsForChannel("C1"), the arrival never reaches it, and the
+	// assertion below would hold trivially without testing anything.
+	app.messagepane.SetChannel("C1", "general")
 	app.messagepane.SetLastReadTS("1.000000")
 
 	_, cmd := app.Update(NewMessageMsg{
@@ -1764,11 +1781,18 @@ func TestFocusedArrivalLeavesDividerInPlace(t *testing.T) {
 	})
 	feed(t, app, cmd, 0)
 
+	// Guard the guard: prove the arrival actually landed in the pane,
+	// so this test fails if the binding above ever stops working.
+	if n := len(app.messagepane.Messages()); n == 0 {
+		t.Fatal("arrival never reached the pane; the divider assertion would be vacuous")
+	}
 	if got := app.messagepane.LastReadTS(); got != "1.000000" {
 		t.Errorf("messagepane LastReadTS = %q, want the divider left at 1.000000", got)
 	}
 }
 ```
+
+`SetChannel` and `Messages()` are the assumed accessor names on the messages pane model. Check `internal/ui/messages/model.go` for the real ones and use whatever the existing pane tests use to bind a channel and read back its buffer — the point is that the arrival must demonstrably reach the pane before the divider assertion runs.
 
 Add `"strings"`, `"time"`, and the `ids` / `messages` imports to the file.
 

--- a/docs/superpowers/plans/2026-09-04-focus-gated-read-marking.md
+++ b/docs/superpowers/plans/2026-09-04-focus-gated-read-marking.md
@@ -1,0 +1,2159 @@
+# Focus-Gated Read Marking Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Advance Slack's server-side read cursor for messages arriving in the channel/thread slk is displaying, but only while the terminal is focused — and fix the thread read-state defects that block doing so correctly.
+
+**Architecture:** Terminal focus is tracked on the Bubble Tea UI goroutine via `tea.View.ReportFocus` plus `tea.FocusMsg`/`tea.BlurMsg`. Arriving messages stage a pending read-cursor advance in a single-slot, newest-wins buffer; a debounced flush issues `conversations.mark` / `subscriptions.thread.mark` through the existing service-closure seams. Local read state is persisted only after Slack accepts the mark.
+
+**Tech Stack:** Go 1.26, `charm.land/bubbletea/v2` v2.0.6, SQLite via `internal/cache`, hand-rolled Slack Web API calls in `internal/slack`.
+
+**Spec:** `docs/superpowers/specs/2026-09-04-focus-gated-read-marking-design.md`
+
+## Global Constraints
+
+- Go module path is `github.com/gammons/slk`. Import internal packages with that prefix.
+- Bubble Tea v2: `App.View()` returns `tea.View`, not `string`. Import as `tea "charm.land/bubbletea/v2"`.
+- Run tests with `make test` (`go test ./... -race -v`). Lint with `make lint` (`golangci-lint run ./...`).
+- Never call `p.Send` from the Bubble Tea `Update` goroutine — the v2 program channel is unbuffered. `p.Send` is only for WS/background goroutines in `cmd/slk`.
+- `cache.UpdateChannelReadState(channelID, lastReadTS, hasUnread)` treats `lastReadTS == ""` as "preserve existing". It is the only function permitted to modify channel read state after bootstrap.
+- Slack timestamps are decimal strings (`"1700000000.000100"`) that compare correctly with Go's `>` / `>=` string operators. Compare them as strings; never parse to float.
+- The repo has a `.worktrees/` directory containing copies of the tree. Never edit anything under `.worktrees/`.
+- Commit after each task. Use Conventional Commits (`fix:`, `feat:`, `refactor:`, `docs:`).
+
+## File Structure
+
+| Path | Responsibility | Tasks |
+|---|---|---|
+| `internal/slack/client.go` | `markChannel`/`markThread` route through `postForm`, parse `ok` | 1 |
+| `internal/slack/client_test.go` | failure-response coverage for mark endpoints | 1 |
+| `internal/cache/thread_subscriptions.go` | `UpdateThreadLastRead`, `GetThreadLastRead` | 2 |
+| `internal/cache/thread_subscriptions_test.go` | cursor accessors preserve `active` | 2 |
+| `internal/ui/threadsview/model.go` | `MarkByThreadTSReadAt` cursor-comparison flag update | 3 |
+| `internal/slack/events.go` | `thread_marked` stops deriving read from `active` | 4 |
+| `cmd/slk/main.go` | handler + service wiring for every task | 4, 5, 6, 7, 9 |
+| `internal/ui/msgs.go` | `ThreadMarkedRemoteMsg` reshape, `ThreadMarkedLocalMsg` | 4, 6 |
+| `internal/ui/app.go` | `applyThreadMark` split, focus flag, pending-mark slots | 4, 7, 8, 9 |
+| `internal/ui/reducer_threads.go` | thread mark arms | 4, 6 |
+| `internal/ui/services.go`, `internal/ui/callbacks.go` | `ThreadService` signature changes | 6, 7 |
+| `internal/ui/reducer_focus.go` | **new** — owns `tea.FocusMsg`/`tea.BlurMsg`/`markFlushMsg` | 8, 9 |
+| `internal/ui/reducer_send.go` | `reduceNewMessage` staging logic | 4, 9 |
+| `wiki/Terminal-Compatibility.md` | focus-reporting docs | 10 |
+
+---
+
+### Task 1: Mark endpoints report real failures
+
+**Files:**
+- Modify: `internal/slack/client.go:1215-1278` (`markChannel`, `markThread`)
+- Test: `internal/slack/client_test.go`
+
+**Interfaces:**
+- Consumes: existing `postForm(ctx, method string, form url.Values) ([]byte, error)` at `client.go:1494`, and `truncateForLog([]byte) string` at `client.go:1547`.
+- Produces: `MarkChannel`, `MarkThread`, `MarkChannelUnread`, `MarkThreadUnread` now return a non-nil error on HTTP failure, HTTP 429, or a Slack `{"ok":false}` body. Signatures are unchanged.
+
+Background: `postForm` injects `token` into the form body itself, checks HTTP status, and maps 429 to `rateLimitError`. It uses `c.apiHTTPClient()`, which returns `c.httpClient` when set (`client.go:211`) — the field `newTestClient` populates — so existing test wiring and Enterprise Grid `apiBaseURL` discovery both keep working.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/slack/client_test.go`:
+
+```go
+func TestMarkChannel_NotOK_ReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":false,"error":"invalid_auth"}`))
+	}))
+	defer srv.Close()
+
+	err := newTestClient(srv).MarkChannel(context.Background(), "C123", "1700000000.000100")
+	if err == nil {
+		t.Fatal("MarkChannel: want error for ok:false, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid_auth") {
+		t.Errorf("error should name the Slack error code, got %q", err)
+	}
+}
+
+func TestMarkChannel_HTTP500_ReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`<html>nope</html>`))
+	}))
+	defer srv.Close()
+
+	if err := newTestClient(srv).MarkChannel(context.Background(), "C123", "1700000000.000100"); err == nil {
+		t.Fatal("MarkChannel: want error for HTTP 500, got nil")
+	}
+}
+
+func TestMarkThread_NotOK_ReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":false,"error":"thread_not_found"}`))
+	}))
+	defer srv.Close()
+
+	err := newTestClient(srv).MarkThread(context.Background(), "C1", "P1", "R5")
+	if err == nil {
+		t.Fatal("MarkThread: want error for ok:false, got nil")
+	}
+	if !strings.Contains(err.Error(), "thread_not_found") {
+		t.Errorf("error should name the Slack error code, got %q", err)
+	}
+}
+
+func TestMarkThreadUnread_NotOK_ReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":false,"error":"thread_not_found"}`))
+	}))
+	defer srv.Close()
+
+	if err := newTestClient(srv).MarkThreadUnread(context.Background(), "C1", "P1", "R5"); err == nil {
+		t.Fatal("MarkThreadUnread: want error for ok:false, got nil")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/slack/ -run 'TestMark.*(NotOK|HTTP500)' -v`
+Expected: FAIL — all four report `want error ..., got nil`, because the current helpers discard the response body.
+
+- [ ] **Step 3: Rewrite the two helpers**
+
+Replace `internal/slack/client.go:1215-1278` in full with:
+
+```go
+// markChannel posts to conversations.mark. Used by both MarkChannel
+// (read up to ts) and MarkChannelUnread (roll the watermark backward to
+// ts). Routed through postForm so HTTP status, 429, and the Slack
+// {"ok":false} envelope are all surfaced as errors — read state must
+// never be persisted locally for a mark Slack rejected.
+func (c *Client) markChannel(ctx context.Context, channelID, ts string) error {
+	raw, err := c.postForm(ctx, "conversations.mark", url.Values{
+		"channel": {channelID},
+		"ts":      {ts},
+	})
+	if err != nil {
+		return err
+	}
+	var resp struct {
+		OK    bool   `json:"ok"`
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return fmt.Errorf("parsing conversations.mark: %w (body=%s)", err, truncateForLog(raw))
+	}
+	if !resp.OK {
+		return fmt.Errorf("conversations.mark: %s (body=%s)", resp.Error, truncateForLog(raw))
+	}
+	return nil
+}
+
+// markThread posts to subscriptions.thread.mark. Used by both MarkThread
+// (read=true => "1") and MarkThreadUnread (read=false => "0").
+// channelID/threadTS empty is a no-op. ts defaults to threadTS when empty
+// (parent has no replies yet). Error handling mirrors markChannel.
+func (c *Client) markThread(ctx context.Context, channelID, threadTS, ts string, read bool) error {
+	if channelID == "" || threadTS == "" {
+		return nil
+	}
+	if ts == "" {
+		ts = threadTS
+	}
+	readVal := "0"
+	if read {
+		readVal = "1"
+	}
+	raw, err := c.postForm(ctx, "subscriptions.thread.mark", url.Values{
+		"channel":   {channelID},
+		"thread_ts": {threadTS},
+		"ts":        {ts},
+		"read":      {readVal},
+	})
+	if err != nil {
+		return err
+	}
+	var resp struct {
+		OK    bool   `json:"ok"`
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return fmt.Errorf("parsing subscriptions.thread.mark: %w (body=%s)", err, truncateForLog(raw))
+	}
+	if !resp.OK {
+		return fmt.Errorf("subscriptions.thread.mark: %s (body=%s)", resp.Error, truncateForLog(raw))
+	}
+	return nil
+}
+```
+
+Leave `MarkChannel`, `MarkThread`, `MarkChannelUnread`, and `MarkThreadUnread` (`client.go:1280-1314`) untouched.
+
+- [ ] **Step 4: Run the full slack package suite**
+
+Run: `go test ./internal/slack/ -race`
+Expected: PASS. The pre-existing `TestMarkChannel_PostsCorrectForm`, `TestMarkChannel_UsesAPIBaseURL`, `TestMarkThread_PostsReadOne`, `TestMarkThread_EmptyArgs_NoOp`, `TestMarkChannelUnread_PostsCorrectForm`, and `TestMarkChannelUnread_EmptyTSSendsZero` must all still pass — `postForm` supplies `token` in the body and sets no `Authorization` header, which is what they assert.
+
+If `go vet` flags unused imports (`net/http`, `strings` may no longer be referenced by these two functions), leave them — they are used elsewhere in the file. Only remove an import if the compiler reports it unused.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/slack/client.go internal/slack/client_test.go
+git commit -m "fix(slack): surface HTTP and ok:false failures from mark endpoints"
+```
+
+---
+
+### Task 2: Thread read-cursor accessors that never touch `active`
+
+**Files:**
+- Modify: `internal/cache/thread_subscriptions.go` (append after `DeleteThreadSubscription`, which ends at line 68)
+- Test: `internal/cache/thread_subscriptions_test.go`
+
+**Interfaces:**
+- Consumes: the `thread_subscriptions` table (`internal/cache/db.go:164-180`), columns `workspace_id, channel_id, thread_ts, last_read, latest_reply, active, updated_at`.
+- Produces:
+  - `func (db *DB) UpdateThreadLastRead(workspaceID, channelID, threadTS, lastRead string) error`
+  - `func (db *DB) GetThreadLastRead(workspaceID, channelID, threadTS string) (string, error)`
+
+Why this exists: `UpsertThreadSubscription` writes `active` on every call. `thread_marked` carries a read cursor, not a subscription change, so it needs a writer that leaves `active` alone. A tombstoned row (`active=0`) must stay tombstoned.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/cache/thread_subscriptions_test.go`:
+
+```go
+func TestUpdateThreadLastRead_PreservesTombstone(t *testing.T) {
+	db := newTestDB(t)
+	// Tombstone the row: active=false.
+	if err := db.UpsertThreadSubscription("T1", "C1", "P1", "R1", false); err != nil {
+		t.Fatalf("UpsertThreadSubscription: %v", err)
+	}
+
+	if err := db.UpdateThreadLastRead("T1", "C1", "P1", "R9"); err != nil {
+		t.Fatalf("UpdateThreadLastRead: %v", err)
+	}
+
+	active, err := db.ListActiveThreadSubscriptions("T1")
+	if err != nil {
+		t.Fatalf("ListActiveThreadSubscriptions: %v", err)
+	}
+	if len(active) != 0 {
+		t.Fatalf("UpdateThreadLastRead must not resurrect a tombstoned row, got %d active", len(active))
+	}
+	got, err := db.GetThreadLastRead("T1", "C1", "P1")
+	if err != nil {
+		t.Fatalf("GetThreadLastRead: %v", err)
+	}
+	if got != "R9" {
+		t.Errorf("GetThreadLastRead = %q, want %q", got, "R9")
+	}
+}
+
+func TestUpdateThreadLastRead_PreservesActive(t *testing.T) {
+	db := newTestDB(t)
+	if err := db.UpsertThreadSubscription("T1", "C1", "P1", "R1", true); err != nil {
+		t.Fatalf("UpsertThreadSubscription: %v", err)
+	}
+
+	if err := db.UpdateThreadLastRead("T1", "C1", "P1", "R9"); err != nil {
+		t.Fatalf("UpdateThreadLastRead: %v", err)
+	}
+
+	active, err := db.ListActiveThreadSubscriptions("T1")
+	if err != nil {
+		t.Fatalf("ListActiveThreadSubscriptions: %v", err)
+	}
+	if len(active) != 1 {
+		t.Fatalf("want 1 active row, got %d", len(active))
+	}
+	if active[0].LastRead != "R9" {
+		t.Errorf("LastRead = %q, want %q", active[0].LastRead, "R9")
+	}
+}
+
+func TestUpdateThreadLastRead_InsertsActiveRow(t *testing.T) {
+	db := newTestDB(t)
+	// No prior row: Slack only sends thread_marked for threads the user
+	// is subscribed to, so an inserted row starts active.
+	if err := db.UpdateThreadLastRead("T1", "C1", "P1", "R5"); err != nil {
+		t.Fatalf("UpdateThreadLastRead: %v", err)
+	}
+
+	active, err := db.ListActiveThreadSubscriptions("T1")
+	if err != nil {
+		t.Fatalf("ListActiveThreadSubscriptions: %v", err)
+	}
+	if len(active) != 1 || active[0].LastRead != "R5" {
+		t.Fatalf("want one active row with LastRead=R5, got %+v", active)
+	}
+}
+
+func TestGetThreadLastRead_MissingRowReturnsEmpty(t *testing.T) {
+	db := newTestDB(t)
+	got, err := db.GetThreadLastRead("T1", "C1", "P1")
+	if err != nil {
+		t.Fatalf("GetThreadLastRead on missing row: %v", err)
+	}
+	if got != "" {
+		t.Errorf("GetThreadLastRead = %q, want empty", got)
+	}
+}
+
+func TestUpdateThreadLastRead_RejectsEmptyKey(t *testing.T) {
+	db := newTestDB(t)
+	if err := db.UpdateThreadLastRead("", "C1", "P1", "R5"); err == nil {
+		t.Error("want error for empty workspaceID, got nil")
+	}
+	if err := db.UpdateThreadLastRead("T1", "", "P1", "R5"); err == nil {
+		t.Error("want error for empty channelID, got nil")
+	}
+	if err := db.UpdateThreadLastRead("T1", "C1", "", "R5"); err == nil {
+		t.Error("want error for empty threadTS, got nil")
+	}
+}
+```
+
+If `newTestDB` is not already available in `internal/cache`'s test package, find the existing helper the other tests in `internal/cache/*_test.go` use to open a temp DB and use that name instead. Do not add a second helper.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/cache/ -run 'ThreadLastRead' -v`
+Expected: FAIL to compile — `db.UpdateThreadLastRead undefined` and `db.GetThreadLastRead undefined`.
+
+- [ ] **Step 3: Implement both accessors**
+
+Insert into `internal/cache/thread_subscriptions.go` immediately after `DeleteThreadSubscription` (line 68):
+
+```go
+// UpdateThreadLastRead advances (or rewinds) a thread's read cursor
+// WITHOUT touching `active`. thread_marked carries a read cursor, not a
+// subscription change, so it must not be able to tombstone a row or
+// resurrect one: `active` is owned solely by thread_subscribed,
+// thread_unsubscribed, and the getView reconcile.
+//
+// A missing row is inserted with active=1 because Slack only pushes
+// thread_marked for threads the user is subscribed to.
+func (db *DB) UpdateThreadLastRead(workspaceID, channelID, threadTS, lastRead string) error {
+	if workspaceID == "" || channelID == "" || threadTS == "" {
+		return fmt.Errorf("UpdateThreadLastRead: workspace/channel/thread_ts required")
+	}
+	const q = `
+INSERT INTO thread_subscriptions
+    (workspace_id, channel_id, thread_ts, last_read, active, updated_at)
+VALUES (?, ?, ?, ?, 1, ?)
+ON CONFLICT(workspace_id, channel_id, thread_ts) DO UPDATE SET
+    last_read  = excluded.last_read,
+    updated_at = excluded.updated_at
+`
+	if _, err := db.conn.Exec(q, workspaceID, channelID, threadTS, lastRead, time.Now().Unix()); err != nil {
+		return fmt.Errorf("updating thread last_read: %w", err)
+	}
+	return nil
+}
+
+// GetThreadLastRead returns a thread's read cursor, or "" when no row
+// exists (which the thread panel treats as "no unread boundary").
+// A missing row is not an error.
+func (db *DB) GetThreadLastRead(workspaceID, channelID, threadTS string) (string, error) {
+	const q = `SELECT last_read FROM thread_subscriptions
+WHERE workspace_id=? AND channel_id=? AND thread_ts=?`
+	var lastRead string
+	err := db.conn.QueryRow(q, workspaceID, channelID, threadTS).Scan(&lastRead)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("reading thread last_read: %w", err)
+	}
+	return lastRead, nil
+}
+```
+
+Add `"database/sql"` and `"errors"` to the import block at `internal/cache/thread_subscriptions.go:3-6`, which currently holds only `"fmt"` and `"time"`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/cache/ -race`
+Expected: PASS, including the pre-existing `db_test.go` column-count assertion (no schema change was made).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/cache/thread_subscriptions.go internal/cache/thread_subscriptions_test.go
+git commit -m "feat(cache): add thread read-cursor accessors that preserve active"
+```
+
+---
+
+### Task 3: Threads-view unread flag derived from the cursor
+
+**Files:**
+- Modify: `internal/ui/threadsview/model.go` (add after `MarkByThreadTSUnread`, which ends at line 470)
+- Test: `internal/ui/threadsview/model_test.go`
+
+**Interfaces:**
+- Consumes: `cache.ThreadSummary` fields `ChannelID`, `ThreadTS`, `LastReplyTS`, `Unread` (`internal/cache/threads.go:12-24`); the private `m.summaries []cache.ThreadSummary` and `m.dirty()`.
+- Produces: `func (m *Model) MarkByThreadTSReadAt(channelID, threadTS, lastRead string) bool` — sets `Unread = LastReplyTS > lastRead` on the matching row. Returns true only when the flag actually changed.
+
+`MarkByThreadTSRead` and `MarkByThreadTSUnread` stay: the explicit user-initiated mark-unread flow still needs to force a row unread (Task 4 keeps it on a separate path).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/ui/threadsview/model_test.go`:
+
+```go
+func TestMarkByThreadTSReadAt_CursorBehindLatestSetsUnread(t *testing.T) {
+	m := New(map[string]string{}, "USELF")
+	m.SetSummaries([]cache.ThreadSummary{
+		{ChannelID: "C1", ThreadTS: "P1", LastReplyTS: "5.000000", Unread: false},
+	})
+
+	if !m.MarkByThreadTSReadAt("C1", "P1", "4.000000") {
+		t.Fatal("want true when the flag flips to unread")
+	}
+	if !m.Summaries()[0].Unread {
+		t.Error("cursor behind latest reply must render unread")
+	}
+}
+
+func TestMarkByThreadTSReadAt_CursorAtLatestClearsUnread(t *testing.T) {
+	m := New(map[string]string{}, "USELF")
+	m.SetSummaries([]cache.ThreadSummary{
+		{ChannelID: "C1", ThreadTS: "P1", LastReplyTS: "5.000000", Unread: true},
+	})
+
+	if !m.MarkByThreadTSReadAt("C1", "P1", "5.000000") {
+		t.Fatal("want true when the flag flips to read")
+	}
+	if m.Summaries()[0].Unread {
+		t.Error("cursor at latest reply must render read")
+	}
+}
+
+func TestMarkByThreadTSReadAt_NoChangeReturnsFalse(t *testing.T) {
+	m := New(map[string]string{}, "USELF")
+	m.SetSummaries([]cache.ThreadSummary{
+		{ChannelID: "C1", ThreadTS: "P1", LastReplyTS: "5.000000", Unread: true},
+	})
+
+	if m.MarkByThreadTSReadAt("C1", "P1", "4.000000") {
+		t.Error("want false when the flag is already correct")
+	}
+}
+
+func TestMarkByThreadTSReadAt_UnknownThreadReturnsFalse(t *testing.T) {
+	m := New(map[string]string{}, "USELF")
+	m.SetSummaries([]cache.ThreadSummary{
+		{ChannelID: "C1", ThreadTS: "P1", LastReplyTS: "5.000000", Unread: true},
+	})
+
+	if m.MarkByThreadTSReadAt("C1", "P_MISSING", "9.000000") {
+		t.Error("want false for a thread not in the list")
+	}
+	if m.MarkByThreadTSReadAt("", "P1", "9.000000") {
+		t.Error("want false for an empty channelID")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/ui/threadsview/ -run MarkByThreadTSReadAt -v`
+Expected: FAIL to compile — `m.MarkByThreadTSReadAt undefined`.
+
+- [ ] **Step 3: Implement the method**
+
+Insert into `internal/ui/threadsview/model.go` after `MarkByThreadTSUnread` (line 470):
+
+```go
+// MarkByThreadTSReadAt sets the Unread flag on the summary matching
+// (channelID, threadTS) by comparing the thread's read cursor against
+// its newest known reply: unread iff LastReplyTS > lastRead. Returns
+// true only when the flag actually changed, so callers can skip the
+// sidebar badge refresh.
+//
+// This is the correct handler for an inbound thread_marked echo, which
+// carries a cursor. Slack's subscription `active` flag means
+// "subscribed", not "unread", and must never be used for this decision.
+// Presentation-only: the next cache.ListSubscribedThreads refresh
+// recomputes Unread from the same rule against durable state.
+func (m *Model) MarkByThreadTSReadAt(channelID, threadTS, lastRead string) bool {
+	if channelID == "" || threadTS == "" {
+		return false
+	}
+	for i := range m.summaries {
+		if m.summaries[i].ChannelID != channelID || m.summaries[i].ThreadTS != threadTS {
+			continue
+		}
+		want := m.summaries[i].LastReplyTS > lastRead
+		if m.summaries[i].Unread == want {
+			return false
+		}
+		m.summaries[i].Unread = want
+		m.dirty()
+		return true
+	}
+	return false
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/ui/threadsview/ -race`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/ui/threadsview/model.go internal/ui/threadsview/model_test.go
+git commit -m "feat(threadsview): derive unread from the thread read cursor"
+```
+
+---
+
+### Task 4: Stop conflating subscription `active` with unread
+
+This is the fix for the reported bug: posting a thread reply auto-subscribes you, Slack echoes `thread_marked` with `subscription.active=true`, and slk currently reads that as "unread" and re-flags the thread you are looking at.
+
+**Files:**
+- Modify: `internal/slack/events.go:37-40` (`EventHandler.OnThreadMarked`), `:246-259` (comment), `:377-387` (dispatch)
+- Modify: `cmd/slk/main.go:4409-4440` (`OnThreadMarked`)
+- Modify: `internal/ui/msgs.go:525-534` (`ThreadMarkedRemoteMsg`)
+- Modify: `internal/ui/app.go:3149-3174` (`applyThreadMark`)
+- Modify: `internal/ui/reducer_threads.go:55-57`
+- Modify: `internal/ui/reducer_send.go:172`
+- Test: `internal/slack/events_test.go:505-537`, `cmd/slk/event_handler_test.go:235-265` and `:320-344`, `internal/ui/app_test.go:2942-2981`
+
+**Interfaces:**
+- Consumes: `db.UpdateThreadLastRead` (Task 2), `threadsView.MarkByThreadTSReadAt` (Task 3).
+- Produces:
+  - `EventHandler.OnThreadMarked(channelID, threadTS, lastRead string)` — the `read bool` parameter is gone.
+  - `ui.ThreadMarkedRemoteMsg{ChannelID, ThreadTS, LastRead string}` — `TS` and `Read` are gone.
+  - `(*App).applyThreadMark(channelID, threadTS, lastRead string)` — cursor-based, used by the remote echo path.
+  - `(*App).applyThreadMarkUnread(channelID, threadTS, boundaryTS string)` — forces unread, used by the user-initiated `U` mark-unread flow.
+
+Why the split: Slack's mark-unread sets the cursor to just *before* the boundary ts. Passing `boundaryTS` into a `LastReplyTS > lastRead` comparison would report the thread read when the boundary is the newest reply. The user-initiated path already knows the intent, so it forces the flag directly.
+
+- [ ] **Step 1: Update the event-dispatch tests**
+
+In `internal/slack/events_test.go`, replace `TestDispatch_ThreadMarked_Unread_CallsHandler` (line 505) and `TestDispatch_ThreadMarked_Read_CallsHandler` (line 522) with:
+
+```go
+func TestDispatch_ThreadMarked_PassesCursorThrough(t *testing.T) {
+	handler := &mockEventHandler{}
+	data := []byte(`{"type":"thread_marked","subscription":{"channel":"C1","thread_ts":"1700000000.000100","last_read":"1700000000.000200","active":true}}`)
+	dispatchWebSocketEvent(data, handler)
+
+	if len(handler.threadMarks) != 1 {
+		t.Fatalf("expected 1 threadMark, got %d", len(handler.threadMarks))
+	}
+	got := handler.threadMarks[0]
+	if got.channelID != "C1" || got.threadTS != "1700000000.000100" || got.lastRead != "1700000000.000200" {
+		t.Errorf("unexpected: %+v", got)
+	}
+}
+
+// active=false previously meant "read". It means "unsubscribed", which
+// thread_marked does not report, so it must not change what we pass on.
+func TestDispatch_ThreadMarked_IgnoresActiveFlag(t *testing.T) {
+	handler := &mockEventHandler{}
+	data := []byte(`{"type":"thread_marked","subscription":{"channel":"C1","thread_ts":"P1","last_read":"R5","active":false}}`)
+	dispatchWebSocketEvent(data, handler)
+
+	if len(handler.threadMarks) != 1 {
+		t.Fatalf("expected 1 threadMark, got %d", len(handler.threadMarks))
+	}
+	if handler.threadMarks[0].lastRead != "R5" {
+		t.Errorf("lastRead = %q, want R5", handler.threadMarks[0].lastRead)
+	}
+}
+```
+
+Then update `mockEventHandler` in the same file: its `threadMarks` element struct currently has fields `channelID, threadTS, ts string; read bool`. Change it to `channelID, threadTS, lastRead string` and update its `OnThreadMarked` method to the three-argument signature. Leave `TestDispatch_ThreadMarked_MalformedJSON_NoCall` (line 535) unchanged.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/slack/ -run ThreadMarked -v`
+Expected: FAIL to compile — the mock no longer matches `EventHandler`, and `got.lastRead` does not exist yet.
+
+- [ ] **Step 3: Change the interface and dispatch**
+
+In `internal/slack/events.go`, change the interface method at line 40 to:
+
+```go
+	// OnThreadMarked is delivered when Slack pushes a thread_marked
+	// event: the user's read cursor inside a thread moved (in either
+	// direction). lastRead is the new cursor. The subscription block's
+	// `active` flag is deliberately NOT passed on — it means
+	// "subscribed", not "unread"; see OnThreadSubscriptionChanged,
+	// which owns that bit.
+	OnThreadMarked(channelID, threadTS, lastRead string)
+```
+
+Replace the `case "thread_marked":` body (lines 377-387) with:
+
+```go
+	case "thread_marked":
+		var evt wsThreadMarkedEvent
+		if err := json.Unmarshal(data, &evt); err != nil {
+			return
+		}
+		debuglog.WS("thread_marked: channel=%s thread_ts=%s last_read=%s",
+			evt.Subscription.Channel, evt.Subscription.ThreadTS, evt.Subscription.LastRead)
+		handler.OnThreadMarked(evt.Subscription.Channel, evt.Subscription.ThreadTS, evt.Subscription.LastRead)
+```
+
+Fix the now-wrong doc comment on `wsThreadMarkedEvent` (lines 246-250):
+
+```go
+// wsThreadMarkedEvent represents a thread_marked event from Slack's
+// browser-protocol WebSocket. The subscription block carries the
+// channel/thread and the new last-read ts. It also carries an `active`
+// flag, which means "subscribed for unread updates" — the same meaning
+// it has in wsThreadSubscribedEvent — and is NOT a read/unread signal.
+```
+
+- [ ] **Step 4: Update the WS handler**
+
+Replace `cmd/slk/main.go:4409-4440` (the whole `OnThreadMarked` function, from its doc comment through its closing brace) with:
+
+```go
+// OnThreadMarked persists a thread read-cursor move from Slack's
+// thread_marked event. It writes last_read ONLY: `active` is owned by
+// thread_subscribed / thread_unsubscribed / the getView reconcile.
+// Writing `active` here used to tombstone the row on every read, which
+// made the thread vanish from the Threads list until the next sweep.
+func (h *rtmEventHandler) OnThreadMarked(channelID, threadTS, lastRead string) {
+	// Persist regardless of active-workspace state, matching OnMessage
+	// and OnChannelMarked: dropping the write on inactive workspaces
+	// leaves stale read state behind on the next switch.
+	if h.db != nil {
+		if err := h.db.UpdateThreadLastRead(h.workspaceID, channelID, threadTS, lastRead); err != nil {
+			debuglog.Cache("OnThreadMarked: UpdateThreadLastRead %s/%s: %v",
+				channelID, threadTS, err)
+		}
+	}
+
+	// UI dispatch is active-only: the threads-view list and sidebar
+	// badge live on the active workspace; inactive workspaces pick up
+	// fresh state on the next switch via threadsListFetcher.
+	if h.isActive != nil && !h.isActive() {
+		return
+	}
+	if h.program == nil {
+		return
+	}
+	h.program.Send(ui.ThreadMarkedRemoteMsg{
+		ChannelID: channelID,
+		ThreadTS:  threadTS,
+		LastRead:  lastRead,
+	})
+	// Optimistic flag updates above are in-memory only; this schedules
+	// the authoritative recompute from cache.ListSubscribedThreads.
+	h.program.Send(ui.ThreadsListDirtyMsg{TeamID: h.workspaceID})
+}
+```
+
+- [ ] **Step 5: Reshape the message and split applyThreadMark**
+
+In `internal/ui/msgs.go`, replace lines 525-534 with:
+
+```go
+// ThreadMarkedRemoteMsg is dispatched by the WS event handler when
+// Slack pushes a thread_marked event. LastRead is the thread's new read
+// cursor; whether that means read or unread is decided by comparing it
+// against the thread's newest known reply.
+type ThreadMarkedRemoteMsg struct {
+	ChannelID string
+	ThreadTS  string
+	LastRead  string
+}
+```
+
+In `internal/ui/app.go`, replace `applyThreadMark` (lines 3149-3174) with these two functions:
+
+```go
+// applyThreadMark updates local state for an inbound thread read-cursor
+// move. Read/unread is derived by comparing the cursor against the
+// thread's newest known reply — never from the subscription's `active`
+// flag, which means "subscribed".
+func (a *App) applyThreadMark(channelID, threadTS, lastRead string) {
+	debuglog.Cache("applyThreadMark: channel=%s thread_ts=%s last_read=%s active=%s",
+		channelID, threadTS, lastRead, a.activeChannelID)
+	if a.threadVisible &&
+		a.threadPanel.ChannelID() == channelID &&
+		a.threadPanel.ThreadTS() == threadTS {
+		// The panel renders its "── new ──" landmark after the boundary
+		// ts, so a fully-caught-up cursor renders no landmark.
+		a.threadPanel.SetUnreadBoundary(lastRead)
+	}
+	if a.threadsView.MarkByThreadTSReadAt(channelID, threadTS, lastRead) {
+		a.sidebar.SetThreadsUnreadCount(a.threadsView.UnreadCount())
+	}
+}
+
+// applyThreadMarkUnread forces a thread unread from boundaryTS. Used by
+// the user-initiated mark-unread flow, which knows its own intent.
+// It does not go through applyThreadMark's cursor comparison: Slack sets
+// the cursor to just BEFORE boundaryTS, so comparing boundaryTS against
+// the newest reply would wrongly report the thread read whenever the
+// boundary is that newest reply.
+func (a *App) applyThreadMarkUnread(channelID, threadTS, boundaryTS string) {
+	debuglog.Cache("applyThreadMarkUnread: channel=%s thread_ts=%s boundary=%s active=%s",
+		channelID, threadTS, boundaryTS, a.activeChannelID)
+	if a.threadVisible &&
+		a.threadPanel.ChannelID() == channelID &&
+		a.threadPanel.ThreadTS() == threadTS {
+		a.threadPanel.SetUnreadBoundary(boundaryTS)
+	}
+	if a.threadsView.MarkByThreadTSUnread(channelID, threadTS) {
+		a.sidebar.SetThreadsUnreadCount(a.threadsView.UnreadCount())
+	}
+}
+```
+
+Update the two call sites:
+
+`internal/ui/reducer_threads.go:55-57` becomes:
+
+```go
+	case ThreadMarkedRemoteMsg:
+		a.applyThreadMark(m.ChannelID, m.ThreadTS, m.LastRead)
+		return nil, true
+```
+
+`internal/ui/reducer_send.go:172` becomes:
+
+```go
+			a.applyThreadMarkUnread(m.ChannelID, m.ThreadTS, m.BoundaryTS)
+```
+
+- [ ] **Step 6: Update the handler and UI tests**
+
+In `cmd/slk/event_handler_test.go`, replace `TestOnThreadMarked_UpsertsSubscription` (line 235 through its closing brace at 265) with:
+
+```go
+func TestOnThreadMarked_AdvancesCursorWithoutTombstoning(t *testing.T) {
+	db := newTestDB(t)
+	h := &rtmEventHandler{
+		db:          db,
+		workspaceID: "T1",
+		isActive:    func() bool { return true },
+	}
+
+	h.OnThreadMarked("C1", "1700000100.000000", "1700000150.000000")
+
+	got, err := db.ListActiveThreadSubscriptions("T1")
+	if err != nil {
+		t.Fatalf("ListActiveThreadSubscriptions: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 active sub after thread_marked, got %d", len(got))
+	}
+	if got[0].ChannelID != "C1" || got[0].ThreadTS != "1700000100.000000" ||
+		got[0].LastRead != "1700000150.000000" || !got[0].Active {
+		t.Fatalf("subscription row mismatch: %+v", got[0])
+	}
+
+	// A later cursor move must advance last_read and leave the row
+	// active. Writing `active` here used to tombstone the row, making
+	// the thread disappear from the Threads list.
+	h.OnThreadMarked("C1", "1700000100.000000", "1700000200.000000")
+	got, err = db.ListActiveThreadSubscriptions("T1")
+	if err != nil {
+		t.Fatalf("ListActiveThreadSubscriptions: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("thread must stay in the list after being read, got %d active", len(got))
+	}
+	if got[0].LastRead != "1700000200.000000" {
+		t.Errorf("LastRead = %q, want 1700000200.000000", got[0].LastRead)
+	}
+}
+```
+
+In the same file, update `TestOnThreadMarked_PersistsOnInactiveWorkspace` (line 320): change the call at line 331 to `h.OnThreadMarked("C1", "1700000100.000000", "1700000150.000000")` and delete the `// read=false → ...` comment above it. Its assertions already expect one active row with `LastRead == "1700000150.000000"` and stay valid.
+
+In `internal/ui/app_test.go`, replace `TestThreadMarkedRemoteMsg_UnreadFlipsRow` (line 2942) and `TestThreadMarkedRemoteMsg_ReadClearsRow` (line 2966) with:
+
+```go
+func TestThreadMarkedRemoteMsg_CursorBehindLatestFlipsRowUnread(t *testing.T) {
+	app := NewApp()
+	app.threadsView.SetSummaries([]cache.ThreadSummary{
+		{ChannelID: "C1", ThreadTS: "P1", LastReplyTS: "5.000000", Unread: false},
+	})
+
+	_, cmd := app.Update(ThreadMarkedRemoteMsg{
+		ChannelID: "C1",
+		ThreadTS:  "P1",
+		LastRead:  "4.000000",
+	})
+
+	if cmd != nil && cmdContainsMsgType(cmd, statusbar.MarkedUnreadMsg{}) {
+		t.Error("expected no toast on remote thread event")
+	}
+	for _, s := range app.threadsView.Summaries() {
+		if s.ThreadTS == "P1" && !s.Unread {
+			t.Error("expected P1 Unread=true when the cursor is behind the latest reply")
+		}
+	}
+}
+
+func TestThreadMarkedRemoteMsg_CursorAtLatestClearsRow(t *testing.T) {
+	app := NewApp()
+	app.threadsView.SetSummaries([]cache.ThreadSummary{
+		{ChannelID: "C1", ThreadTS: "P1", LastReplyTS: "5.000000", Unread: true},
+	})
+
+	_, _ = app.Update(ThreadMarkedRemoteMsg{
+		ChannelID: "C1", ThreadTS: "P1", LastRead: "5.000000",
+	})
+
+	for _, s := range app.threadsView.Summaries() {
+		if s.ThreadTS == "P1" && s.Unread {
+			t.Error("expected P1 Unread=false when the cursor reaches the latest reply")
+		}
+	}
+}
+
+// Regression for the reported bug: posting a reply auto-subscribes you,
+// so Slack echoes thread_marked with active=true. slk used to read that
+// as "unread" and re-flag the thread the user was looking at.
+func TestThreadMarkedRemoteMsg_SelfReplyDoesNotReFlagUnread(t *testing.T) {
+	app := NewApp()
+	app.threadsView.SetSummaries([]cache.ThreadSummary{
+		{ChannelID: "C1", ThreadTS: "P1", LastReplyTS: "7.000000", Unread: false},
+	})
+
+	// Slack's echo after our own reply: cursor caught up to our reply.
+	_, _ = app.Update(ThreadMarkedRemoteMsg{
+		ChannelID: "C1", ThreadTS: "P1", LastRead: "7.000000",
+	})
+
+	for _, s := range app.threadsView.Summaries() {
+		if s.ThreadTS == "P1" && s.Unread {
+			t.Error("replying to a thread must not mark it unread")
+		}
+	}
+}
+```
+
+- [ ] **Step 7: Run the full suite**
+
+Run: `make test`
+Expected: PASS. If any other file fails to compile because it calls `OnThreadMarked` or `applyThreadMark` with the old arity, update it to the new signature; do not reintroduce the `read` bool.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/slack/events.go internal/slack/events_test.go cmd/slk/main.go cmd/slk/event_handler_test.go internal/ui/msgs.go internal/ui/app.go internal/ui/app_test.go internal/ui/reducer_threads.go internal/ui/reducer_send.go
+git commit -m "fix(threads): stop reading subscription active as unread"
+```
+
+---
+
+### Task 5: Channel marks honor Slack's answer
+
+**Files:**
+- Modify: `cmd/slk/main.go:3098-3121` (`markChannelReadAsync`), `:1453-1480` (the two call sites)
+- Test: `cmd/slk/event_handler_marked_test.go` (replace the skipped `TestMarkChannelReadAsync_UpdatesReadState` at line ~129)
+
+**Interfaces:**
+- Consumes: `cache.UpdateChannelReadState`, `ui.ChannelMarkedReadMsg`, and `MarkChannel`'s new error contract from Task 1.
+- Produces:
+  - `type channelMarker interface { MarkChannel(ctx context.Context, channelID, ts string) error }`
+  - `func markChannelRead(ctx context.Context, client channelMarker, db *cache.DB, channelID, ts string) error` — synchronous, testable.
+  - `func markChannelReadAsync(ctx context.Context, client channelMarker, db *cache.DB, p *tea.Program, channelID, ts string)` — the parameter changed from `wctx *WorkspaceContext` to `client channelMarker`.
+
+The synchronous split exists so the failure path is deterministically testable. Asserting "the DB was *not* written" against a fire-and-forget goroutine can only be done with a sleep, which is a flaky test.
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace the skipped test in `cmd/slk/event_handler_marked_test.go` with:
+
+```go
+type fakeChannelMarker struct {
+	err   error
+	calls []string // "channelID/ts" per call
+}
+
+func (f *fakeChannelMarker) MarkChannel(_ context.Context, channelID, ts string) error {
+	f.calls = append(f.calls, channelID+"/"+ts)
+	return f.err
+}
+
+func TestMarkChannelRead_SuccessPersistsReadState(t *testing.T) {
+	db := newTestDB(t)
+	_ = db.UpsertChannel(cache.Channel{ID: "C1", WorkspaceID: "T1", Name: "general", Type: "channel"})
+	if err := db.UpdateChannelReadState("C1", "", true); err != nil {
+		t.Fatalf("seed has_unread: %v", err)
+	}
+	marker := &fakeChannelMarker{}
+
+	if err := markChannelRead(context.Background(), marker, db, "C1", "1700000000.000100"); err != nil {
+		t.Fatalf("markChannelRead: %v", err)
+	}
+
+	if len(marker.calls) != 1 || marker.calls[0] != "C1/1700000000.000100" {
+		t.Fatalf("unexpected MarkChannel calls: %v", marker.calls)
+	}
+	s, _ := db.GetChannelReadState("C1")
+	if s.LastReadTS != "1700000000.000100" || s.HasUnread {
+		t.Errorf("read state = %+v, want LastReadTS advanced and HasUnread=false", s)
+	}
+}
+
+func TestMarkChannelRead_FailureLeavesChannelUnread(t *testing.T) {
+	db := newTestDB(t)
+	_ = db.UpsertChannel(cache.Channel{ID: "C1", WorkspaceID: "T1", Name: "general", Type: "channel"})
+	if err := db.UpdateChannelReadState("C1", "", true); err != nil {
+		t.Fatalf("seed has_unread: %v", err)
+	}
+	marker := &fakeChannelMarker{err: errors.New("conversations.mark: invalid_auth")}
+
+	if err := markChannelRead(context.Background(), marker, db, "C1", "1700000000.000100"); err == nil {
+		t.Fatal("markChannelRead: want error, got nil")
+	}
+
+	s, _ := db.GetChannelReadState("C1")
+	if s.LastReadTS != "" {
+		t.Errorf("LastReadTS = %q, want unchanged after a rejected mark", s.LastReadTS)
+	}
+	if !s.HasUnread {
+		t.Error("HasUnread must stay true so the state can be reconciled later")
+	}
+}
+```
+
+Add `"errors"` to that file's imports if absent. Keep the existing `cache` and `context` imports.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./cmd/slk/ -run MarkChannelRead -v`
+Expected: FAIL to compile — `markChannelRead undefined`.
+
+- [ ] **Step 3: Implement the seam**
+
+Replace `cmd/slk/main.go:3098-3121` (the `markChannelReadAsync` doc comment through its closing brace) with:
+
+```go
+// channelMarker is the single Slack operation the mark-read path needs.
+// Narrowing it to an interface (rather than taking *WorkspaceContext and
+// reaching through to a concrete *slackclient.Client) is what makes the
+// failure path testable without real HTTP wiring.
+type channelMarker interface {
+	MarkChannel(ctx context.Context, channelID, ts string) error
+}
+
+// markChannelRead calls conversations.mark and, ONLY if Slack accepts
+// it, persists the local read state. On failure the channel stays
+// unread locally, which is the honest state: it reconciles on the next
+// channel entry or reconnect sync. Synchronous so the failure path is
+// deterministically testable; markChannelReadAsync is the goroutine
+// wrapper.
+func markChannelRead(ctx context.Context, client channelMarker, db *cache.DB, channelID, ts string) error {
+	if err := client.MarkChannel(ctx, channelID, ts); err != nil {
+		return err
+	}
+	if db != nil {
+		if err := db.UpdateChannelReadState(channelID, ts, false); err != nil {
+			log.Printf("Warning: failed to update read state in markChannelRead %s/%s: %v", channelID, ts, err)
+		}
+	}
+	return nil
+}
+
+// markChannelReadAsync fires markChannelRead in a background goroutine
+// and returns immediately. client may be nil (returns silently).
+func markChannelReadAsync(
+	ctx context.Context,
+	client channelMarker,
+	db *cache.DB,
+	p *tea.Program,
+	channelID, ts string,
+) {
+	if client == nil || ts == "" {
+		return
+	}
+	go func() {
+		if err := markChannelRead(ctx, client, db, channelID, ts); err != nil {
+			log.Printf("Warning: conversations.mark %s/%s failed, leaving channel unread: %v", channelID, ts, err)
+			return
+		}
+		if p != nil {
+			p.Send(ui.ChannelMarkedReadMsg{ChannelID: channelID})
+		}
+	}()
+}
+```
+
+- [ ] **Step 4: Update both call sites**
+
+`ChannelService.Fetch` (`cmd/slk/main.go`, the `markChannelReadAsync(ctx, wctx, db, p, chIDStr, latestTS)` line around 1467) becomes:
+
+```go
+			markChannelReadAsync(ctx, wctx.Client, db, p, chIDStr, latestTS)
+```
+
+That closure already returns early when `wctx == nil`, so `wctx.Client` is safe there.
+
+`ChannelService.MarkRead` (around line 1476) currently passes a possibly-nil `wctx` and relies on the old internal nil check. Replace the whole closure with:
+
+```go
+			MarkRead: func(channelID ids.ChannelID, ts ids.MessageTS) tea.Msg {
+				wctx := router.Active()
+				if wctx == nil {
+					return nil
+				}
+				markChannelReadAsync(ctx, wctx.Client, db, p, string(channelID), string(ts))
+				return nil // ChannelMarkedReadMsg is emitted from inside the goroutine
+			},
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `go test ./cmd/slk/ -race`
+Expected: PASS, with the previously skipped mark-read test now replaced by two real ones.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/slk/main.go cmd/slk/event_handler_marked_test.go
+git commit -m "fix: only persist channel read state after Slack accepts the mark"
+```
+
+---
+
+### Task 6: Thread marks persist the cursor and report their outcome
+
+**Files:**
+- Modify: `internal/ui/callbacks.go:78-82` (`ThreadMarkFunc`)
+- Modify: `internal/ui/services.go:146-150` (interface), `:223-228` (adapter)
+- Modify: `internal/ui/msgs.go` (add `ThreadMarkedLocalMsg`)
+- Modify: `cmd/slk/main.go:1741-1755` (`ThreadService.Mark` closure)
+- Modify: `internal/ui/reducer_threads.go:109-137` (call site) and add a new arm
+- Test: `internal/ui/reducer_threads_test.go`
+
+**Interfaces:**
+- Consumes: `db.UpdateThreadLastRead` (Task 2), `applyThreadMark` (Task 4), `MarkThread`'s error contract (Task 1), `WorkspaceContext.TeamID`.
+- Produces:
+  - `type ThreadMarkFunc func(channelID ids.ChannelID, threadTS ids.ThreadTS, ts ids.MessageTS) tea.Cmd`
+  - `ThreadService.Mark(...) tea.Cmd`
+  - `ui.ThreadMarkedLocalMsg{ChannelID, ThreadTS, TS string; Err error}`
+
+Today `Mark` is `void` and remote-only, so `thread_subscriptions.last_read` only ever advances via a WS echo. That lag is what lets a stale cursor flip a thread back to unread on the next list refresh.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/ui/reducer_threads_test.go`:
+
+```go
+func TestThreadMarkedLocalMsg_SuccessAppliesCursor(t *testing.T) {
+	app := NewApp()
+	app.threadsView.SetSummaries([]cache.ThreadSummary{
+		{ChannelID: "C1", ThreadTS: "P1", LastReplyTS: "5.000000", Unread: true},
+	})
+
+	_, _ = app.Update(ThreadMarkedLocalMsg{ChannelID: "C1", ThreadTS: "P1", TS: "5.000000"})
+
+	for _, s := range app.threadsView.Summaries() {
+		if s.ThreadTS == "P1" && s.Unread {
+			t.Error("a successful thread mark must clear the unread flag")
+		}
+	}
+}
+
+func TestThreadMarkedLocalMsg_FailureLeavesFlagAlone(t *testing.T) {
+	app := NewApp()
+	app.threadsView.SetSummaries([]cache.ThreadSummary{
+		{ChannelID: "C1", ThreadTS: "P1", LastReplyTS: "5.000000", Unread: true},
+	})
+
+	_, _ = app.Update(ThreadMarkedLocalMsg{
+		ChannelID: "C1", ThreadTS: "P1", TS: "5.000000",
+		Err: errors.New("subscriptions.thread.mark: thread_not_found"),
+	})
+
+	for _, s := range app.threadsView.Summaries() {
+		if s.ThreadTS == "P1" && !s.Unread {
+			t.Error("a rejected thread mark must leave the thread unread")
+		}
+	}
+}
+
+func TestThreadRepliesLoaded_ReturnsMarkCmd(t *testing.T) {
+	app := NewApp()
+	var got []string
+	app.SetThreadService(NewThreadService(ThreadServiceFuncs{
+		Mark: func(channelID ids.ChannelID, threadTS ids.ThreadTS, ts ids.MessageTS) tea.Cmd {
+			got = append(got, string(channelID)+"/"+string(threadTS)+"/"+string(ts))
+			return nil
+		},
+	}))
+	app.threadVisible = true
+	app.threadPanel.SetThread(messages.MessageItem{TS: "P1"}, nil, "C1", "P1")
+
+	_, _ = app.Update(ThreadRepliesLoadedMsg{
+		ThreadTS: "P1",
+		Replies:  []messages.MessageItem{{TS: "R1"}, {TS: "R5"}},
+	})
+
+	if len(got) != 1 || got[0] != "C1/P1/R5" {
+		t.Fatalf("Mark calls = %v, want one call marking up to the newest reply", got)
+	}
+}
+```
+
+Add `"errors"` and any missing imports (`cache`, `ids`, `messages`, `tea`) to that file.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/ui/ -run 'ThreadMarkedLocalMsg|ThreadRepliesLoaded_ReturnsMarkCmd' -v`
+Expected: FAIL to compile — `ThreadMarkedLocalMsg` undefined, and the `Mark` closure returns `tea.Cmd` which does not match the current `ThreadMarkFunc`.
+
+- [ ] **Step 3: Change the signature through the layers**
+
+`internal/ui/callbacks.go`, replace the `ThreadMarkFunc` declaration (line 82):
+
+```go
+// ThreadMarkFunc is called to mark a thread as read on Slack's servers
+// (subscriptions.thread.mark) and, on success, to advance the local
+// thread_subscriptions cursor. Returns a tea.Cmd yielding
+// ThreadMarkedLocalMsg, or nil when no workspace is active.
+type ThreadMarkFunc func(channelID ids.ChannelID, threadTS ids.ThreadTS, ts ids.MessageTS) tea.Cmd
+```
+
+`internal/ui/services.go`, replace the interface method (lines 146-150):
+
+```go
+	// Mark marks the thread as read on Slack's servers
+	// (subscriptions.thread.mark) and, on success, advances the local
+	// thread_subscriptions cursor. channelID is the parent channel,
+	// threadTS is the parent message ts, ts is the latest reply ts the
+	// user has now seen. Returns a tea.Cmd yielding ThreadMarkedLocalMsg.
+	Mark(channelID ids.ChannelID, threadTS ids.ThreadTS, ts ids.MessageTS) tea.Cmd
+```
+
+And the adapter (lines 223-228):
+
+```go
+func (t threadAdapter) Mark(channelID ids.ChannelID, threadTS ids.ThreadTS, ts ids.MessageTS) tea.Cmd {
+	if t.fns.Mark == nil {
+		return nil
+	}
+	return t.fns.Mark(channelID, threadTS, ts)
+}
+```
+
+`internal/ui/msgs.go`, add near `ThreadMarkedRemoteMsg`:
+
+```go
+// ThreadMarkedLocalMsg reports the outcome of an slk-initiated
+// subscriptions.thread.mark. Err is nil on success, in which case
+// thread_subscriptions.last_read has already been advanced to TS.
+type ThreadMarkedLocalMsg struct {
+	ChannelID string
+	ThreadTS  string
+	TS        string
+	Err       error
+}
+```
+
+- [ ] **Step 4: Rewire the production closure**
+
+Replace the `Mark:` closure in `cmd/slk/main.go` (lines 1741-1755) with:
+
+```go
+			Mark: func(channelID ids.ChannelID, threadTS ids.ThreadTS, ts ids.MessageTS) tea.Cmd {
+				chIDStr, threadTSStr, tsStr := string(channelID), string(threadTS), string(ts)
+				wctx := router.Active()
+				if wctx == nil {
+					return nil
+				}
+				client := wctx.Client
+				teamID := wctx.TeamID
+				return func() tea.Msg {
+					ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+					defer cancel()
+					if err := client.MarkThread(ctx, chIDStr, threadTSStr, tsStr); err != nil {
+						log.Printf("Warning: MarkThread(%s, %s): %v", chIDStr, threadTSStr, err)
+						return ui.ThreadMarkedLocalMsg{
+							ChannelID: chIDStr, ThreadTS: threadTSStr, TS: tsStr, Err: err,
+						}
+					}
+					// Persist only after Slack accepts. Without this the
+					// cursor advanced solely via the WS echo, and a lost
+					// echo left last_read stale enough to flip the thread
+					// back to unread on the next list refresh.
+					if err := db.UpdateThreadLastRead(teamID, chIDStr, threadTSStr, tsStr); err != nil {
+						debuglog.Cache("ThreadService.Mark: UpdateThreadLastRead %s/%s: %v",
+							chIDStr, threadTSStr, err)
+					}
+					return ui.ThreadMarkedLocalMsg{
+						ChannelID: chIDStr, ThreadTS: threadTSStr, TS: tsStr,
+					}
+				}
+			},
+```
+
+- [ ] **Step 5: Update the reducer**
+
+In `internal/ui/reducer_threads.go`, replace lines 123-136 (from `var cmd tea.Cmd` through the `MarkByThreadTSRead` block) with:
+
+```go
+		var cmd tea.Cmd
+		if channelID != "" && m.ThreadTS != "" {
+			cmd = a.threads.Mark(
+				ids.ChannelID(channelID),
+				ids.ThreadTS(m.ThreadTS),
+				ids.MessageTS(latestTS),
+			)
+		}
+		// Optimistic local clear so the badge updates immediately; the
+		// ThreadMarkedLocalMsg above reconciles it against the cursor
+		// Slack actually accepted.
+		if a.threadsView.MarkByThreadTSReadAt(channelID, m.ThreadTS, latestTS) {
+			a.sidebar.SetThreadsUnreadCount(a.threadsView.UnreadCount())
+		}
+		return cmd, true
+```
+
+Add a new arm to the same switch, immediately after the `ThreadMarkedRemoteMsg` arm:
+
+```go
+	case ThreadMarkedLocalMsg:
+		if m.Err != nil {
+			debuglog.Cache("ThreadMarkedLocalMsg: channel=%s thread_ts=%s failed: %v",
+				m.ChannelID, m.ThreadTS, m.Err)
+			return nil, true
+		}
+		a.applyThreadMark(m.ChannelID, m.ThreadTS, m.TS)
+		return nil, true
+```
+
+Add `"github.com/gammons/slk/internal/debuglog"` to that file's imports if it is not already present.
+
+- [ ] **Step 6: Run the full suite**
+
+Run: `make test`
+Expected: PASS. Any test that supplied a `Mark` closure with the old void signature must be updated to return `tea.Cmd` (return `nil`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/ui/callbacks.go internal/ui/services.go internal/ui/msgs.go internal/ui/reducer_threads.go internal/ui/reducer_threads_test.go cmd/slk/main.go
+git commit -m "feat(threads): persist the thread read cursor after a successful mark"
+```
+
+---
+
+### Task 7: Thread divider uses the thread's cursor, not the channel's
+
+**Files:**
+- Modify: `internal/ui/services.go:174-177` (interface), `:183-191` (funcs), `:251-256` (adapter)
+- Modify: `cmd/slk/main.go:1831-1843` (`ChannelLastRead` closure)
+- Modify: `internal/ui/app.go:1814-1823` (`applyThreadUnreadBoundary`), `:1592`, `:1784`
+- Test: `internal/ui/app_test.go`
+
+**Interfaces:**
+- Consumes: `db.GetThreadLastRead` (Task 2), `WorkspaceContext.TeamID`.
+- Produces: `ThreadService.ThreadLastRead(channelID ids.ChannelID, threadTS ids.ThreadTS) string`, replacing `ChannelLastRead(channelID ids.ChannelID) string`, which is removed. `(*App).applyThreadUnreadBoundary(channelID, threadTS string)` gains the second parameter.
+
+Plain thread replies never advance the channel watermark, so the channel cursor is systematically older than the thread's own. Feeding it to the thread panel puts the `── new ──` divider too early, showing already-read replies as new.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/ui/app_test.go`:
+
+```go
+func TestOpenThreadPanel_BoundaryUsesThreadCursor(t *testing.T) {
+	app := NewApp()
+	var gotChannel, gotThread string
+	app.SetThreadService(NewThreadService(ThreadServiceFuncs{
+		ThreadLastRead: func(channelID ids.ChannelID, threadTS ids.ThreadTS) string {
+			gotChannel, gotThread = string(channelID), string(threadTS)
+			return "R7"
+		},
+	}))
+
+	_ = app.openThreadPanel(messages.MessageItem{TS: "P1"}, "C1", "P1")
+
+	if gotChannel != "C1" || gotThread != "P1" {
+		t.Fatalf("ThreadLastRead called with (%q, %q), want (C1, P1)", gotChannel, gotThread)
+	}
+	if got := app.threadPanel.UnreadBoundary(); got != "R7" {
+		t.Errorf("thread panel boundary = %q, want the thread cursor R7", got)
+	}
+}
+```
+
+If `thread.Model` has no `UnreadBoundary()` accessor, add one next to `SetUnreadBoundary` in `internal/ui/thread/model.go`:
+
+```go
+// UnreadBoundary returns the ts after which replies render as new.
+func (m *Model) UnreadBoundary() string { return m.unreadBoundaryTS }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/ui/ -run OpenThreadPanel_BoundaryUsesThreadCursor -v`
+Expected: FAIL to compile — `ThreadServiceFuncs` has no field `ThreadLastRead`.
+
+- [ ] **Step 3: Swap the accessor**
+
+`internal/ui/services.go`, replace the `ChannelLastRead` interface method (lines 174-177):
+
+```go
+	// ThreadLastRead returns the thread's own last-read cursor from
+	// thread_subscriptions so the thread panel can render a "── new ──"
+	// boundary. The parent channel's cursor is NOT a substitute: plain
+	// thread replies never advance it, so it is systematically stale and
+	// puts the divider too early. Optional; "" disables the boundary.
+	ThreadLastRead(channelID ids.ChannelID, threadTS ids.ThreadTS) string
+```
+
+In `ThreadServiceFuncs` (lines 183-191), replace the `ChannelLastRead` field with:
+
+```go
+	ThreadLastRead      func(channelID ids.ChannelID, threadTS ids.ThreadTS) string
+```
+
+Replace the adapter method (lines 251-256):
+
+```go
+func (t threadAdapter) ThreadLastRead(channelID ids.ChannelID, threadTS ids.ThreadTS) string {
+	if t.fns.ThreadLastRead == nil {
+		return ""
+	}
+	return t.fns.ThreadLastRead(channelID, threadTS)
+}
+```
+
+`cmd/slk/main.go`, replace the `ChannelLastRead:` closure (lines 1831-1843):
+
+```go
+			ThreadLastRead: func(channelID ids.ChannelID, threadTS ids.ThreadTS) string {
+				wctx := router.Active()
+				if wctx == nil {
+					return ""
+				}
+				lastRead, err := db.GetThreadLastRead(wctx.TeamID, string(channelID), string(threadTS))
+				if err != nil {
+					debuglog.Cache("ThreadLastRead: %s/%s: %v", channelID, threadTS, err)
+					return ""
+				}
+				return lastRead
+			},
+```
+
+`internal/ui/app.go`, replace `applyThreadUnreadBoundary` (lines 1814-1823):
+
+```go
+// applyThreadUnreadBoundary tells the thread panel where the unread
+// boundary is for (channelID, threadTS) so it can render a "── new ──"
+// landmark. Sourced from the thread's own cursor in
+// thread_subscriptions — the parent channel's cursor is stale for
+// threads, since plain replies never advance it.
+func (a *App) applyThreadUnreadBoundary(channelID, threadTS string) {
+	if channelID == "" || threadTS == "" {
+		return
+	}
+	a.threadPanel.SetUnreadBoundary(a.threads.ThreadLastRead(
+		ids.ChannelID(channelID), ids.ThreadTS(threadTS)))
+}
+```
+
+Update the two call sites:
+
+- `internal/ui/app.go:1592` → `a.applyThreadUnreadBoundary(channelID, threadTS)`
+- `internal/ui/app.go:1784` → `a.applyThreadUnreadBoundary(sum.ChannelID, sum.ThreadTS)`
+
+At line 1780, replace the now-inaccurate comment ("Snapshot the parent channel's last_read_ts...") with:
+
+```go
+	// Snapshot the thread's own last-read cursor BEFORE the local mark-
+	// read flips below, so the "── new ──" landmark reflects what the
+	// user had actually seen prior to opening this thread.
+```
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `make test`
+Expected: PASS. The compiler will point at any remaining `ChannelLastRead` reference; remove each one rather than reintroducing the method.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/ui/services.go internal/ui/app.go internal/ui/app_test.go internal/ui/thread/model.go cmd/slk/main.go
+git commit -m "fix(threads): draw the unread divider from the thread cursor"
+```
+
+---
+
+### Task 8: Track terminal focus
+
+**Files:**
+- Create: `internal/ui/reducer_focus.go`
+- Modify: `internal/ui/app.go` (add `terminalFocused` field near `threadsDirtyDebounce` at line 206; initialize in `NewApp` near line 517; set `ReportFocus` in `View` at line 2767; add `reduceFocus` to the chain at line 609)
+- Test: `internal/ui/reducer_focus_test.go`
+
+**Interfaces:**
+- Consumes: `tea.FocusMsg`, `tea.BlurMsg`, `tea.View.ReportFocus` (all from `charm.land/bubbletea/v2` v2.0.6).
+- Produces: `App.terminalFocused bool`, true by default. Task 9 reads it.
+
+Terminals report focus *transitions* only — enabling DECSET 1004 elicits no current-state report. Initializing to `true` means a terminal without focus-event support never sends `BlurMsg`, the flag stays `true`, and behavior is identical to today's. Initializing to `false` would make the feature permanently dead there.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/ui/reducer_focus_test.go`:
+
+```go
+package ui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestNewApp_StartsFocused(t *testing.T) {
+	// Terminals report focus transitions only, never current state. A
+	// terminal without focus-event support sends nothing at all, so
+	// defaulting to focused is what preserves today's behavior there.
+	if !NewApp().terminalFocused {
+		t.Error("terminalFocused must default to true")
+	}
+}
+
+func TestBlurMsg_ClearsFocus(t *testing.T) {
+	app := NewApp()
+	_, _ = app.Update(tea.BlurMsg{})
+	if app.terminalFocused {
+		t.Error("terminalFocused must be false after BlurMsg")
+	}
+}
+
+func TestFocusMsg_RestoresFocus(t *testing.T) {
+	app := NewApp()
+	_, _ = app.Update(tea.BlurMsg{})
+	_, _ = app.Update(tea.FocusMsg{})
+	if !app.terminalFocused {
+		t.Error("terminalFocused must be true after FocusMsg")
+	}
+}
+
+func TestView_EnablesFocusReporting(t *testing.T) {
+	app := NewApp()
+	app.width, app.height = 80, 24
+	if !app.View().ReportFocus {
+		t.Error("View must set ReportFocus so the terminal sends focus events")
+	}
+}
+```
+
+`App.View()` is a large function with memoization and sixel handling. If a bare `NewApp()` with only width/height set panics or short-circuits, build the app with whatever helper the existing view tests in `internal/ui/` use (look for `newTestApp`-style helpers near the other `App.View()` assertions) rather than weakening the assertion. `ReportFocus` must be verified on a real `tea.View`.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/ui/ -run 'StartsFocused|BlurMsg_ClearsFocus|FocusMsg_RestoresFocus|EnablesFocusReporting' -v`
+Expected: FAIL to compile — `app.terminalFocused` undefined.
+
+- [ ] **Step 3: Add the field and the reducer**
+
+In `internal/ui/app.go`, add after the `threadsDirtyDebounce` field (line 206):
+
+```go
+	// terminalFocused tracks whether the terminal running slk currently
+	// has focus, via tea.FocusMsg / tea.BlurMsg (enabled by
+	// View().ReportFocus). Terminals report transitions only — there is
+	// no way to query current state — so this starts true: the user just
+	// launched slk, and a terminal without focus-event support will never
+	// send BlurMsg, leaving the flag true and behavior unchanged.
+	//
+	// tmux users need `set -g focus-events on` for this to be accurate;
+	// see wiki/Terminal-Compatibility.md.
+	terminalFocused bool
+```
+
+In `NewApp`, add to the struct literal next to `threadsDirtyDebounce` (line 517):
+
+```go
+		terminalFocused:       true,
+```
+
+In `View`, add after `v.MouseMode = tea.MouseModeCellMotion` (line 2769):
+
+```go
+	v.ReportFocus = true
+```
+
+Create `internal/ui/reducer_focus.go`:
+
+```go
+// internal/ui/reducer_focus.go
+//
+// Terminal-focus reducer for App.Update.
+//
+// Owns:
+//
+//	tea.FocusMsg - the terminal running slk gained focus.
+//	tea.BlurMsg  - the terminal running slk lost focus.
+//
+// Focus gates automatic read-marking: a channel being *selected* does
+// not mean the user can see it. slk may be sitting in a background
+// terminal, an inactive tmux window, or an unfocused tmux pane with the
+// same channel still selected. Marking those messages read would
+// diverge from Slack and suppress mobile notifications for messages the
+// user never saw.
+package ui
+
+import (
+	tea "charm.land/bubbletea/v2"
+)
+
+var reduceFocus reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
+	switch msg.(type) {
+	case tea.FocusMsg:
+		a.terminalFocused = true
+		return nil, true
+
+	case tea.BlurMsg:
+		a.terminalFocused = false
+		return nil, true
+	}
+	return nil, false
+}
+```
+
+Add `reduceFocus,` to the `dispatchReducers` chain in `App.Update` (`internal/ui/app.go:609-626`), immediately after `reduceThreads,`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/ui/ -race`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/ui/reducer_focus.go internal/ui/reducer_focus_test.go internal/ui/app.go
+git commit -m "feat(ui): track terminal focus via ReportFocus"
+```
+
+---
+
+### Task 9: Focus-gated auto-marking
+
+The headline feature. Arriving messages stage a pending cursor advance; a debounced flush issues the marks, but only while focused. A blurred arrival stays pending and flushes on the next `FocusMsg`.
+
+**Files:**
+- Modify: `internal/ui/app.go` (four fields + three methods)
+- Modify: `internal/ui/reducer_focus.go` (flush on focus, `markFlushMsg` arm)
+- Modify: `internal/ui/reducer_send.go:289-333` (`reduceNewMessage` tail)
+- Modify: `cmd/slk/main.go:4025-4048` (drop the active-channel exemption)
+- Test: `internal/ui/reducer_focus_test.go`, `cmd/slk/event_handler_test.go:165-181`
+
+**Interfaces:**
+- Consumes: `App.terminalFocused` (Task 8), `ChannelService.MarkRead(channelID ids.ChannelID, ts ids.MessageTS) tea.Msg`, `ThreadService.Mark(...) tea.Cmd` (Task 6), `App.scheduleThreadsDirty`, `App.notifyReadStateChanged`.
+- Produces:
+  - `App.recordChannelMark(channelID, ts string)`, `App.recordThreadMark(channelID, threadTS, ts string)`
+  - `App.scheduleMarkFlush() tea.Cmd`, `App.flushPendingMarks() tea.Cmd`
+  - `markFlushMsg struct{}`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/ui/reducer_focus_test.go`:
+
+```go
+// markCapture wires fake mark services and records every call.
+func markCapture(t *testing.T) (*App, *[]string) {
+	t.Helper()
+	app := NewApp()
+	app.markFlushDebounce = time.Millisecond
+	calls := &[]string{}
+	app.SetChannelService(NewChannelService(ChannelServiceFuncs{
+		MarkRead: func(channelID ids.ChannelID, ts ids.MessageTS) tea.Msg {
+			*calls = append(*calls, "ch:"+string(channelID)+"/"+string(ts))
+			return nil
+		},
+	}))
+	app.SetThreadService(NewThreadService(ThreadServiceFuncs{
+		Mark: func(channelID ids.ChannelID, threadTS ids.ThreadTS, ts ids.MessageTS) tea.Cmd {
+			*calls = append(*calls, "th:"+string(channelID)+"/"+string(threadTS)+"/"+string(ts))
+			return nil
+		},
+	}))
+	return app, calls
+}
+
+// feed runs cmd to completion and pushes every resulting message back
+// through app.Update, so a scheduled flush tick actually fires within
+// the test. Reuses the existing drainBatch helper in
+// internal/ui/app_selection_test.go:29. Depth-bounded so a
+// self-rescheduling cmd cannot loop forever.
+func feed(t *testing.T, app *App, cmd tea.Cmd, depth int) {
+	t.Helper()
+	if cmd == nil || depth > 5 {
+		return
+	}
+	for _, msg := range drainBatch(cmd) {
+		if msg == nil {
+			continue
+		}
+		_, next := app.Update(msg)
+		feed(t, app, next, depth+1)
+	}
+}
+
+func TestFocusedArrival_MarksActiveChannelRead(t *testing.T) {
+	app, calls := markCapture(t)
+	app.activeChannelID = "C1"
+
+	_, cmd := app.Update(NewMessageMsg{
+		ChannelID: "C1",
+		Message:   messages.MessageItem{TS: "5.000000", UserID: "U2"},
+	})
+	feed(t, app, cmd, 0)
+
+	if len(*calls) != 1 || (*calls)[0] != "ch:C1/5.000000" {
+		t.Fatalf("calls = %v, want one channel mark at 5.000000", *calls)
+	}
+}
+
+func TestBlurredArrival_DoesNotMarkUntilFocusReturns(t *testing.T) {
+	app, calls := markCapture(t)
+	app.activeChannelID = "C1"
+	_, _ = app.Update(tea.BlurMsg{})
+
+	_, cmd := app.Update(NewMessageMsg{
+		ChannelID: "C1",
+		Message:   messages.MessageItem{TS: "5.000000", UserID: "U2"},
+	})
+	feed(t, app, cmd, 0)
+
+	if len(*calls) != 0 {
+		t.Fatalf("blurred arrival must not mark read, got %v", *calls)
+	}
+
+	_, cmd = app.Update(tea.FocusMsg{})
+	feed(t, app, cmd, 0)
+
+	if len(*calls) != 1 || (*calls)[0] != "ch:C1/5.000000" {
+		t.Fatalf("calls after refocus = %v, want the staged mark to flush", *calls)
+	}
+}
+
+func TestBurstCoalescesToNewestTS(t *testing.T) {
+	app, calls := markCapture(t)
+	app.activeChannelID = "C1"
+
+	var last tea.Cmd
+	for _, ts := range []string{"1.000000", "2.000000", "3.000000"} {
+		_, last = app.Update(NewMessageMsg{
+			ChannelID: "C1",
+			Message:   messages.MessageItem{TS: ts, UserID: "U2"},
+		})
+	}
+	feed(t, app, last, 0)
+
+	if len(*calls) != 1 || (*calls)[0] != "ch:C1/3.000000" {
+		t.Fatalf("calls = %v, want a single mark at the newest ts", *calls)
+	}
+}
+
+func TestPlainThreadReplyDoesNotMarkChannel(t *testing.T) {
+	app, calls := markCapture(t)
+	app.activeChannelID = "C1"
+
+	_, cmd := app.Update(NewMessageMsg{
+		ChannelID: "C1",
+		Message:   messages.MessageItem{TS: "5.000000", ThreadTS: "1.000000", UserID: "U2"},
+	})
+	feed(t, app, cmd, 0)
+
+	for _, c := range *calls {
+		if strings.HasPrefix(c, "ch:") {
+			t.Fatalf("a plain thread reply must not advance the channel cursor, got %v", *calls)
+		}
+	}
+}
+
+func TestBroadcastReplyMarksChannel(t *testing.T) {
+	app, calls := markCapture(t)
+	app.activeChannelID = "C1"
+
+	_, cmd := app.Update(NewMessageMsg{
+		ChannelID: "C1",
+		Message: messages.MessageItem{
+			TS: "5.000000", ThreadTS: "1.000000", Subtype: "thread_broadcast", UserID: "U2",
+		},
+	})
+	feed(t, app, cmd, 0)
+
+	var found bool
+	for _, c := range *calls {
+		if c == "ch:C1/5.000000" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("a broadcast reply must advance the channel cursor, got %v", *calls)
+	}
+}
+
+func TestFocusedReplyInOpenThreadMarksThread(t *testing.T) {
+	app, calls := markCapture(t)
+	app.activeChannelID = "C1"
+	app.threadVisible = true
+	app.threadPanel.SetThread(messages.MessageItem{TS: "1.000000"}, nil, "C1", "1.000000")
+
+	_, cmd := app.Update(NewMessageMsg{
+		ChannelID: "C1",
+		Message:   messages.MessageItem{TS: "5.000000", ThreadTS: "1.000000", UserID: "U2"},
+	})
+	feed(t, app, cmd, 0)
+
+	if len(*calls) != 1 || (*calls)[0] != "th:C1/1.000000/5.000000" {
+		t.Fatalf("calls = %v, want one thread mark", *calls)
+	}
+}
+
+func TestReplyInClosedThreadDoesNotMark(t *testing.T) {
+	app, calls := markCapture(t)
+	app.activeChannelID = "C1"
+	app.threadVisible = false
+
+	_, cmd := app.Update(NewMessageMsg{
+		ChannelID: "C1",
+		Message:   messages.MessageItem{TS: "5.000000", ThreadTS: "1.000000", UserID: "U2"},
+	})
+	feed(t, app, cmd, 0)
+
+	if len(*calls) != 0 {
+		t.Fatalf("a reply in a thread the user is not viewing must not mark, got %v", *calls)
+	}
+}
+
+func TestInactiveChannelArrivalDoesNotMark(t *testing.T) {
+	app, calls := markCapture(t)
+	app.activeChannelID = "C_OTHER"
+
+	_, cmd := app.Update(NewMessageMsg{
+		ChannelID: "C1",
+		Message:   messages.MessageItem{TS: "5.000000", UserID: "U2"},
+	})
+	feed(t, app, cmd, 0)
+
+	if len(*calls) != 0 {
+		t.Fatalf("a message in a non-active channel must not mark, got %v", *calls)
+	}
+}
+
+func TestFocusedArrivalLeavesDividerInPlace(t *testing.T) {
+	app, _ := markCapture(t)
+	app.activeChannelID = "C1"
+	app.messagepane.SetLastReadTS("1.000000")
+
+	_, cmd := app.Update(NewMessageMsg{
+		ChannelID: "C1",
+		Message:   messages.MessageItem{TS: "5.000000", UserID: "U2"},
+	})
+	feed(t, app, cmd, 0)
+
+	if got := app.messagepane.LastReadTS(); got != "1.000000" {
+		t.Errorf("messagepane LastReadTS = %q, want the divider left at 1.000000", got)
+	}
+}
+```
+
+Add `"strings"`, `"time"`, and the `ids` / `messages` imports to the file.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/ui/ -run 'Focused|Blurred|Burst|ThreadReply|Broadcast|InactiveChannelArrival' -v`
+Expected: FAIL to compile — `app.markFlushDebounce` undefined.
+
+- [ ] **Step 3: Add the pending-mark machinery**
+
+This step alone will not compile: `scheduleMarkFlush` references `markFlushMsg`, which Step 4 declares. Do Steps 3 and 4 back to back before building.
+
+In `internal/ui/app.go`, add next to `terminalFocused` (Task 8):
+
+```go
+	// pendingChannelMark / pendingThreadMark stage a read-cursor advance
+	// for a message that arrived in what the user is currently looking
+	// at. Single-slot and newest-wins: a burst coalesces into one
+	// request, and a slot can never issue a ts older than one it already
+	// holds. Staged while blurred, flushed on the next FocusMsg.
+	pendingChannelMark pendingChannelMarkState
+	pendingThreadMark  pendingThreadMarkState
+	// markFlushScheduled guards against stacking flush ticks; see
+	// scheduleMarkFlush.
+	markFlushScheduled bool
+	// markFlushDebounce bounds a burst to one network write per
+	// interval per target. Longer than threadsDirtyDebounce (150ms)
+	// because that one only re-queries local SQLite.
+	markFlushDebounce time.Duration
+```
+
+Add the two state types near the field block:
+
+```go
+type pendingChannelMarkState struct {
+	channelID string
+	ts        string
+}
+
+type pendingThreadMarkState struct {
+	channelID string
+	threadTS  string
+	ts        string
+}
+```
+
+In `NewApp`, next to `terminalFocused: true`:
+
+```go
+		markFlushDebounce:     time.Second,
+```
+
+Add these three methods next to `scheduleThreadsDirty` in `internal/ui/app.go`:
+
+```go
+// recordChannelMark stages a channel read-cursor advance. Newest-wins:
+// an older ts for the same channel is ignored, so out-of-order arrivals
+// can never roll the cursor backward.
+func (a *App) recordChannelMark(channelID, ts string) {
+	if channelID == "" || ts == "" {
+		return
+	}
+	if a.pendingChannelMark.channelID == channelID && a.pendingChannelMark.ts >= ts {
+		return
+	}
+	a.pendingChannelMark = pendingChannelMarkState{channelID: channelID, ts: ts}
+}
+
+// recordThreadMark stages a thread read-cursor advance. Newest-wins for
+// the same (channel, thread); a different thread replaces the slot.
+func (a *App) recordThreadMark(channelID, threadTS, ts string) {
+	if channelID == "" || threadTS == "" || ts == "" {
+		return
+	}
+	if a.pendingThreadMark.channelID == channelID &&
+		a.pendingThreadMark.threadTS == threadTS &&
+		a.pendingThreadMark.ts >= ts {
+		return
+	}
+	a.pendingThreadMark = pendingThreadMarkState{channelID: channelID, threadTS: threadTS, ts: ts}
+}
+
+// scheduleMarkFlush returns a tick that flushes the pending marks after
+// the debounce interval, or nil when nothing is pending, a tick is
+// already in flight, or the terminal is blurred. Blurred slots stay
+// staged and flush on the next FocusMsg instead.
+func (a *App) scheduleMarkFlush() tea.Cmd {
+	if a.markFlushScheduled || !a.terminalFocused {
+		return nil
+	}
+	if a.pendingChannelMark.ts == "" && a.pendingThreadMark.ts == "" {
+		return nil
+	}
+	a.markFlushScheduled = true
+	d := a.markFlushDebounce
+	if d == 0 {
+		d = time.Second
+	}
+	return tea.Tick(d, func(time.Time) tea.Msg { return markFlushMsg{} })
+}
+
+// flushPendingMarks clears both slots and returns the commands that
+// issue their marks. Clearing before issuing is deliberate: a mark
+// Slack rejects is not retried here, it is reconciled by the next
+// arrival, the next channel entry, or reconnect sync. Retrying a
+// rejected mark risks hammering a rate-limited endpoint.
+//
+// Note this does NOT move any on-screen "── new ──" divider. MarkRead
+// yields ChannelMarkedReadMsg, whose reducer arm only invalidates the
+// sidebar; the divider recomputes on the next channel entry.
+func (a *App) flushPendingMarks() tea.Cmd {
+	var cmds []tea.Cmd
+	if pc := a.pendingChannelMark; pc.ts != "" {
+		a.pendingChannelMark = pendingChannelMarkState{}
+		channels := a.channels
+		chID := ids.ChannelID(pc.channelID)
+		ts := ids.MessageTS(pc.ts)
+		cmds = append(cmds, func() tea.Msg { return channels.MarkRead(chID, ts) })
+	}
+	if pt := a.pendingThreadMark; pt.ts != "" {
+		a.pendingThreadMark = pendingThreadMarkState{}
+		if c := a.threads.Mark(
+			ids.ChannelID(pt.channelID),
+			ids.ThreadTS(pt.threadTS),
+			ids.MessageTS(pt.ts),
+		); c != nil {
+			cmds = append(cmds, c)
+		}
+	}
+	if len(cmds) == 0 {
+		return nil
+	}
+	return tea.Batch(cmds...)
+}
+```
+
+- [ ] **Step 4: Wire the flush into the focus reducer**
+
+In `internal/ui/reducer_focus.go`, add the message type below the imports:
+
+```go
+// markFlushMsg fires after the mark debounce interval; see
+// App.scheduleMarkFlush.
+type markFlushMsg struct{}
+```
+
+Replace the reducer body with:
+
+```go
+var reduceFocus reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
+	switch msg.(type) {
+	case tea.FocusMsg:
+		a.terminalFocused = true
+		// Catch-up: marks staged while blurred go out now. Without
+		// this, a user who alt-tabs back, reads everything, and never
+		// switches channels leaves the channel unread on Slack.
+		return a.flushPendingMarks(), true
+
+	case tea.BlurMsg:
+		a.terminalFocused = false
+		return nil, true
+
+	case markFlushMsg:
+		a.markFlushScheduled = false
+		if !a.terminalFocused {
+			// Blurred between scheduling and firing: keep the slots
+			// staged rather than dropping them.
+			return nil, true
+		}
+		return a.flushPendingMarks(), true
+	}
+	return nil, false
+}
+```
+
+- [ ] **Step 5: Rewrite the reduceNewMessage tail**
+
+In `internal/ui/reducer_send.go`, replace everything from line 289 (`if m.ChannelID == a.activeChannelID {`) through line 333 (`return nil`) with:
+
+```go
+	isThreadReply := m.Message.ThreadTS != "" && m.Message.ThreadTS != m.Message.TS
+	isBroadcast := m.Message.Subtype == "thread_broadcast"
+
+	// Thread-eligible: a reply landing in the thread panel the user has
+	// open. The gate mirrors the channel rule — panel open on this
+	// thread, not "the thread pane holds slk-internal focus" — and the
+	// reply is already rendered there by the AddReply above.
+	if isThreadReply && a.terminalFocused &&
+		a.threadVisible &&
+		m.ChannelID == a.threadPanel.ChannelID() &&
+		m.Message.ThreadTS == a.threadPanel.ThreadTS() {
+		a.recordThreadMark(m.ChannelID, m.Message.ThreadTS, m.Message.TS)
+	}
+
+	// Channel-eligible: top-level messages and thread_broadcasts. Plain
+	// thread replies never advance the parent channel cursor on Slack.
+	if !isThreadReply || isBroadcast {
+		switch {
+		case m.ChannelID != a.activeChannelID:
+			// Not the channel on screen. The has_unread=true DB write
+			// already happened in the WS handler; force the sidebar and
+			// workspace rail to re-read it.
+			debuglog.Cache("NewMessageMsg: channel=%s ts=%s decision=mark_unread",
+				m.ChannelID, m.Message.TS)
+			a.notifyReadStateChanged()
+		case a.terminalFocused:
+			// On screen AND the user can actually see it: stage a read-
+			// cursor advance. No notifyReadStateChanged, so this event
+			// triggers no sidebar repaint and the dot never appears.
+			debuglog.Cache("NewMessageMsg: channel=%s ts=%s decision=active_focused_mark_read",
+				m.ChannelID, m.Message.TS)
+			a.recordChannelMark(m.ChannelID, m.Message.TS)
+		default:
+			// Selected, but slk is in a background terminal / inactive
+			// tmux window or pane. The user has NOT seen this. Leave it
+			// unread locally and on Slack; the staged nothing here means
+			// it reconciles on channel entry.
+			debuglog.Cache("NewMessageMsg: channel=%s ts=%s decision=active_blurred_stay_unread",
+				m.ChannelID, m.Message.TS)
+			a.notifyReadStateChanged()
+		}
+	} else {
+		debuglog.Cache("NewMessageMsg: channel=%s ts=%s decision=skipped_thread_reply",
+			m.ChannelID, m.Message.TS)
+	}
+
+	var cmds []tea.Cmd
+	if c := a.scheduleMarkFlush(); c != nil {
+		cmds = append(cmds, c)
+	}
+	// A thread reply (regardless of channel) may have changed the
+	// involved-threads list -- schedule a debounced re-query so a
+	// burst of replies coalesces into a single fetch.
+	if m.Message.ThreadTS != "" {
+		if c := a.scheduleThreadsDirty(); c != nil {
+			cmds = append(cmds, c)
+		}
+	}
+	if len(cmds) == 0 {
+		return nil
+	}
+	return tea.Batch(cmds...)
+}
+```
+
+Note this changes the tail from returning a single cmd to returning a batch — the previous code returned early on `scheduleThreadsDirty`, which would have dropped the flush tick.
+
+Blurred arrivals stage nothing for the channel path: the message is genuinely unread, so there is no cursor to advance. The `FocusMsg` catch-up covers threads staged before a blur; a channel the user returns to is reconciled by its entry mark.
+
+- [ ] **Step 6: Drop the active-channel exemption in the WS handler**
+
+In `cmd/slk/main.go`, replace lines 4025-4048 (the read-state comment block through the closing brace of the `if h.db != nil && ...` statement) with:
+
+```go
+	// Read-state: mark the channel has_unread=true for every eligible
+	// message. Mirrors Slack's channel-unread semantics — non-broadcast
+	// thread replies do not mark the parent channel unread (only
+	// top-level messages and thread_broadcast subtypes do).
+	//
+	// There is deliberately NO active-channel exemption here. Whether
+	// the user can actually see the active channel depends on terminal
+	// focus, which is only known on the UI goroutine. reduceNewMessage
+	// owns that decision and clears this flag by marking read when the
+	// terminal is focused; if the mark fails, or the terminal is
+	// blurred, the flag correctly stands.
+	//
+	// This write runs for BOTH active and inactive workspaces; the
+	// active/inactive split below only governs the UI dispatch path,
+	// not durable read state.
+	isThreadReply := threadTS != "" && threadTS != ts
+	isBroadcast := subtype == "thread_broadcast"
+	shouldMarkChannel := !isThreadReply || isBroadcast
+	if h.db != nil && shouldMarkChannel {
+		if err := h.db.UpdateChannelReadState(channelID, "", true); err != nil {
+			log.Printf("Warning: failed to set has_unread for %s: %v", channelID, err)
+		}
+	}
+```
+
+`h.activeChannelID` is still used by the notification block above, so leave the struct field in place — only the local `activeChIDForRead` variable goes.
+
+Replace `TestOnMessage_ActiveChannel_DoesNotSetHasUnread` in `cmd/slk/event_handler_test.go` (lines 165-181) with:
+
+```go
+// The active channel is no longer exempt: whether the user can see it
+// depends on terminal focus, which only the UI goroutine knows. The WS
+// handler always flags, and reduceNewMessage clears it by marking read
+// when focused.
+func TestOnMessage_ActiveChannel_StillSetsHasUnread(t *testing.T) {
+	db := newTestDB(t)
+	_ = db.UpsertChannel(cache.Channel{ID: "C1", WorkspaceID: "T1", Name: "general", Type: "channel"})
+	h := &rtmEventHandler{
+		db:              db,
+		wsCtx:           &WorkspaceContext{},
+		isActive:        func() bool { return true },
+		activeChannelID: func() string { return "C1" },
+	}
+	h.OnMessage("C1", "U1", "1.001", "hi", "", "", false, nil, slack.Blocks{}, nil, "", "")
+
+	s, _ := db.GetChannelReadState("C1")
+	if !s.HasUnread {
+		t.Error("HasUnread = false, want true: the UI layer owns the focus-gated clear")
+	}
+}
+```
+
+- [ ] **Step 7: Run the full suite**
+
+Run: `make test`
+Expected: PASS. If a pre-existing test asserted that an active-channel arrival leaves the sidebar untouched, update it: a *blurred* arrival now calls `notifyReadStateChanged`, a focused one still does not.
+
+- [ ] **Step 8: Lint and commit**
+
+```bash
+make lint
+git add internal/ui/app.go internal/ui/reducer_focus.go internal/ui/reducer_focus_test.go internal/ui/reducer_send.go cmd/slk/main.go cmd/slk/event_handler_test.go
+git commit -m "feat: mark messages read on Slack only while the terminal is focused (#159)"
+```
+
+---
+
+### Task 10: Document focus reporting
+
+**Files:**
+- Modify: `wiki/Terminal-Compatibility.md` (insert after the "Unread indicator in the window title" section, which ends at line 89)
+
+**Interfaces:**
+- Consumes: nothing. Documentation only.
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Add the section**
+
+Insert between the "Unread indicator in the window title" section and "Overriding the image protocol":
+
+```markdown
+## Focus reporting and read state
+
+slk marks a message read on Slack's servers when it arrives in the
+channel you're viewing — but only while the terminal running slk is
+focused. Having a channel selected doesn't mean you can see it: slk may
+be sitting in a background terminal, an inactive tmux window, or an
+unfocused tmux pane. Marking those messages read would diverge from
+Slack's own read state and suppress the mobile notification for a
+message you never saw.
+
+Focus is detected with DECSET 1004 focus reporting, which every modern
+terminal supports (kitty, Ghostty, WezTerm, foot, iTerm2, Alacritty,
+gnome-terminal, Windows Terminal).
+
+Inside tmux there's an extra step. tmux swallows focus events unless you
+turn them on explicitly. Add this to `~/.tmux.conf`:
+
+    set -g focus-events on
+
+Without it, tmux never tells slk that its pane lost focus, so slk
+behaves as though the terminal is always focused and marks messages read
+even when the pane is in the background.
+
+Terminals report focus *transitions*, never their current state, so slk
+assumes it starts focused — you did just launch it. On a terminal with
+no focus reporting at all, slk stays in that assumed-focused state and
+marks read exactly as it did before this feature existed.
+```
+
+- [ ] **Step 2: Verify the surrounding structure still reads correctly**
+
+Run: `grep -n '^## ' wiki/Terminal-Compatibility.md`
+Expected: the new `## Focus reporting and read state` heading appears between `## Unread indicator in the window title` and `## Overriding the image protocol`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add wiki/Terminal-Compatibility.md
+git commit -m "docs: document focus reporting and tmux focus-events"
+```
+
+---
+
+## Verification
+
+After Task 10, confirm the whole feature end to end:
+
+- [ ] `make test` passes with `-race`.
+- [ ] `make lint` is clean.
+- [ ] `make build` succeeds.
+- [ ] Manual: run slk in tmux with `set -g focus-events on`. Post to the open channel from another client while the pane is focused — the channel should show read in the official Slack client within ~1s. Repeat with the tmux pane unfocused — the message must stay unread in both slk and Slack until you focus the pane again.
+- [ ] Manual: reply to a thread from inside slk. The thread must not flip to unread in the Threads list, and it must not disappear from that list.
+

--- a/docs/superpowers/specs/2026-09-04-focus-gated-read-marking-design.md
+++ b/docs/superpowers/specs/2026-09-04-focus-gated-read-marking-design.md
@@ -164,14 +164,30 @@ not equivalent to "a mark from another client."** Slack broadcasts
 `TestThreadMarkedRemoteMsg_SelfReplyDoesNotReFlagUnread` documents slk receiving
 one after posting its own reply — so slk's own thread marks used to erase the
 panel landmark by the remote route. `App.selfThreadMarks`, a second
-`selfMarkDedup` instance keyed on `(channel, threadTS, ts)`, closes it: the
-`ThreadMarkedLocalMsg` success arm records the mark (that arm runs on the Update
-goroutine, whereas `markThreadRead` issues from a cmd goroutine and must not
-touch `App` state), and `applyThreadMarkEcho` — what the
-`ThreadMarkedRemoteMsg` arm calls — consumes a matching record and skips
-`SetUnreadBoundary` while still settling the threads-list flag and the sidebar
-badge. Suppression is per-record and consumed on match, never blanket, because a
-thread mark genuinely made in another client must still move the landmark.
+`selfMarkDedup` instance keyed on `(channel, threadTS, ts)` and bounded
+independently of the channel set, closes it. Both thread issue sites record —
+the mark-on-open in `reduceThreads`' `ThreadRepliesLoadedMsg` arm and the
+auto-mark in `flushPendingMarks` — and both record *before* handing the mark's
+`tea.Cmd` on, which is what makes the record beat the echo. `ThreadService.Mark`
+only builds the cmd, so no request has been sent when the record lands; the
+`markThreadRead` call that does send runs on a cmd goroutine and must not touch
+`App` state, which is why the record is taken here and not there.
+`applyThreadMarkEcho` — what the `ThreadMarkedRemoteMsg` arm calls — consumes a
+matching record and skips `SetUnreadBoundary` while still settling the
+threads-list flag and the sidebar badge.
+
+Recording on *completion* (`ThreadMarkedLocalMsg`) was rejected: Slack's
+broadcast and the mark's HTTP response are independent, so an echo can arrive
+first, and every thread mark — the mark-on-open above all — would then be
+exposed to that race. Recording on issue instead means a mark Slack rejects
+leaves a record no echo consumes; it ages out via `selfMarkLimit`, and until
+then it can only hold a landmark still, never move one wrongly.
+
+Suppression is per-record and consumed on match, never blanket, because a thread
+mark genuinely made in another client must still move the landmark. Note also
+that the thread mark-unread press hits the same endpoint (`read=0`) and so
+echoes here too; it is deliberately unrecorded, so its echo is treated as
+foreign and moves the landmark to where the press asked for it.
 
 ### The decision lives in the UI reducer
 
@@ -293,7 +309,11 @@ successful `MarkThread`. One existing call site updates,
 ### Thread `active`/unread conflation fix
 
 `OnThreadMarked` becomes `(channelID, threadTS, lastRead string, subscribed
-bool)`. The derived `read` bool is deleted at its source in `events.go`: nothing
+Subscribed)`, where `Subscribed` is a named bool type. The name is the point:
+`OnThreadSubscriptionChanged(channelID, threadTS, lastRead string, active bool)`
+has the identical shape but the opposite obligation — it MUST write the `active`
+column, which `OnThreadMarked` must never touch — so distinct types keep the two
+from being transposed silently. The derived `read` bool is deleted at its source in `events.go`: nothing
 downstream may infer read/unread from the subscription block. `subscribed` is
 that block's `active` flag forwarded under its true meaning, and it does exactly
 one job — choose the cursor writer, both of which leave the durable `active`
@@ -386,10 +406,10 @@ otherwise need" — no longer holds.
 | Layer | Coverage |
 |---|---|
 | `internal/slack` | Mark helpers against HTTP 500, `{"ok":false,"error":"invalid_auth"}`, and 429. `newTestClient` (`client_test.go:1330`) provides the harness. |
-| `internal/slack/events` | `thread_marked` passes `last_read` through and no longer derives a read bool; `active` is forwarded as `subscribed` and the cursor it forwards is unchanged either way. |
+| `internal/slack/events` | `thread_marked` passes `last_read` through and no longer derives a read bool; `active` is forwarded as `Subscribed` and the cursor it forwards is unchanged either way. |
 | `internal/cache` | `UpdateThreadLastRead` preserves `active`; `ListSubscribedThreads` recomputes unread correctly as the cursor moves in both directions. |
 | `cmd/slk` | `OnMessage` sets `has_unread` even for the active channel; `OnThreadMarked` updates the cursor and leaves the row active (rewrite of `event_handler_test.go:245`), creates no row when `subscribed` is false, and leaves a tombstoned row tombstoned when it is true; `markChannelReadAsync` skips the local write on error via the new seam. |
-| `internal/ui` | Matrix of focused/blurred × active/inactive channel × top-level/plain reply/broadcast. Plus focus-regain flush, burst coalescing (N arrivals produce one `MarkRead`), blurred arrivals staying pending until `FocusMsg`, and the divider unmoved after an auto-mark *and after the `channel_marked` echo of that mark*, with a foreign `channel_marked` still moving it as the control; and the same pair on the thread side, where slk's own `thread_marked` echo leaves the panel landmark alone while a foreign one moves it. All via the existing `ChannelServiceFuncs` / `ThreadServiceFuncs` closure seams. |
+| `internal/ui` | Matrix of focused/blurred × active/inactive channel × top-level/plain reply/broadcast. Plus focus-regain flush, burst coalescing (N arrivals produce one `MarkRead`), blurred arrivals staying pending until `FocusMsg`, and the divider unmoved after an auto-mark *and after the `channel_marked` echo of that mark*, with a foreign `channel_marked` still moving it as the control; and the same pair on the thread side, where slk's own `thread_marked` echo leaves the panel landmark alone — in both orderings, echo-after-response and echo-before-response — while a foreign one moves it. All via the existing `ChannelServiceFuncs` / `ThreadServiceFuncs` closure seams. |
 
 ## Documentation
 

--- a/docs/superpowers/specs/2026-09-04-focus-gated-read-marking-design.md
+++ b/docs/superpowers/specs/2026-09-04-focus-gated-read-marking-design.md
@@ -265,10 +265,28 @@ Rules:
 Focus-regain catch-up falls out of this mechanism rather than needing a separate
 path, and a burst coalesces to one request per interval per target.
 
-Debounce default is 1 s, in a configurable `App` field. `threadsDirtyDebounce`
-is 150 ms because it re-queries local SQLite; this is a network write, so a full
-second is the right order of magnitude. Tests set it to zero or drive the flush
-message directly.
+Debounce default is 5 s (`defaultMarkFlushDebounce`), in a configurable `App`
+field. What fixes that number is `conversations.mark`'s rate tier, not the
+general observation that network writes cost more than local ones:
+`conversations.mark` is Tier 3, roughly 50 requests a minute. The interval is
+the ceiling on how often a focused target spends one, so 5 s caps the
+steady-state cost at 60/5 = 12 a minute and leaves room for the entry marks and
+mark-unread presses that mark on other paths. The 1 s this design originally
+specified put a channel receiving about a message a second at ~60 a minute —
+over the tier, where `postForm` returns `rateLimitError`, `markChannelRead`
+returns before the local write, and `markChannelReadAndNotify` logs and drops
+it. `markChannel` does not retry, and nothing in this design does either (see
+the flush rule above). Self-healing on the next arrival makes that survivable
+but not acceptable: a mark dropped with no sign to the user is the
+cross-client divergence this design exists to remove.
+
+The longer interval costs nothing the user perceives, because the flush changes
+nothing on screen — it moves Slack's server-side cursor, and the local divider
+deliberately stays put. Compare `threadsDirtyDebounce` at 150 ms, which delays
+a query against local SQLite and so is bounded by nothing but responsiveness.
+
+Tests set the field to 1 ms or drive `markFlushMsg` directly rather than
+waiting out the real interval.
 
 ### Channel path
 

--- a/docs/superpowers/specs/2026-09-04-focus-gated-read-marking-design.md
+++ b/docs/superpowers/specs/2026-09-04-focus-gated-read-marking-design.md
@@ -134,19 +134,40 @@ every channel mark slk issues, at all three issuing sites: the tier-1 entry mark
 in `reduceChannelSelected`, the auto-mark in `flushPendingMarks`, and
 `ChannelService.Fetch`'s entry mark — the last reported back on the Update
 goroutine as `MessagesLoadedMsg.MarkedTS`, since the fetcher marks from a cmd
-goroutine and must not touch `App` state. `applyChannelMark` consumes a matching
-record and skips the `SetLastReadTS` loop, while still calling
-`notifyReadStateChanged()` so the sidebar dot and workspace rail clear.
+goroutine and must not touch `App` state. `applyChannelMarkEcho`, which is what
+the `ChannelMarkedRemoteMsg` arm calls, consumes a matching record and skips the
+cursor update, while still calling `notifyReadStateChanged()` so the sidebar dot
+and workspace rail clear.
 
-Records are consumed on match and the set is bounded, so a `channel_marked` slk
-did not issue — the user reading the channel in another Slack client — still
-moves the divider, which is the correct response to that event.
+The dedup deliberately sits in `applyChannelMarkEcho` rather than in the shared
+`applyChannelMark` helper. `applyChannelMark`'s other caller is the local
+mark-unread press (`MessageMarkedUnreadMsg`), a deliberate user action that must
+move the divider unconditionally — and the two collide on ts routinely, since
+slk auto-marks at the newest message and "mark this newest message unread"
+targets the same one. Consuming in the shared helper would silently swallow the
+press for as long as the record lives: one round trip normally, unbounded if the
+echo never arrives.
 
-The thread panel's landmark has the same shape and the same rule.
+Records are consumed on match and the set is bounded (oldest evicted first), so
+a `channel_marked` slk did not issue — the user reading the channel in another
+Slack client — still moves the divider, which is the correct response to that
+event.
+
+The thread panel's landmark has the same shape, and is only half fixed.
 `ThreadMarkedLocalMsg` reports slk's own `subscriptions.thread.mark` completing;
-its arm applies threads-list state only and leaves the panel boundary at the
-pre-open snapshot. `ThreadMarkedRemoteMsg`, a mark from another client, still
-moves it.
+its arm applies threads-list state only (`applyThreadMarkListState`) and leaves
+the panel boundary at the pre-open snapshot.
+
+`ThreadMarkedRemoteMsg` still calls the full `applyThreadMark` and still moves
+the boundary. **That is not equivalent to "a mark from another client."** Slack
+broadcasts `thread_marked` back to the issuing client exactly as it does
+`channel_marked` — `TestThreadMarkedRemoteMsg_SelfReplyDoesNotReFlagUnread`
+documents slk receiving one after posting its own reply — so slk's own thread
+marks can still erase the panel landmark by the remote route. This is a known,
+unfixed gap, left open deliberately: closing it needs a thread-side dedup keyed
+on `(channel, threadTS, ts)` mirroring `selfMarkDedup`, and blanket suppression
+would be wrong, because a thread mark genuinely made in another client must
+still move the landmark.
 
 ### The decision lives in the UI reducer
 

--- a/docs/superpowers/specs/2026-09-04-focus-gated-read-marking-design.md
+++ b/docs/superpowers/specs/2026-09-04-focus-gated-read-marking-design.md
@@ -153,21 +153,25 @@ a `channel_marked` slk did not issue — the user reading the channel in another
 Slack client — still moves the divider, which is the correct response to that
 event.
 
-The thread panel's landmark has the same shape, and is only half fixed.
+The thread panel's landmark has the same shape and the same two-sided fix.
 `ThreadMarkedLocalMsg` reports slk's own `subscriptions.thread.mark` completing;
 its arm applies threads-list state only (`applyThreadMarkListState`) and leaves
 the panel boundary at the pre-open snapshot.
 
-`ThreadMarkedRemoteMsg` still calls the full `applyThreadMark` and still moves
-the boundary. **That is not equivalent to "a mark from another client."** Slack
-broadcasts `thread_marked` back to the issuing client exactly as it does
-`channel_marked` — `TestThreadMarkedRemoteMsg_SelfReplyDoesNotReFlagUnread`
-documents slk receiving one after posting its own reply — so slk's own thread
-marks can still erase the panel landmark by the remote route. This is a known,
-unfixed gap, left open deliberately: closing it needs a thread-side dedup keyed
-on `(channel, threadTS, ts)` mirroring `selfMarkDedup`, and blanket suppression
-would be wrong, because a thread mark genuinely made in another client must
-still move the landmark.
+The remote side needed the same treatment, because **`ThreadMarkedRemoteMsg` is
+not equivalent to "a mark from another client."** Slack broadcasts
+`thread_marked` back to the issuing client exactly as it does `channel_marked` —
+`TestThreadMarkedRemoteMsg_SelfReplyDoesNotReFlagUnread` documents slk receiving
+one after posting its own reply — so slk's own thread marks used to erase the
+panel landmark by the remote route. `App.selfThreadMarks`, a second
+`selfMarkDedup` instance keyed on `(channel, threadTS, ts)`, closes it: the
+`ThreadMarkedLocalMsg` success arm records the mark (that arm runs on the Update
+goroutine, whereas `markThreadRead` issues from a cmd goroutine and must not
+touch `App` state), and `applyThreadMarkEcho` — what the
+`ThreadMarkedRemoteMsg` arm calls — consumes a matching record and skips
+`SetUnreadBoundary` while still settling the threads-list flag and the sidebar
+badge. Suppression is per-record and consumed on match, never blanket, because a
+thread mark genuinely made in another client must still move the landmark.
 
 ### The decision lives in the UI reducer
 
@@ -288,11 +292,21 @@ successful `MarkThread`. One existing call site updates,
 
 ### Thread `active`/unread conflation fix
 
-`OnThreadMarked` becomes `(channelID, threadTS, lastRead string)`. The derived
-`read` bool is deleted at its source, `events.go:384`. The handler writes the
-cursor via a new `cache.UpdateThreadLastRead`, which never touches `active`.
-Ownership of `active` belongs solely to `thread_subscribed`,
+`OnThreadMarked` becomes `(channelID, threadTS, lastRead string, subscribed
+bool)`. The derived `read` bool is deleted at its source in `events.go`: nothing
+downstream may infer read/unread from the subscription block. `subscribed` is
+that block's `active` flag forwarded under its true meaning, and it does exactly
+one job — choose the cursor writer, both of which leave the durable `active`
+column alone. Ownership of `active` belongs solely to `thread_subscribed`,
 `thread_unsubscribed`, and `getView`.
+
+The writer choice matters because slk's own `subscriptions.thread.mark` echoes
+back as `thread_marked`, so this handler sees marks for threads the user merely
+opened and never subscribed to. `markThreadRead` refuses to create a row for
+those (`UpdateThreadLastReadIfExists`); without the same check here, the echo
+would insert the `active=1` row it refused to create and put a phantom entry in
+the Threads list. So: `subscribed` → `cache.UpdateThreadLastRead` (insert is a
+legitimate cache repair), otherwise → `cache.UpdateThreadLastReadIfExists`.
 
 Read/unread is decided by comparing `last_read` against the newest known reply —
 logic that already exists at `internal/cache/threads.go:105-130`.
@@ -372,10 +386,10 @@ otherwise need" — no longer holds.
 | Layer | Coverage |
 |---|---|
 | `internal/slack` | Mark helpers against HTTP 500, `{"ok":false,"error":"invalid_auth"}`, and 429. `newTestClient` (`client_test.go:1330`) provides the harness. |
-| `internal/slack/events` | `thread_marked` passes `last_read` through and no longer derives a read bool. |
+| `internal/slack/events` | `thread_marked` passes `last_read` through and no longer derives a read bool; `active` is forwarded as `subscribed` and the cursor it forwards is unchanged either way. |
 | `internal/cache` | `UpdateThreadLastRead` preserves `active`; `ListSubscribedThreads` recomputes unread correctly as the cursor moves in both directions. |
-| `cmd/slk` | `OnMessage` sets `has_unread` even for the active channel; `OnThreadMarked` updates the cursor and leaves the row active (rewrite of `event_handler_test.go:245`); `markChannelReadAsync` skips the local write on error via the new seam. |
-| `internal/ui` | Matrix of focused/blurred × active/inactive channel × top-level/plain reply/broadcast. Plus focus-regain flush, burst coalescing (N arrivals produce one `MarkRead`), blurred arrivals staying pending until `FocusMsg`, and the divider unmoved after an auto-mark *and after the `channel_marked` echo of that mark*, with a foreign `channel_marked` still moving it as the control. All via the existing `ChannelServiceFuncs` / `ThreadServiceFuncs` closure seams. |
+| `cmd/slk` | `OnMessage` sets `has_unread` even for the active channel; `OnThreadMarked` updates the cursor and leaves the row active (rewrite of `event_handler_test.go:245`), creates no row when `subscribed` is false, and leaves a tombstoned row tombstoned when it is true; `markChannelReadAsync` skips the local write on error via the new seam. |
+| `internal/ui` | Matrix of focused/blurred × active/inactive channel × top-level/plain reply/broadcast. Plus focus-regain flush, burst coalescing (N arrivals produce one `MarkRead`), blurred arrivals staying pending until `FocusMsg`, and the divider unmoved after an auto-mark *and after the `channel_marked` echo of that mark*, with a foreign `channel_marked` still moving it as the control; and the same pair on the thread side, where slk's own `thread_marked` echo leaves the panel landmark alone while a foreign one moves it. All via the existing `ChannelServiceFuncs` / `ThreadServiceFuncs` closure seams. |
 
 ## Documentation
 

--- a/docs/superpowers/specs/2026-09-04-focus-gated-read-marking-design.md
+++ b/docs/superpowers/specs/2026-09-04-focus-gated-read-marking-design.md
@@ -109,16 +109,44 @@ On `FocusMsg`, pending marks accumulated while blurred are issued immediately.
 Without this, a user who alt-tabs back, reads everything, and never switches
 channels leaves the channel unread on Slack indefinitely.
 
-### The divider does not move
+### The divider does not move, but only because the echo is suppressed
 
-Advancing the cursor updates `last_read_ts` in SQLite and on Slack, but does not
-push a new value into the on-screen message models. The `── new ──` divider
-stays at the entry point and recomputes on next entry.
+The `── new ──` divider must stay where the user entered the channel and
+recompute on next entry. Advancing the cursor writes `last_read_ts` to SQLite
+and to Slack; the local path does not push a new value into the on-screen
+message models. `MarkRead` produces `ChannelMarkedReadMsg`, whose arm calls
+`notifyReadStateChanged()` and nothing else, and channel entry already installs
+the pre-mark cursor — `MessagesLoadedMsg` carries `LastReadTS` read before the
+mark.
 
-This requires no extra work: `MarkRead` produces `ChannelMarkedReadMsg`, whose
-arm at `reducer_channels.go:191` calls `notifyReadStateChanged()` and nothing
-else. It never touches `SetLastReadTS`. It also matches what channel entry
-already does — `MessagesLoadedMsg` carries the pre-mark `LastReadTS`.
+The local path is not the whole system, and an earlier revision of this section
+reasoned only from it. Slack broadcasts `channel_marked` to every connected
+client **including the one that issued the mark**. That echo arrives at
+`rtmEventHandler.OnChannelMarked`, becomes a `ChannelMarkedRemoteMsg`, and its
+arm calls `applyChannelMark`, which does run `SetLastReadTS` on every window
+viewing the channel. So without further work the divider moved to the newest
+message a round trip after every mark — including the entry mark, which
+predates this feature.
+
+Suppressing that echo is therefore part of the design, not a free consequence
+of it. `selfMarkDedup` (`internal/ui/app.go`) records the `(channel, ts)` of
+every channel mark slk issues, at all three issuing sites: the tier-1 entry mark
+in `reduceChannelSelected`, the auto-mark in `flushPendingMarks`, and
+`ChannelService.Fetch`'s entry mark — the last reported back on the Update
+goroutine as `MessagesLoadedMsg.MarkedTS`, since the fetcher marks from a cmd
+goroutine and must not touch `App` state. `applyChannelMark` consumes a matching
+record and skips the `SetLastReadTS` loop, while still calling
+`notifyReadStateChanged()` so the sidebar dot and workspace rail clear.
+
+Records are consumed on match and the set is bounded, so a `channel_marked` slk
+did not issue — the user reading the channel in another Slack client — still
+moves the divider, which is the correct response to that event.
+
+The thread panel's landmark has the same shape and the same rule.
+`ThreadMarkedLocalMsg` reports slk's own `subscriptions.thread.mark` completing;
+its arm applies threads-list state only and leaves the panel boundary at the
+pre-open snapshot. `ThreadMarkedRemoteMsg`, a mark from another client, still
+moves it.
 
 ### The decision lives in the UI reducer
 
@@ -326,7 +354,7 @@ otherwise need" — no longer holds.
 | `internal/slack/events` | `thread_marked` passes `last_read` through and no longer derives a read bool. |
 | `internal/cache` | `UpdateThreadLastRead` preserves `active`; `ListSubscribedThreads` recomputes unread correctly as the cursor moves in both directions. |
 | `cmd/slk` | `OnMessage` sets `has_unread` even for the active channel; `OnThreadMarked` updates the cursor and leaves the row active (rewrite of `event_handler_test.go:245`); `markChannelReadAsync` skips the local write on error via the new seam. |
-| `internal/ui` | Matrix of focused/blurred × active/inactive channel × top-level/plain reply/broadcast. Plus focus-regain flush, burst coalescing (N arrivals produce one `MarkRead`), blurred arrivals staying pending until `FocusMsg`, and the divider unmoved after an auto-mark. All via the existing `ChannelServiceFuncs` / `ThreadServiceFuncs` closure seams. |
+| `internal/ui` | Matrix of focused/blurred × active/inactive channel × top-level/plain reply/broadcast. Plus focus-regain flush, burst coalescing (N arrivals produce one `MarkRead`), blurred arrivals staying pending until `FocusMsg`, and the divider unmoved after an auto-mark *and after the `channel_marked` echo of that mark*, with a foreign `channel_marked` still moving it as the control. All via the existing `ChannelServiceFuncs` / `ThreadServiceFuncs` closure seams. |
 
 ## Documentation
 

--- a/docs/superpowers/specs/2026-09-04-focus-gated-read-marking-design.md
+++ b/docs/superpowers/specs/2026-09-04-focus-gated-read-marking-design.md
@@ -129,15 +129,24 @@ message a round trip after every mark — including the entry mark, which
 predates this feature.
 
 Suppressing that echo is therefore part of the design, not a free consequence
-of it. `selfMarkDedup` (`internal/ui/app.go`) records the `(channel, ts)` of
-every channel mark slk issues, at all three issuing sites: the tier-1 entry mark
-in `reduceChannelSelected`, the auto-mark in `flushPendingMarks`, and
+of it. `selfMarkDedup` (`internal/ui/app.go`) records the `(channel, ts)` of the
+channel marks slk issues, at three issuing sites: the tier-1 entry mark in
+`reduceChannelSelected`, the auto-mark in `flushPendingMarks`, and
 `ChannelService.Fetch`'s entry mark — the last reported back on the Update
 goroutine as `MessagesLoadedMsg.MarkedTS`, since the fetcher marks from a cmd
 goroutine and must not touch `App` state. `applyChannelMarkEcho`, which is what
 the `ChannelMarkedRemoteMsg` arm calls, consumes a matching record and skips the
 cursor update, while still calling `notifyReadStateChanged()` so the sidebar dot
 and workspace rail clear.
+
+"Chiefly", not "only" — the same qualification the thread side carries in
+`applyThreadMarkEcho`'s doc. The channel mark-unread press is a fourth issuer of
+the same endpoint: `MarkChannelUnread` posts to `conversations.mark` through the
+same `markChannel` helper the read marks use, so it broadcasts back as a
+`channel_marked` like any other. It is deliberately left unrecorded, so its echo
+is treated as foreign and moves the divider — which is exactly what the press
+asked for. The collision described next is why completing the list here would be
+a bug rather than a tidy-up.
 
 The dedup deliberately sits in `applyChannelMarkEcho` rather than in the shared
 `applyChannelMark` helper. `applyChannelMark`'s other caller is the local

--- a/docs/superpowers/specs/2026-09-04-focus-gated-read-marking-design.md
+++ b/docs/superpowers/specs/2026-09-04-focus-gated-read-marking-design.md
@@ -1,0 +1,370 @@
+# Focus-Gated Read Marking
+
+Design for [issue #159](https://github.com/gammons/slk/issues/159), plus the
+adjacent thread read-state defects uncovered while scoping it.
+
+## Problem
+
+When a message arrives in the channel the user is currently viewing, slk treats
+it as read locally but never advances Slack's server-side read cursor.
+`conversations.mark` fires only on channel entry, so its timestamp covers
+messages that existed when the channel was opened — not messages received
+afterward.
+
+Two consequences:
+
+- Cross-client read state diverges. slk shows a message as read while Slack
+  still considers it unread.
+- Slack may push a mobile notification for a message already visible in slk.
+
+The deeper flaw is the assumption that "this channel is selected" means "the
+user can see it." slk may be running in a background terminal, an inactive tmux
+window, or an unfocused tmux pane with the same channel still selected.
+
+Two independent gates encode that assumption, and both key on channel ID alone:
+
+- `cmd/slk/main.go:4029` — `activeChIDForRead != channelID` suppresses the
+  `has_unread` DB write.
+- `internal/ui/reducer_send.go:289` — `m.ChannelID == a.activeChannelID` skips
+  the unread bump.
+
+Three supporting defects surfaced during exploration and are in scope because
+this work touches all of them:
+
+1. `markChannel` / `markThread` (`internal/slack/client.go:1215`, `:1246`) never
+   read the response body. They check neither HTTP status nor the JSON `ok`
+   field, so `{"ok":false,"error":"invalid_auth"}` is reported as success.
+   `markChannelReadAsync` (`cmd/slk/main.go:3098`) then discards the returned
+   error and writes local read state unconditionally.
+2. `internal/slack/events.go:384` derives `read := !evt.Subscription.Active`
+   from `thread_marked`. That field means *subscribed*, not *unread* — proven
+   inside the repo by `wsThreadSubscribedEvent` (`events.go:265`), a
+   byte-identical block whose `active` is read as "subscribed" at `events.go:397`.
+   The same field cannot carry both meanings.
+3. `applyThreadUnreadBoundary` (`internal/ui/app.go:1822`) feeds the thread
+   panel's `── new ──` divider the *channel's* `last_read_ts`. Plain thread
+   replies never advance the channel watermark, so that value is systematically
+   older than the thread's real cursor and the divider lands too early.
+
+### Observed symptom of defect 2
+
+Posting a reply into a thread makes slk show that thread as unread. It clears
+only after switching to another channel and back. Intermittent.
+
+Chain: posting a reply auto-subscribes you, so Slack's `thread_marked` carries
+`subscription.active = true`. `events.go:384` computes `read = false`.
+`OnThreadMarked` emits `ThreadMarkedRemoteMsg{Read: false}`, `applyThreadMark`
+calls `threadsView.MarkByThreadTSUnread` (`app.go:3170`), and the thread renders
+unread. That flag is in-memory only; it is wiped when `SetSummaries` replaces
+the list from `ListSubscribedThreads`, which recomputes from durable state where
+the self-send suppression at `internal/cache/threads.go:127` correctly fires.
+Switching channels and back forces that refresh.
+
+It is intermittent because it races the 150 ms `ThreadsListDirtyMsg` debounce
+that the reply itself schedules. If the refresh lands after the `thread_marked`,
+the bogus flag is wiped and nothing is visible. If it lands before, the flag
+sticks.
+
+The same conflation causes a second bug: `OnThreadMarked` writes that bit into
+the `active` column (`cmd/slk/main.go:4419`), which `ListSubscribedThreads` uses
+as the *subscribed* filter (`internal/cache/threads.go:76`). Marking a thread
+read tombstones its row, so the thread disappears from the Threads list until
+the next 30-minute `getView` sweep. `cmd/slk/event_handler_test.go:259` asserts
+this as intended behavior.
+
+## Expected behavior
+
+When a top-level message or broadcast thread reply arrives in the active channel
+of the active workspace, slk advances Slack's read cursor only if the terminal
+containing slk is focused. When a reply arrives in a thread whose panel is open,
+slk advances that thread's cursor under the same focus condition.
+
+If slk is running in an unfocused terminal, tmux window, or tmux pane, the
+message stays unread both locally and on Slack. When focus returns, the
+accumulated marks are issued.
+
+Plain thread replies continue to use thread-specific read handling and never
+advance the parent channel cursor unless broadcast.
+
+## Design decisions
+
+### Initial focus state: assume focused
+
+Terminals report focus *transitions* only. Enabling DECSET 1004 does not elicit
+a current-state report, so a user who launches slk and never leaves the terminal
+receives no `FocusMsg` — ever.
+
+slk therefore initializes `terminalFocused` to `true`. The user typed a command
+to launch slk, so the terminal was focused at that moment. On a terminal with no
+focus-event support, no `BlurMsg` ever arrives, the flag stays `true`, and
+behavior is identical to today's. No regression and no capability probe.
+
+This deliberately departs from the issue's "if focus state is unknown, do not
+mark read." Taken literally, that would leave the feature permanently dead on
+terminals without DECSET 1004 and inert for any user who never alt-tabs away.
+
+### Focus-regain catch-up
+
+On `FocusMsg`, pending marks accumulated while blurred are issued immediately.
+Without this, a user who alt-tabs back, reads everything, and never switches
+channels leaves the channel unread on Slack indefinitely.
+
+### The divider does not move
+
+Advancing the cursor updates `last_read_ts` in SQLite and on Slack, but does not
+push a new value into the on-screen message models. The `── new ──` divider
+stays at the entry point and recomputes on next entry.
+
+This requires no extra work: `MarkRead` produces `ChannelMarkedReadMsg`, whose
+arm at `reducer_channels.go:191` calls `notifyReadStateChanged()` and nothing
+else. It never touches `SetLastReadTS`. It also matches what channel entry
+already does — `MessagesLoadedMsg` carries the pre-mark `LastReadTS`.
+
+### The decision lives in the UI reducer
+
+Focus is known on the UI goroutine via `FocusMsg`/`BlurMsg`. The `has_unread` DB
+write happens on the RTM goroutine in `OnMessage`. Rather than duplicate focus
+state across goroutines behind an atomic, the decision moves to the reducer:
+
+- `OnMessage` drops its active-channel exemption and always writes
+  `has_unread = true` for eligible messages.
+- `reduceNewMessage`, which only runs for the active workspace, checks focus and
+  issues the mark, clearing the flag on success.
+
+Focus never leaves the UI goroutine. Failure naturally leaves the channel
+unread. The path is fully testable through the existing `ChannelServiceFuncs`
+closure seam.
+
+Cost: one extra DB write per message, and a sub-second window in which the
+active channel is `has_unread = true`. Nothing on this path repaints the
+sidebar, so no dot appears; an unrelated event repainting within that window
+would briefly show a dot that self-corrects on flush. Accepted.
+
+## Architecture
+
+### Terminology
+
+**Channel-eligible** message: a top-level message (`thread_ts` empty or equal to
+`ts`) or a `thread_broadcast`. Only these advance a channel's read cursor, which
+is the rule already encoded at `cmd/slk/main.go:4022-4024` and duplicated at
+`reducer_send.go:309-310`.
+
+**Thread-eligible** message: any message with a `thread_ts` that differs from
+its `ts`. A `thread_broadcast` is both channel- and thread-eligible.
+
+### Focus tracking
+
+`App.View` already returns `tea.View` and sets `AltScreen` / `MouseMode` at
+`internal/ui/app.go:2767`. Add `v.ReportFocus = true` beside them. Add
+`App.terminalFocused bool`, initialized `true`.
+
+A new `internal/ui/reducer_focus.go` joins the dispatch chain and owns
+`tea.FocusMsg`, `tea.BlurMsg`, and the mark-flush tick. `reduceIO` owns terminal
+leftovers such as `tea.PasteMsg`, but focus here drives read-state marking — a
+cohesive family, matching the repo's reducer doctrine.
+
+### Pending-mark slots
+
+Two single-slot pending marks on `App`:
+
+```
+pendingChannelMark {channelID, ts}
+pendingThreadMark  {channelID, threadTS, ts}
+```
+
+Rules:
+
+- An eligible message arrives: overwrite the slot with the newer ts
+  (newest-wins). A slot can never issue a request for a ts older than one it
+  already holds.
+- Focused: also schedule a flush tick via `tea.Tick` if one is not already
+  pending — the `scheduleThreadsDirty` idiom (`app.go:1831`).
+- Blurred: record only, no tick.
+- `FocusMsg`: if a slot is non-empty, flush immediately.
+- Flush tick: flush if focused. If blurred, leave the slot pending rather than
+  dropping it.
+- Flushing clears the slot, then issues the request. A failed request is
+  therefore not retried by this mechanism; it is reconciled by the next arrival,
+  the next channel entry, or reconnect sync. This is deliberate — retrying a
+  mark that Slack rejected risks a hammering loop against a rate-limited
+  endpoint, the same hazard `threadSubsGate` guards against by recording its
+  timestamp at admission rather than completion.
+- Channel switch: clear the channel slot. The entry-mark supersedes it.
+- `BlurMsg`: no flush, and any already-scheduled tick becomes a no-op on
+  arrival per the rule above.
+
+Focus-regain catch-up falls out of this mechanism rather than needing a separate
+path, and a burst coalesces to one request per interval per target.
+
+Debounce default is 1 s, in a configurable `App` field. `threadsDirtyDebounce`
+is 150 ms because it re-queries local SQLite; this is a network write, so a full
+second is the right order of magnitude. Tests set it to zero or drive the flush
+message directly.
+
+### Channel path
+
+`cmd/slk/main.go:4028` drops the `activeChIDForRead != channelID` condition.
+`has_unread = true` is written for every eligible message — top-level or
+`thread_broadcast` — regardless of which channel is active. The
+`activeChannelID` closure remains; notifications still use it.
+
+`reduceNewMessage`'s active-channel branch (`reducer_send.go:289`), currently a
+bare debug log, becomes:
+
+- Focused: record the pending channel mark. Do not call
+  `notifyReadStateChanged`, so this event triggers no sidebar repaint.
+- Blurred: call `notifyReadStateChanged()` so the unread dot appears. This is
+  the new "remain unread locally" behavior.
+
+Flush calls the existing `ChannelService.MarkRead` → `markChannelReadAsync` →
+`ChannelMarkedReadMsg`.
+
+### Thread path
+
+In `reduceNewMessage`'s reply branch (`reducer_send.go:198`), if the terminal is
+focused and the thread panel is open on that thread, record the pending thread
+mark. A `thread_broadcast` records both slots.
+
+The visibility gate is "terminal focused and thread panel open on that thread" —
+not `focusedPanel == PanelThread`. This mirrors the channel rule, which is "this
+channel is active," not "the messages pane holds slk-internal focus."
+`reduceNewMessage` already routes replies on exactly this predicate.
+
+`ThreadService.Mark` is today `void` and remote-only (`main.go:1741`), so
+`thread_subscriptions.last_read` never advances locally. It changes to return a
+`tea.Cmd` yielding `ThreadMarkedLocalMsg{ChannelID, ThreadTS, TS, Err}` —
+convention (b) in `services.go`. The closure writes `last_read` only after a
+successful `MarkThread`. One existing call site updates,
+`reducer_threads.go:130`.
+
+### Thread `active`/unread conflation fix
+
+`OnThreadMarked` becomes `(channelID, threadTS, lastRead string)`. The derived
+`read` bool is deleted at its source, `events.go:384`. The handler writes the
+cursor via a new `cache.UpdateThreadLastRead`, which never touches `active`.
+Ownership of `active` belongs solely to `thread_subscribed`,
+`thread_unsubscribed`, and `getView`.
+
+Read/unread is decided by comparing `last_read` against the newest known reply —
+logic that already exists at `internal/cache/threads.go:105-130`.
+
+`ThreadMarkedRemoteMsg` loses its `TS` and `Read` fields and gains `LastRead`.
+`applyThreadMark` correspondingly stops trusting `active`: it sets the thread
+panel's unread boundary from `LastRead`, and updates the threads-view flag as
+`Unread = LastReplyTS > LastRead` via a new
+`threadsview.MarkByThreadTSReadAt(channelID, threadTS, lastRead)` replacing the
+`MarkByThreadTSRead` / `MarkByThreadTSUnread` pair on this path. A
+`ThreadsListDirtyMsg` still follows for authoritative reconcile from the cache.
+
+This also cleans up mark-unread. `MessageService.MarkUnread`'s thread branch
+currently depends on the echo arriving with `active = true`. Under a `last_read`
+comparison, Slack rolling the cursor backward naturally yields unread. One rule
+serves both directions.
+
+`cmd/slk/event_handler_test.go:245-264` is rewritten; it currently asserts the
+vanishing-thread behavior as correct.
+
+### Thread divider fix
+
+`applyThreadUnreadBoundary` (`app.go:1822`) switches from the channel cursor to
+the thread cursor, using the `thread_subscriptions.last_read` accessor added
+above.
+
+### Slack client error handling
+
+`markChannel` and `markThread` are rewritten as thin `postForm` callers that then
+parse `{ok, error}` and return an error when `ok` is false. `postForm`
+(`client.go:1489`) already supplies the `token` field, checks HTTP status, maps
+429 to `rateLimitError`, and truncates bodies for logs. The helpers lose more
+code than they gain.
+
+`apiHTTPClient()` returns `c.httpClient` when set (`client.go:211`), which is
+what `newTestClient` populates, and `postForm` uses `c.apiBaseURL` — so this
+preserves both the existing test wiring and Enterprise Grid host discovery.
+
+Four public methods begin returning real errors: `MarkChannel`, `MarkThread`,
+`MarkChannelUnread`, `MarkThreadUnread`. `MessageService.MarkUnread`'s thread
+branch already surfaces `Err` into a toast (`main.go:1670`), so its "Marked
+unread" toast stops lying on failure as a side effect.
+
+### `markChannelReadAsync` and its test seam
+
+On error: log, skip the `UpdateChannelReadState` write, skip the
+`ChannelMarkedReadMsg`. The channel stays unread locally, which is the honest
+state, and it self-heals on the next channel entry or reconnect sync. This
+applies to every caller, including channel entry.
+
+`WorkspaceContext.Client` is a concrete `*slackclient.Client`, the sole reason
+`TestMarkChannelReadAsync_UpdatesReadState` is skipped
+(`event_handler_marked_test.go:138`). Introduce a one-method interface in
+`cmd/slk`:
+
+```go
+type channelMarker interface {
+	MarkChannel(ctx context.Context, channelID, ts string) error
+}
+```
+
+`markChannelReadAsync` takes that instead of reaching through `wctx.Client`. The
+skip comment's objection — "would require introducing an interface seam we don't
+otherwise need" — no longer holds.
+
+## Error handling
+
+| Failure | Behavior |
+|---|---|
+| `conversations.mark` transport error, non-2xx, or `ok:false` | Log. Local `last_read_ts` unchanged, `has_unread` stays true. No `ChannelMarkedReadMsg`. Self-heals on next channel entry or reconnect sync. |
+| `subscriptions.thread.mark` failure | Log. `thread_subscriptions.last_read` unchanged. `ThreadMarkedLocalMsg.Err` set. |
+| HTTP 429 | Surfaces as `rateLimitError` from `postForm`. Treated as failure; the pending slot is already cleared, so the mark is retried on the next arrival or channel entry rather than immediately. |
+| Focus state unavailable | Treated as focused. See "Initial focus state". |
+
+## Testing
+
+| Layer | Coverage |
+|---|---|
+| `internal/slack` | Mark helpers against HTTP 500, `{"ok":false,"error":"invalid_auth"}`, and 429. `newTestClient` (`client_test.go:1330`) provides the harness. |
+| `internal/slack/events` | `thread_marked` passes `last_read` through and no longer derives a read bool. |
+| `internal/cache` | `UpdateThreadLastRead` preserves `active`; `ListSubscribedThreads` recomputes unread correctly as the cursor moves in both directions. |
+| `cmd/slk` | `OnMessage` sets `has_unread` even for the active channel; `OnThreadMarked` updates the cursor and leaves the row active (rewrite of `event_handler_test.go:245`); `markChannelReadAsync` skips the local write on error via the new seam. |
+| `internal/ui` | Matrix of focused/blurred × active/inactive channel × top-level/plain reply/broadcast. Plus focus-regain flush, burst coalescing (N arrivals produce one `MarkRead`), blurred arrivals staying pending until `FocusMsg`, and the divider unmoved after an auto-mark. All via the existing `ChannelServiceFuncs` / `ThreadServiceFuncs` closure seams. |
+
+## Documentation
+
+A "Focus reporting" section is added to `wiki/Terminal-Compatibility.md`,
+adjacent to "Unread indicator in the window title" (lines 57-89), which already
+establishes the doc's tmux-caveat convention. It covers what focus reporting
+does for read state, the `set -g focus-events on` requirement for tmux users,
+and the assume-focused fallback for terminals without DECSET 1004.
+
+## Sequencing
+
+Bottom-up. Each step is independently testable.
+
+1. `internal/slack` mark helpers route through `postForm` and parse `ok`.
+2. `cache.UpdateThreadLastRead`.
+3. `events.go` and `OnThreadMarked` conflation fix, `applyThreadMark`
+   correction, test rewrite.
+4. `channelMarker` seam and `markChannelReadAsync` error honoring.
+5. `ThreadService.Mark` returns a result; durable `last_read` write.
+6. Thread-divider fix.
+7. Focus tracking: `ReportFocus`, `terminalFocused`, `reducer_focus.go`.
+8. Pending-mark slots and flush, wired into `reduceNewMessage`; drop the
+   `OnMessage` active-channel exemption.
+9. Documentation.
+
+Steps 1-6 are the thread-correctness half and are independently shippable.
+Steps 7-8 are the issue's headline feature.
+
+## Out of scope
+
+- Opening the Threads view or pressing `G` silently marks the top thread read on
+  Slack (`reducer_threads.go:162` → `:130`), and a warm cache fires
+  `subscriptions.thread.mark` twice per open, the first at a stale ts. Separable
+  behavioral change; worth its own issue.
+- `WorkspaceContext.ThreadsHasUnreads` is written at `main.go:2597` and read
+  nowhere, with struct and API docs still describing a suppression mechanism
+  deleted in `6133ba3`. Dead-but-documented state.
+- `ThreadService.ListFetch` uses `router.Active()` for the self-user ID while
+  querying an arbitrary team (`main.go:1789`), which misfires the self-send
+  suppression on Enterprise Grid.
+- A dwell delay before marking read on focus regain.

--- a/internal/cache/thread_subscriptions.go
+++ b/internal/cache/thread_subscriptions.go
@@ -79,13 +79,16 @@ func (db *DB) DeleteThreadSubscription(workspaceID, channelID, threadTS string) 
 // callers that can prove the user is subscribed to the thread, because
 // ListSubscribedThreads filters on active=1 and would surface the
 // inserted row in the Threads list. The sole such caller is
-// rtmEventHandler.OnThreadMarked: Slack only pushes thread_marked for
-// threads the user is subscribed to, so the insert reconstructs a row
-// the local cache merely hasn't seen yet.
+// rtmEventHandler.OnThreadMarked, and only on the branch where the
+// thread_marked event's subscription block reports active=true: there
+// the insert reconstructs a row the local cache merely hasn't seen yet.
+// The precondition is checked by that caller, not assumed here — slk's
+// own subscriptions.thread.mark echoes back as thread_marked, so the
+// event by itself does not prove subscription.
 //
-// Callers that CANNOT prove subscription — notably the local mark path,
-// which fires for any thread the user opens — must use
-// UpdateThreadLastReadIfExists instead.
+// Callers that CANNOT prove subscription — the local mark path, which
+// fires for any thread the user opens, and OnThreadMarked's
+// active=false branch — must use UpdateThreadLastReadIfExists instead.
 func (db *DB) UpdateThreadLastRead(workspaceID, channelID, threadTS, lastRead string) error {
 	if workspaceID == "" || channelID == "" || threadTS == "" {
 		return fmt.Errorf("UpdateThreadLastRead: workspace/channel/thread_ts required")

--- a/internal/cache/thread_subscriptions.go
+++ b/internal/cache/thread_subscriptions.go
@@ -1,6 +1,8 @@
 package cache
 
 import (
+	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 )
@@ -65,6 +67,49 @@ func (db *DB) DeleteThreadSubscription(workspaceID, channelID, threadTS string) 
 		return fmt.Errorf("deleting thread_subscriptions: %w", err)
 	}
 	return nil
+}
+
+// UpdateThreadLastRead advances (or rewinds) a thread's read cursor
+// WITHOUT touching `active`. thread_marked carries a read cursor, not a
+// subscription change, so it must not be able to tombstone a row or
+// resurrect one: `active` is owned solely by thread_subscribed,
+// thread_unsubscribed, and the getView reconcile.
+//
+// A missing row is inserted with active=1 because Slack only pushes
+// thread_marked for threads the user is subscribed to.
+func (db *DB) UpdateThreadLastRead(workspaceID, channelID, threadTS, lastRead string) error {
+	if workspaceID == "" || channelID == "" || threadTS == "" {
+		return fmt.Errorf("UpdateThreadLastRead: workspace/channel/thread_ts required")
+	}
+	const q = `
+INSERT INTO thread_subscriptions
+    (workspace_id, channel_id, thread_ts, last_read, active, updated_at)
+VALUES (?, ?, ?, ?, 1, ?)
+ON CONFLICT(workspace_id, channel_id, thread_ts) DO UPDATE SET
+    last_read  = excluded.last_read,
+    updated_at = excluded.updated_at
+`
+	if _, err := db.conn.Exec(q, workspaceID, channelID, threadTS, lastRead, time.Now().Unix()); err != nil {
+		return fmt.Errorf("updating thread last_read: %w", err)
+	}
+	return nil
+}
+
+// GetThreadLastRead returns a thread's read cursor, or "" when no row
+// exists (which the thread panel treats as "no unread boundary").
+// A missing row is not an error.
+func (db *DB) GetThreadLastRead(workspaceID, channelID, threadTS string) (string, error) {
+	const q = `SELECT last_read FROM thread_subscriptions
+WHERE workspace_id=? AND channel_id=? AND thread_ts=?`
+	var lastRead string
+	err := db.conn.QueryRow(q, workspaceID, channelID, threadTS).Scan(&lastRead)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("reading thread last_read: %w", err)
+	}
+	return lastRead, nil
 }
 
 // ListActiveThreadSubscriptions returns every active subscription in

--- a/internal/cache/thread_subscriptions.go
+++ b/internal/cache/thread_subscriptions.go
@@ -70,10 +70,13 @@ func (db *DB) DeleteThreadSubscription(workspaceID, channelID, threadTS string) 
 }
 
 // UpdateThreadLastRead advances (or rewinds) a thread's read cursor
-// WITHOUT touching `active`. thread_marked carries a read cursor, not a
-// subscription change, so it must not be able to tombstone a row or
-// resurrect one: `active` is owned solely by thread_subscribed,
-// thread_unsubscribed, and the getView reconcile.
+// WITHOUT touching `active` on a row that already exists — the ON
+// CONFLICT clause updates last_read and updated_at and nothing else.
+// thread_marked carries a read cursor, not a subscription change, so it
+// must not be able to tombstone a row or resurrect one: `active` is
+// owned solely by thread_subscribed, thread_unsubscribed, and the
+// getView reconcile. Creating a missing row is the one exception, and
+// the paragraph below is its precondition.
 //
 // A missing row is inserted with active=1. That branch is ONLY valid for
 // callers that can prove the user is subscribed to the thread, because
@@ -118,8 +121,9 @@ ON CONFLICT(workspace_id, channel_id, thread_ts) DO UPDATE SET
 // worth storing, and if the user later becomes subscribed the getView
 // reconcile supplies last_read from Slack.
 //
-// Like UpdateThreadLastRead it never touches `active` (so a tombstoned
-// row stays tombstoned) or `latest_reply`.
+// It never touches `active` (so a tombstoned row stays tombstoned) or
+// `latest_reply` — unlike UpdateThreadLastRead, which leaves `active`
+// alone on an existing row but writes active=1 when it inserts one.
 func (db *DB) UpdateThreadLastReadIfExists(workspaceID, channelID, threadTS, lastRead string) error {
 	if workspaceID == "" || channelID == "" || threadTS == "" {
 		return fmt.Errorf("UpdateThreadLastReadIfExists: workspace/channel/thread_ts required")

--- a/internal/cache/thread_subscriptions.go
+++ b/internal/cache/thread_subscriptions.go
@@ -75,8 +75,17 @@ func (db *DB) DeleteThreadSubscription(workspaceID, channelID, threadTS string) 
 // resurrect one: `active` is owned solely by thread_subscribed,
 // thread_unsubscribed, and the getView reconcile.
 //
-// A missing row is inserted with active=1 because Slack only pushes
-// thread_marked for threads the user is subscribed to.
+// A missing row is inserted with active=1. That branch is ONLY valid for
+// callers that can prove the user is subscribed to the thread, because
+// ListSubscribedThreads filters on active=1 and would surface the
+// inserted row in the Threads list. The sole such caller is
+// rtmEventHandler.OnThreadMarked: Slack only pushes thread_marked for
+// threads the user is subscribed to, so the insert reconstructs a row
+// the local cache merely hasn't seen yet.
+//
+// Callers that CANNOT prove subscription — notably the local mark path,
+// which fires for any thread the user opens — must use
+// UpdateThreadLastReadIfExists instead.
 func (db *DB) UpdateThreadLastRead(workspaceID, channelID, threadTS, lastRead string) error {
 	if workspaceID == "" || channelID == "" || threadTS == "" {
 		return fmt.Errorf("UpdateThreadLastRead: workspace/channel/thread_ts required")
@@ -90,6 +99,34 @@ ON CONFLICT(workspace_id, channel_id, thread_ts) DO UPDATE SET
     updated_at = excluded.updated_at
 `
 	if _, err := db.conn.Exec(q, workspaceID, channelID, threadTS, lastRead, time.Now().Unix()); err != nil {
+		return fmt.Errorf("updating thread last_read: %w", err)
+	}
+	return nil
+}
+
+// UpdateThreadLastReadIfExists advances a thread's read cursor only when
+// a subscription row already exists, and never creates one. Used by the
+// local mark path, which fires for ANY thread the user opens — including
+// threads they were never subscribed to. Inserting there would fabricate
+// an active=1 row and surface a phantom entry in the Threads list, since
+// ListSubscribedThreads filters on active=1.
+//
+// A missing row is not an error: an unsubscribed thread has no cursor
+// worth storing, and if the user later becomes subscribed the getView
+// reconcile supplies last_read from Slack.
+//
+// Like UpdateThreadLastRead it never touches `active` (so a tombstoned
+// row stays tombstoned) or `latest_reply`.
+func (db *DB) UpdateThreadLastReadIfExists(workspaceID, channelID, threadTS, lastRead string) error {
+	if workspaceID == "" || channelID == "" || threadTS == "" {
+		return fmt.Errorf("UpdateThreadLastReadIfExists: workspace/channel/thread_ts required")
+	}
+	const q = `
+UPDATE thread_subscriptions
+SET last_read = ?, updated_at = ?
+WHERE workspace_id=? AND channel_id=? AND thread_ts=?
+`
+	if _, err := db.conn.Exec(q, lastRead, time.Now().Unix(), workspaceID, channelID, threadTS); err != nil {
 		return fmt.Errorf("updating thread last_read: %w", err)
 	}
 	return nil

--- a/internal/cache/thread_subscriptions_test.go
+++ b/internal/cache/thread_subscriptions_test.go
@@ -185,3 +185,122 @@ func TestReconcileThreadSubscriptions_PerWorkspaceIsolation(t *testing.T) {
 		t.Fatalf("T2 should be unaffected, got %d active rows", len(got))
 	}
 }
+
+func TestUpdateThreadLastRead_PreservesTombstone(t *testing.T) {
+	db := setupDBWithWorkspace(t)
+	// Tombstone the row: active=false.
+	if err := db.UpsertThreadSubscription("T1", "C1", "P1", "R1", false); err != nil {
+		t.Fatalf("UpsertThreadSubscription: %v", err)
+	}
+
+	if err := db.UpdateThreadLastRead("T1", "C1", "P1", "R9"); err != nil {
+		t.Fatalf("UpdateThreadLastRead: %v", err)
+	}
+
+	active, err := db.ListActiveThreadSubscriptions("T1")
+	if err != nil {
+		t.Fatalf("ListActiveThreadSubscriptions: %v", err)
+	}
+	if len(active) != 0 {
+		t.Fatalf("UpdateThreadLastRead must not resurrect a tombstoned row, got %d active", len(active))
+	}
+	got, err := db.GetThreadLastRead("T1", "C1", "P1")
+	if err != nil {
+		t.Fatalf("GetThreadLastRead: %v", err)
+	}
+	if got != "R9" {
+		t.Errorf("GetThreadLastRead = %q, want %q", got, "R9")
+	}
+}
+
+func TestUpdateThreadLastRead_PreservesActive(t *testing.T) {
+	db := setupDBWithWorkspace(t)
+	if err := db.UpsertThreadSubscription("T1", "C1", "P1", "R1", true); err != nil {
+		t.Fatalf("UpsertThreadSubscription: %v", err)
+	}
+
+	if err := db.UpdateThreadLastRead("T1", "C1", "P1", "R9"); err != nil {
+		t.Fatalf("UpdateThreadLastRead: %v", err)
+	}
+
+	active, err := db.ListActiveThreadSubscriptions("T1")
+	if err != nil {
+		t.Fatalf("ListActiveThreadSubscriptions: %v", err)
+	}
+	if len(active) != 1 {
+		t.Fatalf("want 1 active row, got %d", len(active))
+	}
+	if active[0].LastRead != "R9" {
+		t.Errorf("LastRead = %q, want %q", active[0].LastRead, "R9")
+	}
+}
+
+func TestUpdateThreadLastRead_InsertsActiveRow(t *testing.T) {
+	db := setupDBWithWorkspace(t)
+	// No prior row: Slack only sends thread_marked for threads the user
+	// is subscribed to, so an inserted row starts active.
+	if err := db.UpdateThreadLastRead("T1", "C1", "P1", "R5"); err != nil {
+		t.Fatalf("UpdateThreadLastRead: %v", err)
+	}
+
+	active, err := db.ListActiveThreadSubscriptions("T1")
+	if err != nil {
+		t.Fatalf("ListActiveThreadSubscriptions: %v", err)
+	}
+	if len(active) != 1 || active[0].LastRead != "R5" {
+		t.Fatalf("want one active row with LastRead=R5, got %+v", active)
+	}
+}
+
+func TestGetThreadLastRead_MissingRowReturnsEmpty(t *testing.T) {
+	db := setupDBWithWorkspace(t)
+	got, err := db.GetThreadLastRead("T1", "C1", "P1")
+	if err != nil {
+		t.Fatalf("GetThreadLastRead on missing row: %v", err)
+	}
+	if got != "" {
+		t.Errorf("GetThreadLastRead = %q, want empty", got)
+	}
+}
+
+func TestUpdateThreadLastRead_RejectsEmptyKey(t *testing.T) {
+	db := setupDBWithWorkspace(t)
+	if err := db.UpdateThreadLastRead("", "C1", "P1", "R5"); err == nil {
+		t.Error("want error for empty workspaceID, got nil")
+	}
+	if err := db.UpdateThreadLastRead("T1", "", "P1", "R5"); err == nil {
+		t.Error("want error for empty channelID, got nil")
+	}
+	if err := db.UpdateThreadLastRead("T1", "C1", "", "R5"); err == nil {
+		t.Error("want error for empty threadTS, got nil")
+	}
+}
+
+// latest_reply is the authoritative "newest activity" watermark set by
+// the getView reconcile. A read cursor update must not clobber it, or
+// the thread would look read-with-no-activity until the next reconcile.
+func TestUpdateThreadLastRead_PreservesLatestReply(t *testing.T) {
+	db := setupDBWithWorkspace(t)
+	fresh := []ThreadSubscription{{
+		WorkspaceID: "T1", ChannelID: "C1", ThreadTS: "1700000100.000000",
+		LastRead: "1700000150.000000", LatestReply: "1700000200.000000", Active: true,
+	}}
+	if err := db.ReconcileThreadSubscriptions("T1", fresh); err != nil {
+		t.Fatalf("ReconcileThreadSubscriptions: %v", err)
+	}
+
+	if err := db.UpdateThreadLastRead("T1", "C1", "1700000100.000000", "1700000200.000000"); err != nil {
+		t.Fatalf("UpdateThreadLastRead: %v", err)
+	}
+
+	var latestReply string
+	if err := db.conn.QueryRow(
+		`SELECT latest_reply FROM thread_subscriptions WHERE workspace_id=? AND channel_id=? AND thread_ts=?`,
+		"T1", "C1", "1700000100.000000",
+	).Scan(&latestReply); err != nil {
+		t.Fatalf("query latest_reply: %v", err)
+	}
+	if latestReply != "1700000200.000000" {
+		t.Errorf("latest_reply = %q, want it preserved as %q", latestReply, "1700000200.000000")
+	}
+}

--- a/internal/cache/thread_subscriptions_test.go
+++ b/internal/cache/thread_subscriptions_test.go
@@ -304,3 +304,121 @@ func TestUpdateThreadLastRead_PreservesLatestReply(t *testing.T) {
 		t.Errorf("latest_reply = %q, want it preserved as %q", latestReply, "1700000200.000000")
 	}
 }
+
+// The local mark path fires for ANY thread the user opens, including
+// threads opened from the messages pane that they were never subscribed
+// to. Inserting a row there would fabricate active=1 and put a phantom
+// entry in the Threads list (ListSubscribedThreads filters active=1)
+// until the next getView reconcile tombstoned it.
+func TestUpdateThreadLastReadIfExists_MissingRowIsNotCreated(t *testing.T) {
+	db := setupDBWithWorkspace(t)
+
+	if err := db.UpdateThreadLastReadIfExists("T1", "C1", "P1", "R5"); err != nil {
+		t.Fatalf("a missing row must not be an error: %v", err)
+	}
+
+	active, err := db.ListActiveThreadSubscriptions("T1")
+	if err != nil {
+		t.Fatalf("ListActiveThreadSubscriptions: %v", err)
+	}
+	if len(active) != 0 {
+		t.Fatalf("must not fabricate a subscription row, got %+v", active)
+	}
+	got, err := db.GetThreadLastRead("T1", "C1", "P1")
+	if err != nil {
+		t.Fatalf("GetThreadLastRead: %v", err)
+	}
+	if got != "" {
+		t.Errorf("GetThreadLastRead = %q, want empty; no row should exist at all", got)
+	}
+}
+
+func TestUpdateThreadLastReadIfExists_AdvancesExistingRow(t *testing.T) {
+	db := setupDBWithWorkspace(t)
+	if err := db.UpsertThreadSubscription("T1", "C1", "P1", "R1", true); err != nil {
+		t.Fatalf("UpsertThreadSubscription: %v", err)
+	}
+
+	if err := db.UpdateThreadLastReadIfExists("T1", "C1", "P1", "R9"); err != nil {
+		t.Fatalf("UpdateThreadLastReadIfExists: %v", err)
+	}
+
+	active, err := db.ListActiveThreadSubscriptions("T1")
+	if err != nil {
+		t.Fatalf("ListActiveThreadSubscriptions: %v", err)
+	}
+	if len(active) != 1 {
+		t.Fatalf("want 1 active row, got %d", len(active))
+	}
+	if active[0].LastRead != "R9" {
+		t.Errorf("LastRead = %q, want %q", active[0].LastRead, "R9")
+	}
+}
+
+// `active` is owned solely by thread_subscribed, thread_unsubscribed and
+// the getView reconcile. Advancing a cursor must neither resurrect a
+// tombstone nor refuse to record the read.
+func TestUpdateThreadLastReadIfExists_PreservesTombstone(t *testing.T) {
+	db := setupDBWithWorkspace(t)
+	if err := db.UpsertThreadSubscription("T1", "C1", "P1", "R1", false); err != nil {
+		t.Fatalf("UpsertThreadSubscription: %v", err)
+	}
+
+	if err := db.UpdateThreadLastReadIfExists("T1", "C1", "P1", "R9"); err != nil {
+		t.Fatalf("UpdateThreadLastReadIfExists: %v", err)
+	}
+
+	active, err := db.ListActiveThreadSubscriptions("T1")
+	if err != nil {
+		t.Fatalf("ListActiveThreadSubscriptions: %v", err)
+	}
+	if len(active) != 0 {
+		t.Fatalf("must not resurrect a tombstoned row, got %d active", len(active))
+	}
+	got, err := db.GetThreadLastRead("T1", "C1", "P1")
+	if err != nil {
+		t.Fatalf("GetThreadLastRead: %v", err)
+	}
+	if got != "R9" {
+		t.Errorf("GetThreadLastRead = %q, want the cursor still advanced to R9", got)
+	}
+}
+
+func TestUpdateThreadLastReadIfExists_PreservesLatestReply(t *testing.T) {
+	db := setupDBWithWorkspace(t)
+	fresh := []ThreadSubscription{{
+		WorkspaceID: "T1", ChannelID: "C1", ThreadTS: "1700000100.000000",
+		LastRead: "1700000150.000000", LatestReply: "1700000200.000000", Active: true,
+	}}
+	if err := db.ReconcileThreadSubscriptions("T1", fresh); err != nil {
+		t.Fatalf("ReconcileThreadSubscriptions: %v", err)
+	}
+
+	if err := db.UpdateThreadLastReadIfExists("T1", "C1", "1700000100.000000", "1700000200.000000"); err != nil {
+		t.Fatalf("UpdateThreadLastReadIfExists: %v", err)
+	}
+
+	var latestReply string
+	if err := db.conn.QueryRow(
+		`SELECT latest_reply FROM thread_subscriptions WHERE workspace_id=? AND channel_id=? AND thread_ts=?`,
+		"T1", "C1", "1700000100.000000",
+	).Scan(&latestReply); err != nil {
+		t.Fatalf("reading latest_reply: %v", err)
+	}
+	if latestReply != "1700000200.000000" {
+		t.Errorf("latest_reply = %q, want it preserved", latestReply)
+	}
+}
+
+func TestUpdateThreadLastReadIfExists_RejectsEmptyKey(t *testing.T) {
+	db := setupDBWithWorkspace(t)
+	if err := db.UpdateThreadLastReadIfExists("", "C1", "P1", "R5"); err == nil {
+		t.Error("want error for empty workspaceID, got nil")
+	}
+	if err := db.UpdateThreadLastReadIfExists("T1", "", "P1", "R5"); err == nil {
+		t.Error("want error for empty channelID, got nil")
+	}
+	if err := db.UpdateThreadLastReadIfExists("T1", "C1", "", "R5"); err == nil {
+		t.Error("want error for empty threadTS, got nil")
+	}
+}

--- a/internal/slack/client.go
+++ b/internal/slack/client.go
@@ -1212,37 +1212,43 @@ func (c *Client) GetPermalink(ctx context.Context, channelID, ts string) (string
 	return url, nil
 }
 
-// markChannel posts to conversations.mark with the given form values.
-// Used by both MarkChannel (read up to ts) and MarkChannelUnread (roll the
-// watermark backward to ts). Uses c.httpClient for the request so tests
-// can substitute an httptest.NewServer; production wiring (NewClient) sets
-// httpClient to a cookie-bearing client.
-func (c *Client) markChannel(ctx context.Context, channelID, ts string) error {
-	data := url.Values{
-		"token":   {c.token},
-		"channel": {channelID},
-		"ts":      {ts},
+// parseOKResponse checks a Slack Web API response envelope. Slack
+// answers HTTP 200 even for failures, so the {"ok":false,"error":...}
+// body is the only signal that a call was rejected.
+func parseOKResponse(method string, raw []byte) error {
+	var resp struct {
+		OK    bool   `json:"ok"`
+		Error string `json:"error"`
 	}
-
-	req, err := http.NewRequestWithContext(ctx, "POST", c.apiBaseURL+"conversations.mark",
-		strings.NewReader(data.Encode()))
-	if err != nil {
-		return fmt.Errorf("creating mark request: %w", err)
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return fmt.Errorf("parsing %s: %w (body=%s)", method, err, truncateForLog(raw))
 	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("marking channel: %w", err)
+	if !resp.OK {
+		return fmt.Errorf("%s: %s (body=%s)", method, resp.Error, truncateForLog(raw))
 	}
-	defer resp.Body.Close()
 	return nil
 }
 
-// markThread posts to subscriptions.thread.mark with the given args.
-// Used by both MarkThread (read=true => "1") and MarkThreadUnread
-// (read=false => "0"). channelID/threadTS empty is a no-op. ts defaults
-// to threadTS when empty (parent has no replies yet).
+// markChannel posts to conversations.mark. Used by both MarkChannel
+// (read up to ts) and MarkChannelUnread (roll the watermark backward to
+// ts). Routed through postForm so HTTP status, 429, and the Slack
+// {"ok":false} envelope are all surfaced as errors — read state must
+// never be persisted locally for a mark Slack rejected.
+func (c *Client) markChannel(ctx context.Context, channelID, ts string) error {
+	raw, err := c.postForm(ctx, "conversations.mark", url.Values{
+		"channel": {channelID},
+		"ts":      {ts},
+	})
+	if err != nil {
+		return err
+	}
+	return parseOKResponse("conversations.mark", raw)
+}
+
+// markThread posts to subscriptions.thread.mark. Used by both MarkThread
+// (read=true => "1") and MarkThreadUnread (read=false => "0").
+// channelID/threadTS empty is a no-op. ts defaults to threadTS when empty
+// (parent has no replies yet). Error handling mirrors markChannel.
 func (c *Client) markThread(ctx context.Context, channelID, threadTS, ts string, read bool) error {
 	if channelID == "" || threadTS == "" {
 		return nil
@@ -1254,27 +1260,16 @@ func (c *Client) markThread(ctx context.Context, channelID, threadTS, ts string,
 	if read {
 		readVal = "1"
 	}
-	data := url.Values{
-		"token":     {c.token},
+	raw, err := c.postForm(ctx, "subscriptions.thread.mark", url.Values{
 		"channel":   {channelID},
 		"thread_ts": {threadTS},
 		"ts":        {ts},
 		"read":      {readVal},
-	}
-
-	req, err := http.NewRequestWithContext(ctx, "POST", c.apiBaseURL+"subscriptions.thread.mark",
-		strings.NewReader(data.Encode()))
+	})
 	if err != nil {
-		return fmt.Errorf("creating thread mark request: %w", err)
+		return err
 	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("marking thread: %w", err)
-	}
-	defer resp.Body.Close()
-	return nil
+	return parseOKResponse("subscriptions.thread.mark", raw)
 }
 
 // MarkChannel marks a channel as read up to the given timestamp.

--- a/internal/slack/client_test.go
+++ b/internal/slack/client_test.go
@@ -941,6 +941,7 @@ func TestMarkChannel_UsesAPIBaseURL(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
 		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
 	}))
 	defer srv.Close()
 
@@ -963,6 +964,7 @@ func TestMarkThread_UsesAPIBaseURL(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
 		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
 	}))
 	defer srv.Close()
 
@@ -1462,6 +1464,7 @@ func TestMarkChannelUnread_EmptyTSSendsZero(t *testing.T) {
 		body, _ := io.ReadAll(r.Body)
 		gotBody = string(body)
 		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
 	}))
 	defer srv.Close()
 
@@ -3171,5 +3174,61 @@ func TestPostForm_BodyFieldOrderIsAlphabeticalThenEnvelope(t *testing.T) {
 			"If the lead is no longer alphabetical, postForm stopped using url.Values.Encode(): "+
 			"that is an improvement only if slack-go's bodies were fixed too, otherwise slk now "+
 			"emits two different body shapes. Update the residual-divergence table either way.", raw, want)
+	}
+}
+
+func TestMarkChannel_NotOK_ReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":false,"error":"invalid_auth"}`))
+	}))
+	defer srv.Close()
+
+	err := newTestClient(srv).MarkChannel(context.Background(), "C123", "1700000000.000100")
+	if err == nil {
+		t.Fatal("MarkChannel: want error for ok:false, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid_auth") {
+		t.Errorf("error should name the Slack error code, got %q", err)
+	}
+}
+
+func TestMarkChannel_HTTP500_ReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`<html>nope</html>`))
+	}))
+	defer srv.Close()
+
+	if err := newTestClient(srv).MarkChannel(context.Background(), "C123", "1700000000.000100"); err == nil {
+		t.Fatal("MarkChannel: want error for HTTP 500, got nil")
+	}
+}
+
+func TestMarkThread_NotOK_ReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":false,"error":"thread_not_found"}`))
+	}))
+	defer srv.Close()
+
+	err := newTestClient(srv).MarkThread(context.Background(), "C1", "P1", "R5")
+	if err == nil {
+		t.Fatal("MarkThread: want error for ok:false, got nil")
+	}
+	if !strings.Contains(err.Error(), "thread_not_found") {
+		t.Errorf("error should name the Slack error code, got %q", err)
+	}
+}
+
+func TestMarkThreadUnread_NotOK_ReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":false,"error":"thread_not_found"}`))
+	}))
+	defer srv.Close()
+
+	if err := newTestClient(srv).MarkThreadUnread(context.Background(), "C1", "P1", "R5"); err == nil {
+		t.Fatal("MarkThreadUnread: want error for ok:false, got nil")
 	}
 }

--- a/internal/slack/client_test.go
+++ b/internal/slack/client_test.go
@@ -3232,3 +3232,47 @@ func TestMarkThreadUnread_NotOK_ReturnsError(t *testing.T) {
 		t.Fatal("MarkThreadUnread: want error for ok:false, got nil")
 	}
 }
+
+// The mark helpers must reject a 200 with an empty body. Slack always
+// returns a JSON envelope, so an empty 200 is a proxy/edge failure, not a
+// successful mark. Treating it as success would silently drop read state —
+// the failure mode issue #159 exists to eliminate. Pinned explicitly
+// because every other mark stub in this file now returns {"ok":true}, so
+// nothing else would catch a regression here.
+func TestMarkChannel_EmptyBody_ReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	if err := newTestClient(srv).MarkChannel(context.Background(), "C123", "1700000000.000100"); err == nil {
+		t.Fatal("MarkChannel: want error for empty 200 body, got nil")
+	}
+}
+
+// Same constraint on the thread path: parseOKResponse is shared, but
+// markChannel and markThread call it independently.
+func TestMarkThread_EmptyBody_ReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	if err := newTestClient(srv).MarkThread(context.Background(), "C1", "P1", "R5"); err == nil {
+		t.Fatal("MarkThread: want error for empty 200 body, got nil")
+	}
+}
+
+// A 200 carrying an HTML error page (captive portal, gateway, edge node)
+// is not a successful mark either.
+func TestMarkChannel_NonJSONBody_ReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`<html>gateway</html>`))
+	}))
+	defer srv.Close()
+
+	if err := newTestClient(srv).MarkChannel(context.Background(), "C123", "1700000000.000100"); err == nil {
+		t.Fatal("MarkChannel: want error for non-JSON 200 body, got nil")
+	}
+}

--- a/internal/slack/events.go
+++ b/internal/slack/events.go
@@ -36,11 +36,20 @@ type EventHandler interface {
 	OnChannelMarked(channelID, ts string, unreadCount int)
 	// OnThreadMarked is delivered when Slack pushes a thread_marked
 	// event: the user's read cursor inside a thread moved (in either
-	// direction). lastRead is the new cursor. The subscription block's
-	// `active` flag is deliberately NOT passed on — it means
-	// "subscribed", not "unread"; see OnThreadSubscriptionChanged,
-	// which owns that bit.
-	OnThreadMarked(channelID, threadTS, lastRead string)
+	// direction). lastRead is the new cursor.
+	//
+	// subscribed is the subscription block's `active` flag, and means
+	// exactly what it says: the user is subscribed to this thread. It
+	// must NEVER be used to derive read/unread — doing so was the
+	// reported bug, because replying to a thread auto-subscribes you
+	// and so echoes active=true, which slk read as "unread" and used
+	// to re-flag the thread the user was looking at. Read/unread is a
+	// comparison of lastRead against the thread's newest known reply,
+	// nothing else. What subscribed IS good for is telling a receiver
+	// whether creating a missing thread_subscriptions row is
+	// legitimate; the durable `active` column stays owned by
+	// OnThreadSubscriptionChanged and the getView reconcile.
+	OnThreadMarked(channelID, threadTS, lastRead string, subscribed bool)
 
 	// OnThreadSubscriptionChanged is delivered for thread_subscribed and
 	// thread_unsubscribed WS events. active=true on subscribe,
@@ -382,9 +391,14 @@ func dispatchWebSocketEvent(data []byte, handler EventHandler) {
 		if err := json.Unmarshal(data, &evt); err != nil {
 			return
 		}
-		debuglog.WS("thread_marked: channel=%s thread_ts=%s last_read=%s",
-			evt.Subscription.Channel, evt.Subscription.ThreadTS, evt.Subscription.LastRead)
-		handler.OnThreadMarked(evt.Subscription.Channel, evt.Subscription.ThreadTS, evt.Subscription.LastRead)
+		debuglog.WS("thread_marked: channel=%s thread_ts=%s last_read=%s active=%t",
+			evt.Subscription.Channel, evt.Subscription.ThreadTS,
+			evt.Subscription.LastRead, evt.Subscription.Active)
+		// Active is forwarded as `subscribed`, a subscription signal
+		// only. See OnThreadMarked's doc for why it must never reach a
+		// read/unread decision.
+		handler.OnThreadMarked(evt.Subscription.Channel, evt.Subscription.ThreadTS,
+			evt.Subscription.LastRead, evt.Subscription.Active)
 
 	case "thread_subscribed", "thread_unsubscribed":
 		var evt wsThreadSubscribedEvent

--- a/internal/slack/events.go
+++ b/internal/slack/events.go
@@ -9,6 +9,16 @@ import (
 	"github.com/slack-go/slack"
 )
 
+// Subscribed is thread_marked's subscription.active flag, carried under
+// its true meaning: the user is subscribed to this thread. It is a
+// named type rather than a bool so that it cannot be transposed with
+// OnThreadSubscriptionChanged's `active` parameter, which is the same
+// shape but obliges the receiver to do the opposite thing — write the
+// durable `active` column, which OnThreadMarked must never touch.
+//
+// It is NOT a read/unread signal. See OnThreadMarked.
+type Subscribed bool
+
 // EventHandler processes real-time events from Slack.
 type EventHandler interface {
 	// OnMessage delivers a new or edited message. subtype mirrors
@@ -49,16 +59,21 @@ type EventHandler interface {
 	// whether creating a missing thread_subscriptions row is
 	// legitimate; the durable `active` column stays owned by
 	// OnThreadSubscriptionChanged and the getView reconcile.
-	OnThreadMarked(channelID, threadTS, lastRead string, subscribed bool)
+	OnThreadMarked(channelID, threadTS, lastRead string, subscribed Subscribed)
 
 	// OnThreadSubscriptionChanged is delivered for thread_subscribed and
 	// thread_unsubscribed WS events. active=true on subscribe,
 	// active=false on unsubscribe. lastRead is the per-thread last_read ts
 	// the server reports — pass-through to thread_subscriptions.last_read.
-	// The payload shape is identical to thread_marked.subscription, so
-	// implementations can share state-update logic with OnThreadMarked
-	// (this handler is the persistence-only path; OnThreadMarked also
-	// drives the UI's read-state side effects).
+	//
+	// The payload shape is identical to thread_marked.subscription, but
+	// the HANDLING must not be shared: this handler owns the `active`
+	// column and is required to write it, while OnThreadMarked is
+	// forbidden from writing it — a thread_marked that tombstoned or
+	// resurrected a row is a bug slk has already shipped once. Only the
+	// last_read pass-through is common. The bool parameters are
+	// distinctly typed (Subscribed vs plain bool) so that the two
+	// handlers cannot be transposed silently.
 	OnThreadSubscriptionChanged(channelID, threadTS, lastRead string, active bool)
 
 	// OnConversationOpened is delivered when a new or previously-closed
@@ -398,7 +413,7 @@ func dispatchWebSocketEvent(data []byte, handler EventHandler) {
 		// only. See OnThreadMarked's doc for why it must never reach a
 		// read/unread decision.
 		handler.OnThreadMarked(evt.Subscription.Channel, evt.Subscription.ThreadTS,
-			evt.Subscription.LastRead, evt.Subscription.Active)
+			evt.Subscription.LastRead, Subscribed(evt.Subscription.Active))
 
 	case "thread_subscribed", "thread_unsubscribed":
 		var evt wsThreadSubscribedEvent

--- a/internal/slack/events.go
+++ b/internal/slack/events.go
@@ -35,9 +35,12 @@ type EventHandler interface {
 	// drive the sidebar badge).
 	OnChannelMarked(channelID, ts string, unreadCount int)
 	// OnThreadMarked is delivered when Slack pushes a thread_marked
-	// event. read indicates whether the thread is now read (true) or
-	// unread (false). ts is the new boundary within the thread.
-	OnThreadMarked(channelID, threadTS, ts string, read bool)
+	// event: the user's read cursor inside a thread moved (in either
+	// direction). lastRead is the new cursor. The subscription block's
+	// `active` flag is deliberately NOT passed on — it means
+	// "subscribed", not "unread"; see OnThreadSubscriptionChanged,
+	// which owns that bit.
+	OnThreadMarked(channelID, threadTS, lastRead string)
 
 	// OnThreadSubscriptionChanged is delivered for thread_subscribed and
 	// thread_unsubscribed WS events. active=true on subscribe,
@@ -245,9 +248,9 @@ func (e wsPrefChangeEvent) stringValue() string {
 
 // wsThreadMarkedEvent represents a thread_marked event from Slack's
 // browser-protocol WebSocket. The subscription block carries the
-// channel/thread/last-read-ts and an `active` flag (true means the
-// thread is now unread / subscribed for unread updates; false means
-// the thread is now read).
+// channel/thread and the new last-read ts. It also carries an `active`
+// flag, which means "subscribed for unread updates" — the same meaning
+// it has in wsThreadSubscribedEvent — and is NOT a read/unread signal.
 type wsThreadMarkedEvent struct {
 	Type         string `json:"type"`
 	Subscription struct {
@@ -379,12 +382,9 @@ func dispatchWebSocketEvent(data []byte, handler EventHandler) {
 		if err := json.Unmarshal(data, &evt); err != nil {
 			return
 		}
-		// active=true means subscribed-for-unread, i.e. the thread is
-		// now unread. Invert for the read flag we hand to the handler.
-		read := !evt.Subscription.Active
-		debuglog.WS("thread_marked: channel=%s thread_ts=%s last_read=%s read=%v",
-			evt.Subscription.Channel, evt.Subscription.ThreadTS, evt.Subscription.LastRead, read)
-		handler.OnThreadMarked(evt.Subscription.Channel, evt.Subscription.ThreadTS, evt.Subscription.LastRead, read)
+		debuglog.WS("thread_marked: channel=%s thread_ts=%s last_read=%s",
+			evt.Subscription.Channel, evt.Subscription.ThreadTS, evt.Subscription.LastRead)
+		handler.OnThreadMarked(evt.Subscription.Channel, evt.Subscription.ThreadTS, evt.Subscription.LastRead)
 
 	case "thread_subscribed", "thread_unsubscribed":
 		var evt wsThreadSubscribedEvent

--- a/internal/slack/events_test.go
+++ b/internal/slack/events_test.go
@@ -113,8 +113,8 @@ func (m *mockEventHandler) OnChannelMarked(channelID, ts string, unreadCount int
 	m.channelMarks = append(m.channelMarks, channelMarkRecord{channelID, ts, unreadCount})
 }
 
-func (m *mockEventHandler) OnThreadMarked(channelID, threadTS, lastRead string, subscribed bool) {
-	m.threadMarks = append(m.threadMarks, threadMarkRecord{channelID, threadTS, lastRead, subscribed})
+func (m *mockEventHandler) OnThreadMarked(channelID, threadTS, lastRead string, subscribed Subscribed) {
+	m.threadMarks = append(m.threadMarks, threadMarkRecord{channelID, threadTS, lastRead, bool(subscribed)})
 }
 
 func (m *mockEventHandler) OnThreadSubscriptionChanged(channelID, threadTS, lastRead string, active bool) {

--- a/internal/slack/events_test.go
+++ b/internal/slack/events_test.go
@@ -66,8 +66,7 @@ type channelMarkRecord struct {
 }
 
 type threadMarkRecord struct {
-	channelID, threadTS, ts string
-	read                    bool
+	channelID, threadTS, lastRead string
 }
 
 type threadSubChangeRecord struct {
@@ -113,8 +112,8 @@ func (m *mockEventHandler) OnChannelMarked(channelID, ts string, unreadCount int
 	m.channelMarks = append(m.channelMarks, channelMarkRecord{channelID, ts, unreadCount})
 }
 
-func (m *mockEventHandler) OnThreadMarked(channelID, threadTS, ts string, read bool) {
-	m.threadMarks = append(m.threadMarks, threadMarkRecord{channelID, threadTS, ts, read})
+func (m *mockEventHandler) OnThreadMarked(channelID, threadTS, lastRead string) {
+	m.threadMarks = append(m.threadMarks, threadMarkRecord{channelID, threadTS, lastRead})
 }
 
 func (m *mockEventHandler) OnThreadSubscriptionChanged(channelID, threadTS, lastRead string, active bool) {
@@ -502,7 +501,7 @@ func TestDispatch_ChannelMarked_MalformedJSON_NoCall(t *testing.T) {
 	}
 }
 
-func TestDispatch_ThreadMarked_Unread_CallsHandler(t *testing.T) {
+func TestDispatch_ThreadMarked_PassesCursorThrough(t *testing.T) {
 	handler := &mockEventHandler{}
 	data := []byte(`{"type":"thread_marked","subscription":{"channel":"C1","thread_ts":"1700000000.000100","last_read":"1700000000.000200","active":true}}`)
 	dispatchWebSocketEvent(data, handler)
@@ -511,15 +510,14 @@ func TestDispatch_ThreadMarked_Unread_CallsHandler(t *testing.T) {
 		t.Fatalf("expected 1 threadMark, got %d", len(handler.threadMarks))
 	}
 	got := handler.threadMarks[0]
-	if got.channelID != "C1" || got.threadTS != "1700000000.000100" || got.ts != "1700000000.000200" {
+	if got.channelID != "C1" || got.threadTS != "1700000000.000100" || got.lastRead != "1700000000.000200" {
 		t.Errorf("unexpected: %+v", got)
-	}
-	if got.read {
-		t.Error("expected read=false (active=true means unread)")
 	}
 }
 
-func TestDispatch_ThreadMarked_Read_CallsHandler(t *testing.T) {
+// active=false previously meant "read". It means "unsubscribed", which
+// thread_marked does not report, so it must not change what we pass on.
+func TestDispatch_ThreadMarked_IgnoresActiveFlag(t *testing.T) {
 	handler := &mockEventHandler{}
 	data := []byte(`{"type":"thread_marked","subscription":{"channel":"C1","thread_ts":"P1","last_read":"R5","active":false}}`)
 	dispatchWebSocketEvent(data, handler)
@@ -527,8 +525,8 @@ func TestDispatch_ThreadMarked_Read_CallsHandler(t *testing.T) {
 	if len(handler.threadMarks) != 1 {
 		t.Fatalf("expected 1 threadMark, got %d", len(handler.threadMarks))
 	}
-	if !handler.threadMarks[0].read {
-		t.Error("expected read=true (active=false means read)")
+	if handler.threadMarks[0].lastRead != "R5" {
+		t.Errorf("lastRead = %q, want R5", handler.threadMarks[0].lastRead)
 	}
 }
 

--- a/internal/slack/events_test.go
+++ b/internal/slack/events_test.go
@@ -67,6 +67,7 @@ type channelMarkRecord struct {
 
 type threadMarkRecord struct {
 	channelID, threadTS, lastRead string
+	subscribed                    bool
 }
 
 type threadSubChangeRecord struct {
@@ -112,8 +113,8 @@ func (m *mockEventHandler) OnChannelMarked(channelID, ts string, unreadCount int
 	m.channelMarks = append(m.channelMarks, channelMarkRecord{channelID, ts, unreadCount})
 }
 
-func (m *mockEventHandler) OnThreadMarked(channelID, threadTS, lastRead string) {
-	m.threadMarks = append(m.threadMarks, threadMarkRecord{channelID, threadTS, lastRead})
+func (m *mockEventHandler) OnThreadMarked(channelID, threadTS, lastRead string, subscribed bool) {
+	m.threadMarks = append(m.threadMarks, threadMarkRecord{channelID, threadTS, lastRead, subscribed})
 }
 
 func (m *mockEventHandler) OnThreadSubscriptionChanged(channelID, threadTS, lastRead string, active bool) {
@@ -513,11 +514,17 @@ func TestDispatch_ThreadMarked_PassesCursorThrough(t *testing.T) {
 	if got.channelID != "C1" || got.threadTS != "1700000000.000100" || got.lastRead != "1700000000.000200" {
 		t.Errorf("unexpected: %+v", got)
 	}
+	if !got.subscribed {
+		t.Errorf("subscribed = false, want true for active:true")
+	}
 }
 
-// active=false previously meant "read". It means "unsubscribed", which
-// thread_marked does not report, so it must not change what we pass on.
-func TestDispatch_ThreadMarked_IgnoresActiveFlag(t *testing.T) {
+// `active` means "subscribed", never "read". The dispatcher forwards it
+// as `subscribed` so the handler can decide whether inserting a
+// subscription row is legitimate; the cursor it forwards must be the
+// one the event carried either way, so that no downstream read/unread
+// decision can be derived from the flag.
+func TestDispatch_ThreadMarked_InactiveSubscriptionStillPassesCursor(t *testing.T) {
 	handler := &mockEventHandler{}
 	data := []byte(`{"type":"thread_marked","subscription":{"channel":"C1","thread_ts":"P1","last_read":"R5","active":false}}`)
 	dispatchWebSocketEvent(data, handler)
@@ -527,6 +534,9 @@ func TestDispatch_ThreadMarked_IgnoresActiveFlag(t *testing.T) {
 	}
 	if handler.threadMarks[0].lastRead != "R5" {
 		t.Errorf("lastRead = %q, want R5", handler.threadMarks[0].lastRead)
+	}
+	if handler.threadMarks[0].subscribed {
+		t.Errorf("subscribed = true, want false for active:false")
 	}
 }
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -204,6 +204,20 @@ type App struct {
 	threads ThreadService
 
 	threadsDirtyDebounce time.Duration
+
+	// terminalFocused tracks whether the terminal running slk currently
+	// has focus. Maintained by reduceFocus from tea.FocusMsg /
+	// tea.BlurMsg, which the terminal only emits once View sets
+	// ReportFocus.
+	//
+	// Terminals report focus *transitions* only — enabling focus
+	// reporting elicits no current-state report — so NewApp starts this
+	// true. A terminal with no focus-event support sends nothing at
+	// all, and there the flag simply stays true for the whole session.
+	// tmux forwards focus events only when `set -g focus-events on`, so
+	// tmux users without that setting are in the same position.
+	terminalFocused bool
+
 	// fetchingOlder tracks in-flight older-history backfills per
 	// channel ID (Phase 3: a global bool would let one window's
 	// backfill block another channel's, and a fetch completing for
@@ -515,6 +529,7 @@ func NewApp() *App {
 		bootstrap:             newWorkspaceBootstrap(),
 		windowTitle:           "slk",
 		threadsDirtyDebounce:  150 * time.Millisecond,
+		terminalFocused:       true,
 		channelSearchDebounce: channelSearchDebounceDelay,
 		fetchingOlder:         map[string]bool{},
 		mouseWheelLines:       3,
@@ -614,6 +629,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.bootstrap,
 		reduceReactions,
 		reduceThreads,
+		reduceFocus,
 		reduceSend,
 		reduceChannels,
 		reduceLinks,
@@ -2770,6 +2786,10 @@ func (a *App) View() tea.View {
 	v := tea.NewView(screen)
 	v.AltScreen = true
 	v.MouseMode = tea.MouseModeCellMotion
+	// Ask the terminal to report focus gain/loss so reduceFocus can keep
+	// a.terminalFocused current. Bubble Tea diffs this against the
+	// previous frame and only emits the enable sequence on change.
+	v.ReportFocus = true
 	if debuglog.Enabled() {
 		// panel: 0=workspace 1=sidebar 2=messages 3=thread
 		// view:  0=channels 1=threads

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -234,8 +234,16 @@ type App struct {
 	// threadsListFetchMsg that ends the wait arrives. Further
 	// ThreadsListDirtyMsg deliveries are dropped while it is set: the
 	// refresh they would ask for is already scheduled, and it reads
-	// the cache when it runs rather than when it was scheduled. The
-	// coalescing lives here, on the receiving side, because the
+	// the cache when it runs rather than when it was scheduled.
+	//
+	// That holds except across a workspace switch, where a dirty for
+	// the newly-active team can be dropped into a window opened for
+	// the old one, whose fetch is then discarded by the team check in
+	// the threadsListFetchMsg arm — so neither refreshes. Benign:
+	// reduceWorkspaceSwitched dispatches its own ListFetch for the new
+	// team, and the window reopens for the next dirty either way.
+	//
+	// The coalescing lives here, on the receiving side, because the
 	// message's senders — the thread_marked and
 	// thread_subscription_changed WS handlers, the subscription
 	// sync's completion callback, and scheduleThreadsDirty's two
@@ -646,8 +654,14 @@ type selfMarkKey struct {
 // recording sites record before the mark is issued and so cannot lose
 // that race: reduceChannelSelected's tier-1 entry mark, both legs of
 // flushPendingMarks, and reduceThreads' ThreadRepliesLoadedMsg
-// mark-on-open. Each of those calls a service method that only BUILDS
-// a tea.Cmd, so nothing has reached Slack when the record lands.
+// mark-on-open. What makes them safe is that each writes its record
+// before the tea.Cmd carrying the mark is handed to Bubble Tea — not a
+// shared service shape, because the two families differ. The thread
+// sites call ThreadService.Mark, which only BUILDS a tea.Cmd. The
+// channel sites call ChannelService.MarkRead, which returns a tea.Msg
+// and issues the mark itself; they wrap that call in a closure, and
+// the closure has not run yet. Either way nothing has reached Slack
+// when the record lands.
 //
 // The one exposed site is MessagesLoadedMsg.MarkedTS: ChannelService's
 // fetcher issues that mark itself on a cmd goroutine and reports the ts
@@ -2079,6 +2093,14 @@ func (a *App) applyThreadUnreadBoundary(channelID, threadTS string) {
 // ListSubscribedThreads query is the receiving arm's job in
 // reduceThreads, where the dirty messages the WS handlers send are
 // collapsed with them.
+//
+// Which leaves this tick redundant, and additive with the one the
+// receiving arm arms: a reply's list re-query now lands roughly two
+// debounce intervals after the reply. Deliberately left in place when
+// the receive-side window was added — it predates that window and has
+// two callers, so removing it is a separate change. Doing so would
+// also improve coalescing slightly, by letting a reply's dirty join a
+// window already open instead of arriving after it closed.
 func (a *App) scheduleThreadsDirty() tea.Cmd {
 	if a.activeTeamID == "" {
 		return nil

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -251,10 +251,13 @@ type App struct {
 	pendingChannelMark pendingChannelMarkState
 	pendingThreadMark  pendingThreadMarkState
 
-	// selfMarks records the channel marks slk issued itself so their
-	// Slack-broadcast echoes can be told apart from a mark made in
-	// another client. See selfMarkDedup.
-	selfMarks selfMarkDedup
+	// selfMarks and selfThreadMarks record the channel and thread marks
+	// slk issued itself so their Slack-broadcast echoes can be told
+	// apart from a mark made in another client. Two sets rather than
+	// one so a burst on either side cannot evict the other's records.
+	// See selfMarkDedup.
+	selfMarks       selfMarkDedup
+	selfThreadMarks selfMarkDedup
 
 	// markFlushScheduled caps the conversations.mark RATE at one per
 	// markFlushDebounce per target, not merely the number of live
@@ -563,37 +566,48 @@ type pendingThreadMarkState struct {
 	ts        string
 }
 
-// selfMarkLimit caps the number of DISTINCT (channel, ts) pairs
-// selfMarkDedup holds. slk issues at most one channel mark per channel
-// entry and one per markFlushDebounce, and each echo consumes its entry
-// within a round trip, so the live set is normally one or two. The cap
-// only exists so a session whose echoes never arrive — a WebSocket that
-// dropped and reconnected past them, say — cannot grow the set for the
-// life of the process. Oldest entries are evicted first.
+// selfMarkLimit caps the number of DISTINCT keys ONE selfMarkDedup
+// holds (App keeps two: one for channel marks, one for thread marks).
+// slk issues at most one mark per channel or thread entry and one per
+// markFlushDebounce, and each echo consumes its entry within a round
+// trip, so a live set is normally one or two. The cap only exists so a
+// session whose echoes never arrive — a WebSocket that dropped and
+// reconnected past them, say — cannot grow a set for the life of the
+// process. Oldest entries are evicted first.
 const selfMarkLimit = 64
 
-// selfMarkKey identifies one issued channel mark.
+// selfMarkKey identifies one read mark slk issued. threadTS is empty
+// for a channel mark (conversations.mark) and set for a thread mark
+// (subscriptions.thread.mark); ts is the cursor the mark carried, which
+// is what the matching echo reports back.
 type selfMarkKey struct {
 	channelID string
+	threadTS  string
 	ts        string
 }
 
-// selfMarkDedup records the conversations.mark calls slk issued itself
-// so applyChannelMark can tell slk's own channel_marked echo from one
-// raised by another Slack client.
+// selfMarkDedup records the read marks slk issued itself so the echo
+// helpers can tell slk's own channel_marked / thread_marked echo from
+// one raised by another Slack client.
 //
-// Slack broadcasts channel_marked to every connected client including
-// the issuer, so each mark slk sends comes back a round trip later as a
-// ChannelMarkedRemoteMsg carrying the ts slk just set. Applying that
-// echo would drag the on-screen "── new ──" divider to the newest
-// message — deleting the user's place moments after they looked at it.
-// A mark from another client carries no such record and still moves the
-// divider, which is correct: it means the user really did read the
-// channel elsewhere.
+// Slack broadcasts both events to every connected client including the
+// issuer, so each mark slk sends comes back a round trip later as a
+// ChannelMarkedRemoteMsg or ThreadMarkedRemoteMsg carrying the ts slk
+// just set. Applying that echo would drag the on-screen "── new ──"
+// divider to the newest message — deleting the user's place moments
+// after they looked at it. A mark from another client carries no such
+// record and still moves the divider, which is correct: it means the
+// user really did read the channel or thread elsewhere.
 //
 // Entries are counted, not merely present, and one echo consumes one
-// count: N issued marks at the same ts suppress N echoes, and the next
+// count: N issued marks at the same key suppress N echoes, and the next
 // one is treated as foreign.
+//
+// Recording races the echo in one direction only: an echo that arrives
+// BEFORE its record is applied, not suppressed. Both recording sites
+// that follow a network round trip (MessagesLoadedMsg.MarkedTS,
+// ThreadMarkedLocalMsg) normally win that race, and losing it costs a
+// divider move, not correctness of read state.
 //
 // Not goroutine-safe. Every caller runs on the Bubble Tea Update
 // goroutine.
@@ -606,12 +620,14 @@ type selfMarkDedup struct {
 	order []selfMarkKey
 }
 
-// record notes that slk has issued a channel mark for channelID at ts.
-func (d *selfMarkDedup) record(channelID, ts string) {
-	if channelID == "" || ts == "" {
+// record notes that slk has issued the mark k. A key missing the
+// channel or the cursor identifies nothing and is dropped: callers
+// record unconditionally from paths that may not have issued a mark at
+// all (see MessagesLoadedMsg.MarkedTS).
+func (d *selfMarkDedup) record(k selfMarkKey) {
+	if k.channelID == "" || k.ts == "" {
 		return
 	}
-	k := selfMarkKey{channelID: channelID, ts: ts}
 	if d.counts == nil {
 		d.counts = make(map[selfMarkKey]int)
 	}
@@ -625,10 +641,9 @@ func (d *selfMarkDedup) record(channelID, ts string) {
 	}
 }
 
-// consume reports whether (channelID, ts) matches a mark slk issued and
-// has not yet seen echoed, decrementing that mark's count if so.
-func (d *selfMarkDedup) consume(channelID, ts string) bool {
-	k := selfMarkKey{channelID: channelID, ts: ts}
+// consume reports whether k matches a mark slk issued and has not yet
+// seen echoed, decrementing that mark's count if so.
+func (d *selfMarkDedup) consume(k selfMarkKey) bool {
 	n, ok := d.counts[k]
 	if !ok {
 		return false
@@ -2117,7 +2132,7 @@ func (a *App) flushPendingMarks() tea.Cmd {
 		channels := a.channels
 		chID := ids.ChannelID(pc.channelID)
 		ts := ids.MessageTS(pc.ts)
-		a.selfMarks.record(pc.channelID, pc.ts)
+		a.selfMarks.record(selfMarkKey{channelID: pc.channelID, ts: pc.ts})
 		cmds = append(cmds, func() tea.Msg { return channels.MarkRead(chID, ts) })
 	}
 	if pt := a.pendingThreadMark; pt.ts != "" {
@@ -3470,7 +3485,7 @@ func (a *App) applyChannelMark(channelID, ts string, unreadCount int) {
 // self-mark record lives — one round trip normally, unbounded if the
 // echo never arrives.
 func (a *App) applyChannelMarkEcho(channelID, ts string, unreadCount int) {
-	if a.selfMarks.consume(channelID, ts) {
+	if a.selfMarks.consume(selfMarkKey{channelID: channelID, ts: ts}) {
 		debuglog.Cache("applyChannelMarkEcho: channel=%s ts=%s self_echo=true (cursor held)",
 			channelID, ts)
 		a.notifyReadStateChanged()
@@ -3479,10 +3494,16 @@ func (a *App) applyChannelMarkEcho(channelID, ts string, unreadCount int) {
 	a.applyChannelMark(channelID, ts, unreadCount)
 }
 
-// applyThreadMark updates local state for an inbound thread read-cursor
-// move. Read/unread is derived by comparing the cursor against the
-// thread's newest known reply — never from the subscription's `active`
-// flag, which means "subscribed".
+// applyThreadMark updates local state for a thread read-cursor move.
+// Read/unread is derived by comparing the cursor against the thread's
+// newest known reply — never from the subscription's `active` flag,
+// which means "subscribed".
+//
+// This ALWAYS moves the panel landmark. Its callers are
+// applyThreadMarkEcho, which has already decided the inbound
+// thread_marked is not slk's own, and tests exercising that behaviour
+// directly. Mirrors applyChannelMark; see applyThreadMarkEcho for why
+// the dedup does not live here.
 func (a *App) applyThreadMark(channelID, threadTS, lastRead string) {
 	debuglog.Cache("applyThreadMark: channel=%s thread_ts=%s last_read=%s active=%s",
 		channelID, threadTS, lastRead, a.activeChannelID)
@@ -3500,30 +3521,50 @@ func (a *App) applyThreadMark(channelID, threadTS, lastRead string) {
 // settles the row's unread flag and the sidebar badge against lastRead
 // without touching an open thread panel's landmark.
 //
-// This is what ThreadMarkedLocalMsg gets — slk's own
-// subscriptions.thread.mark reporting success. The panel is on screen,
-// the user is reading it, and its boundary was deliberately set on open
-// from the pre-open cursor (see openSelectedThreadCmd). That mark
-// carries the cursor slk just set — the newest reply — so applying it
-// to the panel would erase the landmark.
-//
-// KNOWN GAP, deliberately out of scope: this covers only the local
-// completion message. Slack also broadcasts thread_marked back to the
-// issuing client, and that arrives as ThreadMarkedRemoteMsg, which
-// still calls the full applyThreadMark and so can move the panel
-// boundary for a mark slk issued itself — the same defect by the other
-// route. ThreadMarkedRemoteMsg therefore does NOT mean "another
-// client"; it carries slk's own echoes too (see
-// TestThreadMarkedRemoteMsg_SelfReplyDoesNotReFlagUnread, which
-// documents Slack echoing thread_marked after slk posts a reply).
-// Closing it needs a thread-side dedup keyed on
-// (channel, threadTS, ts), mirroring selfMarkDedup; blanket
-// suppression would be wrong, because a thread mark genuinely made in
-// another client must still move the landmark.
+// Both of slk's own-mark paths land here. ThreadMarkedLocalMsg is the
+// HTTP call reporting success; applyThreadMarkEcho is Slack's
+// broadcast of that same mark coming back. In both cases the panel is
+// on screen, the user is reading it, and its boundary was deliberately
+// set on open from the pre-open cursor (see openSelectedThreadCmd).
+// The mark carries the cursor slk just set — the newest reply — so
+// applying it to the panel would erase the landmark. The read state
+// itself is real, though, so the list flag and badge must still settle.
 func (a *App) applyThreadMarkListState(channelID, threadTS, lastRead string) {
 	if a.threadsView.MarkByThreadTSReadAt(channelID, threadTS, lastRead) {
 		a.sidebar.SetThreadsUnreadCount(a.threadsView.UnreadCount())
 	}
+}
+
+// applyThreadMarkEcho handles an inbound thread_marked WS event.
+//
+// Slack broadcasts thread_marked to every connected client INCLUDING
+// the one that issued the mark, so ThreadMarkedRemoteMsg does NOT mean
+// "another client": it carries slk's own marks back too, both the
+// mark-on-open from reducer_threads' ThreadRepliesLoadedMsg arm and the
+// auto-mark from flushPendingMarks. Those echoes carry the newest
+// reply, and the panel renders no landmark once its boundary reaches
+// the newest reply — so applying one wipes the "── new ──" divider a
+// round trip after the user opened the thread to look at it. They are
+// suppressed: the threads-list flag and sidebar badge still settle, but
+// the landmark is left where opening the thread put it. A mark slk did
+// not issue carries no record and still moves the landmark, which is
+// correct — the user really did read the thread elsewhere. See
+// selfMarkDedup.
+//
+// The dedup lives here rather than inside applyThreadMark for the same
+// reason it lives in applyChannelMarkEcho rather than applyChannelMark:
+// an echo helper may consume records, a shared helper reached by
+// deliberate user actions may not.
+func (a *App) applyThreadMarkEcho(channelID, threadTS, lastRead string) {
+	if a.selfThreadMarks.consume(selfMarkKey{
+		channelID: channelID, threadTS: threadTS, ts: lastRead,
+	}) {
+		debuglog.Cache("applyThreadMarkEcho: channel=%s thread_ts=%s last_read=%s self_echo=true (landmark held)",
+			channelID, threadTS, lastRead)
+		a.applyThreadMarkListState(channelID, threadTS, lastRead)
+		return
+	}
+	a.applyThreadMark(channelID, threadTS, lastRead)
 }
 
 // applyThreadMarkUnread forces a thread unread from boundaryTS. Used by

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -237,7 +237,10 @@ type App struct {
 	// screen — the selected channel, or the open thread panel —
 	// whether or not the user is looking at it. Staging is not
 	// focus-gated; only the flush is, so a slot staged while blurred
-	// waits for the next FocusMsg.
+	// waits for the next FocusMsg. A slot staged while FOCUSED waits
+	// too if auto-marking is not armed — inside a tmux session that
+	// has never reported a focus event that is the whole session, and
+	// the slot is only ever issued if one arrives. See autoMarkArmed.
 	//
 	// Single-slot and newest-wins: a burst coalesces into one request,
 	// and a slot can never issue a ts older than one it already holds

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -219,21 +219,32 @@ type App struct {
 	terminalFocused bool
 
 	// pendingChannelMark / pendingThreadMark stage a read-cursor
-	// advance for a message that arrived in what the user is currently
-	// looking at. Single-slot and newest-wins: a burst coalesces into
-	// one request, and a slot can never issue a ts older than one it
-	// already holds. Staged whether focused or blurred; only the flush
-	// is focus-gated, so a blurred slot waits for the next FocusMsg.
+	// advance for a message that arrived in what is currently on
+	// screen — the selected channel, or the open thread panel —
+	// whether or not the user is looking at it. Staging is not
+	// focus-gated; only the flush is, so a slot staged while blurred
+	// waits for the next FocusMsg.
+	//
+	// Single-slot and newest-wins: a burst coalesces into one request,
+	// and a slot can never issue a ts older than one it already holds
+	// FOR THE SAME TARGET. Switching target (another channel, another
+	// thread) replaces the slot outright, so a staged advance the
+	// flush has not yet issued is dropped. Accepted: that advance is
+	// reconciled by the target's next entry mark or by reconnect sync.
 	pendingChannelMark pendingChannelMarkState
 	pendingThreadMark  pendingThreadMarkState
 
-	// markFlushScheduled guards against stacking flush ticks; see
+	// markFlushScheduled caps the conversations.mark RATE at one per
+	// markFlushDebounce per target, not merely the number of live
+	// timers: without it a stream arriving faster than the debounce
+	// would interleave ticks with arrivals, and each tick would find
+	// the slot already refilled and issue a request. See
 	// scheduleMarkFlush.
 	markFlushScheduled bool
 
-	// markFlushDebounce bounds a burst to one network write per
-	// interval per target. Longer than threadsDirtyDebounce (150ms)
-	// because that one only re-queries local SQLite.
+	// markFlushDebounce is that interval. Longer than
+	// threadsDirtyDebounce (150ms) because that one only re-queries
+	// local SQLite, whereas this one is a network write.
 	markFlushDebounce time.Duration
 
 	// fetchingOlder tracks in-flight older-history backfills per
@@ -1928,9 +1939,15 @@ func (a *App) recordThreadMark(channelID, threadTS, ts string) {
 
 // scheduleMarkFlush returns a tick that flushes the pending marks after
 // the debounce interval, or nil when nothing is staged, a tick is
-// already in flight, or the terminal is blurred. Blurred slots stay
-// staged and flush on the next FocusMsg instead, so no timer is armed
-// while the user is away.
+// already in flight, or the terminal is blurred.
+//
+// The markFlushScheduled arm is what caps the mark rate: while a tick
+// is in flight, further arrivals only update the slots. Drop it and a
+// stream arriving faster than the debounce issues one
+// conversations.mark per message.
+//
+// Blurred slots stay staged and flush on the next FocusMsg instead, so
+// no timer is armed while the user is away.
 func (a *App) scheduleMarkFlush() tea.Cmd {
 	if a.markFlushScheduled || !a.terminalFocused {
 		return nil

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -215,9 +215,22 @@ type App struct {
 	// true. A terminal with no focus-event support sends nothing at
 	// all, and there the flag simply stays true for the whole session.
 	// tmux forwards focus events only when `set -g focus-events on`, so
-	// tmux users without that setting are in the same position. See
-	// wiki/Terminal-Compatibility.md, "Focus reporting and read state".
+	// tmux users without that setting are in the same position; inside
+	// tmux, autoMarkArmed is what keeps that from silently advancing
+	// the read cursor. See wiki/Terminal-Compatibility.md, "Focus
+	// reporting and read state".
 	terminalFocused bool
+
+	// inTmux records whether slk is running inside tmux, captured once
+	// in NewApp from $TMUX. It exists because tmux swallows focus
+	// events unless `set -g focus-events on`, which defaults off — so
+	// inside tmux the assume-focused default is not safe on its own.
+	// See autoMarkArmed.
+	inTmux bool
+
+	// focusEverReported goes true on the first focus event of any kind.
+	// A blur is as much proof that reporting works as a focus is.
+	focusEverReported bool
 
 	// pendingChannelMark / pendingThreadMark stage a read-cursor
 	// advance for a message that arrived in what is currently on
@@ -577,6 +590,7 @@ func NewApp() *App {
 		windowTitle:           "slk",
 		threadsDirtyDebounce:  150 * time.Millisecond,
 		terminalFocused:       true,
+		inTmux:                os.Getenv("TMUX") != "",
 		markFlushDebounce:     time.Second,
 		channelSearchDebounce: channelSearchDebounceDelay,
 		fetchingOlder:         map[string]bool{},
@@ -1938,9 +1952,31 @@ func (a *App) recordThreadMark(channelID, threadTS, ts string) {
 	a.pendingThreadMark = pendingThreadMarkState{channelID: channelID, threadTS: threadTS, ts: ts}
 }
 
+// autoMarkArmed reports whether arrival-driven read-marking may fire.
+// It gates scheduleMarkFlush only: arrivals still stage their slots,
+// and reduceFocus's tea.FocusMsg catch-up still flushes them, because
+// reaching that arm is itself proof that focus reporting works.
+//
+// Outside tmux the assume-focused default of terminalFocused stands. A
+// terminal that never reports focus is indistinguishable there from one
+// that never loses it, and that risk is accepted for the common case.
+//
+// Inside tmux that default is not safe on its own: tmux forwards focus
+// events only when `set -g focus-events on`, which defaults off, so
+// such a user never produces a BlurMsg, terminalFocused stays true for
+// the whole session, and slk would advance Slack's read cursor while
+// the pane sat in the background. Requiring one observed focus event
+// proves reporting is wired up. With the setting on, the first focus
+// change arms this; without it slk never auto-marks and keeps its
+// pre-branch behavior of marking read on channel entry only.
+func (a *App) autoMarkArmed() bool {
+	return !a.inTmux || a.focusEverReported
+}
+
 // scheduleMarkFlush returns a tick that flushes the pending marks after
 // the debounce interval, or nil when nothing is staged, a tick is
-// already in flight, or the terminal is blurred.
+// already in flight, the terminal is blurred, or auto-marking is not
+// yet armed (see autoMarkArmed).
 //
 // The markFlushScheduled arm is what caps the mark rate: while a tick
 // is in flight, further arrivals only update the slots. Drop it and a
@@ -1950,7 +1986,7 @@ func (a *App) recordThreadMark(channelID, threadTS, ts string) {
 // Blurred slots stay staged and flush on the next FocusMsg instead, so
 // no timer is armed while the user is away.
 func (a *App) scheduleMarkFlush() tea.Cmd {
-	if a.markFlushScheduled || !a.terminalFocused {
+	if a.markFlushScheduled || !a.terminalFocused || !a.autoMarkArmed() {
 		return nil
 	}
 	if a.pendingChannelMark.ts == "" && a.pendingThreadMark.ts == "" {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2236,9 +2236,12 @@ func (a *App) flushPendingMarks() tea.Cmd {
 			// has not been issued yet and this record cannot lose the
 			// race against Slack's thread_marked broadcast. A nil cmd
 			// means no mark, hence no echo to suppress.
-			a.selfThreadMarks.record(selfMarkKey{
-				channelID: pt.channelID, threadTS: pt.threadTS, ts: pt.ts,
-			})
+			//
+			// Converted, not aliased: the types stay distinct (staged
+			// vs. issued). Go allows the conversion only while their
+			// fields match in name, type and order, so a later
+			// divergence is a compile error here, not silent drift.
+			a.selfThreadMarks.record(selfMarkKey(pt))
 			cmds = append(cmds, c)
 		}
 	}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -215,7 +215,8 @@ type App struct {
 	// true. A terminal with no focus-event support sends nothing at
 	// all, and there the flag simply stays true for the whole session.
 	// tmux forwards focus events only when `set -g focus-events on`, so
-	// tmux users without that setting are in the same position.
+	// tmux users without that setting are in the same position. See
+	// wiki/Terminal-Compatibility.md, "Focus reporting and read state".
 	terminalFocused bool
 
 	// pendingChannelMark / pendingThreadMark stage a read-cursor

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1589,7 +1589,7 @@ func (a *App) openThreadPanel(parent messages.MessageItem, channelID, threadTS s
 	a.focusedPanel = PanelThread
 	a.threadPanel.SetThread(parent, nil, channelID, threadTS)
 	a.threadCompose.SetChannel("thread")
-	a.applyThreadUnreadBoundary(channelID)
+	a.applyThreadUnreadBoundary(channelID, threadTS)
 
 	threads := a.threads
 	chID := ids.ChannelID(channelID)
@@ -1777,11 +1777,11 @@ func (a *App) openSelectedThreadCmd(debounce bool) tea.Cmd {
 	}
 	a.threadPanel.SetThread(parent, nil, sum.ChannelID, sum.ThreadTS)
 	a.threadCompose.SetChannel("thread")
-	// Snapshot the parent channel's last_read_ts BEFORE the local mark-
+	// Snapshot the thread's own last-read cursor BEFORE the local mark-
 	// read flips below, so the "── new ──" landmark in the thread panel
 	// reflects what the user had actually seen prior to opening this
 	// thread.
-	a.applyThreadUnreadBoundary(sum.ChannelID)
+	a.applyThreadUnreadBoundary(sum.ChannelID, sum.ThreadTS)
 	// Local mark-as-read for the threads list: opening a thread should
 	// clear its unread flag in the threads-view list and the sidebar
 	// badge. This is presentation-only — it does not call Slack's
@@ -1812,14 +1812,17 @@ func (a *App) openSelectedThreadCmd(debounce bool) tea.Cmd {
 }
 
 // applyThreadUnreadBoundary tells the thread panel where the unread
-// boundary is for `channelID` so it can render a "── new ──" landmark
-// before the first reply the user hasn't seen. No-op when no last-read
-// fetcher is wired (e.g. in tests).
-func (a *App) applyThreadUnreadBoundary(channelID string) {
-	if channelID == "" {
+// boundary is for (channelID, threadTS) so it can render a "── new ──"
+// landmark before the first reply the user hasn't seen. Sourced from
+// the thread's own cursor in thread_subscriptions — the parent
+// channel's cursor is stale for threads, since plain replies never
+// advance it. No-op when no last-read fetcher is wired (e.g. in tests).
+func (a *App) applyThreadUnreadBoundary(channelID, threadTS string) {
+	if channelID == "" || threadTS == "" {
 		return
 	}
-	a.threadPanel.SetUnreadBoundary(a.threads.ChannelLastRead(ids.ChannelID(channelID)))
+	a.threadPanel.SetUnreadBoundary(a.threads.ThreadLastRead(
+		ids.ChannelID(channelID), ids.ThreadTS(threadTS)))
 }
 
 // scheduleThreadsDirty returns a tea.Cmd that fires a ThreadsListDirtyMsg

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -3428,31 +3428,55 @@ func (a *App) notifyReadStateChanged() {
 }
 
 // applyChannelMark updates local state for a channel-level read-state
-// change (used by both the local mark-unread press and the inbound
-// channel_marked WS event). channelID is the channel; ts is the new
-// last_read watermark; unreadCount is the canonical unread count to
-// show in the sidebar badge.
+// change. channelID is the channel; ts is the new last_read watermark;
+// unreadCount is the canonical unread count to show in the sidebar
+// badge.
 //
-// When (channelID, ts) matches a mark slk issued itself, this is Slack
-// broadcasting that mark back to us rather than news of the user
-// reading the channel somewhere else. The read-state notification still
-// runs — the sidebar dot and workspace rail must clear — but the
-// on-screen cursor is left alone, so the "── new ──" divider keeps
-// showing what arrived instead of jumping to the newest message a round
-// trip after slk marked it. See selfMarkDedup.
+// This ALWAYS moves the on-screen cursor. Two callers: the local
+// mark-unread press (reducer_send.go's MessageMarkedUnreadMsg arm),
+// which is a deliberate user action, and applyChannelMarkEcho, which
+// has already decided the inbound channel_marked is not slk's own.
 //
 // Idempotent: calling twice with the same values is a no-op past the
 // first one (the underlying setters short-circuit on equality).
 func (a *App) applyChannelMark(channelID, ts string, unreadCount int) {
-	selfEcho := a.selfMarks.consume(channelID, ts)
-	debuglog.Cache("applyChannelMark: channel=%s ts=%s unread_count=%d active=%s self_echo=%v",
-		channelID, ts, unreadCount, a.activeChannelID, selfEcho)
-	if !selfEcho {
-		for _, mm := range a.modelsForChannel(channelID) {
-			mm.SetLastReadTS(ts)
-		}
+	debuglog.Cache("applyChannelMark: channel=%s ts=%s unread_count=%d active=%s",
+		channelID, ts, unreadCount, a.activeChannelID)
+	for _, mm := range a.modelsForChannel(channelID) {
+		mm.SetLastReadTS(ts)
 	}
 	a.notifyReadStateChanged()
+}
+
+// applyChannelMarkEcho handles an inbound channel_marked WS event.
+//
+// Slack broadcasts channel_marked to every connected client INCLUDING
+// the one that issued the mark, so this arrives both for marks made in
+// another Slack client and for slk's own. Applying slk's own would drag
+// the "── new ──" divider to the newest message a round trip after slk
+// marked it, deleting the user's place moments after they looked at it.
+// Those are suppressed: the read-state notification still runs, so the
+// sidebar dot and workspace rail clear, but the cursor is left alone.
+// A mark slk did not issue carries no record and still moves the
+// cursor, which is correct — the user really did read the channel
+// elsewhere. See selfMarkDedup.
+//
+// The dedup lives here rather than inside applyChannelMark because that
+// helper is shared with the local mark-unread press, which must move
+// the divider unconditionally. Those two can collide on ts: slk
+// auto-marks at the newest message, and "mark this newest message
+// unread so I deal with it later" targets that same ts. Consuming there
+// would silently swallow the user's explicit action for as long as the
+// self-mark record lives — one round trip normally, unbounded if the
+// echo never arrives.
+func (a *App) applyChannelMarkEcho(channelID, ts string, unreadCount int) {
+	if a.selfMarks.consume(channelID, ts) {
+		debuglog.Cache("applyChannelMarkEcho: channel=%s ts=%s self_echo=true (cursor held)",
+			channelID, ts)
+		a.notifyReadStateChanged()
+		return
+	}
+	a.applyChannelMark(channelID, ts, unreadCount)
 }
 
 // applyThreadMark updates local state for an inbound thread read-cursor
@@ -3476,14 +3500,26 @@ func (a *App) applyThreadMark(channelID, threadTS, lastRead string) {
 // settles the row's unread flag and the sidebar badge against lastRead
 // without touching an open thread panel's landmark.
 //
-// This is what a thread mark slk issued ITSELF gets. The panel is on
-// screen, the user is reading it, and its boundary was deliberately set
-// on open from the pre-open cursor (see openSelectedThreadCmd). Slack's
-// answer to slk's own subscriptions.thread.mark carries the cursor slk
-// just set — the newest reply — so applying it to the panel would erase
-// that landmark. A thread mark from ANOTHER client is different and
-// still goes through applyThreadMark: it means the user read the thread
-// elsewhere, so the landmark should follow.
+// This is what ThreadMarkedLocalMsg gets — slk's own
+// subscriptions.thread.mark reporting success. The panel is on screen,
+// the user is reading it, and its boundary was deliberately set on open
+// from the pre-open cursor (see openSelectedThreadCmd). That mark
+// carries the cursor slk just set — the newest reply — so applying it
+// to the panel would erase the landmark.
+//
+// KNOWN GAP, deliberately out of scope: this covers only the local
+// completion message. Slack also broadcasts thread_marked back to the
+// issuing client, and that arrives as ThreadMarkedRemoteMsg, which
+// still calls the full applyThreadMark and so can move the panel
+// boundary for a mark slk issued itself — the same defect by the other
+// route. ThreadMarkedRemoteMsg therefore does NOT mean "another
+// client"; it carries slk's own echoes too (see
+// TestThreadMarkedRemoteMsg_SelfReplyDoesNotReFlagUnread, which
+// documents Slack echoing thread_marked after slk posts a reply).
+// Closing it needs a thread-side dedup keyed on
+// (channel, threadTS, ts), mirroring selfMarkDedup; blanket
+// suppression would be wrong, because a thread mark genuinely made in
+// another client must still move the landmark.
 func (a *App) applyThreadMarkListState(channelID, threadTS, lastRead string) {
 	if a.threadsView.MarkByThreadTSReadAt(channelID, threadTS, lastRead) {
 		a.sidebar.SetThreadsUnreadCount(a.threadsView.UnreadCount())

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -251,6 +251,11 @@ type App struct {
 	pendingChannelMark pendingChannelMarkState
 	pendingThreadMark  pendingThreadMarkState
 
+	// selfMarks records the channel marks slk issued itself so their
+	// Slack-broadcast echoes can be told apart from a mark made in
+	// another client. See selfMarkDedup.
+	selfMarks selfMarkDedup
+
 	// markFlushScheduled caps the conversations.mark RATE at one per
 	// markFlushDebounce per target, not merely the number of live
 	// timers: without it a stream arriving faster than the debounce
@@ -557,6 +562,93 @@ type pendingThreadMarkState struct {
 	threadTS  string
 	ts        string
 }
+
+// selfMarkLimit caps the number of DISTINCT (channel, ts) pairs
+// selfMarkDedup holds. slk issues at most one channel mark per channel
+// entry and one per markFlushDebounce, and each echo consumes its entry
+// within a round trip, so the live set is normally one or two. The cap
+// only exists so a session whose echoes never arrive — a WebSocket that
+// dropped and reconnected past them, say — cannot grow the set for the
+// life of the process. Oldest entries are evicted first.
+const selfMarkLimit = 64
+
+// selfMarkKey identifies one issued channel mark.
+type selfMarkKey struct {
+	channelID string
+	ts        string
+}
+
+// selfMarkDedup records the conversations.mark calls slk issued itself
+// so applyChannelMark can tell slk's own channel_marked echo from one
+// raised by another Slack client.
+//
+// Slack broadcasts channel_marked to every connected client including
+// the issuer, so each mark slk sends comes back a round trip later as a
+// ChannelMarkedRemoteMsg carrying the ts slk just set. Applying that
+// echo would drag the on-screen "── new ──" divider to the newest
+// message — deleting the user's place moments after they looked at it.
+// A mark from another client carries no such record and still moves the
+// divider, which is correct: it means the user really did read the
+// channel elsewhere.
+//
+// Entries are counted, not merely present, and one echo consumes one
+// count: N issued marks at the same ts suppress N echoes, and the next
+// one is treated as foreign.
+//
+// Not goroutine-safe. Every caller runs on the Bubble Tea Update
+// goroutine.
+type selfMarkDedup struct {
+	// counts holds the number of issued-but-unechoed marks per key.
+	// A key is deleted once its count reaches zero.
+	counts map[selfMarkKey]int
+	// order lists the distinct keys in counts by first-record time,
+	// oldest first. It is the eviction queue for selfMarkLimit.
+	order []selfMarkKey
+}
+
+// record notes that slk has issued a channel mark for channelID at ts.
+func (d *selfMarkDedup) record(channelID, ts string) {
+	if channelID == "" || ts == "" {
+		return
+	}
+	k := selfMarkKey{channelID: channelID, ts: ts}
+	if d.counts == nil {
+		d.counts = make(map[selfMarkKey]int)
+	}
+	if _, known := d.counts[k]; !known {
+		d.order = append(d.order, k)
+	}
+	d.counts[k]++
+	for len(d.order) > selfMarkLimit {
+		delete(d.counts, d.order[0])
+		d.order = d.order[1:]
+	}
+}
+
+// consume reports whether (channelID, ts) matches a mark slk issued and
+// has not yet seen echoed, decrementing that mark's count if so.
+func (d *selfMarkDedup) consume(channelID, ts string) bool {
+	k := selfMarkKey{channelID: channelID, ts: ts}
+	n, ok := d.counts[k]
+	if !ok {
+		return false
+	}
+	if n > 1 {
+		d.counts[k] = n - 1
+		return true
+	}
+	delete(d.counts, k)
+	for i, e := range d.order {
+		if e == k {
+			d.order = append(d.order[:i], d.order[i+1:]...)
+			break
+		}
+	}
+	return true
+}
+
+// len returns the number of distinct keys held; used to pin the bound.
+func (d *selfMarkDedup) len() int { return len(d.counts) }
 
 func NewApp() *App {
 	// The window tree starts as a single window with no channel; the
@@ -2009,11 +2101,15 @@ func (a *App) scheduleMarkFlush() tea.Cmd {
 // arrival, the next channel entry, or reconnect sync. Retrying a
 // rejected mark risks hammering a rate-limited endpoint.
 //
-// Note this does NOT move any on-screen "── new ──" divider.
+// Neither leg of this moves an on-screen "── new ──" divider.
 // ChannelService.MarkRead yields ChannelMarkedReadMsg, whose reducer
-// arm (reducer_channels.go:188) only calls notifyReadStateChanged and
-// never touches SetLastReadTS; the divider recomputes on the next
-// channel entry.
+// arm only calls notifyReadStateChanged and never touches
+// SetLastReadTS. Slack then broadcasts the channel mark back as a
+// channel_marked event, which DOES reach SetLastReadTS via
+// applyChannelMark — hence the selfMarks.record below, which is what
+// makes applyChannelMark recognise and skip its own echo. The thread
+// leg is symmetric: threads.Mark's ThreadMarkedLocalMsg arm applies
+// list state only. The divider recomputes on the next channel entry.
 func (a *App) flushPendingMarks() tea.Cmd {
 	var cmds []tea.Cmd
 	if pc := a.pendingChannelMark; pc.ts != "" {
@@ -2021,6 +2117,7 @@ func (a *App) flushPendingMarks() tea.Cmd {
 		channels := a.channels
 		chID := ids.ChannelID(pc.channelID)
 		ts := ids.MessageTS(pc.ts)
+		a.selfMarks.record(pc.channelID, pc.ts)
 		cmds = append(cmds, func() tea.Msg { return channels.MarkRead(chID, ts) })
 	}
 	if pt := a.pendingThreadMark; pt.ts != "" {
@@ -3336,13 +3433,24 @@ func (a *App) notifyReadStateChanged() {
 // last_read watermark; unreadCount is the canonical unread count to
 // show in the sidebar badge.
 //
+// When (channelID, ts) matches a mark slk issued itself, this is Slack
+// broadcasting that mark back to us rather than news of the user
+// reading the channel somewhere else. The read-state notification still
+// runs — the sidebar dot and workspace rail must clear — but the
+// on-screen cursor is left alone, so the "── new ──" divider keeps
+// showing what arrived instead of jumping to the newest message a round
+// trip after slk marked it. See selfMarkDedup.
+//
 // Idempotent: calling twice with the same values is a no-op past the
 // first one (the underlying setters short-circuit on equality).
 func (a *App) applyChannelMark(channelID, ts string, unreadCount int) {
-	debuglog.Cache("applyChannelMark: channel=%s ts=%s unread_count=%d active=%s",
-		channelID, ts, unreadCount, a.activeChannelID)
-	for _, mm := range a.modelsForChannel(channelID) {
-		mm.SetLastReadTS(ts)
+	selfEcho := a.selfMarks.consume(channelID, ts)
+	debuglog.Cache("applyChannelMark: channel=%s ts=%s unread_count=%d active=%s self_echo=%v",
+		channelID, ts, unreadCount, a.activeChannelID, selfEcho)
+	if !selfEcho {
+		for _, mm := range a.modelsForChannel(channelID) {
+			mm.SetLastReadTS(ts)
+		}
 	}
 	a.notifyReadStateChanged()
 }
@@ -3361,6 +3469,22 @@ func (a *App) applyThreadMark(channelID, threadTS, lastRead string) {
 		// ts, so a fully-caught-up cursor renders no landmark.
 		a.threadPanel.SetUnreadBoundary(lastRead)
 	}
+	a.applyThreadMarkListState(channelID, threadTS, lastRead)
+}
+
+// applyThreadMarkListState is applyThreadMark's threads-list half: it
+// settles the row's unread flag and the sidebar badge against lastRead
+// without touching an open thread panel's landmark.
+//
+// This is what a thread mark slk issued ITSELF gets. The panel is on
+// screen, the user is reading it, and its boundary was deliberately set
+// on open from the pre-open cursor (see openSelectedThreadCmd). Slack's
+// answer to slk's own subscriptions.thread.mark carries the cursor slk
+// just set — the newest reply — so applying it to the panel would erase
+// that landmark. A thread mark from ANOTHER client is different and
+// still goes through applyThreadMark: it means the user read the thread
+// elsewhere, so the landmark should follow.
+func (a *App) applyThreadMarkListState(channelID, threadTS, lastRead string) {
 	if a.threadsView.MarkByThreadTSReadAt(channelID, threadTS, lastRead) {
 		a.sidebar.SetThreadsUnreadCount(a.threadsView.UnreadCount())
 	}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -674,9 +674,13 @@ type selfMarkKey struct {
 // ThreadMarkedLocalMsg arm, say) would expose every thread mark to the
 // race, including the mark-on-open whose echo is exactly what this
 // dedup exists to suppress. The cost of recording early instead is that
-// a mark Slack rejects leaves a record with no echo to consume it; it
-// is evicted by selfMarkLimit, and until then it can hold a landmark
-// still, never move one wrongly.
+// a mark Slack rejects leaves a record with no echo to consume it — as
+// does a mark issued in one workspace whose echo arrives after a switch
+// to another, since OnChannelMarked returns before dispatching
+// ChannelMarkedRemoteMsg when its workspace is not active. Both leak
+// the same way and cost the same: the record is evicted by
+// selfMarkLimit, and until then it can hold a landmark still, never
+// move one wrongly.
 //
 // Not goroutine-safe. Every caller runs on the Bubble Tea Update
 // goroutine.
@@ -3536,9 +3540,16 @@ func (a *App) notifyReadStateChanged() {
 }
 
 // applyChannelMark updates local state for a channel-level read-state
-// change. channelID is the channel; ts is the new last_read watermark;
-// unreadCount is the canonical unread count to show in the sidebar
-// badge.
+// change. channelID is the channel; ts is the new last_read watermark.
+//
+// unreadCount is diagnostic only: it reaches the debug log and nothing
+// else. No badge is set from it — notifyReadStateChanged invalidates
+// the sidebar, which re-derives its own display from its channel
+// state, and the aggregate that reaches the window title and status
+// report comes from a.sidebar.UnreadChannelCount(). The parameter is
+// kept rather than dropped because logging the count Slack reported
+// next to the state slk derives is what makes a divergence between
+// them debuggable.
 //
 // This ALWAYS moves the on-screen cursor. Two callers: the local
 // mark-unread press (reducer_send.go's MessageMarkedUnreadMsg arm),

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -604,10 +604,15 @@ type selfMarkKey struct {
 // one is treated as foreign.
 //
 // Recording races the echo in one direction only: an echo that arrives
-// BEFORE its record is applied, not suppressed. Both recording sites
-// that follow a network round trip (MessagesLoadedMsg.MarkedTS,
-// ThreadMarkedLocalMsg) normally win that race, and losing it costs a
-// divider move, not correctness of read state.
+// BEFORE its record is applied, not suppressed. Two of the four
+// recording sites (reduceChannelSelected's tier-1 entry mark and
+// flushPendingMarks) record before issuing the mark and so cannot lose
+// that race. The two that instead report a completed round trip
+// (MessagesLoadedMsg.MarkedTS and ThreadMarkedLocalMsg, both recording
+// from the Update goroutine for a call issued on a cmd goroutine) are
+// exposed to it, because the HTTP response and the WebSocket broadcast
+// are independent. Losing it costs a divider move, not the correctness
+// of the read state.
 //
 // Not goroutine-safe. Every caller runs on the Bubble Tea Update
 // goroutine.
@@ -3499,11 +3504,11 @@ func (a *App) applyChannelMarkEcho(channelID, ts string, unreadCount int) {
 // newest known reply — never from the subscription's `active` flag,
 // which means "subscribed".
 //
-// This ALWAYS moves the panel landmark. Its callers are
-// applyThreadMarkEcho, which has already decided the inbound
-// thread_marked is not slk's own, and tests exercising that behaviour
-// directly. Mirrors applyChannelMark; see applyThreadMarkEcho for why
-// the dedup does not live here.
+// This applies lastRead to the panel unconditionally whenever the panel
+// is open on this thread — there is no self-echo check here. Its sole
+// caller is applyThreadMarkEcho, which has already decided the inbound
+// thread_marked is not slk's own. Mirrors applyChannelMark; see
+// applyThreadMarkEcho for why the dedup does not live here.
 func (a *App) applyThreadMark(channelID, threadTS, lastRead string) {
 	debuglog.Cache("applyThreadMark: channel=%s thread_ts=%s last_read=%s active=%s",
 		channelID, threadTS, lastRead, a.activeChannelID)
@@ -3521,14 +3526,17 @@ func (a *App) applyThreadMark(channelID, threadTS, lastRead string) {
 // settles the row's unread flag and the sidebar badge against lastRead
 // without touching an open thread panel's landmark.
 //
-// Both of slk's own-mark paths land here. ThreadMarkedLocalMsg is the
-// HTTP call reporting success; applyThreadMarkEcho is Slack's
-// broadcast of that same mark coming back. In both cases the panel is
-// on screen, the user is reading it, and its boundary was deliberately
-// set on open from the pre-open cursor (see openSelectedThreadCmd).
-// The mark carries the cursor slk just set — the newest reply — so
-// applying it to the panel would erase the landmark. The read state
-// itself is real, though, so the list flag and badge must still settle.
+// Three callers. applyThreadMark runs it as its own tail, after moving
+// the landmark for a mark slk did not issue. The other two are the two
+// ways slk sees its OWN mark: ThreadMarkedLocalMsg, the HTTP call
+// reporting success, and applyThreadMarkEcho's suppressed branch,
+// Slack's broadcast of that same mark coming back. For those two the
+// panel is on screen, the user is reading it, and its boundary was
+// deliberately set on open from the pre-open cursor (see
+// openSelectedThreadCmd); the mark carries the cursor slk just set —
+// the newest reply — so applying it to the panel would erase the
+// landmark. The read state itself is real, though, so the list flag and
+// the badge must still settle, which is what this does.
 func (a *App) applyThreadMarkListState(channelID, threadTS, lastRead string) {
 	if a.threadsView.MarkByThreadTSReadAt(channelID, threadTS, lastRead) {
 		a.sidebar.SetThreadsUnreadCount(a.threadsView.UnreadCount())
@@ -3551,10 +3559,15 @@ func (a *App) applyThreadMarkListState(channelID, threadTS, lastRead string) {
 // correct — the user really did read the thread elsewhere. See
 // selfMarkDedup.
 //
-// The dedup lives here rather than inside applyThreadMark for the same
-// reason it lives in applyChannelMarkEcho rather than applyChannelMark:
-// an echo helper may consume records, a shared helper reached by
-// deliberate user actions may not.
+// The dedup lives here rather than inside applyThreadMark so that
+// consuming a record stays a property of the echo path alone.
+// applyThreadMark has no other caller today — the thread mark-unread
+// press goes through applyThreadMarkUnread — but the channel pair
+// records why the split is worth keeping: applyChannelMark IS shared
+// with the mark-unread press, and folding the dedup into it would
+// silently swallow that deliberate action whenever the two collided on
+// ts. Anything later reaching applyThreadMark inherits the
+// unconditional behaviour rather than the suppression.
 func (a *App) applyThreadMarkEcho(channelID, threadTS, lastRead string) {
 	if a.selfThreadMarks.consume(selfMarkKey{
 		channelID: channelID, threadTS: threadTS, ts: lastRead,

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -94,6 +94,30 @@ const openThreadDebounceDelay = 200 * time.Millisecond
 // pause, never one per keystroke.
 const channelSearchDebounceDelay = 300 * time.Millisecond
 
+// defaultMarkFlushDebounce is the App.markFlushDebounce NewApp starts
+// with, and the fallback scheduleMarkFlush uses for a zero field.
+//
+// conversations.mark is a Tier 3 method — Slack budgets those at
+// roughly 50 requests a minute. This interval is the ceiling on how
+// often the flush spends one: 60/5 = 12 a minute, with room left for
+// the entry marks and mark-unread presses that call it on other paths. One second, the value this started at, put a
+// channel receiving about a message a second at ~60 a minute — over
+// the tier, and an over-tier mark is dropped rather than retried (see
+// flushPendingMarks), which is the cross-client divergence the
+// auto-marking exists to prevent.
+//
+// Five seconds is not felt by the user: nothing on screen changes when
+// the flush fires. It moves Slack's server-side cursor, and the local
+// divider deliberately stays put (again, see flushPendingMarks).
+const defaultMarkFlushDebounce = 5 * time.Second
+
+// defaultThreadsDirtyDebounce is the App.threadsDirtyDebounce NewApp
+// starts with, and the fallback for a zero field in scheduleThreadsDirty
+// and in reduceThreads' ThreadsListDirtyMsg arm. It only delays a query
+// against local SQLite, so it is two orders of magnitude below the mark
+// flush above.
+const defaultThreadsDirtyDebounce = 150 * time.Millisecond
+
 type App struct {
 	// Sub-models
 	workspaceRail    workspace.Model
@@ -205,6 +229,19 @@ type App struct {
 
 	threadsDirtyDebounce time.Duration
 
+	// threadsListFetchScheduled is set while a threads-list refresh is
+	// waiting out threadsDirtyDebounce, and cleared when the
+	// threadsListFetchMsg that ends the wait arrives. Further
+	// ThreadsListDirtyMsg deliveries are dropped while it is set: the
+	// refresh they would ask for is already scheduled, and it reads
+	// the cache when it runs rather than when it was scheduled. The
+	// coalescing lives here, on the receiving side, because the
+	// message's senders — the thread_marked and
+	// thread_subscription_changed WS handlers, the subscription
+	// sync's completion callback, and scheduleThreadsDirty's two
+	// callers — do not coordinate.
+	threadsListFetchScheduled bool
+
 	// terminalFocused tracks whether the terminal running slk currently
 	// has focus. Maintained by reduceFocus from tea.FocusMsg /
 	// tea.BlurMsg, which the terminal only emits once View sets
@@ -267,9 +304,10 @@ type App struct {
 	// scheduleMarkFlush.
 	markFlushScheduled bool
 
-	// markFlushDebounce is that interval. Longer than
-	// threadsDirtyDebounce (150ms) because that one only re-queries
-	// local SQLite, whereas this one is a network write.
+	// markFlushDebounce is that interval. What sets its size is
+	// conversations.mark's rate tier, not merely that it is a network
+	// write; see defaultMarkFlushDebounce before changing it. Tests
+	// shorten it.
 	markFlushDebounce time.Duration
 
 	// fetchingOlder tracks in-flight older-history backfills per
@@ -715,10 +753,10 @@ func NewApp() *App {
 		selfSend:              newSelfSendDedup(),
 		bootstrap:             newWorkspaceBootstrap(),
 		windowTitle:           "slk",
-		threadsDirtyDebounce:  150 * time.Millisecond,
+		threadsDirtyDebounce:  defaultThreadsDirtyDebounce,
 		terminalFocused:       true,
 		inTmux:                os.Getenv("TMUX") != "",
-		markFlushDebounce:     time.Second,
+		markFlushDebounce:     defaultMarkFlushDebounce,
 		channelSearchDebounce: channelSearchDebounceDelay,
 		fetchingOlder:         map[string]bool{},
 		mouseWheelLines:       3,
@@ -2031,11 +2069,16 @@ func (a *App) applyThreadUnreadBoundary(channelID, threadTS string) {
 }
 
 // scheduleThreadsDirty returns a tea.Cmd that fires a ThreadsListDirtyMsg
-// after the configured debounce interval. Used to coalesce bursts of thread
-// replies (each delivered as its own NewMessageMsg) into a single re-query
-// of the involved-threads list. Returns nil when no workspace is active —
-// without an activeTeamID the dirty handler would just drop the message
-// anyway.
+// for the active workspace after the configured debounce interval. Returns
+// nil when no workspace is active — without an activeTeamID the dirty
+// handler would just drop the message anyway.
+//
+// The tick does not itself coalesce anything: tea.Tick arms a one-shot
+// timer per call, so a burst of thread replies arms a timer each and
+// sends a dirty message each. Collapsing those into a single
+// ListSubscribedThreads query is the receiving arm's job in
+// reduceThreads, where the dirty messages the WS handlers send are
+// collapsed with them.
 func (a *App) scheduleThreadsDirty() tea.Cmd {
 	if a.activeTeamID == "" {
 		return nil
@@ -2043,7 +2086,7 @@ func (a *App) scheduleThreadsDirty() tea.Cmd {
 	team := a.activeTeamID
 	d := a.threadsDirtyDebounce
 	if d == 0 {
-		d = 150 * time.Millisecond
+		d = defaultThreadsDirtyDebounce
 	}
 	return tea.Tick(d, func(time.Time) tea.Msg {
 		return ThreadsListDirtyMsg{TeamID: team}
@@ -2122,7 +2165,7 @@ func (a *App) scheduleMarkFlush() tea.Cmd {
 	a.markFlushScheduled = true
 	d := a.markFlushDebounce
 	if d == 0 {
-		d = time.Second
+		d = defaultMarkFlushDebounce
 	}
 	return tea.Tick(d, func(time.Time) tea.Msg { return markFlushMsg{} })
 }

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -3146,30 +3146,41 @@ func (a *App) applyChannelMark(channelID, ts string, unreadCount int) {
 	a.notifyReadStateChanged()
 }
 
-// applyThreadMark updates local state for a thread-level read-state
-// change. read=false means the thread is now unread (move boundary +
-// flip threads-view row); read=true means the thread is now read
-// (clear boundary + clear threads-view row).
-func (a *App) applyThreadMark(channelID, threadTS, ts string, read bool) {
-	debuglog.Cache("applyThreadMark: channel=%s thread_ts=%s ts=%s read=%v active=%s",
-		channelID, threadTS, ts, read, a.activeChannelID)
+// applyThreadMark updates local state for an inbound thread read-cursor
+// move. Read/unread is derived by comparing the cursor against the
+// thread's newest known reply — never from the subscription's `active`
+// flag, which means "subscribed".
+func (a *App) applyThreadMark(channelID, threadTS, lastRead string) {
+	debuglog.Cache("applyThreadMark: channel=%s thread_ts=%s last_read=%s active=%s",
+		channelID, threadTS, lastRead, a.activeChannelID)
 	if a.threadVisible &&
 		a.threadPanel.ChannelID() == channelID &&
 		a.threadPanel.ThreadTS() == threadTS {
-		if read {
-			a.threadPanel.SetUnreadBoundary("")
-		} else {
-			a.threadPanel.SetUnreadBoundary(ts)
-		}
+		// The panel renders its "── new ──" landmark after the boundary
+		// ts, so a fully-caught-up cursor renders no landmark.
+		a.threadPanel.SetUnreadBoundary(lastRead)
 	}
-	if read {
-		if a.threadsView.MarkByThreadTSRead(channelID, threadTS) {
-			a.sidebar.SetThreadsUnreadCount(a.threadsView.UnreadCount())
-		}
-	} else {
-		if a.threadsView.MarkByThreadTSUnread(channelID, threadTS) {
-			a.sidebar.SetThreadsUnreadCount(a.threadsView.UnreadCount())
-		}
+	if a.threadsView.MarkByThreadTSReadAt(channelID, threadTS, lastRead) {
+		a.sidebar.SetThreadsUnreadCount(a.threadsView.UnreadCount())
+	}
+}
+
+// applyThreadMarkUnread forces a thread unread from boundaryTS. Used by
+// the user-initiated mark-unread flow, which knows its own intent.
+// It does not go through applyThreadMark's cursor comparison: Slack sets
+// the cursor to just BEFORE boundaryTS, so comparing boundaryTS against
+// the newest reply would wrongly report the thread read whenever the
+// boundary is that newest reply.
+func (a *App) applyThreadMarkUnread(channelID, threadTS, boundaryTS string) {
+	debuglog.Cache("applyThreadMarkUnread: channel=%s thread_ts=%s boundary=%s active=%s",
+		channelID, threadTS, boundaryTS, a.activeChannelID)
+	if a.threadVisible &&
+		a.threadPanel.ChannelID() == channelID &&
+		a.threadPanel.ThreadTS() == threadTS {
+		a.threadPanel.SetUnreadBoundary(boundaryTS)
+	}
+	if a.threadsView.MarkByThreadTSUnread(channelID, threadTS) {
+		a.sidebar.SetThreadsUnreadCount(a.threadsView.UnreadCount())
 	}
 }
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -218,6 +218,24 @@ type App struct {
 	// tmux users without that setting are in the same position.
 	terminalFocused bool
 
+	// pendingChannelMark / pendingThreadMark stage a read-cursor
+	// advance for a message that arrived in what the user is currently
+	// looking at. Single-slot and newest-wins: a burst coalesces into
+	// one request, and a slot can never issue a ts older than one it
+	// already holds. Staged whether focused or blurred; only the flush
+	// is focus-gated, so a blurred slot waits for the next FocusMsg.
+	pendingChannelMark pendingChannelMarkState
+	pendingThreadMark  pendingThreadMarkState
+
+	// markFlushScheduled guards against stacking flush ticks; see
+	// scheduleMarkFlush.
+	markFlushScheduled bool
+
+	// markFlushDebounce bounds a burst to one network write per
+	// interval per target. Longer than threadsDirtyDebounce (150ms)
+	// because that one only re-queries local SQLite.
+	markFlushDebounce time.Duration
+
 	// fetchingOlder tracks in-flight older-history backfills per
 	// channel ID (Phase 3: a global bool would let one window's
 	// backfill block another channel's, and a fetch completing for
@@ -495,6 +513,23 @@ type App struct {
 	scrollFlushScheduled bool
 }
 
+// pendingChannelMarkState is App.pendingChannelMark's slot: the newest
+// channel read-cursor advance staged but not yet issued. A zero ts
+// means "nothing staged".
+type pendingChannelMarkState struct {
+	channelID string
+	ts        string
+}
+
+// pendingThreadMarkState is App.pendingThreadMark's slot: the newest
+// thread read-cursor advance staged but not yet issued. A zero ts
+// means "nothing staged".
+type pendingThreadMarkState struct {
+	channelID string
+	threadTS  string
+	ts        string
+}
+
 func NewApp() *App {
 	// The window tree starts as a single window with no channel; the
 	// first ChannelSelectedMsg apply records the channel on it.
@@ -530,6 +565,7 @@ func NewApp() *App {
 		windowTitle:           "slk",
 		threadsDirtyDebounce:  150 * time.Millisecond,
 		terminalFocused:       true,
+		markFlushDebounce:     time.Second,
 		channelSearchDebounce: channelSearchDebounceDelay,
 		fetchingOlder:         map[string]bool{},
 		mouseWheelLines:       3,
@@ -1859,6 +1895,91 @@ func (a *App) scheduleThreadsDirty() tea.Cmd {
 	return tea.Tick(d, func(time.Time) tea.Msg {
 		return ThreadsListDirtyMsg{TeamID: team}
 	})
+}
+
+// recordChannelMark stages a channel read-cursor advance. Newest-wins:
+// an older ts for the same channel is ignored, so out-of-order arrivals
+// can never roll the cursor backward. Slack timestamps are decimal
+// strings of equal shape, so the string comparison orders them
+// correctly without parsing.
+func (a *App) recordChannelMark(channelID, ts string) {
+	if channelID == "" || ts == "" {
+		return
+	}
+	if a.pendingChannelMark.channelID == channelID && a.pendingChannelMark.ts >= ts {
+		return
+	}
+	a.pendingChannelMark = pendingChannelMarkState{channelID: channelID, ts: ts}
+}
+
+// recordThreadMark stages a thread read-cursor advance. Newest-wins for
+// the same (channel, thread); a different thread replaces the slot.
+func (a *App) recordThreadMark(channelID, threadTS, ts string) {
+	if channelID == "" || threadTS == "" || ts == "" {
+		return
+	}
+	if a.pendingThreadMark.channelID == channelID &&
+		a.pendingThreadMark.threadTS == threadTS &&
+		a.pendingThreadMark.ts >= ts {
+		return
+	}
+	a.pendingThreadMark = pendingThreadMarkState{channelID: channelID, threadTS: threadTS, ts: ts}
+}
+
+// scheduleMarkFlush returns a tick that flushes the pending marks after
+// the debounce interval, or nil when nothing is staged, a tick is
+// already in flight, or the terminal is blurred. Blurred slots stay
+// staged and flush on the next FocusMsg instead, so no timer is armed
+// while the user is away.
+func (a *App) scheduleMarkFlush() tea.Cmd {
+	if a.markFlushScheduled || !a.terminalFocused {
+		return nil
+	}
+	if a.pendingChannelMark.ts == "" && a.pendingThreadMark.ts == "" {
+		return nil
+	}
+	a.markFlushScheduled = true
+	d := a.markFlushDebounce
+	if d == 0 {
+		d = time.Second
+	}
+	return tea.Tick(d, func(time.Time) tea.Msg { return markFlushMsg{} })
+}
+
+// flushPendingMarks clears both slots and returns the commands that
+// issue their marks. Clearing before issuing is deliberate: a mark
+// Slack rejects is not retried here, it is reconciled by the next
+// arrival, the next channel entry, or reconnect sync. Retrying a
+// rejected mark risks hammering a rate-limited endpoint.
+//
+// Note this does NOT move any on-screen "── new ──" divider.
+// ChannelService.MarkRead yields ChannelMarkedReadMsg, whose reducer
+// arm (reducer_channels.go:188) only calls notifyReadStateChanged and
+// never touches SetLastReadTS; the divider recomputes on the next
+// channel entry.
+func (a *App) flushPendingMarks() tea.Cmd {
+	var cmds []tea.Cmd
+	if pc := a.pendingChannelMark; pc.ts != "" {
+		a.pendingChannelMark = pendingChannelMarkState{}
+		channels := a.channels
+		chID := ids.ChannelID(pc.channelID)
+		ts := ids.MessageTS(pc.ts)
+		cmds = append(cmds, func() tea.Msg { return channels.MarkRead(chID, ts) })
+	}
+	if pt := a.pendingThreadMark; pt.ts != "" {
+		a.pendingThreadMark = pendingThreadMarkState{}
+		if c := a.threads.Mark(
+			ids.ChannelID(pt.channelID),
+			ids.ThreadTS(pt.threadTS),
+			ids.MessageTS(pt.ts),
+		); c != nil {
+			cmds = append(cmds, c)
+		}
+	}
+	if len(cmds) == 0 {
+		return nil
+	}
+	return tea.Batch(cmds...)
 }
 
 // userNameFor returns the display name for a Slack user ID, falling back

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -604,15 +604,27 @@ type selfMarkKey struct {
 // one is treated as foreign.
 //
 // Recording races the echo in one direction only: an echo that arrives
-// BEFORE its record is applied, not suppressed. Two of the four
-// recording sites (reduceChannelSelected's tier-1 entry mark and
-// flushPendingMarks) record before issuing the mark and so cannot lose
-// that race. The two that instead report a completed round trip
-// (MessagesLoadedMsg.MarkedTS and ThreadMarkedLocalMsg, both recording
-// from the Update goroutine for a call issued on a cmd goroutine) are
-// exposed to it, because the HTTP response and the WebSocket broadcast
-// are independent. Losing it costs a divider move, not the correctness
-// of the read state.
+// BEFORE its record is applied, not suppressed. Four of the five
+// recording sites record before the mark is issued and so cannot lose
+// that race: reduceChannelSelected's tier-1 entry mark, both legs of
+// flushPendingMarks, and reduceThreads' ThreadRepliesLoadedMsg
+// mark-on-open. Each of those calls a service method that only BUILDS
+// a tea.Cmd, so nothing has reached Slack when the record lands.
+//
+// The one exposed site is MessagesLoadedMsg.MarkedTS: ChannelService's
+// fetcher issues that mark itself on a cmd goroutine and reports the ts
+// back afterwards, so its record cannot be written until the HTTP
+// response has already returned — and the WebSocket broadcast of the
+// same mark is independent of that response. Losing the race there
+// costs a divider move, not the correctness of the read state.
+//
+// No site records after a mark COMPLETES. Recording on completion (the
+// ThreadMarkedLocalMsg arm, say) would expose every thread mark to the
+// race, including the mark-on-open whose echo is exactly what this
+// dedup exists to suppress. The cost of recording early instead is that
+// a mark Slack rejects leaves a record with no echo to consume it; it
+// is evicted by selfMarkLimit, and until then it can hold a landmark
+// still, never move one wrongly.
 //
 // Not goroutine-safe. Every caller runs on the Bubble Tea Update
 // goroutine.
@@ -2127,9 +2139,12 @@ func (a *App) scheduleMarkFlush() tea.Cmd {
 // SetLastReadTS. Slack then broadcasts the channel mark back as a
 // channel_marked event, which DOES reach SetLastReadTS via
 // applyChannelMark — hence the selfMarks.record below, which is what
-// makes applyChannelMark recognise and skip its own echo. The thread
-// leg is symmetric: threads.Mark's ThreadMarkedLocalMsg arm applies
-// list state only. The divider recomputes on the next channel entry.
+// makes applyChannelMarkEcho recognise and skip its own echo. The
+// thread leg is symmetric on both counts: threads.Mark's
+// ThreadMarkedLocalMsg arm applies list state only, and the leg records
+// into selfThreadMarks so applyThreadMarkEcho skips the thread_marked
+// broadcast of the same mark. The divider recomputes on the next
+// channel entry.
 func (a *App) flushPendingMarks() tea.Cmd {
 	var cmds []tea.Cmd
 	if pc := a.pendingChannelMark; pc.ts != "" {
@@ -2147,6 +2162,14 @@ func (a *App) flushPendingMarks() tea.Cmd {
 			ids.ThreadTS(pt.threadTS),
 			ids.MessageTS(pt.ts),
 		); c != nil {
+			// Recorded before the cmd runs, symmetrically with the
+			// channel leg above: Mark only builds the cmd, so the mark
+			// has not been issued yet and this record cannot lose the
+			// race against Slack's thread_marked broadcast. A nil cmd
+			// means no mark, hence no echo to suppress.
+			a.selfThreadMarks.record(selfMarkKey{
+				channelID: pt.channelID, threadTS: pt.threadTS, ts: pt.ts,
+			})
 			cmds = append(cmds, c)
 		}
 	}
@@ -3547,7 +3570,7 @@ func (a *App) applyThreadMarkListState(channelID, threadTS, lastRead string) {
 //
 // Slack broadcasts thread_marked to every connected client INCLUDING
 // the one that issued the mark, so ThreadMarkedRemoteMsg does NOT mean
-// "another client": it carries slk's own marks back too, both the
+// "another client": it carries slk's own marks back too, chiefly the
 // mark-on-open from reducer_threads' ThreadRepliesLoadedMsg arm and the
 // auto-mark from flushPendingMarks. Those echoes carry the newest
 // reply, and the panel renders no landmark once its boundary reaches
@@ -3558,6 +3581,17 @@ func (a *App) applyThreadMarkListState(channelID, threadTS, lastRead string) {
 // not issue carries no record and still moves the landmark, which is
 // correct — the user really did read the thread elsewhere. See
 // selfMarkDedup.
+//
+// "Chiefly", not "only": the thread mark-unread press is a third
+// self-originated echo. MarkThreadUnread posts to the same
+// subscriptions.thread.mark endpoint with read=0, so it broadcasts back
+// here exactly as the read marks do. It is deliberately NOT recorded,
+// so its echo is treated as foreign and moves the landmark. That is
+// correct: Slack rolls the cursor back to just before the ts the user
+// picked, so applying it renders the landmark exactly where the press
+// asked for it. Do not "complete" the recording sites
+// by adding it: that would suppress the press's own effect, the
+// thread-side form of the applyChannelMark collision described below.
 //
 // The dedup lives here rather than inside applyThreadMark so that
 // consuming a record stays a property of the echo path alone.

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -4484,3 +4484,28 @@ func TestListReactionsNoOpWhenNoReactions(t *testing.T) {
 		t.Fatal("mode should not change when there are no reactions")
 	}
 }
+
+// The thread panel's "── new ──" divider must be sourced from the
+// thread's own cursor in thread_subscriptions, not the parent
+// channel's last_read_ts: plain replies never advance the channel
+// watermark, so the channel cursor is systematically stale and puts
+// the divider too early.
+func TestOpenThreadPanel_BoundaryUsesThreadCursor(t *testing.T) {
+	app := NewApp()
+	var gotChannel, gotThread string
+	app.SetThreadService(NewThreadService(ThreadServiceFuncs{
+		ThreadLastRead: func(channelID ids.ChannelID, threadTS ids.ThreadTS) string {
+			gotChannel, gotThread = string(channelID), string(threadTS)
+			return "R7"
+		},
+	}))
+
+	_ = app.openThreadPanel(messages.MessageItem{TS: "P1"}, "C1", "P1")
+
+	if gotChannel != "C1" || gotThread != "P1" {
+		t.Fatalf("ThreadLastRead called with (%q, %q), want (C1, P1)", gotChannel, gotThread)
+	}
+	if got := app.threadPanel.UnreadBoundaryTS(); got != "R7" {
+		t.Errorf("thread panel boundary = %q, want the thread cursor R7", got)
+	}
+}

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -2954,10 +2954,18 @@ func TestThreadMarkedRemoteMsg_CursorBehindLatestFlipsRowUnread(t *testing.T) {
 	if cmd != nil && cmdContainsMsgType(cmd, statusbar.MarkedUnreadMsg{}) {
 		t.Error("expected no toast on remote thread event")
 	}
+	found := false
 	for _, s := range app.threadsView.Summaries() {
-		if s.ThreadTS == "P1" && !s.Unread {
+		if s.ThreadTS != "P1" {
+			continue
+		}
+		found = true
+		if !s.Unread {
 			t.Error("expected P1 Unread=true when the cursor is behind the latest reply")
 		}
+	}
+	if !found {
+		t.Fatal("summary P1 missing; the assertion above would have passed vacuously")
 	}
 }
 
@@ -2971,10 +2979,18 @@ func TestThreadMarkedRemoteMsg_CursorAtLatestClearsRow(t *testing.T) {
 		ChannelID: "C1", ThreadTS: "P1", LastRead: "5.000000",
 	})
 
+	found := false
 	for _, s := range app.threadsView.Summaries() {
-		if s.ThreadTS == "P1" && s.Unread {
+		if s.ThreadTS != "P1" {
+			continue
+		}
+		found = true
+		if s.Unread {
 			t.Error("expected P1 Unread=false when the cursor reaches the latest reply")
 		}
+	}
+	if !found {
+		t.Fatal("summary P1 missing; the assertion above would have passed vacuously")
 	}
 }
 
@@ -3014,10 +3030,18 @@ func TestThreadMarkedRemoteMsg_SelfReplyDoesNotReFlagUnread(t *testing.T) {
 		ChannelID: "C1", ThreadTS: "P1", LastRead: "7.000000",
 	})
 
+	found := false
 	for _, s := range app.threadsView.Summaries() {
-		if s.ThreadTS == "P1" && s.Unread {
+		if s.ThreadTS != "P1" {
+			continue
+		}
+		found = true
+		if s.Unread {
 			t.Error("replying to a thread must not mark it unread")
 		}
+	}
+	if !found {
+		t.Fatal("summary P1 missing; the assertion above would have passed vacuously")
 	}
 }
 

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -3052,6 +3052,104 @@ func TestThreadMarkedLocalMsg_LeavesOpenPanelBoundaryInPlace(t *testing.T) {
 	}
 }
 
+// threadPanelOnR1R2 opens the thread panel on C1/P1 with two replies
+// and the "── new ──" landmark sitting on R1, which is the state
+// openSelectedThreadCmd's pre-open snapshot produces for a thread whose
+// second reply is unread.
+func threadPanelOnR1R2(t *testing.T) *App {
+	t.Helper()
+	app := NewApp()
+	app.threadPanel.SetThread(
+		messages.MessageItem{TS: "P1", UserID: "U1", Text: "parent"},
+		[]messages.MessageItem{
+			{TS: "R1", UserID: "U1", Text: "r1"},
+			{TS: "R2", UserID: "U1", Text: "r2"},
+		}, "C1", "P1")
+	app.threadVisible = true
+	app.threadPanel.SetUnreadBoundary("R1")
+	return app
+}
+
+// Slack broadcasts thread_marked back to the client that issued the
+// mark, so slk's own subscriptions.thread.mark returns as a
+// ThreadMarkedRemoteMsg carrying the ts slk just set — the newest
+// reply. Applying it would move the landmark past every reply and
+// render no landmark at all, destroying the pre-open snapshot a round
+// trip after the user started reading. The list-state half must still
+// run: the thread really is read.
+func TestThreadMarkedRemoteMsg_SelfEchoHoldsPanelBoundary(t *testing.T) {
+	app := threadPanelOnR1R2(t)
+	app.threadsView.SetSummaries([]cache.ThreadSummary{
+		{ChannelID: "C1", ThreadTS: "P1", LastReplyTS: "R2", Unread: true},
+	})
+
+	// slk's own mark completing. This is where the self-mark is
+	// recorded, on the Update goroutine.
+	_, _ = app.Update(ThreadMarkedLocalMsg{ChannelID: "C1", ThreadTS: "P1", TS: "R2"})
+
+	// Re-flag the row so the list-state assertion below cannot pass
+	// vacuously off the local arm's own work: this stands in for a
+	// threads-list refresh landing between the two messages.
+	app.threadsView.SetSummaries([]cache.ThreadSummary{
+		{ChannelID: "C1", ThreadTS: "P1", LastReplyTS: "R2", Unread: true},
+	})
+
+	// Slack's echo of that same mark.
+	_, _ = app.Update(ThreadMarkedRemoteMsg{ChannelID: "C1", ThreadTS: "P1", LastRead: "R2"})
+
+	if got := app.threadPanel.UnreadBoundaryTS(); got != "R1" {
+		t.Errorf("thread panel unreadBoundary = %q, want the pre-open snapshot R1 held against slk's own echo", got)
+	}
+	found := false
+	for _, s := range app.threadsView.Summaries() {
+		if s.ThreadTS != "P1" {
+			continue
+		}
+		found = true
+		if s.Unread {
+			t.Error("a suppressed self-echo must still settle the threads-list unread flag")
+		}
+	}
+	if !found {
+		t.Fatal("summary P1 missing; the assertion above would have passed vacuously")
+	}
+}
+
+// The control, and the more important half: a thread_marked slk did not
+// issue means the user read that thread in another Slack client, and
+// the landmark must move. Suppression is keyed on the exact mark, so an
+// outstanding record for a DIFFERENT ts must not shield a foreign one.
+func TestThreadMarkedRemoteMsg_ForeignMarkStillMovesBoundary(t *testing.T) {
+	app := threadPanelOnR1R2(t)
+	app.threadPanel.SetUnreadBoundary("P1")
+	app.selfThreadMarks.record(selfMarkKey{channelID: "C1", threadTS: "P1", ts: "R2"})
+
+	_, _ = app.Update(ThreadMarkedRemoteMsg{ChannelID: "C1", ThreadTS: "P1", LastRead: "R1"})
+
+	if got := app.threadPanel.UnreadBoundaryTS(); got != "R1" {
+		t.Errorf("thread panel unreadBoundary = %q, want R1: a mark slk never issued must move the landmark", got)
+	}
+}
+
+// One issued mark suppresses one echo. Slack sends a single
+// thread_marked per mark, so a second one at the same ts is a new
+// event — a genuine cursor move made elsewhere — and must be applied.
+func TestThreadMarkedRemoteMsg_SelfEchoSuppressionIsConsumedOnce(t *testing.T) {
+	app := threadPanelOnR1R2(t)
+
+	_, _ = app.Update(ThreadMarkedLocalMsg{ChannelID: "C1", ThreadTS: "P1", TS: "R2"})
+
+	_, _ = app.Update(ThreadMarkedRemoteMsg{ChannelID: "C1", ThreadTS: "P1", LastRead: "R2"})
+	if got := app.threadPanel.UnreadBoundaryTS(); got != "R1" {
+		t.Fatalf("first echo: unreadBoundary = %q, want R1 held", got)
+	}
+
+	_, _ = app.Update(ThreadMarkedRemoteMsg{ChannelID: "C1", ThreadTS: "P1", LastRead: "R2"})
+	if got := app.threadPanel.UnreadBoundaryTS(); got != "R2" {
+		t.Errorf("second echo: unreadBoundary = %q, want R2 — the record is consumed by the first echo", got)
+	}
+}
+
 // Regression for the reported bug: posting a reply auto-subscribes you,
 // so Slack echoes thread_marked with active=true. slk used to read that
 // as "unread" and re-flag the thread the user was looking at.

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -2939,43 +2939,84 @@ func TestChannelMarkedRemoteMsg_InactiveChannel_OnlyUpdatesSidebar(t *testing.T)
 	}
 }
 
-func TestThreadMarkedRemoteMsg_UnreadFlipsRow(t *testing.T) {
+func TestThreadMarkedRemoteMsg_CursorBehindLatestFlipsRowUnread(t *testing.T) {
 	app := NewApp()
 	app.threadsView.SetSummaries([]cache.ThreadSummary{
-		{ChannelID: "C1", ThreadTS: "P1", Unread: false},
+		{ChannelID: "C1", ThreadTS: "P1", LastReplyTS: "5.000000", Unread: false},
 	})
 
 	_, cmd := app.Update(ThreadMarkedRemoteMsg{
 		ChannelID: "C1",
 		ThreadTS:  "P1",
-		TS:        "R5",
-		Read:      false,
+		LastRead:  "4.000000",
 	})
 
 	if cmd != nil && cmdContainsMsgType(cmd, statusbar.MarkedUnreadMsg{}) {
 		t.Error("expected no toast on remote thread event")
 	}
-
 	for _, s := range app.threadsView.Summaries() {
 		if s.ThreadTS == "P1" && !s.Unread {
-			t.Errorf("expected P1 to be Unread=true after remote thread_marked")
+			t.Error("expected P1 Unread=true when the cursor is behind the latest reply")
 		}
 	}
 }
 
-func TestThreadMarkedRemoteMsg_ReadClearsRow(t *testing.T) {
+func TestThreadMarkedRemoteMsg_CursorAtLatestClearsRow(t *testing.T) {
 	app := NewApp()
 	app.threadsView.SetSummaries([]cache.ThreadSummary{
-		{ChannelID: "C1", ThreadTS: "P1", Unread: true},
+		{ChannelID: "C1", ThreadTS: "P1", LastReplyTS: "5.000000", Unread: true},
 	})
 
 	_, _ = app.Update(ThreadMarkedRemoteMsg{
-		ChannelID: "C1", ThreadTS: "P1", TS: "R5", Read: true,
+		ChannelID: "C1", ThreadTS: "P1", LastRead: "5.000000",
 	})
 
 	for _, s := range app.threadsView.Summaries() {
 		if s.ThreadTS == "P1" && s.Unread {
-			t.Errorf("expected P1 Unread=false after remote thread_marked read=true")
+			t.Error("expected P1 Unread=false when the cursor reaches the latest reply")
+		}
+	}
+}
+
+// The open thread panel draws its "── new ──" landmark after the
+// boundary ts, so a remote cursor move must move the landmark rather
+// than clear it: a cursor mid-thread still has unread replies below it.
+func TestThreadMarkedRemoteMsg_MovesOpenPanelBoundaryToCursor(t *testing.T) {
+	app := NewApp()
+	app.threadPanel.SetThread(
+		messages.MessageItem{TS: "P1", UserID: "U1", Text: "parent"},
+		[]messages.MessageItem{
+			{TS: "R1", UserID: "U1", Text: "r1"},
+			{TS: "R2", UserID: "U1", Text: "r2"},
+		}, "C1", "P1")
+	app.threadVisible = true
+
+	_, _ = app.Update(ThreadMarkedRemoteMsg{
+		ChannelID: "C1", ThreadTS: "P1", LastRead: "R1",
+	})
+
+	if got := app.threadPanel.UnreadBoundaryTS(); got != "R1" {
+		t.Errorf("thread panel unreadBoundary = %q, want R1", got)
+	}
+}
+
+// Regression for the reported bug: posting a reply auto-subscribes you,
+// so Slack echoes thread_marked with active=true. slk used to read that
+// as "unread" and re-flag the thread the user was looking at.
+func TestThreadMarkedRemoteMsg_SelfReplyDoesNotReFlagUnread(t *testing.T) {
+	app := NewApp()
+	app.threadsView.SetSummaries([]cache.ThreadSummary{
+		{ChannelID: "C1", ThreadTS: "P1", LastReplyTS: "7.000000", Unread: false},
+	})
+
+	// Slack's echo after our own reply: cursor caught up to our reply.
+	_, _ = app.Update(ThreadMarkedRemoteMsg{
+		ChannelID: "C1", ThreadTS: "P1", LastRead: "7.000000",
+	})
+
+	for _, s := range app.threadsView.Summaries() {
+		if s.ThreadTS == "P1" && s.Unread {
+			t.Error("replying to a thread must not mark it unread")
 		}
 	}
 }

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -995,20 +995,14 @@ func TestApp_NewThreadReplyTriggersDirtyMsg(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("NewMessageMsg with ThreadTS expected to return a cmd")
 	}
-	// Drive every leaf message produced by the cmd graph back into the app.
-	// tea.Tick blocks for the duration before returning a TickMsg-shaped
-	// value (here, ThreadsListDirtyMsg). drainBatch will block on it, which
-	// is fine because we set the debounce to 5ms.
-	for _, m := range drainBatch(cmd) {
-		if m != nil {
-			_, follow := app.Update(m)
-			for _, fm := range drainBatch(follow) {
-				if fm != nil {
-					app.Update(fm)
-				}
-			}
-		}
-	}
+	// Drive every leaf message produced by the cmd graph back into the
+	// app, to whatever depth it runs to: the reply's dirty tick is only
+	// the first of several hops -- the dirty message opens a coalescing
+	// window whose own tick delivers threadsListFetchMsg, and that arm
+	// is what dispatches the fetch. Each tea.Tick blocks for its
+	// duration inside drainBatch, which is fine at the 5ms debounce set
+	// above.
+	feed(t, app, cmd, 0)
 
 	select {
 	case team := <-fetched:

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -3070,6 +3070,51 @@ func threadPanelOnR1R2(t *testing.T) *App {
 	return app
 }
 
+// issueThreadMarkOnOpen drives the real mark-on-open issue site: the
+// ThreadRepliesLoadedMsg arm calls ThreadService.Mark for the newest
+// reply and records the self-mark BEFORE the returned cmd — and so the
+// subscriptions.thread.mark request — has run. Returns the
+// ThreadMarkedLocalMsg that cmd yields, so callers can deliver it (or
+// deliberately not) to control the ordering against the WS echo.
+//
+// Tests record through this rather than poking selfThreadMarks so that
+// moving or losing the recording site fails them.
+func issueThreadMarkOnOpen(t *testing.T, app *App) ThreadMarkedLocalMsg {
+	t.Helper()
+	var marked []string
+	app.SetThreadService(NewThreadService(ThreadServiceFuncs{
+		Mark: func(channelID ids.ChannelID, threadTS ids.ThreadTS, ts ids.MessageTS) tea.Cmd {
+			marked = append(marked, string(channelID)+"/"+string(threadTS)+"/"+string(ts))
+			return func() tea.Msg {
+				return ThreadMarkedLocalMsg{
+					ChannelID: string(channelID),
+					ThreadTS:  string(threadTS),
+					TS:        string(ts),
+				}
+			}
+		},
+	}))
+	// Same thread identity as the panel already holds, so SetThread
+	// keeps the boundary the pre-open snapshot installed.
+	_, cmd := app.Update(ThreadRepliesLoadedMsg{
+		ThreadTS: "P1",
+		Replies: []messages.MessageItem{
+			{TS: "R1", UserID: "U1", Text: "r1"},
+			{TS: "R2", UserID: "U1", Text: "r2"},
+		},
+	})
+	if len(marked) != 1 || marked[0] != "C1/P1/R2" {
+		t.Fatalf("Mark calls = %v, want one mark of C1/P1 up to R2", marked)
+	}
+	for _, msg := range drainBatch(cmd) {
+		if local, ok := msg.(ThreadMarkedLocalMsg); ok {
+			return local
+		}
+	}
+	t.Fatal("the mark cmd yielded no ThreadMarkedLocalMsg")
+	return ThreadMarkedLocalMsg{}
+}
+
 // Slack broadcasts thread_marked back to the client that issued the
 // mark, so slk's own subscriptions.thread.mark returns as a
 // ThreadMarkedRemoteMsg carrying the ts slk just set — the newest
@@ -3079,17 +3124,14 @@ func threadPanelOnR1R2(t *testing.T) *App {
 // run: the thread really is read.
 func TestThreadMarkedRemoteMsg_SelfEchoHoldsPanelBoundary(t *testing.T) {
 	app := threadPanelOnR1R2(t)
-	app.threadsView.SetSummaries([]cache.ThreadSummary{
-		{ChannelID: "C1", ThreadTS: "P1", LastReplyTS: "R2", Unread: true},
-	})
+	local := issueThreadMarkOnOpen(t, app)
 
-	// slk's own mark completing. This is where the self-mark is
-	// recorded, on the Update goroutine.
-	_, _ = app.Update(ThreadMarkedLocalMsg{ChannelID: "C1", ThreadTS: "P1", TS: "R2"})
+	// The mark's own HTTP response, back on the Update goroutine.
+	_, _ = app.Update(local)
 
 	// Re-flag the row so the list-state assertion below cannot pass
-	// vacuously off the local arm's own work: this stands in for a
-	// threads-list refresh landing between the two messages.
+	// vacuously off work the issue and local arms already did: this
+	// stands in for a threads-list refresh landing before the echo.
 	app.threadsView.SetSummaries([]cache.ThreadSummary{
 		{ChannelID: "C1", ThreadTS: "P1", LastReplyTS: "R2", Unread: true},
 	})
@@ -3115,6 +3157,28 @@ func TestThreadMarkedRemoteMsg_SelfEchoHoldsPanelBoundary(t *testing.T) {
 	}
 }
 
+// The ordering the fix turns on: Slack's WebSocket broadcast and the
+// mark's own HTTP response are independent, so the echo can arrive
+// FIRST. Recording on completion instead of on issue would leave this
+// echo unrecorded and wipe the landmark — in production, silently, for
+// every thread the user opens.
+func TestThreadMarkedRemoteMsg_SelfEchoBeforeLocalMsgStillHoldsBoundary(t *testing.T) {
+	app := threadPanelOnR1R2(t)
+	local := issueThreadMarkOnOpen(t, app)
+
+	// Echo first, before the mark call has even returned.
+	_, _ = app.Update(ThreadMarkedRemoteMsg{ChannelID: "C1", ThreadTS: "P1", LastRead: "R2"})
+	if got := app.threadPanel.UnreadBoundaryTS(); got != "R1" {
+		t.Fatalf("unreadBoundary = %q, want R1: an echo that beats the HTTP response is still slk's own mark", got)
+	}
+
+	// The response then lands and must not disturb the landmark either.
+	_, _ = app.Update(local)
+	if got := app.threadPanel.UnreadBoundaryTS(); got != "R1" {
+		t.Errorf("unreadBoundary = %q after the local completion, want R1", got)
+	}
+}
+
 // The control, and the more important half: a thread_marked slk did not
 // issue means the user read that thread in another Slack client, and
 // the landmark must move. Suppression is keyed on the exact mark, so an
@@ -3136,8 +3200,8 @@ func TestThreadMarkedRemoteMsg_ForeignMarkStillMovesBoundary(t *testing.T) {
 // event — a genuine cursor move made elsewhere — and must be applied.
 func TestThreadMarkedRemoteMsg_SelfEchoSuppressionIsConsumedOnce(t *testing.T) {
 	app := threadPanelOnR1R2(t)
-
-	_, _ = app.Update(ThreadMarkedLocalMsg{ChannelID: "C1", ThreadTS: "P1", TS: "R2"})
+	local := issueThreadMarkOnOpen(t, app)
+	_, _ = app.Update(local)
 
 	_, _ = app.Update(ThreadMarkedRemoteMsg{ChannelID: "C1", ThreadTS: "P1", LastRead: "R2"})
 	if got := app.threadPanel.UnreadBoundaryTS(); got != "R1" {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -3018,11 +3018,13 @@ func TestThreadMarkedRemoteMsg_MovesOpenPanelBoundaryToCursor(t *testing.T) {
 
 // The local counterpart of the test above, and its mirror image.
 // ThreadMarkedLocalMsg reports slk's OWN subscriptions.thread.mark
-// completing — the one openSelectedThreadCmd and flushPendingMarks
-// issue. Moving the boundary to that cursor would land it on the newest
-// reply, rendering no landmark at all, and would destroy the pre-open
-// snapshot openSelectedThreadCmd took (app.go:1861-1865) precisely so
-// the user can see what is new in the panel they are reading.
+// completing — the one issued by reducer_threads.go's
+// ThreadRepliesLoadedMsg arm on open, or by App.flushPendingMarks for a
+// reply that arrived in the open panel. Moving the boundary to that
+// cursor would land it on the newest reply, rendering no landmark at
+// all, and would destroy the pre-open snapshot openSelectedThreadCmd
+// takes via applyThreadUnreadBoundary precisely so the user can see
+// what is new in the panel they are reading.
 func TestThreadMarkedLocalMsg_LeavesOpenPanelBoundaryInPlace(t *testing.T) {
 	app := NewApp()
 	app.threadPanel.SetThread(

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -3016,6 +3016,40 @@ func TestThreadMarkedRemoteMsg_MovesOpenPanelBoundaryToCursor(t *testing.T) {
 	}
 }
 
+// The local counterpart of the test above, and its mirror image.
+// ThreadMarkedLocalMsg reports slk's OWN subscriptions.thread.mark
+// completing — the one openSelectedThreadCmd and flushPendingMarks
+// issue. Moving the boundary to that cursor would land it on the newest
+// reply, rendering no landmark at all, and would destroy the pre-open
+// snapshot openSelectedThreadCmd took (app.go:1861-1865) precisely so
+// the user can see what is new in the panel they are reading.
+func TestThreadMarkedLocalMsg_LeavesOpenPanelBoundaryInPlace(t *testing.T) {
+	app := NewApp()
+	app.threadPanel.SetThread(
+		messages.MessageItem{TS: "P1", UserID: "U1", Text: "parent"},
+		[]messages.MessageItem{
+			{TS: "R1", UserID: "U1", Text: "r1"},
+			{TS: "R2", UserID: "U1", Text: "r2"},
+		}, "C1", "P1")
+	app.threadVisible = true
+	app.threadPanel.SetUnreadBoundary("R1")
+	app.threadsView.SetSummaries([]cache.ThreadSummary{
+		{ChannelID: "C1", ThreadTS: "P1", LastReplyTS: "R2", Unread: true},
+	})
+
+	_, _ = app.Update(ThreadMarkedLocalMsg{ChannelID: "C1", ThreadTS: "P1", TS: "R2"})
+
+	if got := app.threadPanel.UnreadBoundaryTS(); got != "R1" {
+		t.Errorf("thread panel unreadBoundary = %q, want the pre-open snapshot R1 held", got)
+	}
+	// The threads-list side of the same mark must still take effect.
+	for _, s := range app.threadsView.Summaries() {
+		if s.ThreadTS == "P1" && s.Unread {
+			t.Error("a successful local thread mark must still clear the threads-list unread flag")
+		}
+	}
+}
+
 // Regression for the reported bug: posting a reply auto-subscribes you,
 // so Slack echoes thread_marked with active=true. slk used to read that
 // as "unread" and re-flag the thread the user was looking at.

--- a/internal/ui/callbacks.go
+++ b/internal/ui/callbacks.go
@@ -76,10 +76,10 @@ type ThreadFetchFunc func(channelID ids.ChannelID, threadTS ids.ThreadTS) tea.Ms
 type ThreadCacheReadFunc func(channelID ids.ChannelID, threadTS ids.ThreadTS) []messages.MessageItem
 
 // ThreadMarkFunc is called to mark a thread as read on Slack's servers
-// (subscriptions.thread.mark). channelID is the parent channel, threadTS
-// is the parent message ts, and ts is the latest reply ts the user has now
-// seen. Implementations should be best-effort and non-blocking.
-type ThreadMarkFunc func(channelID ids.ChannelID, threadTS ids.ThreadTS, ts ids.MessageTS)
+// (subscriptions.thread.mark) and, on success, to advance the local
+// thread_subscriptions cursor. Returns a tea.Cmd yielding
+// ThreadMarkedLocalMsg, or nil when no workspace is active.
+type ThreadMarkFunc func(channelID ids.ChannelID, threadTS ids.ThreadTS, ts ids.MessageTS) tea.Cmd
 
 // ThreadReplySendFunc is called when the user sends a thread reply.
 type ThreadReplySendFunc func(channelID ids.ChannelID, threadTS ids.ThreadTS, text string) tea.Msg

--- a/internal/ui/fanout_test.go
+++ b/internal/ui/fanout_test.go
@@ -132,20 +132,26 @@ func TestFanout_SameChannelLoadDoesNotAliasSlices(t *testing.T) {
 	}
 }
 
-// TestFanout_MarkReadOnlyOnFocusedSelection pins the spec read-state
-// rule: realtime traffic to an UNFOCUSED window must not trigger a
-// mark-read — the read marker only advances on focused entry.
+// TestFanout_MarkReadOnlyOnFocusedSelection pins the read-state rule
+// for UNFOCUSED windows: realtime traffic to a window that is merely
+// visible must not trigger a mark-read.
 //
-// Seam choice: the only UI-side mark-read producer is
-// ChannelService.MarkRead, dispatched solely from the tier-1 branch
-// of reduceChannelSelected (reducer_channels.go). reduceNewMessage
-// never calls it, and nothing else in the NewMessageMsg path can.
-// The strongest assertions available are therefore both of: (1) a
-// MarkRead spy on the channel service records zero calls when the
-// NewMessageMsg cmd batch is drained — guards against a future
-// fan-out accidentally wiring mark-read into the path; and (2) the
-// unfocused C1 model's LastReadTS is unchanged — guards the
-// per-model write loop against advancing the local watermark.
+// Scope note (#159): reduceNewMessage IS now a mark-read producer —
+// an arrival in the FOCUSED window's channel legitimately stages a
+// cursor advance and flushes it while the terminal has focus (see
+// internal/ui/reducer_focus_test.go). This test covers the other
+// case: twoWindowApp leaves activeChannelID == "C2", so the C1
+// arrival below reaches only the unfocused window, which is exactly
+// the configuration that must stage nothing. The other UI-side
+// producer, ChannelService.MarkRead from the tier-1 branch of
+// reduceChannelSelected (reducer_channels.go), is not on this path
+// either.
+//
+// Two assertions: (1) a MarkRead spy records zero calls when the
+// NewMessageMsg cmd batch is drained — the unfocused window's channel
+// never advances Slack's cursor; and (2) the unfocused C1 model's
+// LastReadTS is unchanged — guards the per-model write loop against
+// advancing the local watermark.
 func TestFanout_MarkReadOnlyOnFocusedSelection(t *testing.T) {
 	a, w1, _ := twoWindowApp(t)
 	a.winModels[w1].SetLastReadTS("5.0")

--- a/internal/ui/msgs.go
+++ b/internal/ui/msgs.go
@@ -532,6 +532,16 @@ type ThreadMarkedRemoteMsg struct {
 	LastRead  string
 }
 
+// ThreadMarkedLocalMsg reports the outcome of an slk-initiated
+// subscriptions.thread.mark. Err is nil on success, in which case
+// thread_subscriptions.last_read has already been advanced to TS.
+type ThreadMarkedLocalMsg struct {
+	ChannelID string
+	ThreadTS  string
+	TS        string
+	Err       error
+}
+
 // WSMessageDeletedMsg is dispatched by the RTM event handler when a
 // message_deleted event arrives. App.Update handles it by removing the
 // message from both panes and the cache.

--- a/internal/ui/msgs.go
+++ b/internal/ui/msgs.go
@@ -70,8 +70,9 @@ type (
 		// MarkedTS is the ts the fetcher already marked the channel
 		// read at, or "" if it marked nothing. ChannelService.Fetch
 		// marks on entry and sets this; the reconnect refresh
-		// (cmd/slk/main.go:2091) reuses this message but deliberately
-		// does not mark, and leaves it empty. The reducer records it
+		// (rtmEventHandler.refreshChannel in cmd/slk/main.go) reuses
+		// this message but deliberately does not mark, and leaves it
+		// empty. The reducer records it
 		// as a self-mark so the resulting channel_marked echo does not
 		// drag the divider off LastReadTS. See selfMarkDedup.
 		MarkedTS string

--- a/internal/ui/msgs.go
+++ b/internal/ui/msgs.go
@@ -523,14 +523,13 @@ type ChannelMarkedRemoteMsg struct {
 }
 
 // ThreadMarkedRemoteMsg is dispatched by the WS event handler when
-// Slack pushes a thread_marked event. Read=true means the thread is
-// now read (clear local boundary + threads-view row); Read=false means
-// it's unread.
+// Slack pushes a thread_marked event. LastRead is the thread's new read
+// cursor; whether that means read or unread is decided by comparing it
+// against the thread's newest known reply.
 type ThreadMarkedRemoteMsg struct {
 	ChannelID string
 	ThreadTS  string
-	TS        string
-	Read      bool
+	LastRead  string
 }
 
 // WSMessageDeletedMsg is dispatched by the RTM event handler when a

--- a/internal/ui/msgs.go
+++ b/internal/ui/msgs.go
@@ -426,6 +426,16 @@ type threadFetchDebounceMsg struct {
 	gen       uint64
 }
 
+// threadsListFetchMsg ends the coalescing window a ThreadsListDirtyMsg
+// opened: it is delivered threadsDirtyDebounce after that message, and
+// its arm is what dispatches the ThreadService.ListFetch the dirty
+// message asked for. teamID is whichever team was active when the window
+// opened, so a workspace switch during the window can be told apart
+// from a refresh that is still wanted.
+type threadsListFetchMsg struct {
+	teamID string
+}
+
 // MessageSentMsg is returned after a message is successfully sent.
 // LocalTS, if non-empty, identifies the optimistic placeholder added
 // when the user pressed Enter. The handler uses it to swap the

--- a/internal/ui/msgs.go
+++ b/internal/ui/msgs.go
@@ -175,6 +175,10 @@ type (
 	// ThreadsListDirtyMsg is dispatched when something that could affect
 	// the involved-threads list has changed (new message, mention, etc.)
 	// and the list should be refetched. Ignored if not the active team.
+	//
+	// Senders need not deduplicate or debounce: reduceThreads coalesces
+	// these on receipt, so several from several senders inside one
+	// threadsDirtyDebounce window cost a single refetch.
 	ThreadsListDirtyMsg struct {
 		TeamID string
 	}

--- a/internal/ui/msgs.go
+++ b/internal/ui/msgs.go
@@ -67,6 +67,14 @@ type (
 		ChannelID  string
 		Messages   []messages.MessageItem
 		LastReadTS string
+		// MarkedTS is the ts the fetcher already marked the channel
+		// read at, or "" if it marked nothing. ChannelService.Fetch
+		// marks on entry and sets this; the reconnect refresh
+		// (cmd/slk/main.go:2091) reuses this message but deliberately
+		// does not mark, and leaves it empty. The reducer records it
+		// as a self-mark so the resulting channel_marked echo does not
+		// drag the divider off LastReadTS. See selfMarkDedup.
+		MarkedTS string
 	}
 	OlderMessagesLoadedMsg struct {
 		ChannelID string

--- a/internal/ui/msgs.go
+++ b/internal/ui/msgs.go
@@ -532,9 +532,12 @@ type ChannelMarkedRemoteMsg struct {
 }
 
 // ThreadMarkedRemoteMsg is dispatched by the WS event handler when
-// Slack pushes a thread_marked event. LastRead is the thread's new read
-// cursor; whether that means read or unread is decided by comparing it
-// against the thread's newest known reply.
+// Slack pushes a thread_marked event (a thread's read cursor moved in
+// another client, or via slk's own subscriptions.thread.mark echoing
+// back — the arm routes through applyThreadMarkEcho, which tells the
+// two apart). LastRead is the thread's new read cursor; whether that
+// means read or unread is decided by comparing it against the thread's
+// newest known reply.
 type ThreadMarkedRemoteMsg struct {
 	ChannelID string
 	ThreadTS  string

--- a/internal/ui/reducer_channels.go
+++ b/internal/ui/reducer_channels.go
@@ -103,7 +103,7 @@ var reduceChannels reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
 		// for loads that issued no mark. Recorded before the no-window
 		// early return: slk sent the mark either way, and a window may
 		// open before the echo lands. See selfMarkDedup.
-		a.selfMarks.record(m.ChannelID, m.MarkedTS)
+		a.selfMarks.record(selfMarkKey{channelID: m.ChannelID, ts: m.MarkedTS})
 		// Fan out to every window viewing the channel, focused or
 		// not (Phase 3).
 		models := a.modelsForChannel(m.ChannelID)
@@ -420,7 +420,7 @@ func reduceChannelSelected(a *App, m ChannelSelectedMsg) (tea.Cmd, bool) {
 		// Record before issuing: Slack echoes this mark back as
 		// channel_marked, and applying that echo would drag the
 		// divider off the pre-entry cursor. See selfMarkDedup.
-		a.selfMarks.record(m.ID, string(latestTS))
+		a.selfMarks.record(selfMarkKey{channelID: m.ID, ts: string(latestTS)})
 		// MarkRead produces ChannelMarkedReadMsg, NOT MessagesLoadedMsg,
 		// so no authoritative permalink completion will follow.
 		return func() tea.Msg { return channels.MarkRead(chID, latestTS) }, false

--- a/internal/ui/reducer_channels.go
+++ b/internal/ui/reducer_channels.go
@@ -97,6 +97,13 @@ var reduceChannels reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
 		}
 		debuglog.Cache("MessagesLoadedMsg: channel=%s active=%s kind=%s count=%d",
 			m.ChannelID, a.activeChannelID, kind, len(m.Messages))
+		// The fetcher marked the channel read on its own goroutine and
+		// reported the ts here; record it on this one so the echo does
+		// not overwrite the pre-mark LastReadTS installed below. Empty
+		// for loads that issued no mark. Recorded before the no-window
+		// early return: slk sent the mark either way, and a window may
+		// open before the echo lands. See selfMarkDedup.
+		a.selfMarks.record(m.ChannelID, m.MarkedTS)
 		// Fan out to every window viewing the channel, focused or
 		// not (Phase 3).
 		models := a.modelsForChannel(m.ChannelID)
@@ -408,6 +415,10 @@ func reduceChannelSelected(a *App, m ChannelSelectedMsg) (tea.Cmd, bool) {
 		channels := a.channels
 		chID := ids.ChannelID(m.ID)
 		latestTS := ids.MessageTS(cached[len(cached)-1].TS)
+		// Record before issuing: Slack echoes this mark back as
+		// channel_marked, and applying that echo would drag the
+		// divider off the pre-entry cursor. See selfMarkDedup.
+		a.selfMarks.record(m.ID, string(latestTS))
 		// MarkRead produces ChannelMarkedReadMsg, NOT MessagesLoadedMsg,
 		// so no authoritative permalink completion will follow.
 		return func() tea.Msg { return channels.MarkRead(chID, latestTS) }, false

--- a/internal/ui/reducer_channels.go
+++ b/internal/ui/reducer_channels.go
@@ -42,7 +42,7 @@
 // that cross-section.
 //
 // Helpers (cancelEdit, CloseThread, clearSelections, SetChannels,
-// SetChannelMembership, notifyReadStateChanged, applyChannelMark,
+// SetChannelMembership, notifyReadStateChanged, applyChannelMarkEcho,
 // uploadToastCmd, userNameFor, nowFormatted) stay on App; the
 // reducer calls them via `a`.
 //
@@ -189,7 +189,9 @@ var reduceChannels reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
 		return nil, true
 
 	case ChannelMarkedRemoteMsg:
-		a.applyChannelMark(m.ChannelID, m.TS, m.UnreadCount)
+		// Echo path: may be slk's own mark coming back. See
+		// applyChannelMarkEcho.
+		a.applyChannelMarkEcho(m.ChannelID, m.TS, m.UnreadCount)
 		return nil, true
 
 	case ChannelMarkedReadMsg:

--- a/internal/ui/reducer_focus.go
+++ b/internal/ui/reducer_focus.go
@@ -33,13 +33,20 @@ var reduceFocus reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
 	switch msg.(type) {
 	case tea.FocusMsg:
 		a.terminalFocused = true
-		// Catch-up: marks staged while blurred go out now. Without
-		// this, a user who alt-tabs back, reads everything, and never
+		a.focusEverReported = true
+		// Not gated on autoMarkArmed: reaching this arm is itself the
+		// proof that arming waits for, and the user is by now looking
+		// at the channel. Catch-up — marks staged while blurred, or
+		// staged inside tmux before arming, go out now. Without this,
+		// a user who alt-tabs back, reads everything, and never
 		// switches channels leaves the channel unread on Slack.
 		return a.flushPendingMarks(), true
 
 	case tea.BlurMsg:
 		a.terminalFocused = false
+		// A blur proves focus reporting is wired up just as well as a
+		// focus does, and inside tmux it is the likelier first event.
+		a.focusEverReported = true
 		return nil, true
 
 	case markFlushMsg:

--- a/internal/ui/reducer_focus.go
+++ b/internal/ui/reducer_focus.go
@@ -1,0 +1,36 @@
+// internal/ui/reducer_focus.go
+//
+// Terminal-focus reducer for App.Update.
+//
+// Owns:
+//
+//	tea.FocusMsg - the terminal running slk gained focus.
+//	tea.BlurMsg  - the terminal running slk lost focus.
+//
+// Both are emitted only once App.View sets ReportFocus, and only by
+// terminals that support focus reporting.
+//
+// Why the App tracks this at all: a channel being *selected* does not
+// mean the user can see it. slk may be sitting in a background
+// terminal, an inactive tmux window, or an unfocused tmux pane with
+// the same channel still selected. Read-marking that follows selection
+// alone would diverge from Slack's own read state and suppress mobile
+// notifications for messages the user never saw.
+package ui
+
+import (
+	tea "charm.land/bubbletea/v2"
+)
+
+var reduceFocus reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
+	switch msg.(type) {
+	case tea.FocusMsg:
+		a.terminalFocused = true
+		return nil, true
+
+	case tea.BlurMsg:
+		a.terminalFocused = false
+		return nil, true
+	}
+	return nil, false
+}

--- a/internal/ui/reducer_focus.go
+++ b/internal/ui/reducer_focus.go
@@ -6,9 +6,12 @@
 //
 //	tea.FocusMsg - the terminal running slk gained focus.
 //	tea.BlurMsg  - the terminal running slk lost focus.
+//	markFlushMsg - the debounced read-cursor flush tick.
 //
-// Both are emitted only once App.View sets ReportFocus, and only by
-// terminals that support focus reporting.
+// The first two are emitted only once App.View sets ReportFocus, and
+// only by terminals that support focus reporting. markFlushMsg lives
+// here because whether a staged mark may be issued is purely a
+// question of focus.
 //
 // Why the App tracks this at all: a channel being *selected* does not
 // mean the user can see it. slk may be sitting in a background
@@ -22,15 +25,32 @@ import (
 	tea "charm.land/bubbletea/v2"
 )
 
+// markFlushMsg fires after the mark debounce interval; see
+// App.scheduleMarkFlush.
+type markFlushMsg struct{}
+
 var reduceFocus reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
 	switch msg.(type) {
 	case tea.FocusMsg:
 		a.terminalFocused = true
-		return nil, true
+		// Catch-up: marks staged while blurred go out now. Without
+		// this, a user who alt-tabs back, reads everything, and never
+		// switches channels leaves the channel unread on Slack.
+		return a.flushPendingMarks(), true
 
 	case tea.BlurMsg:
 		a.terminalFocused = false
 		return nil, true
+
+	case markFlushMsg:
+		a.markFlushScheduled = false
+		if !a.terminalFocused {
+			// Blurred between scheduling and firing: keep the slots
+			// staged rather than dropping them. The FocusMsg arm
+			// above issues them when the user comes back.
+			return nil, true
+		}
+		return a.flushPendingMarks(), true
 	}
 	return nil, false
 }

--- a/internal/ui/reducer_focus_test.go
+++ b/internal/ui/reducer_focus_test.go
@@ -896,3 +896,26 @@ func TestSelfMarkRecords_AreBounded(t *testing.T) {
 		t.Error("the very first record survived; it should have been evicted long ago")
 	}
 }
+
+// The channel and thread sets are bounded independently. Sharing one
+// instance between them would still pass the test above, but a burst of
+// thread marks — a run down the Threads view marks one per thread —
+// would evict outstanding channel records and let those echoes wipe the
+// message pane's divider.
+func TestSelfMarkRecords_ThreadBurstDoesNotEvictChannelRecords(t *testing.T) {
+	app, _ := markCapture(t)
+	app.selfMarks.record(selfMarkKey{channelID: "C1", ts: "5.000000"})
+
+	for i := range selfMarkLimit * 3 {
+		app.selfThreadMarks.record(selfMarkKey{
+			channelID: "C1", threadTS: fmt.Sprintf("P%d", i), ts: "9.000000",
+		})
+	}
+
+	if n := app.selfThreadMarks.len(); n > selfMarkLimit {
+		t.Errorf("recorded thread self-marks = %d, want at most %d", n, selfMarkLimit)
+	}
+	if !app.selfMarks.consume(selfMarkKey{channelID: "C1", ts: "5.000000"}) {
+		t.Error("the channel record was evicted by thread marks; the two sets must be bounded independently")
+	}
+}

--- a/internal/ui/reducer_focus_test.go
+++ b/internal/ui/reducer_focus_test.go
@@ -919,3 +919,108 @@ func TestSelfMarkRecords_ThreadBurstDoesNotEvictChannelRecords(t *testing.T) {
 		t.Error("the channel record was evicted by thread marks; the two sets must be bounded independently")
 	}
 }
+
+// The flush interval is a rate limit, not a UI delay: nothing on screen
+// changes when it fires, so the only thing the number has to respect is
+// conversations.mark's Tier 3 budget of ~50 requests/minute. At 5s a
+// continuously busy focused channel issues at most 60/5 = 12 of them a
+// minute; at the 1s this branch was first written with, a channel
+// receiving roughly a message a second produces ~60 a minute, over the
+// tier, where the mark is dropped with no retry (see flushPendingMarks)
+// and no sign to the user — exactly the cross-client divergence #159
+// exists to fix.
+//
+// Pinned as a value, not observed by timing: asserting the real
+// interval would mean a five-second test.
+func TestMarkFlushDebounce_DefaultFitsTheRateTier(t *testing.T) {
+	if defaultMarkFlushDebounce != 5*time.Second {
+		t.Errorf("defaultMarkFlushDebounce = %v, want 5s: conversations.mark is Tier 3 (~50/min)",
+			defaultMarkFlushDebounce)
+	}
+	if got := NewApp().markFlushDebounce; got != defaultMarkFlushDebounce {
+		t.Errorf("NewApp markFlushDebounce = %v, want the default %v",
+			got, defaultMarkFlushDebounce)
+	}
+}
+
+// threadsDirtyCapture returns an App whose ThreadService counts
+// ListFetch calls, with a tiny dirty debounce so the coalescing window
+// closes without the tests waiting on the 150ms production value.
+func threadsDirtyCapture(t *testing.T) (*App, *int) {
+	t.Helper()
+	app := NewApp()
+	app.activeTeamID = "T1"
+	app.threadsDirtyDebounce = time.Millisecond
+	fetches := new(int)
+	app.SetThreadService(NewThreadService(ThreadServiceFuncs{
+		ListFetch: func(ids.TeamID) tea.Msg {
+			*fetches++
+			return nil
+		},
+	}))
+	return app, fetches
+}
+
+// ThreadsListDirtyMsg has four senders that do not coordinate: the
+// thread_marked and thread_subscription_changed WS handlers send one
+// per event, the subscription sync sends one when it completes, and
+// scheduleThreadsDirty sends one per thread reply and per reply slk
+// itself sends. An actively-read thread therefore produces several for
+// the same stretch of activity, and each delivery re-runs
+// cache.ListSubscribedThreads. Coalescing on receipt is what holds that
+// to one query per window regardless of which senders fired.
+func TestThreadsDirtyBurst_CoalescesToOneListFetch(t *testing.T) {
+	app, fetches := threadsDirtyCapture(t)
+
+	// The whole burst is delivered before anything it scheduled runs:
+	// draining each cmd as it comes would close the window between
+	// messages and the test would prove nothing.
+	var cmds []tea.Cmd
+	for range 3 {
+		if _, cmd := app.Update(ThreadsListDirtyMsg{TeamID: "T1"}); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	}
+	for _, cmd := range cmds {
+		feed(t, app, cmd, 0)
+	}
+
+	if *fetches != 1 {
+		t.Errorf("ListFetch calls = %d, want 1: a burst of dirty messages must coalesce", *fetches)
+	}
+}
+
+// The window must reopen once its fetch has been dispatched. A latch
+// that never cleared would pass the burst test above and then leave the
+// threads list frozen for the rest of the session.
+func TestThreadsDirty_WindowReopensAfterTheFetch(t *testing.T) {
+	app, fetches := threadsDirtyCapture(t)
+
+	for range 2 {
+		_, cmd := app.Update(ThreadsListDirtyMsg{TeamID: "T1"})
+		feed(t, app, cmd, 0)
+	}
+
+	if *fetches != 2 {
+		t.Errorf("ListFetch calls = %d, want 2: dirty messages in separate windows each fetch", *fetches)
+	}
+}
+
+// The team filter has to come before the window opens. Opening it for
+// another workspace's dirty message would swallow the active
+// workspace's next one for the length of the debounce.
+func TestThreadsDirty_ForeignTeamNeitherFetchesNorOpensAWindow(t *testing.T) {
+	app, fetches := threadsDirtyCapture(t)
+
+	_, cmd := app.Update(ThreadsListDirtyMsg{TeamID: "T2"})
+	feed(t, app, cmd, 0)
+	if *fetches != 0 {
+		t.Fatalf("ListFetch calls = %d, want 0 for an inactive team", *fetches)
+	}
+
+	_, cmd = app.Update(ThreadsListDirtyMsg{TeamID: "T1"})
+	feed(t, app, cmd, 0)
+	if *fetches != 1 {
+		t.Errorf("ListFetch calls = %d, want 1: the foreign message must not have taken the window", *fetches)
+	}
+}

--- a/internal/ui/reducer_focus_test.go
+++ b/internal/ui/reducer_focus_test.go
@@ -20,6 +20,17 @@ func TestNewApp_StartsFocused(t *testing.T) {
 	}
 }
 
+func TestNewApp_DetectsTmuxFromEnv(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/tmux-1000/default,1234,0")
+	if !NewApp().inTmux {
+		t.Error("inTmux must be true when $TMUX is set")
+	}
+	t.Setenv("TMUX", "")
+	if NewApp().inTmux {
+		t.Error("inTmux must be false when $TMUX is empty")
+	}
+}
+
 func TestBlurMsg_ClearsFocus(t *testing.T) {
 	app := NewApp()
 	_, _ = app.Update(tea.BlurMsg{})
@@ -63,9 +74,16 @@ func TestReduceFocus_ClaimsOnlyItsOwnMessages(t *testing.T) {
 }
 
 // markCapture wires fake mark services and records every call.
+//
+// It pins inTmux false because NewApp derives it from $TMUX, and every
+// test below that expects an auto-mark is describing the outside-tmux
+// configuration. Without this pin the whole group would flip to the
+// tmux gate whenever the suite happens to be run from inside tmux. The
+// tmux tests set the field back to true themselves.
 func markCapture(t *testing.T) (*App, *[]string) {
 	t.Helper()
 	app := NewApp()
+	app.inTmux = false
 	app.markFlushDebounce = time.Millisecond
 	calls := &[]string{}
 	app.SetChannelService(NewChannelService(ChannelServiceFuncs{
@@ -195,6 +213,83 @@ func TestBlurredArrival_ArmsNoFlushTick(t *testing.T) {
 	if app.pendingChannelMark.ts != "5.000000" {
 		t.Fatalf("pendingChannelMark.ts = %q, want the arrival staged at 5.000000",
 			app.pendingChannelMark.ts)
+	}
+}
+
+func TestTmuxWithoutFocusEvents_DoesNotAutoMark(t *testing.T) {
+	app, calls := markCapture(t)
+	app.inTmux = true
+	app.activeChannelID = "C1"
+
+	_, cmd := app.Update(NewMessageMsg{
+		ChannelID: "C1",
+		Message:   messages.MessageItem{TS: "5.000000", UserID: "U2"},
+	})
+	feed(t, app, cmd, 0)
+
+	if len(*calls) != 0 {
+		t.Fatalf("calls = %v; tmux without focus events must not auto-mark", *calls)
+	}
+}
+
+func TestTmuxAfterBlurEvent_ArmsAutoMarking(t *testing.T) {
+	app, calls := markCapture(t)
+	app.inTmux = true
+	app.activeChannelID = "C1"
+
+	// A blur is as much proof that focus reporting works as a focus is.
+	_, _ = app.Update(tea.BlurMsg{})
+	_, _ = app.Update(tea.FocusMsg{})
+
+	_, cmd := app.Update(NewMessageMsg{
+		ChannelID: "C1",
+		Message:   messages.MessageItem{TS: "5.000000", UserID: "U2"},
+	})
+	feed(t, app, cmd, 0)
+
+	if len(*calls) != 1 || (*calls)[0] != "ch:C1/5.000000" {
+		t.Fatalf("calls = %v; want the mark once focus reporting has proven itself", *calls)
+	}
+}
+
+func TestTmuxFocusCatchUpFlushesStagedMarks(t *testing.T) {
+	app, calls := markCapture(t)
+	app.inTmux = true
+	app.activeChannelID = "C1"
+
+	// Staged before arming: no tick is scheduled, so nothing is issued.
+	_, cmd := app.Update(NewMessageMsg{
+		ChannelID: "C1",
+		Message:   messages.MessageItem{TS: "5.000000", UserID: "U2"},
+	})
+	feed(t, app, cmd, 0)
+	if len(*calls) != 0 {
+		t.Fatalf("calls = %v; nothing may be issued before arming", *calls)
+	}
+
+	// Reaching the FocusMsg arm proves reporting works, and the user is
+	// now looking at the channel, so the staged mark goes out.
+	_, cmd = app.Update(tea.FocusMsg{})
+	feed(t, app, cmd, 0)
+
+	if len(*calls) != 1 || (*calls)[0] != "ch:C1/5.000000" {
+		t.Fatalf("calls = %v; want the staged mark flushed on focus", *calls)
+	}
+}
+
+func TestOutsideTmux_AutoMarksWithoutAnyFocusEvent(t *testing.T) {
+	app, calls := markCapture(t)
+	app.inTmux = false
+	app.activeChannelID = "C1"
+
+	_, cmd := app.Update(NewMessageMsg{
+		ChannelID: "C1",
+		Message:   messages.MessageItem{TS: "5.000000", UserID: "U2"},
+	})
+	feed(t, app, cmd, 0)
+
+	if len(*calls) != 1 {
+		t.Fatalf("calls = %v; outside tmux the assume-focused default stands", *calls)
 	}
 }
 

--- a/internal/ui/reducer_focus_test.go
+++ b/internal/ui/reducer_focus_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -261,6 +262,46 @@ func TestBurstCoalescesToNewestTS(t *testing.T) {
 
 	if len(*calls) != 1 || (*calls)[0] != "ch:C1/3.000000" {
 		t.Fatalf("calls = %v, want a single mark at the newest ts", *calls)
+	}
+}
+
+// markFlushScheduled bounds the conversations.mark RATE, not just the
+// number of live timers. TestBurstCoalescesToNewestTS cannot see this:
+// there the whole burst lands before any tick fires, so the slot is
+// empty by the time the extra ticks arrive and they cost nothing.
+//
+// Under a stream that outpaces the debounce interval the ticks
+// interleave with the arrivals instead, and every tick lands on a slot
+// the next arrival has already refilled -- one mark per message
+// against a Tier-3 endpoint. This loop models that timing discretely:
+// each step delivers one arrival and then fires the tick armed on the
+// PREVIOUS step, i.e. arrivals run at twice the debounce rate.
+func TestSustainedStreamMarksPerWindowNotPerMessage(t *testing.T) {
+	app, calls := markCapture(t)
+	app.activeChannelID = "C1"
+
+	const steps = 8
+	var dueNextStep tea.Cmd
+	for i := 0; i < steps; i++ {
+		_, cmd := app.Update(NewMessageMsg{
+			ChannelID: "C1",
+			Message:   messages.MessageItem{TS: fmt.Sprintf("%d.000000", i), UserID: "U2"},
+		})
+		fireNow := dueNextStep
+		dueNextStep = cmd
+		feed(t, app, fireNow, 0)
+	}
+	feed(t, app, dueNextStep, 0)
+
+	// One mark per debounce window is steps/2 here; one per message
+	// would be steps-1. The midpoint separates them cleanly.
+	if n := len(*calls); n > steps/2 {
+		t.Fatalf("issued %d marks for %d arrivals (%v); the debounce must cap this at %d",
+			n, steps, *calls, steps/2)
+	}
+	// Not vacuous: the stream must still advance the cursor.
+	if len(*calls) == 0 {
+		t.Fatal("a sustained stream issued no mark at all")
 	}
 }
 

--- a/internal/ui/reducer_focus_test.go
+++ b/internal/ui/reducer_focus_test.go
@@ -232,6 +232,27 @@ func TestTmuxWithoutFocusEvents_DoesNotAutoMark(t *testing.T) {
 	}
 }
 
+// A lone blur arms auto-marking, and only a state assertion can show
+// it. No mark-level test can: scheduleMarkFlush needs terminalFocused
+// too, and the only thing that sets that back to true is the FocusMsg
+// arm, which sets focusEverReported itself. So the assignment in the
+// BlurMsg arm is unobservable through marks today and stays that way
+// only as long as nothing else restores terminalFocused. This test is
+// what keeps the two arms from drifting apart.
+func TestBlurMsg_CountsAsProofOfFocusReporting(t *testing.T) {
+	app, _ := markCapture(t)
+	app.inTmux = true
+	if app.autoMarkArmed() {
+		t.Fatal("must start disarmed in tmux, or the assertion below is vacuous")
+	}
+
+	_, _ = app.Update(tea.BlurMsg{})
+
+	if !app.autoMarkArmed() {
+		t.Error("a BlurMsg proves focus reporting works and must arm auto-marking")
+	}
+}
+
 func TestTmuxAfterBlurEvent_ArmsAutoMarking(t *testing.T) {
 	app, calls := markCapture(t)
 	app.inTmux = true

--- a/internal/ui/reducer_focus_test.go
+++ b/internal/ui/reducer_focus_test.go
@@ -230,6 +230,13 @@ func TestTmuxWithoutFocusEvents_DoesNotAutoMark(t *testing.T) {
 	if len(*calls) != 0 {
 		t.Fatalf("calls = %v; tmux without focus events must not auto-mark", *calls)
 	}
+	// Guard the guard: staging is not gated, so the arrival must have
+	// reached the slot. Without this a mis-shaped NewMessageMsg would
+	// satisfy the assertion above for the wrong reason.
+	if app.pendingChannelMark.ts != "5.000000" {
+		t.Fatalf("pendingChannelMark.ts = %q, want the arrival staged at 5.000000",
+			app.pendingChannelMark.ts)
+	}
 }
 
 // A lone blur arms auto-marking, and only a state assertion can show

--- a/internal/ui/reducer_focus_test.go
+++ b/internal/ui/reducer_focus_test.go
@@ -139,6 +139,37 @@ func TestBlurredArrival_DoesNotMarkUntilFocusReturns(t *testing.T) {
 	}
 }
 
+// The blur-mid-flight race: the arrival was focused, so a tick is
+// armed, but the user leaves before it fires. The tick must re-park
+// the slot rather than issue the mark -- the user stopped looking
+// between the two events.
+func TestBlurBeforeFlushTickFires_KeepsMarkStaged(t *testing.T) {
+	app, calls := markCapture(t)
+	app.activeChannelID = "C1"
+
+	_, cmd := app.Update(NewMessageMsg{
+		ChannelID: "C1",
+		Message:   messages.MessageItem{TS: "5.000000", UserID: "U2"},
+	})
+	_, _ = app.Update(tea.BlurMsg{}) // ...before the tick lands
+	feed(t, app, cmd, 0)
+
+	if len(*calls) != 0 {
+		t.Fatalf("a tick firing while blurred must not mark read, got %v", *calls)
+	}
+	if app.pendingChannelMark.ts != "5.000000" {
+		t.Fatalf("pendingChannelMark.ts = %q, want the slot re-parked at 5.000000",
+			app.pendingChannelMark.ts)
+	}
+
+	_, cmd = app.Update(tea.FocusMsg{})
+	feed(t, app, cmd, 0)
+
+	if len(*calls) != 1 || (*calls)[0] != "ch:C1/5.000000" {
+		t.Fatalf("calls after refocus = %v, want the re-parked mark to flush", *calls)
+	}
+}
+
 // A blurred arrival stages its slot but must arm no timer: the only
 // way out of a blurred slot is the FocusMsg catch-up. Without the
 // focus check in scheduleMarkFlush a blurred burst would arm one

--- a/internal/ui/reducer_focus_test.go
+++ b/internal/ui/reducer_focus_test.go
@@ -293,15 +293,23 @@ func TestSustainedStreamMarksPerWindowNotPerMessage(t *testing.T) {
 	}
 	feed(t, app, dueNextStep, 0)
 
-	// One mark per debounce window is steps/2 here; one per message
-	// would be steps-1. The midpoint separates them cleanly.
-	if n := len(*calls); n > steps/2 {
-		t.Fatalf("issued %d marks for %d arrivals (%v); the debounce must cap this at %d",
-			n, steps, *calls, steps/2)
+	// The exact sequence, not just a count. Odd steps are the ones that
+	// fire a tick, and each flush carries the ts of the arrival that
+	// landed in that same step. Asserting the full sequence pins three
+	// things at once: the rate cap (one mark per window, not steps-1),
+	// newest-wins within each window, and — because a short sequence
+	// fails just as loudly as a long one — the markFlushScheduled reset
+	// in reduceFocus's markFlushMsg arm, without which auto-marking
+	// stops dead after the first flush.
+	want := []string{
+		"ch:C1/1.000000",
+		"ch:C1/3.000000",
+		"ch:C1/5.000000",
+		"ch:C1/7.000000",
 	}
-	// Not vacuous: the stream must still advance the cursor.
-	if len(*calls) == 0 {
-		t.Fatal("a sustained stream issued no mark at all")
+	if got := strings.Join(*calls, " "); got != strings.Join(want, " ") {
+		t.Fatalf("marks = %v\nwant  = %v\n(%d arrivals; one mark per debounce window, each at that window's newest ts)",
+			*calls, want, steps)
 	}
 }
 

--- a/internal/ui/reducer_focus_test.go
+++ b/internal/ui/reducer_focus_test.go
@@ -884,15 +884,15 @@ func TestSelfMarkRecords_AreBounded(t *testing.T) {
 	newest := ""
 	for i := range selfMarkLimit * 3 {
 		newest = fmt.Sprintf("%d.000000", i)
-		app.selfMarks.record("C1", newest)
+		app.selfMarks.record(selfMarkKey{channelID: "C1", ts: newest})
 	}
 	if n := app.selfMarks.len(); n > selfMarkLimit {
 		t.Errorf("recorded self-marks = %d, want at most %d", n, selfMarkLimit)
 	}
-	if !app.selfMarks.consume("C1", newest) {
+	if !app.selfMarks.consume(selfMarkKey{channelID: "C1", ts: newest}) {
 		t.Errorf("the most recent record (%s) was evicted; eviction must drop the oldest", newest)
 	}
-	if app.selfMarks.consume("C1", "0.000000") {
+	if app.selfMarks.consume(selfMarkKey{channelID: "C1", ts: "0.000000"}) {
 		t.Error("the very first record survived; it should have been evicted long ago")
 	}
 }

--- a/internal/ui/reducer_focus_test.go
+++ b/internal/ui/reducer_focus_test.go
@@ -822,8 +822,9 @@ func TestFetchMarkEcho_LeavesDividerInPlace(t *testing.T) {
 	}
 }
 
-// The reconnect refresh (cmd/slk/main.go:2091) reuses MessagesLoadedMsg
-// but deliberately does NOT mark read, so it leaves MarkedTS empty. A
+// The reconnect refresh (rtmEventHandler.refreshChannel in
+// cmd/slk/main.go) reuses MessagesLoadedMsg but deliberately does NOT
+// mark read, so it leaves MarkedTS empty. A
 // channel_marked at its newest message is then genuinely foreign — the
 // user read the channel elsewhere while slk was offline — and must move
 // the divider.
@@ -844,13 +845,54 @@ func TestMessagesLoadedWithoutMarkedTS_DoesNotSuppress(t *testing.T) {
 	}
 }
 
-// The recorded set must not grow without bound over a long session.
+// Marking a message unread is a deliberate user action, and it must
+// move the divider even when it targets the same ts as a self-mark
+// whose echo has not landed. That collision is the ordinary case, not a
+// corner: slk auto-marks at the newest message, and "mark this newest
+// message unread so I deal with it later" names that same message. If
+// the dedup lived in applyChannelMark — shared by both paths — the
+// press would silently do nothing.
+func TestMarkUnreadAtSelfMarkedTS_StillMovesDivider(t *testing.T) {
+	app, calls := markCapture(t)
+	app.activeChannelID = "C1"
+	app.messagepane.SetLastReadTS("1.000000")
+
+	_, cmd := app.Update(NewMessageMsg{
+		ChannelID: "C1",
+		Message:   messages.MessageItem{TS: "5.000000", UserID: "U2"},
+	})
+	feed(t, app, cmd, 0)
+	if len(*calls) != 1 || (*calls)[0] != "ch:C1/5.000000" {
+		t.Fatalf("calls = %v, want the auto-mark issued at 5.000000 (the collision needs it)", *calls)
+	}
+
+	// No ChannelMarkedRemoteMsg fed: the self-mark record is still
+	// outstanding, which is the state that makes this a collision.
+	_, _ = app.Update(MessageMarkedUnreadMsg{ChannelID: "C1", BoundaryTS: "5.000000", UnreadCount: 1})
+
+	if got := app.messagepane.LastReadTS(); got != "5.000000" {
+		t.Errorf("messagepane LastReadTS = %q, want the explicit mark-unread applied at 5.000000", got)
+	}
+}
+
+// The recorded set must not grow without bound over a long session, and
+// must evict OLDEST first: an eviction policy that dropped the newest
+// key would keep the count under the cap while discarding exactly the
+// records whose echoes are still in flight.
 func TestSelfMarkRecords_AreBounded(t *testing.T) {
 	app, _ := markCapture(t)
+	newest := ""
 	for i := range selfMarkLimit * 3 {
-		app.selfMarks.record("C1", fmt.Sprintf("%d.000000", i))
+		newest = fmt.Sprintf("%d.000000", i)
+		app.selfMarks.record("C1", newest)
 	}
 	if n := app.selfMarks.len(); n > selfMarkLimit {
 		t.Errorf("recorded self-marks = %d, want at most %d", n, selfMarkLimit)
+	}
+	if !app.selfMarks.consume("C1", newest) {
+		t.Errorf("the most recent record (%s) was evicted; eviction must drop the oldest", newest)
+	}
+	if app.selfMarks.consume("C1", "0.000000") {
+		t.Error("the very first record survived; it should have been evicted long ago")
 	}
 }

--- a/internal/ui/reducer_focus_test.go
+++ b/internal/ui/reducer_focus_test.go
@@ -95,7 +95,19 @@ func markCapture(t *testing.T) (*App, *[]string) {
 	app.SetThreadService(NewThreadService(ThreadServiceFuncs{
 		Mark: func(channelID ids.ChannelID, threadTS ids.ThreadTS, ts ids.MessageTS) tea.Cmd {
 			*calls = append(*calls, "th:"+string(channelID)+"/"+string(threadTS)+"/"+string(ts))
-			return nil
+			// A non-nil cmd, as the production adapter returns for any
+			// mark it will actually issue. Returning nil here made
+			// flushPendingMarks' `if c := …; c != nil` guard false, so
+			// its selfThreadMarks.record was unreachable from every
+			// test in this file and could be deleted without failing
+			// one. The cmd itself yields what the real one yields.
+			return func() tea.Msg {
+				return ThreadMarkedLocalMsg{
+					ChannelID: string(channelID),
+					ThreadTS:  string(threadTS),
+					TS:        string(ts),
+				}
+			}
 		},
 	}))
 	return app, calls
@@ -693,15 +705,62 @@ func TestSelfIssuedMarkEcho_LeavesDividerInPlace(t *testing.T) {
 
 // The control. A channel_marked slk never issued means the user read
 // the channel in another Slack client, and slk's divider must follow.
+//
+// The outstanding record is deliberate: with an empty dedup this would
+// pass against a consume that matched on channelID alone and ignored
+// ts, which is the over-match that would swallow foreign echoes in
+// production. Mirrors TestThreadMarkedRemoteMsg_ForeignMarkStillMoves-
+// Boundary, which holds a record for R2 while echoing R1.
 func TestForeignMarkEcho_MovesDivider(t *testing.T) {
 	app, _ := markCapture(t)
 	app.activeChannelID = "C1"
 	app.messagepane.SetLastReadTS("1.000000")
+	app.selfMarks.record(selfMarkKey{channelID: "C1", ts: "5.000000"})
 
 	_, _ = app.Update(ChannelMarkedRemoteMsg{ChannelID: "C1", TS: "9.000000"})
 
 	if got := app.messagepane.LastReadTS(); got != "9.000000" {
 		t.Errorf("messagepane LastReadTS = %q, want a foreign mark to move the divider to 9.000000", got)
+	}
+}
+
+// The thread-side headline case of #159 end to end: a reply lands in
+// the thread panel the user is looking at, the debounced flush
+// auto-marks it, and Slack broadcasts that mark back a round trip
+// later. The landmark the user is reading against must survive slk's
+// own echo.
+//
+// This is the only test that reaches flushPendingMarks' THREAD leg
+// record. The other thread issue site, the mark-on-open in
+// ThreadRepliesLoadedMsg, is covered in app_test.go via
+// issueThreadMarkOnOpen; before this test, deleting the flush leg's
+// record failed nothing in the package.
+func TestSelfIssuedThreadMarkEcho_HoldsPanelLandmark(t *testing.T) {
+	app, calls := markCapture(t)
+	app.activeChannelID = "C1"
+	app.threadVisible = true
+	app.threadPanel.SetThread(
+		messages.MessageItem{TS: "P1", UserID: "U1", Text: "parent"},
+		[]messages.MessageItem{{TS: "R1", UserID: "U1", Text: "r1"}},
+		"C1", "P1")
+	app.threadPanel.SetUnreadBoundary("R1")
+
+	// A reply into the open thread: staged by reduceNewMessage, issued
+	// by the flush tick that feed drives below.
+	_, cmd := app.Update(NewMessageMsg{
+		ChannelID: "C1",
+		Message:   messages.MessageItem{TS: "R2", UserID: "U2", ThreadTS: "P1"},
+	})
+	feed(t, app, cmd, 0)
+	if len(*calls) != 1 || (*calls)[0] != "th:C1/P1/R2" {
+		t.Fatalf("calls = %v, want the auto-mark of C1/P1 up to R2 (the echo assertion needs it)", *calls)
+	}
+
+	// Slack's thread_marked broadcast of that same mark.
+	_, _ = app.Update(ThreadMarkedRemoteMsg{ChannelID: "C1", ThreadTS: "P1", LastRead: "R2"})
+
+	if got := app.threadPanel.UnreadBoundaryTS(); got != "R1" {
+		t.Errorf("thread panel unreadBoundary = %q, want R1 held against slk's own auto-mark echo", got)
 	}
 }
 

--- a/internal/ui/reducer_focus_test.go
+++ b/internal/ui/reducer_focus_test.go
@@ -654,3 +654,203 @@ func TestFocusedArrivalLeavesDividerInPlace(t *testing.T) {
 		t.Errorf("messagepane LastReadTS = %q, want the divider left at 1.000000", got)
 	}
 }
+
+// The tests above stop at the local path. Slack does not: every
+// conversations.mark slk issues comes back over the WebSocket as a
+// channel_marked event, which cmd/slk/main.go's OnChannelMarked turns
+// into a ChannelMarkedRemoteMsg. markCapture's fake MarkRead returns
+// nil, so that echo has to be synthesised here — its absence is why
+// TestFocusedArrivalLeavesDividerInPlace passed while the divider still
+// vanished in production.
+
+func TestSelfIssuedMarkEcho_LeavesDividerInPlace(t *testing.T) {
+	app, calls := markCapture(t)
+	app.activeChannelID = "C1"
+	app.messagepane.SetLastReadTS("1.000000")
+
+	_, cmd := app.Update(NewMessageMsg{
+		ChannelID: "C1",
+		Message:   messages.MessageItem{TS: "5.000000", UserID: "U2"},
+	})
+	feed(t, app, cmd, 0)
+	if len(*calls) != 1 || (*calls)[0] != "ch:C1/5.000000" {
+		t.Fatalf("calls = %v, want the auto-mark issued at 5.000000 (the echo assertion needs it)", *calls)
+	}
+
+	version := app.sidebar.Version()
+	_, _ = app.Update(ChannelMarkedRemoteMsg{ChannelID: "C1", TS: "5.000000"})
+
+	if got := app.messagepane.LastReadTS(); got != "1.000000" {
+		t.Errorf("messagepane LastReadTS = %q, want the divider held at 1.000000", got)
+	}
+	// sidebar.Invalidate bumps the version (sidebar/model.go:391,556),
+	// so this pins that the suppressed branch still runs
+	// notifyReadStateChanged and clears the unread dot.
+	if app.sidebar.Version() == version {
+		t.Error("a suppressed self-mark echo must still call notifyReadStateChanged")
+	}
+}
+
+// The control. A channel_marked slk never issued means the user read
+// the channel in another Slack client, and slk's divider must follow.
+func TestForeignMarkEcho_MovesDivider(t *testing.T) {
+	app, _ := markCapture(t)
+	app.activeChannelID = "C1"
+	app.messagepane.SetLastReadTS("1.000000")
+
+	_, _ = app.Update(ChannelMarkedRemoteMsg{ChannelID: "C1", TS: "9.000000"})
+
+	if got := app.messagepane.LastReadTS(); got != "9.000000" {
+		t.Errorf("messagepane LastReadTS = %q, want a foreign mark to move the divider to 9.000000", got)
+	}
+}
+
+// One issued mark suppresses exactly one echo. A second channel_marked
+// at the same ts cannot have come from that mark, so it is foreign and
+// must move the divider.
+func TestSelfIssuedMarkEcho_SuppressionIsConsumed(t *testing.T) {
+	app, calls := markCapture(t)
+	app.activeChannelID = "C1"
+	app.messagepane.SetLastReadTS("1.000000")
+
+	_, cmd := app.Update(NewMessageMsg{
+		ChannelID: "C1",
+		Message:   messages.MessageItem{TS: "5.000000", UserID: "U2"},
+	})
+	feed(t, app, cmd, 0)
+	if len(*calls) != 1 {
+		t.Fatalf("calls = %v, want exactly one issued mark", *calls)
+	}
+
+	_, _ = app.Update(ChannelMarkedRemoteMsg{ChannelID: "C1", TS: "5.000000"})
+	if got := app.messagepane.LastReadTS(); got != "1.000000" {
+		t.Fatalf("messagepane LastReadTS = %q after the first echo, want 1.000000", got)
+	}
+
+	_, _ = app.Update(ChannelMarkedRemoteMsg{ChannelID: "C1", TS: "5.000000"})
+	if got := app.messagepane.LastReadTS(); got != "5.000000" {
+		t.Errorf("messagepane LastReadTS = %q after the second echo, want 5.000000 (suppression is single-use)", got)
+	}
+}
+
+// The headline scenario end to end: messages pile up while the user is
+// away, they come back, the FocusMsg catch-up flushes the mark, and the
+// echo lands ~200ms later. The divider showing what arrived must
+// survive it.
+func TestFocusRegainFlushEcho_LeavesDividerInPlace(t *testing.T) {
+	app, calls := markCapture(t)
+	app.activeChannelID = "C1"
+	app.messagepane.SetLastReadTS("1.000000")
+	_, _ = app.Update(tea.BlurMsg{})
+
+	_, cmd := app.Update(NewMessageMsg{
+		ChannelID: "C1",
+		Message:   messages.MessageItem{TS: "5.000000", UserID: "U2"},
+	})
+	feed(t, app, cmd, 0)
+
+	_, cmd = app.Update(tea.FocusMsg{})
+	feed(t, app, cmd, 0)
+	if len(*calls) != 1 || (*calls)[0] != "ch:C1/5.000000" {
+		t.Fatalf("calls after refocus = %v, want the staged mark to flush", *calls)
+	}
+
+	_, _ = app.Update(ChannelMarkedRemoteMsg{ChannelID: "C1", TS: "5.000000"})
+
+	if got := app.messagepane.LastReadTS(); got != "1.000000" {
+		t.Errorf("messagepane LastReadTS = %q, want the divider held at 1.000000", got)
+	}
+}
+
+// The entry mark has the same defect and predates this branch: tier 1
+// of reduceChannelSelected issues conversations.mark straight from the
+// fresh cache, and its echo used to overwrite the pre-entry cursor
+// MessagesLoadedMsg had just installed.
+func TestEntryMarkEcho_LeavesDividerInPlace(t *testing.T) {
+	app, _ := markCapture(t)
+	cached := []messages.MessageItem{
+		{TS: "1.000000", UserID: "U2"},
+		{TS: "5.000000", UserID: "U2"},
+	}
+	calls := &[]string{}
+	app.SetChannelService(NewChannelService(ChannelServiceFuncs{
+		ReadCache: func(ids.ChannelID) []messages.MessageItem { return cached },
+		// syncedAt within cacheFreshThreshold selects tier 1, the
+		// branch that marks read without fetching.
+		SyncedAt: func(ids.ChannelID) int64 { return time.Now().Unix() },
+		MarkRead: func(channelID ids.ChannelID, ts ids.MessageTS) tea.Msg {
+			*calls = append(*calls, "ch:"+string(channelID)+"/"+string(ts))
+			return nil
+		},
+	}))
+
+	_, cmd := app.Update(ChannelSelectedMsg{ID: "C1", Name: "general"})
+	feed(t, app, cmd, 0)
+	if len(*calls) != 1 || (*calls)[0] != "ch:C1/5.000000" {
+		t.Fatalf("calls = %v, want the tier-1 entry mark at 5.000000", *calls)
+	}
+	app.messagepane.SetLastReadTS("1.000000")
+
+	_, _ = app.Update(ChannelMarkedRemoteMsg{ChannelID: "C1", TS: "5.000000"})
+
+	if got := app.messagepane.LastReadTS(); got != "1.000000" {
+		t.Errorf("messagepane LastReadTS = %q, want the entry divider held at 1.000000", got)
+	}
+}
+
+// The third issuer: ChannelService.Fetch marks read on the cmd
+// goroutine and reports the ts it used on MessagesLoadedMsg.MarkedTS,
+// so the recording happens here, on the Update goroutine.
+func TestFetchMarkEcho_LeavesDividerInPlace(t *testing.T) {
+	app, _ := markCapture(t)
+	app.activeChannelID = "C1"
+
+	_, _ = app.Update(MessagesLoadedMsg{
+		ChannelID:  "C1",
+		Messages:   []messages.MessageItem{{TS: "1.000000"}, {TS: "5.000000"}},
+		LastReadTS: "1.000000",
+		MarkedTS:   "5.000000",
+	})
+	if got := app.messagepane.LastReadTS(); got != "1.000000" {
+		t.Fatalf("messagepane LastReadTS = %q after load, want the pre-mark cursor 1.000000", got)
+	}
+
+	_, _ = app.Update(ChannelMarkedRemoteMsg{ChannelID: "C1", TS: "5.000000"})
+
+	if got := app.messagepane.LastReadTS(); got != "1.000000" {
+		t.Errorf("messagepane LastReadTS = %q, want the divider held at 1.000000", got)
+	}
+}
+
+// The reconnect refresh (cmd/slk/main.go:2091) reuses MessagesLoadedMsg
+// but deliberately does NOT mark read, so it leaves MarkedTS empty. A
+// channel_marked at its newest message is then genuinely foreign — the
+// user read the channel elsewhere while slk was offline — and must move
+// the divider.
+func TestMessagesLoadedWithoutMarkedTS_DoesNotSuppress(t *testing.T) {
+	app, _ := markCapture(t)
+	app.activeChannelID = "C1"
+
+	_, _ = app.Update(MessagesLoadedMsg{
+		ChannelID:  "C1",
+		Messages:   []messages.MessageItem{{TS: "1.000000"}, {TS: "5.000000"}},
+		LastReadTS: "1.000000",
+	})
+
+	_, _ = app.Update(ChannelMarkedRemoteMsg{ChannelID: "C1", TS: "5.000000"})
+
+	if got := app.messagepane.LastReadTS(); got != "5.000000" {
+		t.Errorf("messagepane LastReadTS = %q, want 5.000000: a load that issued no mark must not suppress", got)
+	}
+}
+
+// The recorded set must not grow without bound over a long session.
+func TestSelfMarkRecords_AreBounded(t *testing.T) {
+	app, _ := markCapture(t)
+	for i := range selfMarkLimit * 3 {
+		app.selfMarks.record("C1", fmt.Sprintf("%d.000000", i))
+	}
+	if n := app.selfMarks.len(); n > selfMarkLimit {
+		t.Errorf("recorded self-marks = %d, want at most %d", n, selfMarkLimit)
+	}
+}

--- a/internal/ui/reducer_focus_test.go
+++ b/internal/ui/reducer_focus_test.go
@@ -1,9 +1,13 @@
 package ui
 
 import (
+	"strings"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/gammons/slk/internal/ids"
+	"github.com/gammons/slk/internal/ui/messages"
 )
 
 func TestNewApp_StartsFocused(t *testing.T) {
@@ -37,5 +41,387 @@ func TestView_EnablesFocusReporting(t *testing.T) {
 	app.width, app.height = 80, 24
 	if !app.View().ReportFocus {
 		t.Error("View must set ReportFocus so the terminal sends focus events")
+	}
+}
+
+// reduceFocus must CLAIM every message type it owns, so no later
+// reducer in the chain (and not the residual switch) gets a second
+// look at it. The flag is assigned before the return in each arm, so
+// the state assertions above pass even if the claim flag is wrong --
+// this is the only test that pins the flag itself.
+func TestReduceFocus_ClaimsOnlyItsOwnMessages(t *testing.T) {
+	owned := []tea.Msg{tea.FocusMsg{}, tea.BlurMsg{}, markFlushMsg{}}
+	for _, msg := range owned {
+		if _, handled := reduceFocus(NewApp(), msg); !handled {
+			t.Errorf("reduceFocus(%T) handled = false, want true", msg)
+		}
+	}
+	if _, handled := reduceFocus(NewApp(), ChannelMarkedReadMsg{}); handled {
+		t.Error("reduceFocus claimed ChannelMarkedReadMsg, which reduceChannels owns")
+	}
+}
+
+// markCapture wires fake mark services and records every call.
+func markCapture(t *testing.T) (*App, *[]string) {
+	t.Helper()
+	app := NewApp()
+	app.markFlushDebounce = time.Millisecond
+	calls := &[]string{}
+	app.SetChannelService(NewChannelService(ChannelServiceFuncs{
+		MarkRead: func(channelID ids.ChannelID, ts ids.MessageTS) tea.Msg {
+			*calls = append(*calls, "ch:"+string(channelID)+"/"+string(ts))
+			return nil
+		},
+	}))
+	app.SetThreadService(NewThreadService(ThreadServiceFuncs{
+		Mark: func(channelID ids.ChannelID, threadTS ids.ThreadTS, ts ids.MessageTS) tea.Cmd {
+			*calls = append(*calls, "th:"+string(channelID)+"/"+string(threadTS)+"/"+string(ts))
+			return nil
+		},
+	}))
+	return app, calls
+}
+
+// feed runs cmd to completion and pushes every resulting message back
+// through app.Update, so a scheduled flush tick actually fires within
+// the test. Reuses the existing drainBatch helper in
+// internal/ui/app_selection_test.go:29. Depth-bounded so a
+// self-rescheduling cmd cannot loop forever.
+func feed(t *testing.T, app *App, cmd tea.Cmd, depth int) {
+	t.Helper()
+	if cmd == nil || depth > 5 {
+		return
+	}
+	for _, msg := range drainBatch(cmd) {
+		if msg == nil {
+			continue
+		}
+		_, next := app.Update(msg)
+		feed(t, app, next, depth+1)
+	}
+}
+
+func TestFocusedArrival_MarksActiveChannelRead(t *testing.T) {
+	app, calls := markCapture(t)
+	app.activeChannelID = "C1"
+
+	_, cmd := app.Update(NewMessageMsg{
+		ChannelID: "C1",
+		Message:   messages.MessageItem{TS: "5.000000", UserID: "U2"},
+	})
+	feed(t, app, cmd, 0)
+
+	if len(*calls) != 1 || (*calls)[0] != "ch:C1/5.000000" {
+		t.Fatalf("calls = %v, want one channel mark at 5.000000", *calls)
+	}
+}
+
+func TestBlurredArrival_DoesNotMarkUntilFocusReturns(t *testing.T) {
+	app, calls := markCapture(t)
+	app.activeChannelID = "C1"
+	_, _ = app.Update(tea.BlurMsg{})
+
+	_, cmd := app.Update(NewMessageMsg{
+		ChannelID: "C1",
+		Message:   messages.MessageItem{TS: "5.000000", UserID: "U2"},
+	})
+	feed(t, app, cmd, 0)
+
+	if len(*calls) != 0 {
+		t.Fatalf("blurred arrival must not mark read, got %v", *calls)
+	}
+
+	_, cmd = app.Update(tea.FocusMsg{})
+	feed(t, app, cmd, 0)
+
+	if len(*calls) != 1 || (*calls)[0] != "ch:C1/5.000000" {
+		t.Fatalf("calls after refocus = %v, want the staged mark to flush", *calls)
+	}
+}
+
+// A blurred arrival stages its slot but must arm no timer: the only
+// way out of a blurred slot is the FocusMsg catch-up. Without the
+// focus check in scheduleMarkFlush a blurred burst would arm one
+// timer per debounce interval, each firing only to re-park the slot.
+func TestBlurredArrival_ArmsNoFlushTick(t *testing.T) {
+	app, _ := markCapture(t)
+	app.activeChannelID = "C1"
+	_, _ = app.Update(tea.BlurMsg{})
+
+	_, cmd := app.Update(NewMessageMsg{
+		ChannelID: "C1",
+		Message:   messages.MessageItem{TS: "5.000000", UserID: "U2"},
+	})
+
+	for _, msg := range drainBatch(cmd) {
+		if _, ok := msg.(markFlushMsg); ok {
+			t.Fatal("a blurred arrival armed a flush tick; it must wait for FocusMsg")
+		}
+	}
+	// The slot must still be staged -- otherwise the assertion above
+	// would hold for the wrong reason.
+	if app.pendingChannelMark.ts != "5.000000" {
+		t.Fatalf("pendingChannelMark.ts = %q, want the arrival staged at 5.000000",
+			app.pendingChannelMark.ts)
+	}
+}
+
+// The unread dot is the "remains unread locally" half of #159: while
+// blurred, the sidebar must repaint from the has_unread the WS handler
+// just wrote. While focused it must NOT, or the dot flashes on every
+// message in the channel the user is reading.
+func TestActiveChannelArrival_NotifiesReadStateOnlyWhenBlurred(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		blur    bool
+		wantMin int
+	}{
+		{name: "focused", blur: false, wantMin: 0},
+		{name: "blurred", blur: true, wantMin: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			app, _ := markCapture(t)
+			app.activeChannelID = "C1"
+			if tc.blur {
+				_, _ = app.Update(tea.BlurMsg{})
+			}
+			// SetStatusReporter is invoked by every
+			// notifyReadStateChanged call; see app.go:3150.
+			var reports int
+			app.SetStatusReporter(func(int, int, string, string) { reports++ })
+
+			// Deliberately does NOT feed the returned cmd: this
+			// counts only the repaints the arrival itself triggers,
+			// not the one the eventual mark-read echo causes.
+			_, _ = app.Update(NewMessageMsg{
+				ChannelID: "C1",
+				Message:   messages.MessageItem{TS: "5.000000", UserID: "U2"},
+			})
+
+			if reports < tc.wantMin {
+				t.Errorf("read-state notifications = %d, want at least %d", reports, tc.wantMin)
+			}
+			if !tc.blur && reports != 0 {
+				t.Errorf("read-state notifications = %d, want 0: a focused arrival must not flash the dot", reports)
+			}
+		})
+	}
+}
+
+func TestBurstCoalescesToNewestTS(t *testing.T) {
+	app, calls := markCapture(t)
+	app.activeChannelID = "C1"
+
+	// Only the FIRST arrival arms a tick; markFlushScheduled makes the
+	// rest return nil. Collect every cmd and feed them after the whole
+	// burst has landed, so the test does not depend on which one
+	// carries the tick.
+	var cmds []tea.Cmd
+	for _, ts := range []string{"1.000000", "2.000000", "3.000000"} {
+		_, cmd := app.Update(NewMessageMsg{
+			ChannelID: "C1",
+			Message:   messages.MessageItem{TS: ts, UserID: "U2"},
+		})
+		cmds = append(cmds, cmd)
+	}
+	for _, cmd := range cmds {
+		feed(t, app, cmd, 0)
+	}
+
+	if len(*calls) != 1 || (*calls)[0] != "ch:C1/3.000000" {
+		t.Fatalf("calls = %v, want a single mark at the newest ts", *calls)
+	}
+}
+
+// Out-of-order delivery must not roll the cursor backward: the slot
+// keeps the newest ts it has seen, so the older arrival is dropped.
+func TestOutOfOrderArrivalDoesNotRollCursorBack(t *testing.T) {
+	app, calls := markCapture(t)
+	app.activeChannelID = "C1"
+
+	var cmds []tea.Cmd
+	for _, ts := range []string{"9.000000", "4.000000"} {
+		_, cmd := app.Update(NewMessageMsg{
+			ChannelID: "C1",
+			Message:   messages.MessageItem{TS: ts, UserID: "U2"},
+		})
+		cmds = append(cmds, cmd)
+	}
+	for _, cmd := range cmds {
+		feed(t, app, cmd, 0)
+	}
+
+	if len(*calls) != 1 || (*calls)[0] != "ch:C1/9.000000" {
+		t.Fatalf("calls = %v, want the newest ts to win over the late older one", *calls)
+	}
+}
+
+func TestPlainThreadReplyDoesNotMarkChannel(t *testing.T) {
+	app, calls := markCapture(t)
+	app.activeChannelID = "C1"
+
+	_, cmd := app.Update(NewMessageMsg{
+		ChannelID: "C1",
+		Message:   messages.MessageItem{TS: "5.000000", ThreadTS: "1.000000", UserID: "U2"},
+	})
+	feed(t, app, cmd, 0)
+
+	for _, c := range *calls {
+		if strings.HasPrefix(c, "ch:") {
+			t.Fatalf("a plain thread reply must not advance the channel cursor, got %v", *calls)
+		}
+	}
+}
+
+func TestBroadcastReplyMarksChannel(t *testing.T) {
+	app, calls := markCapture(t)
+	app.activeChannelID = "C1"
+
+	_, cmd := app.Update(NewMessageMsg{
+		ChannelID: "C1",
+		Message: messages.MessageItem{
+			TS: "5.000000", ThreadTS: "1.000000", Subtype: "thread_broadcast", UserID: "U2",
+		},
+	})
+	feed(t, app, cmd, 0)
+
+	var found bool
+	for _, c := range *calls {
+		if c == "ch:C1/5.000000" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("a broadcast reply must advance the channel cursor, got %v", *calls)
+	}
+}
+
+func TestFocusedReplyInOpenThreadMarksThread(t *testing.T) {
+	app, calls := markCapture(t)
+	app.activeChannelID = "C1"
+	app.threadVisible = true
+	app.threadPanel.SetThread(messages.MessageItem{TS: "1.000000"}, nil, "C1", "1.000000")
+
+	_, cmd := app.Update(NewMessageMsg{
+		ChannelID: "C1",
+		Message:   messages.MessageItem{TS: "5.000000", ThreadTS: "1.000000", UserID: "U2"},
+	})
+	feed(t, app, cmd, 0)
+
+	if len(*calls) != 1 || (*calls)[0] != "th:C1/1.000000/5.000000" {
+		t.Fatalf("calls = %v, want one thread mark", *calls)
+	}
+}
+
+// A thread reply produces TWO independent cmds -- the mark-flush tick
+// and the threads-list re-query tick. The tail must batch them; an
+// early return on either one silently drops the other.
+func TestThreadReplyArrival_ArmsFlushAndThreadsDirty(t *testing.T) {
+	app, _ := markCapture(t)
+	app.activeChannelID = "C1"
+	app.activeTeamID = "T1" // scheduleThreadsDirty returns nil without one
+	app.threadsDirtyDebounce = time.Millisecond
+	app.threadVisible = true
+	app.threadPanel.SetThread(messages.MessageItem{TS: "1.000000"}, nil, "C1", "1.000000")
+
+	_, cmd := app.Update(NewMessageMsg{
+		ChannelID: "C1",
+		Message:   messages.MessageItem{TS: "5.000000", ThreadTS: "1.000000", UserID: "U2"},
+	})
+
+	var sawFlush, sawDirty bool
+	for _, msg := range drainBatch(cmd) {
+		switch msg.(type) {
+		case markFlushMsg:
+			sawFlush = true
+		case ThreadsListDirtyMsg:
+			sawDirty = true
+		}
+	}
+	if !sawFlush {
+		t.Error("no markFlushMsg tick: the pending thread mark would never be issued")
+	}
+	if !sawDirty {
+		t.Error("no ThreadsListDirtyMsg tick: the involved-threads list would go stale")
+	}
+}
+
+func TestReplyInClosedThreadDoesNotMark(t *testing.T) {
+	app, calls := markCapture(t)
+	app.activeChannelID = "C1"
+	app.threadVisible = false
+
+	_, cmd := app.Update(NewMessageMsg{
+		ChannelID: "C1",
+		Message:   messages.MessageItem{TS: "5.000000", ThreadTS: "1.000000", UserID: "U2"},
+	})
+	feed(t, app, cmd, 0)
+
+	if len(*calls) != 0 {
+		t.Fatalf("a reply in a thread the user is not viewing must not mark, got %v", *calls)
+	}
+}
+
+func TestBlurredReplyInOpenThreadDoesNotMarkUntilFocusReturns(t *testing.T) {
+	app, calls := markCapture(t)
+	app.activeChannelID = "C1"
+	app.threadVisible = true
+	app.threadPanel.SetThread(messages.MessageItem{TS: "1.000000"}, nil, "C1", "1.000000")
+	_, _ = app.Update(tea.BlurMsg{})
+
+	_, cmd := app.Update(NewMessageMsg{
+		ChannelID: "C1",
+		Message:   messages.MessageItem{TS: "5.000000", ThreadTS: "1.000000", UserID: "U2"},
+	})
+	feed(t, app, cmd, 0)
+
+	if len(*calls) != 0 {
+		t.Fatalf("a blurred reply must not mark the thread read, got %v", *calls)
+	}
+
+	_, cmd = app.Update(tea.FocusMsg{})
+	feed(t, app, cmd, 0)
+
+	if len(*calls) != 1 || (*calls)[0] != "th:C1/1.000000/5.000000" {
+		t.Fatalf("calls after refocus = %v, want the staged thread mark to flush", *calls)
+	}
+}
+
+func TestInactiveChannelArrivalDoesNotMark(t *testing.T) {
+	app, calls := markCapture(t)
+	app.activeChannelID = "C_OTHER"
+
+	_, cmd := app.Update(NewMessageMsg{
+		ChannelID: "C1",
+		Message:   messages.MessageItem{TS: "5.000000", UserID: "U2"},
+	})
+	feed(t, app, cmd, 0)
+
+	if len(*calls) != 0 {
+		t.Fatalf("a message in a non-active channel must not mark, got %v", *calls)
+	}
+}
+
+func TestFocusedArrivalLeavesDividerInPlace(t *testing.T) {
+	app, _ := markCapture(t)
+	// modelsForChannel routes the focused window by activeChannelID
+	// (winmodels.go:60), and app.messagepane IS the focused window's
+	// model, so this alone puts the arrival into the pane.
+	app.activeChannelID = "C1"
+	app.messagepane.SetLastReadTS("1.000000")
+
+	_, cmd := app.Update(NewMessageMsg{
+		ChannelID: "C1",
+		Message:   messages.MessageItem{TS: "5.000000", UserID: "U2"},
+	})
+	feed(t, app, cmd, 0)
+
+	// Guard the guard: prove the arrival actually landed in the pane,
+	// so this test fails if the routing above ever stops working.
+	if n := len(app.messagepane.Messages()); n == 0 {
+		t.Fatal("arrival never reached the pane; the divider assertion would be vacuous")
+	}
+	if got := app.messagepane.LastReadTS(); got != "1.000000" {
+		t.Errorf("messagepane LastReadTS = %q, want the divider left at 1.000000", got)
 	}
 }

--- a/internal/ui/reducer_focus_test.go
+++ b/internal/ui/reducer_focus_test.go
@@ -1006,6 +1006,28 @@ func TestThreadsDirty_WindowReopensAfterTheFetch(t *testing.T) {
 	}
 }
 
+// A workspace switch inside an open window drops that window's fetch —
+// it was for the workspace the user just left — but must still close
+// the window. The clear has to happen before the fetch arm's team
+// check, not after it: after, this path would leave the window latched
+// open and freeze the new workspace's threads list for the session.
+func TestThreadsDirty_WorkspaceSwitchInsideTheWindowStillReopensIt(t *testing.T) {
+	app, fetches := threadsDirtyCapture(t)
+
+	_, cmd := app.Update(ThreadsListDirtyMsg{TeamID: "T1"})
+	app.activeTeamID = "T2"
+	feed(t, app, cmd, 0)
+	if *fetches != 0 {
+		t.Fatalf("ListFetch calls = %d, want 0: the window's fetch was for the team just left", *fetches)
+	}
+
+	_, cmd = app.Update(ThreadsListDirtyMsg{TeamID: "T2"})
+	feed(t, app, cmd, 0)
+	if *fetches != 1 {
+		t.Errorf("ListFetch calls = %d, want 1: the abandoned window must not stay latched open", *fetches)
+	}
+}
+
 // The team filter has to come before the window opens. Opening it for
 // another workspace's dirty message would swallow the active
 // workspace's next one for the length of the debounce.

--- a/internal/ui/reducer_focus_test.go
+++ b/internal/ui/reducer_focus_test.go
@@ -1,0 +1,41 @@
+package ui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestNewApp_StartsFocused(t *testing.T) {
+	// Terminals report focus transitions only, never current state. A
+	// terminal without focus-event support sends nothing at all, so
+	// defaulting to focused is what preserves today's behavior there.
+	if !NewApp().terminalFocused {
+		t.Error("terminalFocused must default to true")
+	}
+}
+
+func TestBlurMsg_ClearsFocus(t *testing.T) {
+	app := NewApp()
+	_, _ = app.Update(tea.BlurMsg{})
+	if app.terminalFocused {
+		t.Error("terminalFocused must be false after BlurMsg")
+	}
+}
+
+func TestFocusMsg_RestoresFocus(t *testing.T) {
+	app := NewApp()
+	_, _ = app.Update(tea.BlurMsg{})
+	_, _ = app.Update(tea.FocusMsg{})
+	if !app.terminalFocused {
+		t.Error("terminalFocused must be true after FocusMsg")
+	}
+}
+
+func TestView_EnablesFocusReporting(t *testing.T) {
+	app := NewApp()
+	app.width, app.height = 80, 24
+	if !app.View().ReportFocus {
+		t.Error("View must set ReportFocus so the terminal sends focus events")
+	}
+}

--- a/internal/ui/reducer_focus_test.go
+++ b/internal/ui/reducer_focus_test.go
@@ -256,6 +256,32 @@ func TestOutOfOrderArrivalDoesNotRollCursorBack(t *testing.T) {
 	}
 }
 
+// The thread slot is newest-wins on its own, independent of the
+// channel slot: a burst of replies coalesces to one mark, and a late
+// older reply does not roll the thread cursor backward.
+func TestThreadBurstCoalescesToNewestTS(t *testing.T) {
+	app, calls := markCapture(t)
+	app.activeChannelID = "C1"
+	app.threadVisible = true
+	app.threadPanel.SetThread(messages.MessageItem{TS: "1.000000"}, nil, "C1", "1.000000")
+
+	var cmds []tea.Cmd
+	for _, ts := range []string{"2.000000", "9.000000", "4.000000"} {
+		_, cmd := app.Update(NewMessageMsg{
+			ChannelID: "C1",
+			Message:   messages.MessageItem{TS: ts, ThreadTS: "1.000000", UserID: "U2"},
+		})
+		cmds = append(cmds, cmd)
+	}
+	for _, cmd := range cmds {
+		feed(t, app, cmd, 0)
+	}
+
+	if len(*calls) != 1 || (*calls)[0] != "th:C1/1.000000/9.000000" {
+		t.Fatalf("calls = %v, want a single thread mark at the newest ts", *calls)
+	}
+}
+
 func TestPlainThreadReplyDoesNotMarkChannel(t *testing.T) {
 	app, calls := markCapture(t)
 	app.activeChannelID = "C1"

--- a/internal/ui/reducer_send.go
+++ b/internal/ui/reducer_send.go
@@ -325,7 +325,11 @@ func reduceNewMessage(a *App, m NewMessageMsg) tea.Cmd {
 			// cursor advance. No notifyReadStateChanged, so this event
 			// triggers no sidebar repaint -- the has_unread=true the WS
 			// handler just wrote is cleared by the flush before
-			// anything normally repaints the dot.
+			// anything normally repaints the dot. Inside a tmux
+			// session that has not yet proven focus reporting no flush
+			// is armed (see autoMarkArmed), so there has_unread
+			// survives and the dot appears at the next repaint --
+			// which is what this arm did before it marked anything.
 			debuglog.Cache("NewMessageMsg: channel=%s ts=%s decision=active_focused_mark_read",
 				m.ChannelID, m.Message.TS)
 			a.recordChannelMark(m.ChannelID, m.Message.TS)

--- a/internal/ui/reducer_send.go
+++ b/internal/ui/reducer_send.go
@@ -355,8 +355,9 @@ func reduceNewMessage(a *App, m NewMessageMsg) tea.Cmd {
 		cmds = append(cmds, c)
 	}
 	// A thread reply (regardless of channel) may have changed the
-	// involved-threads list -- schedule a debounced re-query so a
-	// burst of replies coalesces into a single fetch.
+	// involved-threads list -- ask for a re-query. A burst of replies
+	// sends one dirty message each; the receiving arm in reduceThreads
+	// is what collapses them into a single fetch.
 	if m.Message.ThreadTS != "" {
 		if c := a.scheduleThreadsDirty(); c != nil {
 			cmds = append(cmds, c)

--- a/internal/ui/reducer_send.go
+++ b/internal/ui/reducer_send.go
@@ -9,9 +9,10 @@
 //	NewMessageMsg            - inbound WS event for any channel:
 //	                           edit-echo update, self-send dedup
 //	                           (recorded + early-arrival in-flight
-//	                           guards), append-to-pane or
-//	                           mark-channel-unread, and threads-list
-//	                           dirty-bump for replies.
+//	                           guards), append-to-pane, staging a
+//	                           focus-gated read-cursor advance or
+//	                           surfacing the unread dot, and
+//	                           threads-list dirty-bump for replies.
 //	SendMessageMsg           - user send: optimistic placeholder +
 //	                           chat.postMessage call.
 //	MessageSentMsg           - send landed: swap placeholder for
@@ -41,6 +42,7 @@
 // controller owns all of that cross-section.
 //
 // Helpers (applyChannelMark, applyThreadMarkUnread, scheduleThreadsDirty,
+// recordChannelMark, recordThreadMark, scheduleMarkFlush,
 // notifyReadStateChanged, userNameFor, nowFormatted, cancelEdit,
 // CloseThread) stay on App; the reducer calls them via `a`.
 package ui
@@ -206,8 +208,9 @@ var reduceSend reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
 
 // reduceNewMessage handles NewMessageMsg. Extracted because the
 // arm is ~100 lines covering five decision branches (edit echo,
-// self-send dedup, early-arrival in-flight guard, active vs
-// inactive channel, threads-list dirty bump).
+// self-send dedup, early-arrival in-flight guard, the read-state
+// decision for the channel and thread cursors, threads-list dirty
+// bump).
 func reduceNewMessage(a *App, m NewMessageMsg) tea.Cmd {
 	debuglog.Cache("NewMessageMsg: channel=%s ts=%s thread_ts=%s active=%s",
 		m.ChannelID, m.Message.TS, m.Message.ThreadTS, a.activeChannelID)
@@ -281,56 +284,82 @@ func reduceNewMessage(a *App, m NewMessageMsg) tea.Cmd {
 	// activeChannelID — and live replies must still land.
 	// (Previously this lived inside the active-channel branch below,
 	// so those panels went stale until a reopen forced a refetch.)
-	if a.threadVisible &&
+	//
+	// Shared with the thread read-cursor gate below, which must not
+	// drift from this one: the message is marked read exactly when it
+	// is rendered into the open panel.
+	inOpenThreadPanel := a.threadVisible &&
 		m.ChannelID == a.threadPanel.ChannelID() &&
-		m.Message.ThreadTS == a.threadPanel.ThreadTS() {
+		m.Message.ThreadTS == a.threadPanel.ThreadTS()
+	if inOpenThreadPanel {
 		a.threadPanel.AddReply(m.Message)
 	}
-	if m.ChannelID == a.activeChannelID {
-		// "active_channel_no_unread_bump": message arrived for the
-		// FOCUSED channel, so no unread bump is applied -- the user
-		// is actively reading (the read marker advances on focused
-		// entry via MarkChannel/MarkRead elsewhere).
-		debuglog.Cache("NewMessageMsg: channel=%s ts=%s decision=active_channel_no_unread_bump",
-			m.ChannelID, m.Message.TS)
-	} else {
-		// Message arrived for a channel that is NOT focused -- bump
-		// its unread state so the sidebar shows the dot + bold
-		// indicator. This runs regardless of whether some UNFOCUSED
-		// window views the channel: the read marker only advances on
-		// focused entry, so a visible-but-unfocused window's channel
-		// is still unread. Only the focused channel is auto-marked-
-		// read (MarkChannel on entry), so only it skips the bump.
-		//
-		// Skip plain thread replies: a reply inside a thread does
-		// not mark the parent channel as unread on Slack -- only
-		// top-level messages and thread_broadcasts do. The Threads
-		// view tracks its own unread state separately.
-		isThreadReply := m.Message.ThreadTS != "" && m.Message.ThreadTS != m.Message.TS
-		if !isThreadReply || m.Message.Subtype == "thread_broadcast" {
+	isThreadReply := m.Message.ThreadTS != "" && m.Message.ThreadTS != m.Message.TS
+	isBroadcast := m.Message.Subtype == "thread_broadcast"
+
+	// Thread-eligible: a reply the user has on screen in the open
+	// thread panel. The visibility gate mirrors the channel rule --
+	// "the panel is open on this thread", not "the thread pane holds
+	// slk-internal focus". Terminal focus is NOT checked here; it
+	// gates the flush (scheduleMarkFlush), so a blurred reply stays
+	// staged until the FocusMsg catch-up.
+	if isThreadReply && inOpenThreadPanel {
+		a.recordThreadMark(m.ChannelID, m.Message.ThreadTS, m.Message.TS)
+	}
+
+	// Channel-eligible: top-level messages and thread_broadcasts. Plain
+	// thread replies never advance the parent channel cursor on Slack.
+	if !isThreadReply || isBroadcast {
+		switch {
+		case m.ChannelID != a.activeChannelID:
+			// Not the channel on screen. The has_unread=true DB write
+			// already happened in the WS handler; force the sidebar and
+			// workspace rail to re-read it.
 			debuglog.Cache("NewMessageMsg: channel=%s ts=%s decision=mark_unread",
 				m.ChannelID, m.Message.TS)
-			// The DB write that flips has_unread=true for this
-			// channel already happened in the WS-handler path
-			// (cache.UpdateChannelReadState). Force the sidebar
-			// to re-read read state so the dot appears on the
-			// next render, and refresh the workspace rail so its
-			// HasUnread flag picks up the change too.
 			a.notifyReadStateChanged()
-		} else {
-			debuglog.Cache("NewMessageMsg: channel=%s ts=%s decision=skipped_thread_reply_inactive",
+		case a.terminalFocused:
+			// On screen AND the user can actually see it: stage a read-
+			// cursor advance. No notifyReadStateChanged, so this event
+			// triggers no sidebar repaint -- the has_unread=true the WS
+			// handler just wrote is cleared by the flush before
+			// anything normally repaints the dot.
+			debuglog.Cache("NewMessageMsg: channel=%s ts=%s decision=active_focused_mark_read",
 				m.ChannelID, m.Message.TS)
+			a.recordChannelMark(m.ChannelID, m.Message.TS)
+		default:
+			// Selected, but slk is in a background terminal / inactive
+			// tmux window or pane. The user has NOT seen this, so show
+			// the dot from the has_unread the WS handler just wrote.
+			// The advance is still staged, but scheduleMarkFlush arms
+			// no tick while blurred, so it sits until the FocusMsg
+			// catch-up in reducer_focus.go issues it.
+			debuglog.Cache("NewMessageMsg: channel=%s ts=%s decision=active_blurred_stay_unread",
+				m.ChannelID, m.Message.TS)
+			a.recordChannelMark(m.ChannelID, m.Message.TS)
+			a.notifyReadStateChanged()
 		}
+	} else {
+		debuglog.Cache("NewMessageMsg: channel=%s ts=%s decision=skipped_thread_reply",
+			m.ChannelID, m.Message.TS)
+	}
+
+	var cmds []tea.Cmd
+	if c := a.scheduleMarkFlush(); c != nil {
+		cmds = append(cmds, c)
 	}
 	// A thread reply (regardless of channel) may have changed the
 	// involved-threads list -- schedule a debounced re-query so a
 	// burst of replies coalesces into a single fetch.
 	if m.Message.ThreadTS != "" {
 		if c := a.scheduleThreadsDirty(); c != nil {
-			return c
+			cmds = append(cmds, c)
 		}
 	}
-	return nil
+	if len(cmds) == 0 {
+		return nil
+	}
+	return tea.Batch(cmds...)
 }
 
 // reduceSendMessage handles SendMessageMsg. Extracted to keep the

--- a/internal/ui/reducer_send.go
+++ b/internal/ui/reducer_send.go
@@ -286,8 +286,10 @@ func reduceNewMessage(a *App, m NewMessageMsg) tea.Cmd {
 	// so those panels went stale until a reopen forced a refetch.)
 	//
 	// Shared with the thread read-cursor gate below, which must not
-	// drift from this one: the message is marked read exactly when it
-	// is rendered into the open panel.
+	// drift from this one: the message is staged for a read-cursor
+	// advance exactly when it is rendered into the open panel. Whether
+	// that advance is actually issued is decided later, at flush time,
+	// by terminal focus.
 	inOpenThreadPanel := a.threadVisible &&
 		m.ChannelID == a.threadPanel.ChannelID() &&
 		m.Message.ThreadTS == a.threadPanel.ThreadTS()

--- a/internal/ui/reducer_send.go
+++ b/internal/ui/reducer_send.go
@@ -40,7 +40,7 @@
 // read-state, and the message service. No single existing
 // controller owns all of that cross-section.
 //
-// Helpers (applyChannelMark, applyThreadMark, scheduleThreadsDirty,
+// Helpers (applyChannelMark, applyThreadMarkUnread, scheduleThreadsDirty,
 // notifyReadStateChanged, userNameFor, nowFormatted, cancelEdit,
 // CloseThread) stay on App; the reducer calls them via `a`.
 package ui
@@ -169,7 +169,7 @@ var reduceSend reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
 		if m.ThreadTS == "" {
 			a.applyChannelMark(m.ChannelID, m.BoundaryTS, m.UnreadCount)
 		} else {
-			a.applyThreadMark(m.ChannelID, m.ThreadTS, m.BoundaryTS, false)
+			a.applyThreadMarkUnread(m.ChannelID, m.ThreadTS, m.BoundaryTS)
 		}
 		return func() tea.Msg {
 			return statusbar.MarkedUnreadMsg{}

--- a/internal/ui/reducer_threads.go
+++ b/internal/ui/reducer_threads.go
@@ -2,7 +2,7 @@
 //
 // Thread-family reducer for App.Update (Phase 4h).
 //
-// Owns the ten Update arms that drive the thread panel, the
+// Owns the eleven Update arms that drive the thread panel, the
 // threads-list view, and the thread-reply send path:
 //
 //	ThreadMarkedRemoteMsg       - apply an inbound thread_marked event
@@ -27,8 +27,12 @@
 //	ThreadsListLoadedMsg        - threads-list fetch returned: push
 //	                              summaries + refresh badge, re-open
 //	                              the highlighted thread if visible.
-//	ThreadsListDirtyMsg         - a debounced "list might be stale"
-//	                              trigger: kick a refresh fetch.
+//	ThreadsListDirtyMsg         - "the list might be stale" from any of
+//	                              its uncoordinated senders: open a
+//	                              coalescing window, or join the open
+//	                              one.
+//	threadsListFetchMsg         - that window closing: run the refresh
+//	                              fetch the window's messages asked for.
 //	SendThreadReplyMsg          - user sent a reply: optimistic
 //	                              placeholder + chat.postMessage call.
 //	ThreadReplySentMsg          - reply landed: swap placeholder for
@@ -50,6 +54,8 @@
 package ui
 
 import (
+	"time"
+
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/gammons/slk/internal/debuglog"
@@ -235,7 +241,36 @@ var reduceThreads reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
 		return nil, true
 
 	case ThreadsListDirtyMsg:
+		// Team check first: a dirty message for another workspace must
+		// not take the coalescing window from the active one.
 		if m.TeamID != a.activeTeamID {
+			return nil, true
+		}
+		// Drop it if a refresh is already waiting: that fetch has not
+		// run yet, so it will see this change too. Senders do not
+		// coalesce among themselves — a thread being read produces one
+		// from the thread_marked handler per auto-mark on top of the
+		// one scheduleThreadsDirty schedules per reply, and each
+		// uncoalesced delivery is another ListSubscribedThreads query.
+		if a.threadsListFetchScheduled {
+			return nil, true
+		}
+		a.threadsListFetchScheduled = true
+		team := a.activeTeamID
+		d := a.threadsDirtyDebounce
+		if d == 0 {
+			d = defaultThreadsDirtyDebounce
+		}
+		return tea.Tick(d, func(time.Time) tea.Msg {
+			return threadsListFetchMsg{teamID: team}
+		}), true
+
+	case threadsListFetchMsg:
+		// Cleared before either return so the window always reopens.
+		// Leaving it set when the team check below drops the fetch
+		// would freeze the threads list for the rest of the session.
+		a.threadsListFetchScheduled = false
+		if m.teamID != a.activeTeamID {
 			return nil, true
 		}
 		threads := a.threads

--- a/internal/ui/reducer_threads.go
+++ b/internal/ui/reducer_threads.go
@@ -10,11 +10,15 @@
 //	                              panel landmark when it is the echo of
 //	                              a mark slk itself issued.
 //	ThreadMarkedLocalMsg        - outcome of an slk-initiated
-//	                              subscriptions.thread.mark: record the
-//	                              mark for echo suppression and apply
-//	                              the accepted cursor to the list, or
-//	                              log and leave the read state alone
-//	                              when Slack rejected it.
+//	                              subscriptions.thread.mark: apply the
+//	                              accepted cursor to list state only,
+//	                              leaving the open panel's landmark
+//	                              where opening the thread put it, or
+//	                              log and leave read state alone when
+//	                              Slack rejected it. The
+//	                              echo-suppression record is written at
+//	                              each issue site before the mark goes
+//	                              out, never here — see selfMarkDedup.
 //	threadFetchDebounceMsg      - debounced j/k stop: fire the actual
 //	                              thread fetch (drops stale generations
 //	                              and post-navigation ticks).

--- a/internal/ui/reducer_threads.go
+++ b/internal/ui/reducer_threads.go
@@ -2,11 +2,15 @@
 //
 // Thread-family reducer for App.Update (Phase 4h).
 //
-// Owns the nine Update arms that drive the thread panel, the
+// Owns the ten Update arms that drive the thread panel, the
 // threads-list view, and the thread-reply send path:
 //
 //	ThreadMarkedRemoteMsg       - apply a remote subscriptions.thread.mark
 //	                              echo to the local read state.
+//	ThreadMarkedLocalMsg        - outcome of an slk-initiated
+//	                              subscriptions.thread.mark: apply the
+//	                              accepted cursor, or log and leave the
+//	                              read state alone when Slack rejected it.
 //	threadFetchDebounceMsg      - debounced j/k stop: fire the actual
 //	                              thread fetch (drops stale generations
 //	                              and post-navigation ticks).
@@ -44,6 +48,7 @@ package ui
 import (
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/gammons/slk/internal/debuglog"
 	"github.com/gammons/slk/internal/ids"
 	"github.com/gammons/slk/internal/slack/mrkdwn"
 	"github.com/gammons/slk/internal/ui/messages"
@@ -54,6 +59,15 @@ var reduceThreads reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
 	switch m := msg.(type) {
 	case ThreadMarkedRemoteMsg:
 		a.applyThreadMark(m.ChannelID, m.ThreadTS, m.LastRead)
+		return nil, true
+
+	case ThreadMarkedLocalMsg:
+		if m.Err != nil {
+			debuglog.Cache("ThreadMarkedLocalMsg: channel=%s thread_ts=%s failed: %v",
+				m.ChannelID, m.ThreadTS, m.Err)
+			return nil, true
+		}
+		a.applyThreadMark(m.ChannelID, m.ThreadTS, m.TS)
 		return nil, true
 
 	case threadFetchDebounceMsg:
@@ -107,9 +121,10 @@ var reduceThreads reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
 		a.threadPanel.SetThread(parentMsg, m.Replies, channelID, m.ThreadTS)
 
 		// Mark the thread as read now that the user has actually
-		// seen the replies. Server-side: fire-and-forget against
-		// Slack's subscriptions.thread.mark with the latest reply
-		// ts (or the parent ts when the thread has no replies).
+		// seen the replies. Server-side: subscriptions.thread.mark
+		// with the latest reply ts (or the parent ts when the thread
+		// has no replies); the returned cmd persists the cursor and
+		// reports back as ThreadMarkedLocalMsg.
 		// Local-side: clear the Unread flag in the threads-list
 		// view and refresh the sidebar's threads-row badge so the
 		// UI reflects the change immediately, regardless of which
@@ -122,16 +137,16 @@ var reduceThreads reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
 		}
 		var cmd tea.Cmd
 		if channelID != "" && m.ThreadTS != "" {
-			threads := a.threads
-			chID := ids.ChannelID(channelID)
-			threadTS := ids.ThreadTS(m.ThreadTS)
-			ts := ids.MessageTS(latestTS)
-			cmd = func() tea.Msg {
-				threads.Mark(chID, threadTS, ts)
-				return nil
-			}
+			cmd = a.threads.Mark(
+				ids.ChannelID(channelID),
+				ids.ThreadTS(m.ThreadTS),
+				ids.MessageTS(latestTS),
+			)
 		}
-		if a.threadsView.MarkByThreadTSRead(channelID, m.ThreadTS) {
+		// Optimistic local clear so the badge updates immediately; the
+		// ThreadMarkedLocalMsg above reconciles it against the cursor
+		// Slack actually accepted.
+		if a.threadsView.MarkByThreadTSReadAt(channelID, m.ThreadTS, latestTS) {
 			a.sidebar.SetThreadsUnreadCount(a.threadsView.UnreadCount())
 		}
 		return cmd, true

--- a/internal/ui/reducer_threads.go
+++ b/internal/ui/reducer_threads.go
@@ -144,13 +144,15 @@ var reduceThreads reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
 			)
 		}
 		// Optimistic local recompute so the badge updates immediately
-		// rather than waiting on the round-trip. Usually this clears
-		// Unread, but it re-derives the flag from latestTS, so it can
-		// also set it (a reply that landed after the summary's
-		// LastReplyTS leaves the thread legitimately unread).
-		// ThreadMarkedLocalMsg reconciles this against the cursor Slack
-		// accepted on success; a rejected mark leaves state untouched
-		// and heals on the next list refresh.
+		// rather than waiting on the round-trip. MarkByThreadTSReadAt
+		// sets Unread = summary.LastReplyTS > latestTS, so it usually
+		// clears the flag; but it re-derives rather than clears, so it
+		// can also set it. That happens when the summary knows a newer
+		// reply than this fetch returned (LastReplyTS > latestTS), in
+		// which case the thread really is still unread and stays
+		// flagged. ThreadMarkedLocalMsg reconciles this against the
+		// cursor Slack accepted on success; a rejected mark leaves
+		// state untouched and heals on the next list refresh.
 		if a.threadsView.MarkByThreadTSReadAt(channelID, m.ThreadTS, latestTS) {
 			a.sidebar.SetThreadsUnreadCount(a.threadsView.UnreadCount())
 		}

--- a/internal/ui/reducer_threads.go
+++ b/internal/ui/reducer_threads.go
@@ -5,8 +5,10 @@
 // Owns the ten Update arms that drive the thread panel, the
 // threads-list view, and the thread-reply send path:
 //
-//	ThreadMarkedRemoteMsg       - apply a remote subscriptions.thread.mark
-//	                              echo to the local read state.
+//	ThreadMarkedRemoteMsg       - apply an inbound thread_marked event
+//	                              to the local read state, skipping the
+//	                              panel landmark when it is the echo of
+//	                              a mark slk itself issued.
 //	ThreadMarkedLocalMsg        - outcome of an slk-initiated
 //	                              subscriptions.thread.mark: apply the
 //	                              accepted cursor, or log and leave the
@@ -40,9 +42,9 @@
 // of that cross-section, and creating one would be a rename rather
 // than an extraction (see Phase 3's WorkspaceService skip rationale).
 //
-// The helpers (applyThreadMark, scheduleThreadsDirty,
-// openSelectedThreadCmd) stay on App; this reducer calls them via
-// `a`.
+// The helpers (applyThreadMarkEcho, applyThreadMarkListState,
+// scheduleThreadsDirty, openSelectedThreadCmd) stay on App; this
+// reducer calls them via `a`.
 package ui
 
 import (
@@ -58,7 +60,9 @@ import (
 var reduceThreads reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
 	switch m := msg.(type) {
 	case ThreadMarkedRemoteMsg:
-		a.applyThreadMark(m.ChannelID, m.ThreadTS, m.LastRead)
+		// Via the echo helper: this event is also how slk's own thread
+		// marks come back. See applyThreadMarkEcho.
+		a.applyThreadMarkEcho(m.ChannelID, m.ThreadTS, m.LastRead)
 		return nil, true
 
 	case ThreadMarkedLocalMsg:
@@ -67,6 +71,16 @@ var reduceThreads reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
 				m.ChannelID, m.ThreadTS, m.Err)
 			return nil, true
 		}
+		// Slack broadcasts this same mark back as thread_marked, which
+		// returns as a ThreadMarkedRemoteMsg carrying m.TS. Record it
+		// here so applyThreadMarkEcho recognises that echo as slk's
+		// own. This arm is the recording site because it is the first
+		// point on the Update goroutine that knows the mark succeeded:
+		// markThreadRead issues it from a cmd goroutine, which must not
+		// touch App state. See selfMarkDedup.
+		a.selfThreadMarks.record(selfMarkKey{
+			channelID: m.ChannelID, threadTS: m.ThreadTS, ts: m.TS,
+		})
 		// List state only: this is slk's own mark completing, so the
 		// open panel's landmark stays where opening the thread put it.
 		// See applyThreadMarkListState.

--- a/internal/ui/reducer_threads.go
+++ b/internal/ui/reducer_threads.go
@@ -53,7 +53,7 @@ import (
 var reduceThreads reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
 	switch m := msg.(type) {
 	case ThreadMarkedRemoteMsg:
-		a.applyThreadMark(m.ChannelID, m.ThreadTS, m.TS, m.Read)
+		a.applyThreadMark(m.ChannelID, m.ThreadTS, m.LastRead)
 		return nil, true
 
 	case threadFetchDebounceMsg:

--- a/internal/ui/reducer_threads.go
+++ b/internal/ui/reducer_threads.go
@@ -67,7 +67,10 @@ var reduceThreads reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
 				m.ChannelID, m.ThreadTS, m.Err)
 			return nil, true
 		}
-		a.applyThreadMark(m.ChannelID, m.ThreadTS, m.TS)
+		// List state only: this is slk's own mark completing, so the
+		// open panel's landmark stays where opening the thread put it.
+		// See applyThreadMarkListState.
+		a.applyThreadMarkListState(m.ChannelID, m.ThreadTS, m.TS)
 		return nil, true
 
 	case threadFetchDebounceMsg:

--- a/internal/ui/reducer_threads.go
+++ b/internal/ui/reducer_threads.go
@@ -143,9 +143,14 @@ var reduceThreads reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
 				ids.MessageTS(latestTS),
 			)
 		}
-		// Optimistic local clear so the badge updates immediately; the
-		// ThreadMarkedLocalMsg above reconciles it against the cursor
-		// Slack actually accepted.
+		// Optimistic local recompute so the badge updates immediately
+		// rather than waiting on the round-trip. Usually this clears
+		// Unread, but it re-derives the flag from latestTS, so it can
+		// also set it (a reply that landed after the summary's
+		// LastReplyTS leaves the thread legitimately unread).
+		// ThreadMarkedLocalMsg reconciles this against the cursor Slack
+		// accepted on success; a rejected mark leaves state untouched
+		// and heals on the next list refresh.
 		if a.threadsView.MarkByThreadTSReadAt(channelID, m.ThreadTS, latestTS) {
 			a.sidebar.SetThreadsUnreadCount(a.threadsView.UnreadCount())
 		}

--- a/internal/ui/reducer_threads.go
+++ b/internal/ui/reducer_threads.go
@@ -73,16 +73,11 @@ var reduceThreads reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
 				m.ChannelID, m.ThreadTS, m.Err)
 			return nil, true
 		}
-		// Slack broadcasts this same mark back as thread_marked, which
-		// returns as a ThreadMarkedRemoteMsg carrying m.TS. Record it
-		// here so applyThreadMarkEcho recognises that echo as slk's
-		// own. This arm is the recording site because it is the first
-		// point on the Update goroutine that knows the mark succeeded:
-		// markThreadRead issues it from a cmd goroutine, which must not
-		// touch App state. See selfMarkDedup.
-		a.selfThreadMarks.record(selfMarkKey{
-			channelID: m.ChannelID, threadTS: m.ThreadTS, ts: m.TS,
-		})
+		// No self-mark recording here: both issue sites record before
+		// handing off the cmd, so by the time this arrives the record
+		// already exists and recording again would double-count and
+		// suppress a second, foreign echo. See selfMarkDedup.
+		//
 		// List state only: this is slk's own mark completing, so the
 		// open panel's landmark stays where opening the thread put it.
 		// See applyThreadMarkListState.
@@ -161,6 +156,20 @@ var reduceThreads reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
 				ids.ThreadTS(m.ThreadTS),
 				ids.MessageTS(latestTS),
 			)
+			if cmd != nil {
+				// Record BEFORE the cmd runs, i.e. before the mark is
+				// issued: Slack's thread_marked broadcast races the
+				// mark's own HTTP response, and this is the mark whose
+				// echo would otherwise wipe the landmark the user just
+				// opened the thread to read. Mark only builds the cmd,
+				// so nothing has been sent yet and this record cannot
+				// lose that race. A nil cmd means no mark will be
+				// issued (no active workspace), hence no echo to
+				// suppress. See selfMarkDedup.
+				a.selfThreadMarks.record(selfMarkKey{
+					channelID: channelID, threadTS: m.ThreadTS, ts: latestTS,
+				})
+			}
 		}
 		// Optimistic local recompute so the badge updates immediately
 		// rather than waiting on the round-trip. MarkByThreadTSReadAt

--- a/internal/ui/reducer_threads.go
+++ b/internal/ui/reducer_threads.go
@@ -10,9 +10,11 @@
 //	                              panel landmark when it is the echo of
 //	                              a mark slk itself issued.
 //	ThreadMarkedLocalMsg        - outcome of an slk-initiated
-//	                              subscriptions.thread.mark: apply the
-//	                              accepted cursor, or log and leave the
-//	                              read state alone when Slack rejected it.
+//	                              subscriptions.thread.mark: record the
+//	                              mark for echo suppression and apply
+//	                              the accepted cursor to the list, or
+//	                              log and leave the read state alone
+//	                              when Slack rejected it.
 //	threadFetchDebounceMsg      - debounced j/k stop: fire the actual
 //	                              thread fetch (drops stale generations
 //	                              and post-navigation ticks).

--- a/internal/ui/reducer_threads_test.go
+++ b/internal/ui/reducer_threads_test.go
@@ -95,24 +95,48 @@ func TestThreadMarkedLocalMsg_FailureLeavesFlagAlone(t *testing.T) {
 	}
 }
 
+// markSentinelMsg stands in for the ThreadMarkedLocalMsg the production
+// Mark cmd yields, so the test can prove the reducer actually propagated
+// the cmd rather than merely calling Mark for its side effect.
+type markSentinelMsg struct{}
+
+// The cmd returned by Mark is the entire delivery mechanism for this
+// task: it is what persists the read cursor and hands
+// ThreadMarkedLocalMsg back to the reducer. If the reducer drops it,
+// MarkThread still fires but the cursor is never written locally and
+// slk regresses to the stale-cursor bug. Asserting only that Mark was
+// called cannot see that, so this asserts the cmd reaches the caller
+// and yields the sentinel.
 func TestThreadRepliesLoaded_ReturnsMarkCmd(t *testing.T) {
 	app := NewApp()
 	var got []string
 	app.SetThreadService(NewThreadService(ThreadServiceFuncs{
 		Mark: func(channelID ids.ChannelID, threadTS ids.ThreadTS, ts ids.MessageTS) tea.Cmd {
 			got = append(got, string(channelID)+"/"+string(threadTS)+"/"+string(ts))
-			return nil
+			return func() tea.Msg { return markSentinelMsg{} }
 		},
 	}))
 	app.threadVisible = true
 	app.threadPanel.SetThread(messages.MessageItem{TS: "P1"}, nil, "C1", "P1")
 
-	_, _ = app.Update(ThreadRepliesLoadedMsg{
+	_, cmd := app.Update(ThreadRepliesLoadedMsg{
 		ThreadTS: "P1",
 		Replies:  []messages.MessageItem{{TS: "R1"}, {TS: "R5"}},
 	})
 
 	if len(got) != 1 || got[0] != "C1/P1/R5" {
 		t.Fatalf("Mark calls = %v, want one call marking up to the newest reply", got)
+	}
+	if cmd == nil {
+		t.Fatal("Update returned no cmd; the mark cmd was dropped, so the read cursor would never be persisted")
+	}
+	var found bool
+	for _, m := range drainBatch(cmd) {
+		if _, ok := m.(markSentinelMsg); ok {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("the cmd returned by Mark did not reach the caller; ThreadMarkedLocalMsg would never reach the reducer")
 	}
 }

--- a/internal/ui/reducer_threads_test.go
+++ b/internal/ui/reducer_threads_test.go
@@ -1,11 +1,14 @@
 package ui
 
 import (
+	"errors"
 	"testing"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/gammons/slk/internal/cache"
 	"github.com/gammons/slk/internal/ids"
+	"github.com/gammons/slk/internal/ui/messages"
 )
 
 // TestApp_WorkspaceReadyAndActivationBothEnsureSubscriptions pins where
@@ -56,5 +59,60 @@ func TestApp_WorkspaceReadyAndActivationBothEnsureSubscriptions(t *testing.T) {
 		}
 	case <-time.After(100 * time.Millisecond):
 		t.Fatal("opening the Threads view did not ensure subscriptions")
+	}
+}
+
+func TestThreadMarkedLocalMsg_SuccessAppliesCursor(t *testing.T) {
+	app := NewApp()
+	app.threadsView.SetSummaries([]cache.ThreadSummary{
+		{ChannelID: "C1", ThreadTS: "P1", LastReplyTS: "5.000000", Unread: true},
+	})
+
+	_, _ = app.Update(ThreadMarkedLocalMsg{ChannelID: "C1", ThreadTS: "P1", TS: "5.000000"})
+
+	for _, s := range app.threadsView.Summaries() {
+		if s.ThreadTS == "P1" && s.Unread {
+			t.Error("a successful thread mark must clear the unread flag")
+		}
+	}
+}
+
+func TestThreadMarkedLocalMsg_FailureLeavesFlagAlone(t *testing.T) {
+	app := NewApp()
+	app.threadsView.SetSummaries([]cache.ThreadSummary{
+		{ChannelID: "C1", ThreadTS: "P1", LastReplyTS: "5.000000", Unread: true},
+	})
+
+	_, _ = app.Update(ThreadMarkedLocalMsg{
+		ChannelID: "C1", ThreadTS: "P1", TS: "5.000000",
+		Err: errors.New("subscriptions.thread.mark: thread_not_found"),
+	})
+
+	for _, s := range app.threadsView.Summaries() {
+		if s.ThreadTS == "P1" && !s.Unread {
+			t.Error("a rejected thread mark must leave the thread unread")
+		}
+	}
+}
+
+func TestThreadRepliesLoaded_ReturnsMarkCmd(t *testing.T) {
+	app := NewApp()
+	var got []string
+	app.SetThreadService(NewThreadService(ThreadServiceFuncs{
+		Mark: func(channelID ids.ChannelID, threadTS ids.ThreadTS, ts ids.MessageTS) tea.Cmd {
+			got = append(got, string(channelID)+"/"+string(threadTS)+"/"+string(ts))
+			return nil
+		},
+	}))
+	app.threadVisible = true
+	app.threadPanel.SetThread(messages.MessageItem{TS: "P1"}, nil, "C1", "P1")
+
+	_, _ = app.Update(ThreadRepliesLoadedMsg{
+		ThreadTS: "P1",
+		Replies:  []messages.MessageItem{{TS: "R1"}, {TS: "R5"}},
+	})
+
+	if len(got) != 1 || got[0] != "C1/P1/R5" {
+		t.Fatalf("Mark calls = %v, want one call marking up to the newest reply", got)
 	}
 }

--- a/internal/ui/services.go
+++ b/internal/ui/services.go
@@ -125,9 +125,8 @@ func (r reactionAdapter) RecordFrecent(emoji string) {
 // ThreadService is the App's interface to Slack's thread surfaces:
 // fetching replies, marking threads read, posting replies, and loading
 // the involved-threads list for the user's threads view. Includes
-// ChannelLastRead because the thread panel needs the parent channel's
-// last_read_ts to render its unread boundary — that's a thread-display
-// concern even though the data is channel-scoped.
+// ThreadLastRead because the thread panel needs the thread's own
+// last-read cursor to render its unread boundary.
 //
 // Implementations are wired by cmd/slk/main.go. Build one via
 // NewThreadService from a ThreadServiceFuncs struct so unused
@@ -172,10 +171,12 @@ type ThreadService interface {
 	// a 1000-item hard cap — measured at ~62 requests per workspace.
 	EnsureSubscriptions(teamID ids.TeamID)
 
-	// ChannelLastRead returns the parent channel's last_read_ts so
-	// the thread panel can render a "── new ──" boundary. Optional;
-	// returning "" disables the unread boundary in the thread panel.
-	ChannelLastRead(channelID ids.ChannelID) string
+	// ThreadLastRead returns the thread's own last-read cursor from
+	// thread_subscriptions so the thread panel can render a "── new ──"
+	// boundary. The parent channel's cursor is NOT a substitute: plain
+	// thread replies never advance it, so it is systematically stale and
+	// puts the divider too early. Optional; "" disables the boundary.
+	ThreadLastRead(channelID ids.ChannelID, threadTS ids.ThreadTS) string
 }
 
 // ThreadServiceFuncs is the closure bundle accepted by
@@ -188,7 +189,7 @@ type ThreadServiceFuncs struct {
 	SendReply           ThreadReplySendFunc
 	ListFetch           ThreadsListFetchFunc
 	EnsureSubscriptions func(teamID ids.TeamID)
-	ChannelLastRead     func(channelID ids.ChannelID) string
+	ThreadLastRead      func(channelID ids.ChannelID, threadTS ids.ThreadTS) string
 }
 
 // NewThreadService builds a ThreadService from a ThreadServiceFuncs
@@ -249,11 +250,11 @@ func (t threadAdapter) EnsureSubscriptions(teamID ids.TeamID) {
 	t.fns.EnsureSubscriptions(teamID)
 }
 
-func (t threadAdapter) ChannelLastRead(channelID ids.ChannelID) string {
-	if t.fns.ChannelLastRead == nil {
+func (t threadAdapter) ThreadLastRead(channelID ids.ChannelID, threadTS ids.ThreadTS) string {
+	if t.fns.ThreadLastRead == nil {
 		return ""
 	}
-	return t.fns.ChannelLastRead(channelID)
+	return t.fns.ThreadLastRead(channelID, threadTS)
 }
 
 // MessageService is the App's interface to Slack's per-message

--- a/internal/ui/services.go
+++ b/internal/ui/services.go
@@ -144,10 +144,11 @@ type ThreadService interface {
 	CacheRead(channelID ids.ChannelID, threadTS ids.ThreadTS) []messages.MessageItem
 
 	// Mark marks the thread as read on Slack's servers
-	// (subscriptions.thread.mark). channelID is the parent channel,
-	// threadTS is the parent message ts, ts is the latest reply ts
-	// the user has now seen. Best-effort and non-blocking.
-	Mark(channelID ids.ChannelID, threadTS ids.ThreadTS, ts ids.MessageTS)
+	// (subscriptions.thread.mark) and, on success, advances the local
+	// thread_subscriptions cursor. channelID is the parent channel,
+	// threadTS is the parent message ts, ts is the latest reply ts the
+	// user has now seen. Returns a tea.Cmd yielding ThreadMarkedLocalMsg.
+	Mark(channelID ids.ChannelID, threadTS ids.ThreadTS, ts ids.MessageTS) tea.Cmd
 
 	// SendReply posts a reply to threadTS in channelID. Returns a
 	// tea.Msg (typically ThreadReplySentMsg or ThreadReplySendFailedMsg).
@@ -220,11 +221,11 @@ func (t threadAdapter) CacheRead(channelID ids.ChannelID, threadTS ids.ThreadTS)
 	return t.fns.CacheRead(channelID, threadTS)
 }
 
-func (t threadAdapter) Mark(channelID ids.ChannelID, threadTS ids.ThreadTS, ts ids.MessageTS) {
+func (t threadAdapter) Mark(channelID ids.ChannelID, threadTS ids.ThreadTS, ts ids.MessageTS) tea.Cmd {
 	if t.fns.Mark == nil {
-		return
+		return nil
 	}
-	t.fns.Mark(channelID, threadTS, ts)
+	return t.fns.Mark(channelID, threadTS, ts)
 }
 
 func (t threadAdapter) SendReply(channelID ids.ChannelID, threadTS ids.ThreadTS, text string) tea.Msg {

--- a/internal/ui/thread/model.go
+++ b/internal/ui/thread/model.go
@@ -336,7 +336,7 @@ func (m *Model) SetThread(parent messages.MessageItem, replies []messages.Messag
 // this thread. A "── new ──" landmark is rendered between the last reply
 // with TS <= boundary and the first reply with TS > boundary. Pass "" to
 // clear the boundary. Typically called by the App right after SetThread,
-// using the parent channel's last_read_ts as the boundary.
+// using the thread's own last-read cursor from thread_subscriptions.
 func (m *Model) SetUnreadBoundary(ts string) {
 	if m.unreadBoundaryTS == ts {
 		return

--- a/internal/ui/threadsview/model.go
+++ b/internal/ui/threadsview/model.go
@@ -469,6 +469,36 @@ func (m *Model) MarkByThreadTSUnread(channelID, threadTS string) bool {
 	return false
 }
 
+// MarkByThreadTSReadAt sets the Unread flag on the summary matching
+// (channelID, threadTS) by comparing the thread's read cursor against
+// its newest known reply: unread iff LastReplyTS > lastRead. Returns
+// true only when the flag actually changed, so callers can skip the
+// sidebar badge refresh.
+//
+// This is the correct handler for an inbound thread_marked echo, which
+// carries a cursor. Slack's subscription `active` flag means
+// "subscribed", not "unread", and must never be used for this decision.
+// Presentation-only: the next cache.ListSubscribedThreads refresh
+// recomputes Unread from the same rule against durable state.
+func (m *Model) MarkByThreadTSReadAt(channelID, threadTS, lastRead string) bool {
+	if channelID == "" || threadTS == "" {
+		return false
+	}
+	for i := range m.summaries {
+		if m.summaries[i].ChannelID != channelID || m.summaries[i].ThreadTS != threadTS {
+			continue
+		}
+		want := m.summaries[i].LastReplyTS > lastRead
+		if m.summaries[i].Unread == want {
+			return false
+		}
+		m.summaries[i].Unread = want
+		m.dirty()
+		return true
+	}
+	return false
+}
+
 // UnreadCount returns the number of summaries currently flagged as unread.
 func (m *Model) UnreadCount() int {
 	n := 0

--- a/internal/ui/threadsview/model.go
+++ b/internal/ui/threadsview/model.go
@@ -418,32 +418,10 @@ func (m *Model) MarkSelectedRead() bool {
 	return true
 }
 
-// MarkByThreadTSRead clears the local Unread flag on the summary matching
-// (channelID, threadTS), regardless of whether it is the currently selected
-// row. Returns true when a flag was actually flipped, so callers can refresh
-// dependent state (sidebar threads-row badge). Like MarkSelectedRead this is
-// presentation-only and does not touch Slack server state.
-func (m *Model) MarkByThreadTSRead(channelID, threadTS string) bool {
-	if channelID == "" || threadTS == "" {
-		return false
-	}
-	for i := range m.summaries {
-		if m.summaries[i].ChannelID == channelID && m.summaries[i].ThreadTS == threadTS {
-			if !m.summaries[i].Unread {
-				return false
-			}
-			m.summaries[i].Unread = false
-			m.dirty()
-			return true
-		}
-	}
-	return false
-}
-
 // MarkByThreadTSUnread sets the local Unread flag on the summary matching
 // (channelID, threadTS) to true. Returns true when a flag was actually
 // flipped (i.e., the row existed and was previously read). Like
-// MarkByThreadTSRead this is presentation-only: it does not touch Slack
+// MarkByThreadTSReadAt this is presentation-only: it does not touch Slack
 // server state. Used by the U-key mark-unread flow and by the inbound
 // thread_marked WS handler.
 //

--- a/internal/ui/threadsview/model_test.go
+++ b/internal/ui/threadsview/model_test.go
@@ -570,3 +570,79 @@ func TestClickAt_AccountsForYOffset(t *testing.T) {
 		t.Errorf("ClickAt(0) at yOffset=6 should select card 1; got %d", got)
 	}
 }
+
+func TestMarkByThreadTSReadAt_CursorBehindLatestSetsUnread(t *testing.T) {
+	m := New(map[string]string{}, "USELF")
+	m.SetSummaries([]cache.ThreadSummary{
+		{ChannelID: "C1", ThreadTS: "P1", LastReplyTS: "5.000000", Unread: false},
+	})
+
+	if !m.MarkByThreadTSReadAt("C1", "P1", "4.000000") {
+		t.Fatal("want true when the flag flips to unread")
+	}
+	if !m.Summaries()[0].Unread {
+		t.Error("cursor behind latest reply must render unread")
+	}
+}
+
+func TestMarkByThreadTSReadAt_CursorAtLatestClearsUnread(t *testing.T) {
+	m := New(map[string]string{}, "USELF")
+	m.SetSummaries([]cache.ThreadSummary{
+		{ChannelID: "C1", ThreadTS: "P1", LastReplyTS: "5.000000", Unread: true},
+	})
+
+	if !m.MarkByThreadTSReadAt("C1", "P1", "5.000000") {
+		t.Fatal("want true when the flag flips to read")
+	}
+	if m.Summaries()[0].Unread {
+		t.Error("cursor at latest reply must render read")
+	}
+}
+
+func TestMarkByThreadTSReadAt_NoChangeReturnsFalse(t *testing.T) {
+	m := New(map[string]string{}, "USELF")
+	m.SetSummaries([]cache.ThreadSummary{
+		{ChannelID: "C1", ThreadTS: "P1", LastReplyTS: "5.000000", Unread: true},
+	})
+
+	if m.MarkByThreadTSReadAt("C1", "P1", "4.000000") {
+		t.Error("want false when the flag is already correct")
+	}
+}
+
+func TestMarkByThreadTSReadAt_UnknownThreadReturnsFalse(t *testing.T) {
+	m := New(map[string]string{}, "USELF")
+	m.SetSummaries([]cache.ThreadSummary{
+		{ChannelID: "C1", ThreadTS: "P1", LastReplyTS: "5.000000", Unread: true},
+	})
+
+	if m.MarkByThreadTSReadAt("C1", "P_MISSING", "9.000000") {
+		t.Error("want false for a thread not in the list")
+	}
+	if m.MarkByThreadTSReadAt("", "P1", "9.000000") {
+		t.Error("want false for an empty channelID")
+	}
+}
+
+func TestMarkByThreadTSReadAt_BumpsVersionOnlyOnChange(t *testing.T) {
+	m := New(map[string]string{}, "USELF")
+	m.SetSummaries([]cache.ThreadSummary{
+		{ChannelID: "C1", ThreadTS: "P1", LastReplyTS: "5.000000", Unread: false},
+	})
+
+	before := m.Version()
+	if !m.MarkByThreadTSReadAt("C1", "P1", "4.000000") {
+		t.Fatal("want true when the flag flips to unread")
+	}
+	if m.Version() == before {
+		t.Error("a changed flag must bump the version so the list re-renders")
+	}
+
+	after := m.Version()
+	if m.MarkByThreadTSReadAt("C1", "P1", "4.000000") {
+		t.Fatal("want false on the repeated no-op call")
+	}
+	if m.Version() != after {
+		t.Error("a no-op must not bump the version")
+	}
+}

--- a/wiki/Terminal-Compatibility.md
+++ b/wiki/Terminal-Compatibility.md
@@ -88,6 +88,41 @@ Expected output: `on` and `#T`.
 Passing the title escape through tmux's DCS passthrough instead — which
 would work with no tmux config at all — is a possible follow-up.
 
+## Focus reporting and read state
+
+slk marks a message read on Slack's servers when it arrives in the
+channel you're viewing — or in the thread panel you have open — but only
+while the terminal running slk is focused. Having a channel selected
+doesn't mean you can see it: slk may be sitting in a background terminal,
+an inactive tmux window, or an unfocused tmux pane. Marking those
+messages read would diverge from Slack's own read state and suppress the
+mobile notification for a message you never saw. A message that arrives
+while you're away stays unread until you come back; the mark goes out on
+the next focus.
+
+Focus is detected with DECSET 1004 focus reporting, which recent versions
+of the terminals at the top of the table above implement (kitty, Ghostty,
+WezTerm, foot, iTerm2, Alacritty, gnome-terminal).
+
+Inside tmux there's an extra step. tmux swallows focus events unless you
+turn them on explicitly. Add this to `~/.tmux.conf`:
+
+```tmux
+set -g focus-events on
+```
+
+Without it, tmux never tells slk that its pane lost focus, so slk behaves
+as though the terminal is always focused and marks messages read even
+when the pane is in the background.
+
+Terminals report focus *transitions*, never their current state, so slk
+assumes it starts focused — you did just launch it. slk cannot probe for
+focus reporting either, so a terminal that never sends focus events is
+indistinguishable from one that never loses focus: the assumed-focused
+state persists for the whole session, and arriving messages in the open
+channel are marked read whether or not you were there to see them. That
+is the same position as a tmux user without `focus-events on`.
+
 ## Overriding the image protocol
 
 You can override slk's image-protocol pick via the `[appearance] image_protocol`

--- a/wiki/Terminal-Compatibility.md
+++ b/wiki/Terminal-Compatibility.md
@@ -92,7 +92,8 @@ would work with no tmux config at all — is a possible follow-up.
 
 slk marks a message read on Slack's servers when it arrives in the
 channel you're viewing — or in the thread panel you have open — but only
-while the terminal running slk is focused. Having a channel selected
+while the terminal running slk is focused, and inside tmux only once
+focus reporting has proven itself (see below). Having a channel selected
 doesn't mean you can see it: slk may be sitting in a background terminal,
 an inactive tmux window, or an unfocused tmux pane. Marking those
 messages read would diverge from Slack's own read state and suppress the
@@ -104,24 +105,36 @@ Focus is detected with DECSET 1004 focus reporting, which recent versions
 of the terminals at the top of the table above implement (kitty, Ghostty,
 WezTerm, foot, iTerm2, Alacritty, gnome-terminal).
 
-Inside tmux there's an extra step. tmux swallows focus events unless you
-turn them on explicitly. Add this to `~/.tmux.conf`:
+Inside tmux there's an extra step. tmux forwards focus events to the
+programs it runs only if you ask it to. Add this to `~/.tmux.conf`:
 
 ```tmux
 set -g focus-events on
 ```
 
-Without it, tmux never tells slk that its pane lost focus, so slk behaves
-as though the terminal is always focused and marks messages read even
-when the pane is in the background.
+Without that line tmux never tells slk that its pane lost focus, and slk
+has no way to ask. So inside tmux slk holds auto-marking back until it
+has actually seen a focus event — a gain or a loss, either one proves the
+wiring works. With `focus-events on` the first switch away from or back
+to slk's pane arms it, and from then on messages arriving in the channel
+you're viewing are marked read while the pane is focused. Without it no
+event ever arrives, auto-marking stays disarmed for the whole session,
+and slk falls back to marking a channel read when you open it — exactly
+what it did before this feature existed.
 
-Terminals report focus *transitions*, never their current state, so slk
-assumes it starts focused — you did just launch it. slk cannot probe for
-focus reporting either, so a terminal that never sends focus events is
-indistinguishable from one that never loses focus: the assumed-focused
-state persists for the whole session, and arriving messages in the open
-channel are marked read whether or not you were there to see them. That
-is the same position as a tmux user without `focus-events on`.
+slk detects tmux from the `$TMUX` environment variable, read once at
+startup. It does not inspect your tmux config, so with `focus-events`
+left off you get that fallback silently rather than a warning.
+
+Outside tmux there is no such gate. Terminals report focus *transitions*,
+never their current state, so slk assumes it starts focused — you did
+just launch it — and marks read on arrival from the very first message.
+slk cannot probe for focus-reporting support either, so a terminal that
+never sends focus events is indistinguishable from one that never loses
+focus, and there the assumed-focused state persists for the whole
+session. That risk is accepted outside tmux, where focus reporting is
+widely supported; inside tmux, where the stock config breaks it for
+everyone, it is not.
 
 ## Overriding the image protocol
 

--- a/wiki/Terminal-Compatibility.md
+++ b/wiki/Terminal-Compatibility.md
@@ -120,7 +120,7 @@ to slk's pane arms it, and from then on messages arriving in the channel
 you're viewing are marked read while the pane is focused. Without it no
 event ever arrives, auto-marking stays disarmed for the whole session,
 and slk falls back to marking a channel read when you open it — exactly
-what it did before this feature existed.
+the read-marking behavior it had before this feature existed.
 
 slk detects tmux from the `$TMUX` environment variable, read once at
 startup. It does not inspect your tmux config, so with `focus-events`


### PR DESCRIPTION
Fixes #159.

## The bug

When a message arrived in the channel slk was displaying, slk treated it as read locally but never advanced Slack's server-side read cursor — `conversations.mark` fired only on channel entry, so its timestamp covered messages that existed when the channel was opened, not ones received afterward. Slack kept considering them unread, cross-client read state diverged, and a mobile notification could fire for a message already on screen.

The subtlety the issue calls out: a channel being *selected* does not mean the user can see it. slk may sit in a background terminal, an inactive tmux window, or an unfocused tmux pane with the same channel selected.

## Approach

Arriving messages stage a pending cursor advance in single-slot, newest-wins buffers. A debounced flush issues the marks, but only while the terminal is focused. A blurred arrival stays staged and flushes on the next `FocusMsg`, which doubles as focus-regain catch-up. Focus comes from DECSET 1004 via Bubble Tea v2's `tea.View.ReportFocus` plus `tea.FocusMsg`/`tea.BlurMsg`.

`terminalFocused` starts `true`, because terminals report focus *transitions* only — there is no way to query current state, so a user who launches slk and never leaves the terminal would otherwise never arm the feature. That default is unsafe under tmux, which swallows focus events unless `set -g focus-events on` (default off), so auto-marking is additionally disarmed inside tmux until one real focus event proves reporting is wired up. Outside tmux, behavior is unchanged from the always-on design; inside tmux without the setting, slk falls back to marking on channel entry only — exactly its pre-existing read-marking behavior.

## Bugs found and fixed along the way

All in the same read-state domain, all uncovered by the work:

- **Mark endpoints reported failure as success.** `markChannel`/`markThread` never read the response body, so a `{"ok":false,"error":"invalid_auth"}` was indistinguishable from success — and `markChannelReadAsync` discarded the error and wrote local read state anyway. Both now route through `postForm` (status, 429, envelope) and local state is persisted only after Slack accepts.
- **`subscription.active` was read as "unread" when it means "subscribed".** This is the cause of the reported symptom where replying to a thread made it show unread until you switched channels and back. The same conflation wrote that bit into the `active` column, which `ListSubscribedThreads` uses as the subscribed filter — so reading a thread tombstoned its row and the thread vanished from the Threads list until the next 30-minute sweep.
- **The thread divider was drawn from the parent channel's cursor.** Plain thread replies never advance that watermark, so it was systematically older than the thread's own and the `── new ──` landmark landed too early.
- **slk's own marks wiped the divider.** A mark echoes back as `channel_marked` and reached `applyChannelMark` → `SetLastReadTS`. This predated the branch — the entry mark already did it, so the divider disappeared ~200ms after opening a channel with unreads. Suppressed now via a bounded, consume-once dedup, on both the channel and thread paths. Marks from *other* Slack clients still move the divider, which is correct and has a dedicated control test on each path.

## Testing

36 commits, each written test-first and mutation-tested. `go test ./... -race` passes with `$TMUX` both set and unset (`NewApp` reads it). `gofmt` and `go vet` clean.

## Before merging

Two things I could not do in this environment:

1. **Run `golangci-lint`** — not installed where this was developed; verification used `gofmt` + `go vet` only.
2. **One live smoke test**, covering two things in a single session:
   - Whether Slack reports `subscription.active:false` in the `thread_marked` echo for a thread the user merely *opened*. If `subscriptions.thread.mark` auto-subscribes, the phantom-row fix is inert for its motivating case.
   - Whether Slack echoes back a **byte-identical** cursor. Both dedups key on exact ts equality (`channel_marked.ts`, `thread_marked.subscription.last_read`). If Slack normalizes the value, `consume` misses, the echo is treated as foreign, and the divider is wiped exactly as before the fix — silently, with the full suite green.

   Both dispatchers already log the needed fields, so this is one session with debug logging on.

## Follow-ups worth their own issues

- Auto-mark silently defeats a just-pressed mark-unread if another message arrives in the focused channel. Predates this branch.
- Opening the Threads view or pressing `G` marks the top thread read on Slack without the user reading it; a warm cache also fires `subscriptions.thread.mark` twice per open, the first at a stale ts.
- ~121 lines of pending-mark machinery live in `internal/ui/app.go` (3200+ lines); extracting `internal/ui/marks.go` with its tests would put the machinery where a reader looks.
- Zellij and `screen` get the outside-tmux path silently — same position as before this branch.
