### PR TITLE
fix (slackdesktop): detect MSIX/Store Slack installations on Windows

### DIFF
--- a/cmd/slk/onboarding.go
+++ b/cmd/slk/onboarding.go
@@ -141,6 +141,8 @@ func desktopErrorMessage(err error) string {
 		return "Could not decrypt the Slack session cookie: " + err.Error() +
 			". If you have had more than one Slack build installed (App Store and standalone), " +
 			"sign out of the one you no longer use. Otherwise please file an issue with your OS + Slack version."
+	case errors.Is(err, slackdesktop.ErrCookieLocked):
+		return "Your Slack cookie is locked by a running process of Slack. Close Slack and try again."
 	default:
 		return "Could not read Slack desktop session: " + err.Error()
 	}

--- a/internal/slackdesktop/configdir.go
+++ b/internal/slackdesktop/configdir.go
@@ -11,12 +11,17 @@ import (
 func configDirForOS(goos string, getenv func(string) string, exists func(string) bool) string {
 	switch goos {
 	case "windows":
-		first := filepath.Join(getenv("APPDATA"), "Slack")
-		second := filepath.Join(getenv("LOCALAPPDATA"), "Packages", "com.tinyspeck.slackdesktop_8yrtsj140pw4g", "LocalCache", "Roaming", "Slack")
-		if exists(first) {
-			return first
+		var candidates = [...]string {
+			filepath.Join(getenv("APPDATA"), "Slack"),
+			filepath.Join(getenv("LOCALAPPDATA"), "Packages", "com.tinyspeck.slackdesktop_8yrtsj140pw4g", "LocalCache", "Roaming", "Slack"),
 		}
-		return second
+		for _, c := range candidates {
+			if exists(c) {
+				return c
+			}
+		}
+		// Fall back to the first candidate if none was found.
+		return candidates[0]
 	case "darwin":
 		home := getenv("HOME")
 		first := filepath.Join(home, "Library", "Application Support", "Slack")

--- a/internal/slackdesktop/configdir.go
+++ b/internal/slackdesktop/configdir.go
@@ -11,10 +11,9 @@ import (
 func configDirForOS(goos string, getenv func(string) string, exists func(string) bool) string {
 	switch goos {
 	case "windows":
-		var candidates = [...]string {
-			filepath.Join(getenv("APPDATA"), "Slack"),
-			filepath.Join(getenv("LOCALAPPDATA"), "Packages", "com.tinyspeck.slackdesktop_8yrtsj140pw4g", "LocalCache", "Roaming", "Slack"),
-		}
+		var candidates []string
+		candidates = append(candidates, filepath.Join(getenv("APPDATA"), "Slack"))
+		candidates = append(candidates, filepath.Join(getenv("LOCALAPPDATA"), "Packages", "com.tinyspeck.slackdesktop_8yrtsj140pw4g", "LocalCache", "Roaming", "Slack"))
 		for _, c := range candidates {
 			if exists(c) {
 				return c

--- a/internal/slackdesktop/configdir.go
+++ b/internal/slackdesktop/configdir.go
@@ -11,7 +11,12 @@ import (
 func configDirForOS(goos string, getenv func(string) string, exists func(string) bool) string {
 	switch goos {
 	case "windows":
-		return filepath.Join(getenv("APPDATA"), "Slack")
+		first := filepath.Join(getenv("APPDATA"), "Slack")
+		second := filepath.Join(getenv("LOCALAPPDATA"), "Packages", "com.tinyspeck.slackdesktop_8yrtsj140pw4g", "LocalCache", "Roaming", "Slack")
+		if exists(first) {
+			return first
+		}
+		return second
 	case "darwin":
 		home := getenv("HOME")
 		first := filepath.Join(home, "Library", "Application Support", "Slack")

--- a/internal/slackdesktop/configdir_test.go
+++ b/internal/slackdesktop/configdir_test.go
@@ -16,13 +16,40 @@ func TestConfigDirForOS(t *testing.T) {
 	}{
 		{"linux", map[string]string{"HOME": "/home/x"}, "/home/x/.config/Slack"},
 		{"linux", map[string]string{"HOME": "/home/x", "XDG_CONFIG_DIR": "/cfg"}, "/cfg/Slack"},
-		{"windows", map[string]string{"APPDATA": `C:\Users\x\AppData\Roaming`}, filepath.Join(`C:\Users\x\AppData\Roaming`, "Slack")},
 	}
 	for _, c := range cases {
 		got := configDirForOS(c.goos, env(c.env), func(string) bool { return false })
 		if got != c.want {
 			t.Errorf("configDirForOS(%s) = %q, want %q", c.goos, got, c.want)
 		}
+	}
+}
+
+func TestConfigDirForOSWindowsPrefersFirstExisting(t *testing.T) {
+	home := `C:\Users\x\AppData\Roaming`
+	first := filepath.Join(home, "Slack")
+	got := configDirForOS("windows", func(k string) string {
+		if k == "APPDATA" {
+			return home
+		}
+		return ""
+	}, func(p string) bool { return p == first })
+	if got != first {
+		t.Errorf("windows config dir = %q, want %q", got, first)
+	}
+}
+
+func TestConfigDirForOSWindowsReturnsSecondWhenFirstDoestNotExist(t *testing.T) {
+	localappdata := `C:\Users\x\AppData\Local`
+	second := filepath.Join(localappdata, "Packages", "com.tinyspeck.slackdesktop_8yrtsj140pw4g", "LocalCache", "Roaming", "Slack")
+	got := configDirForOS("windows", func(k string) string {
+		if k == "LOCALAPPDATA" {
+			return localappdata
+		}
+		return ""
+	}, func(p string) bool { return p == second })
+	if got != second {
+		t.Errorf("windows config dir = %q, want %q", got, second)
 	}
 }
 

--- a/internal/slackdesktop/cookiedb.go
+++ b/internal/slackdesktop/cookiedb.go
@@ -24,7 +24,7 @@ func readCookieRow(dbPath string) (string, []byte, error) {
 		return "", nil, ErrCookieDBMissing
 	}
 
-	tmp, err := copyToTemp(dbPath)
+	tmp, err := copyToTemp(dbPath, IsFileLockError)
 	if err != nil {
 		return "", nil, err
 	}
@@ -50,17 +50,16 @@ func readCookieRow(dbPath string) (string, []byte, error) {
 
 // copyToTemp copies src to a fresh temp file and returns its path. The caller
 // is responsible for removing it.
-func copyToTemp(src string) (string, error) {
+func copyToTemp(src string, isLockError func(error) bool) (string, error) {
 	in, err := os.Open(src)
 	if err != nil {
 		// In Windows, a running Slack process locks the Cookie file,
 		// preventing access to other processes. If the Cookie file is locked,
 		// inform the user to close Slack and try again.
-		if IsFileLockError(err) {
-			return "", ErrCookieDBMissing
-		} else {
-			return "", ErrCookieDBMissing
+		if isLockError(err) {
+			return "", ErrCookieLocked
 		}
+		return "", ErrCookieDBMissing
 	}
 	defer in.Close()
 

--- a/internal/slackdesktop/cookiedb.go
+++ b/internal/slackdesktop/cookiedb.go
@@ -53,7 +53,14 @@ func readCookieRow(dbPath string) (string, []byte, error) {
 func copyToTemp(src string) (string, error) {
 	in, err := os.Open(src)
 	if err != nil {
-		return "", ErrCookieDBMissing
+		// In Windows, a running Slack process locks the Cookie file,
+		// preventing access to other processes. If the Cookie file is locked,
+		// inform the user to close Slack and try again.
+		if IsFileLockError(err) {
+			return "", ErrCookieDBMissing
+		} else {
+			return "", ErrCookieDBMissing
+		}
 	}
 	defer in.Close()
 

--- a/internal/slackdesktop/cookiedb_test.go
+++ b/internal/slackdesktop/cookiedb_test.go
@@ -39,3 +39,11 @@ func TestReadCookieRow(t *testing.T) {
 		t.Errorf("enc len = %d, want 3", len(enc))
 	}
 }
+
+func TestCopyToTempWithLockedCookie(t *testing.T) {
+	_, err := copyToTemp("/Slack/Network/Cookie", func(err error) bool { return true })
+
+	if err == nil || err != ErrCookieLocked {
+		t.Errorf("error = %q, expected = %q", err, ErrCookieLocked)
+	}
+}

--- a/internal/slackdesktop/errors.go
+++ b/internal/slackdesktop/errors.go
@@ -10,4 +10,5 @@ var (
 	ErrNoSecretService = errors.New("no system secret service available")
 	ErrSecretNotFound  = errors.New("slack secret not found in system keyring")
 	ErrDecryptFailed   = errors.New("failed to decrypt slack session cookie")
+	ErrCookieLocked    = errors.New("slack cookie database is locked")
 )

--- a/internal/slackdesktop/lock.go
+++ b/internal/slackdesktop/lock.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package slackdesktop
+
+// IsFileLockError checks if the error obtained from a file operation is a lock
+// violation. Not yet implemented for non-Windows operating systems.
+func IsFileLockError(err error) bool {
+	return false
+}

--- a/internal/slackdesktop/lock_windows.go
+++ b/internal/slackdesktop/lock_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package slackdesktop
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// IsFileLockError checks if the error obtained from a file operation is a lock
+// violation.
+func IsFileLockError(err error) bool {
+	if pathError, ok := errors.AsType[*os.PathError](err); ok {
+		if errno, ok := errors.AsType[windows.Errno](pathError); ok {
+			return errno == windows.ERROR_SHARING_VIOLATION
+		}
+	}
+	return false
+}

--- a/internal/slackdesktop/lock_windows_test.go
+++ b/internal/slackdesktop/lock_windows_test.go
@@ -1,0 +1,141 @@
+//go:build windows
+
+package slackdesktop
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+const childFlag = "--run-lock-child-process"
+const filePathEnv = "FILE_PATH"
+
+func TestMain(m *testing.M) {
+	// Check if this execution is the spawned child process, and lock the file
+	// if it is.
+	for _, arg := range os.Args {
+		if arg == childFlag {
+			openFileNoSharing()
+			os.Exit(0)
+		}
+	}
+
+	// If not a child process, run the normal tests.
+	os.Exit(m.Run())
+}
+
+func openFileNoSharing() {
+	// Get file path from the environment variable.
+	filePath := os.Getenv(filePathEnv)
+	if filePath == "" {
+		fmt.Fprintln(os.Stderr, filePathEnv+" missing")
+		os.Exit(1)
+	}
+
+	path16, err := windows.UTF16PtrFromString(filePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "could not create pointer to the path string: %v\n", err)
+		os.Exit(1)
+	}
+
+	// dwShareMode = 0 prevents any other process from reading, writing, or
+	// deleting
+	handle, err := windows.CreateFile(
+		path16,
+		windows.GENERIC_READ|windows.GENERIC_WRITE, // Desired access
+		0,                             // dwShareMode: 0 = NO SHARING
+		nil,                           // Security attributes
+		windows.OPEN_ALWAYS,           // Creation disposition
+		windows.FILE_ATTRIBUTE_NORMAL, // Flags and attributes
+		0,                             // Template file
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "could not create file handle: %v\n", err)
+		os.Exit(1)
+	}
+	defer windows.CloseHandle(handle)
+
+	// Signal to the parent process via stdout that the lock is active
+	fmt.Println("LOCKED")
+
+	// Wait for parent signal on stdin to unlock and terminate
+	scanner := bufio.NewScanner(os.Stdin)
+	if scanner.Scan() {
+		_ = scanner.Text() // Parent sent signal to exit
+	}
+}
+
+func TestIsFileLockError(t *testing.T) {
+	// Create file and write to it.
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "LockFile.txt")
+	if err := os.WriteFile(filePath, []byte("test data"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	// Run child process to lock the file
+	execPath, err := os.Executable()
+	if err != nil {
+		t.Fatalf("Failed to get test executable path: %v", err)
+	}
+
+	cmd := exec.Command(execPath, "-test.run=TestMain", "--", childFlag)
+	cmd.Env = append(os.Environ(), filePathEnv+"="+filePath)
+	cmd.Stderr = os.Stderr
+
+	stdinPipe, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatalf("failed to create stdin pipe: %v", err)
+	}
+
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("failed to create stdout pipe: %v", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start child process: %v", err)
+	}
+	t.Logf("child process running: %d", cmd.Process.Pid)
+
+	// Ensure child process gets killed if test fails prematurely
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+	})
+
+	// Perform the tests after the child process returns LOCKED
+	reader := bufio.NewReader(stdoutPipe)
+	status, err := reader.ReadString('\n')
+	if err != nil || status != "LOCKED\n" {
+		t.Fatalf("child process failed to lock file: %v", status)
+	} else {
+		t.Log("child process has locked the file. Running assertions...")
+	}
+
+	_, err = os.OpenFile(filePath, os.O_RDWR, 0)
+	if err == nil {
+		t.Error("expected file lock error")
+	} else {
+		if !IsFileLockError(err) {
+			t.Error("expected file lock error")
+		} else {
+			t.Log("file lock detected")
+		}
+	}
+
+	// Signal child process to release lock and exit
+	_, _ = io.WriteString(stdinPipe, "RELEASE\n")
+	_ = stdinPipe.Close()
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("child process exited with error: %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #183.

## The Bug

Slack installed using the MSIX installer or Microsoft Store is not detected by slk. The only path checked is `%APPDATA%/Slack`, which corresponds to the Slack instance installed via the Legacy Installer (SlackSetup.exe).

## Approach

Try to detect Slack's folder, checking `%APPDATA%/Slack` first, and then `%LOCALAPPDATA%\Packages\com.tinyspeck.slackdesktop_8yrtsj140pw4g\LocalCache\Roaming\Slack` if the first doesn't exist.

## Bug Fixed Along the Way

When a Slack process is running on Windows, the Cookie database is exclusively locked. The attempt to open this file in `copyToTemp` returns the OS-level error `windows.ERROR_SHARING_VIOLATION (32)`, however, the error message returned to the user is generic: "slack cookie database not found".

In this update, the error message returned to the user is improved by first detecting this Cookie database lock by the running Slack process and informing the user to close Slack before trying again.

## Testing
- Wrote tests for detecting a lock on the Cookie database on Windows and for ensuring the MSIX/Store-installed Slack instances are detected
- `make test`, `go vet ./...`, `make build` on Windows and Linux

## Side Note
- Detection of exclusive locks on the Cookie database is detected on Windows only. Implementations for other OS' are not done.