### PR TITLE
fix(ui): ignore lock-state modifier bits in ctrl-key checks

### DIFF
--- a/internal/ui/compose/model.go
+++ b/internal/ui/compose/model.go
@@ -542,15 +542,22 @@ func (m *Model) autoGrow() {
 	}
 }
 
+// isCtrl reports whether mod represents Ctrl held, ignoring lock-state
+// bits (NumLock/CapsLock/ScrollLock) that ride along on terminals
+// implementing the Kitty Keyboard Protocol.
+func isCtrl(mod tea.KeyMod) bool {
+	return mod&^(tea.ModCapsLock|tea.ModNumLock|tea.ModScrollLock) == tea.ModCtrl
+}
+
 // handleMentionKey processes key events when the mention picker is active.
 func (m Model) handleMentionKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 	k := msg.Key()
 	switch {
-	case k.Code == tea.KeyUp || (k.Code == 'p' && k.Mod == tea.ModCtrl):
+	case k.Code == tea.KeyUp || (k.Code == 'p' && isCtrl(k.Mod)):
 		m.mentionPicker.MoveUp()
 		return m, nil
 
-	case k.Code == tea.KeyDown || (k.Code == 'n' && k.Mod == tea.ModCtrl):
+	case k.Code == tea.KeyDown || (k.Code == 'n' && isCtrl(k.Mod)):
 		m.mentionPicker.MoveDown()
 		return m, nil
 
@@ -639,11 +646,11 @@ func (m *Model) insertMention(result *mentionpicker.MentionResult) {
 func (m Model) handleChannelKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 	k := msg.Key()
 	switch {
-	case k.Code == tea.KeyUp || (k.Code == 'p' && k.Mod == tea.ModCtrl):
+	case k.Code == tea.KeyUp || (k.Code == 'p' && isCtrl(k.Mod)):
 		m.channelPicker.MoveUp()
 		return m, nil
 
-	case k.Code == tea.KeyDown || (k.Code == 'n' && k.Mod == tea.ModCtrl):
+	case k.Code == tea.KeyDown || (k.Code == 'n' && isCtrl(k.Mod)):
 		m.channelPicker.MoveDown()
 		return m, nil
 
@@ -1121,11 +1128,11 @@ func (m *Model) maybeOpenEmojiPicker() {
 func (m Model) handleEmojiKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 	k := msg.Key()
 	switch {
-	case k.Code == tea.KeyUp || (k.Code == 'p' && k.Mod == tea.ModCtrl):
+	case k.Code == tea.KeyUp || (k.Code == 'p' && isCtrl(k.Mod)):
 		m.emojiPicker.MoveUp()
 		return m, nil
 
-	case k.Code == tea.KeyDown || (k.Code == 'n' && k.Mod == tea.ModCtrl):
+	case k.Code == tea.KeyDown || (k.Code == 'n' && isCtrl(k.Mod)):
 		m.emojiPicker.MoveDown()
 		return m, nil
 

--- a/internal/ui/compose/model_test.go
+++ b/internal/ui/compose/model_test.go
@@ -294,6 +294,65 @@ func TestMentionNavigateUpDown(t *testing.T) {
 	}
 }
 
+func TestIsCtrl_IgnoresLockStateBits(t *testing.T) {
+	cases := []struct {
+		name string
+		mod  tea.KeyMod
+		want bool
+	}{
+		{"plain ctrl", tea.ModCtrl, true},
+		{"ctrl + numlock", tea.ModCtrl | tea.ModNumLock, true},
+		{"ctrl + capslock", tea.ModCtrl | tea.ModCapsLock, true},
+		{"ctrl + scrolllock", tea.ModCtrl | tea.ModScrollLock, true},
+		{"ctrl + all lock bits", tea.ModCtrl | tea.ModNumLock | tea.ModCapsLock | tea.ModScrollLock, true},
+		{"no ctrl", 0, false},
+		{"numlock alone", tea.ModNumLock, false},
+		{"ctrl + shift", tea.ModCtrl | tea.ModShift, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isCtrl(c.mod); got != c.want {
+				t.Errorf("isCtrl(%v) = %v, want %v", c.mod, got, c.want)
+			}
+		})
+	}
+}
+
+// TestMentionNavigateUpDown_WithNumLock guards the picker-closing
+// regression: Ctrl+P/Ctrl+N must still navigate the list, not fall
+// through to the picker's default case (which closes it) whenever
+// NumLock's Mod bit rides along.
+func TestMentionNavigateUpDown_WithNumLock(t *testing.T) {
+	m := New("general")
+	m.SetUsers([]mentionpicker.User{
+		{ID: "U1", DisplayName: "Alice", Username: "alice"},
+		{ID: "U2", DisplayName: "Bob", Username: "bob"},
+	})
+	m.SetWidth(80)
+	m.Focus()
+
+	m, _ = m.Update(tea.KeyPressMsg{Code: '@', Text: "@"})
+	if !m.IsMentionActive() {
+		t.Fatal("expected mention picker to be active")
+	}
+
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'n', Mod: tea.ModCtrl | tea.ModNumLock})
+	if !m.IsMentionActive() {
+		t.Fatal("ctrl+n with NumLock closed the picker instead of navigating")
+	}
+	if m.mentionPicker.Selected() != 1 {
+		t.Errorf("expected selection 1 after ctrl+n, got %d", m.mentionPicker.Selected())
+	}
+
+	m, _ = m.Update(tea.KeyPressMsg{Code: 'p', Mod: tea.ModCtrl | tea.ModNumLock})
+	if !m.IsMentionActive() {
+		t.Fatal("ctrl+p with NumLock closed the picker instead of navigating")
+	}
+	if m.mentionPicker.Selected() != 0 {
+		t.Errorf("expected selection 0 after ctrl+p, got %d", m.mentionPicker.Selected())
+	}
+}
+
 func TestMentionBackspaceCancelsMention(t *testing.T) {
 	m := New("general")
 	m.SetUsers([]mentionpicker.User{

--- a/internal/ui/mode_insert.go
+++ b/internal/ui/mode_insert.go
@@ -110,7 +110,10 @@ func handleInsertMode(a *App, msg tea.KeyMsg) tea.Cmd {
 	}
 
 	code := msg.Key().Code
-	mod := msg.Key().Mod
+	// Lock-state bits (NumLock/CapsLock) ride along in Mod on terminals
+	// implementing the Kitty Keyboard Protocol, regardless of whether
+	// they're relevant to the binding — strip them before comparing.
+	mod := msg.Key().Mod &^ (tea.ModCapsLock | tea.ModNumLock | tea.ModScrollLock)
 	isPaste := code == 'v' && mod == tea.ModCtrl
 	if isPaste {
 		return a.smartPaste()

--- a/internal/ui/mode_insert_keys_test.go
+++ b/internal/ui/mode_insert_keys_test.go
@@ -725,6 +725,26 @@ func TestInsertModeKeys(t *testing.T) {
 			},
 		},
 		{
+			// NumLock's Mod bit rides along on terminals implementing
+			// the Kitty Keyboard Protocol even for a bare Up press. Before
+			// the isCtrl-style masking on `mod` at mode_insert.go:116,
+			// `mod == 0` never matched, so this jump silently stopped
+			// working under NumLock.
+			name:     "up on the first line with NumLock still jumps to the start of the textarea",
+			opts:     insertOpts(),
+			setup:    func(t *testing.T, a *App) { typeInto(t, &a.compose, "abc") },
+			key:      keyMod(tea.KeyUp, tea.ModNumLock),
+			wantMode: ModeInsert,
+			assert: func(t *testing.T, a *App, cmd tea.Cmd) {
+				if cmd != nil {
+					t.Errorf("cmd = %T, want nil", cmd)
+				}
+				if got := afterKeyValue(&a.compose, 'X'); got != "Xabc" {
+					t.Errorf("value after a follow-up key = %q, want %q (cursor at the start)", got, "Xabc")
+				}
+			},
+		},
+		{
 			// The picker guard: with a suggestion list up, Up belongs to
 			// the picker, not to the jump shortcut. Without the guard
 			// the cursor would be dragged to column 0 and the follow-up
@@ -748,6 +768,22 @@ func TestInsertModeKeys(t *testing.T) {
 			opts:     insertOpts(),
 			setup:    func(t *testing.T, a *App) { typeInto(t, &a.compose, "abc"); a.compose.MoveCursorToStart() },
 			key:      keyCode(tea.KeyDown),
+			wantMode: ModeInsert,
+			assert: func(t *testing.T, a *App, cmd tea.Cmd) {
+				if cmd != nil {
+					t.Errorf("cmd = %T, want nil", cmd)
+				}
+				if got := afterKeyValue(&a.compose, 'X'); got != "abcX" {
+					t.Errorf("value after a follow-up key = %q, want %q (cursor at the end)", got, "abcX")
+				}
+			},
+		},
+		{
+			// CapsLock's Mod bit variant of the row above.
+			name:     "down on the last line with CapsLock still jumps to the end of the textarea",
+			opts:     insertOpts(),
+			setup:    func(t *testing.T, a *App) { typeInto(t, &a.compose, "abc"); a.compose.MoveCursorToStart() },
+			key:      keyMod(tea.KeyDown, tea.ModCapsLock),
 			wantMode: ModeInsert,
 			assert: func(t *testing.T, a *App, cmd tea.Cmd) {
 				if cmd != nil {

--- a/internal/ui/mode_insert_lockmod_test.go
+++ b/internal/ui/mode_insert_lockmod_test.go
@@ -1,0 +1,45 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// TestHandleInsertMode_CtrlUIgnoresNumLock guards the regression: with
+// NumLock's Mod bit set, Ctrl+U must still clear the whole compose box
+// rather than falling through to the textarea's own default binding
+// (delete-to-line-start).
+func TestHandleInsertMode_CtrlUIgnoresNumLock(t *testing.T) {
+	a := newTestAppWithMessages(t)
+	a.SetMode(ModeInsert)
+	a.focusedPanel = PanelMessages
+	_ = a.compose.Focus()
+	a.compose.SetValue("some draft text")
+
+	_ = a.handleKey(tea.KeyPressMsg{Code: 'u', Mod: tea.ModCtrl | tea.ModNumLock})
+
+	if a.compose.Value() != "" {
+		t.Fatalf("want compose fully cleared, got %q", a.compose.Value())
+	}
+}
+
+// TestHandleInsertMode_PasteIgnoresCapsLock mirrors the above for
+// Ctrl+V: with CapsLock set, it must still dispatch to smartPaste
+// (inserting the clipboard's text) rather than falling through to the
+// textarea's own default paste binding.
+func TestHandleInsertMode_PasteIgnoresCapsLock(t *testing.T) {
+	a := newTestAppWithMessages(t)
+	a.SetMode(ModeInsert)
+	a.focusedPanel = PanelMessages
+	a.SetClipboardAvailable(true)
+	a.SetClipboardReader(fakeClipboard(nil, []byte("pasted via ctrl+v")))
+	_ = a.compose.Focus()
+
+	_ = a.handleKey(tea.KeyPressMsg{Code: 'v', Mod: tea.ModCtrl | tea.ModCapsLock})
+
+	if !strings.Contains(a.compose.Value(), "pasted via ctrl+v") {
+		t.Fatalf("want clipboard text pasted, got compose value %q", a.compose.Value())
+	}
+}


### PR DESCRIPTION
On terminals implementing the [Kitty Keyboard Protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/), `NumLock`/`CapsLock`/`ScrollLock` state is reported as extra bits riding along in the key event's `Mod` field — even for bindings that have nothing to do with those locks. Every ctrl-key check in this codebase used exact equality (`k.Mod == tea.ModCtrl`), so on those terminals, having NumLock or CapsLock **on** silently broke every affected Ctrl-binding below.

Terminals that don't implement the protocol never set those bits, so they were unaffected, this bug is Kitty-protocol-specific.

## Fix

Added `isCtrl(mod)` in `internal/ui/compose/model.go`, which masks out `ModCapsLock | ModNumLock | ModScrollLock` before comparing to `ModCtrl`, and applied the same masking inline in `internal/ui/mode_insert.go` by stripping those bits from `mod` once, up front, before any comparison uses it. Because every check in `mode_insert.go` (Ctrl+U, Ctrl+V, Ctrl+J-as-newline, and the plain Up/Down jump-to-edge check) reads that same masked `mod`, the one change fixes all of them — the Up/Down fix isn't a separate code change, just a side effect of masking at the source. Both are no-ops on terminals that never set those bits, so behavior on non-Kitty terminals is unchanged.

## Behavior matrix

| Keybind | Terminal | Lock keys (NumLock/CapsLock) | Expected | Before fix | After fix |
|---|---|:-:|---|---|---|
| Ctrl+N/P — mention picker (`@`) | Non-Kitty | off / on | move selection | ✅ correct | ✅ correct |
| Ctrl+N/P — mention picker (`@`) | Kitty-protocol | off | move selection | ✅ correct | ✅ correct |
| Ctrl+N/P — mention picker (`@`) | Kitty-protocol | **on** | move selection | ❌ falls through to `default:`, **closes the picker** | ✅ correct |
| Ctrl+N/P — channel picker (`#`) | Non-Kitty | off / on | move selection | ✅ correct | ✅ correct |
| Ctrl+N/P — channel picker (`#`) | Kitty-protocol | off | move selection | ✅ correct | ✅ correct |
| Ctrl+N/P — channel picker (`#`) | Kitty-protocol | **on** | move selection | ❌ falls through to `default:`, **closes the picker** | ✅ correct |
| Ctrl+N/P — emoji picker (`:`) | Non-Kitty | off / on | move selection | ✅ correct | ✅ correct |
| Ctrl+N/P — emoji picker (`:`) | Kitty-protocol | off | move selection | ✅ correct | ✅ correct |
| Ctrl+N/P — emoji picker (`:`) | Kitty-protocol | **on** | move selection | ❌ falls through to `default:`, **closes the picker** | ✅ correct |
| Ctrl+U — clear compose | Non-Kitty | off / on | clear text + attachments + uploading flag | ✅ correct | ✅ correct |
| Ctrl+U — clear compose | Kitty-protocol | off | clear text + attachments + uploading flag | ✅ correct | ✅ correct |
| Ctrl+U — clear compose | Kitty-protocol | **on** | clear text + attachments + uploading flag | ❌ falls through to textarea's default binding (**delete to line start only**) | ✅ correct |
| Ctrl+V — paste | Non-Kitty | off / on | `smartPaste` (clipboard, attachment-aware) | ✅ correct | ✅ correct |
| Ctrl+V — paste | Kitty-protocol | off | `smartPaste` | ✅ correct | ✅ correct |
| Ctrl+V — paste | Kitty-protocol | **on** | `smartPaste` | ❌ falls through to textarea's default paste binding | ✅ correct |
| Up/Down at first/last line — jump to start/end | Non-Kitty | off / on | jump to start/end of textarea | ✅ correct | ✅ correct |
| Up/Down at first/last line — jump to start/end | Kitty-protocol | off | jump to start/end of textarea | ✅ correct | ✅ correct |
| Up/Down at first/last line — jump to start/end | Kitty-protocol | **on** | jump to start/end of textarea | ❌ falls through to the textarea's own cursor movement (line-relative only, never reaches column 0 / the true end) | ✅ correct |

The bug only ever manifests in the bolded **on** rows — a Kitty-protocol terminal with a lock key active. Everything else was already correct and stays correct.

## Is my terminal affected?

Only terminals implementing the Kitty Keyboard Protocol are affected, and only while NumLock/CapsLock is on. Quick check from a real TTY:

```bash
old_stty=$(stty -g)
stty raw -echo min 0 time 3        # raw mode, 0.3s read timeout
printf '\e[?u' > /dev/tty          # ask the terminal to report its flags
reply=$(dd bs=1 count=32 2>/dev/null < /dev/tty)
stty "$old_stty"

if [[ "$reply" == *'?'*u* ]]; then
  echo "Kitty keyboard protocol: SUPPORTED"
else
  echo "Kitty keyboard protocol: not supported (no reply)"
fi
```

A supporting terminal replies `ESC [ ? <flags> u`; a non-supporting one stays silent and the read times out.

Note: **Konsole does not implement this protocol**, so it is unaffected regardless of NumLock/CapsLock state.


## Reproduction (for review)

1. Open a Kitty-protocol terminal (e.g. kitty, WezTerm, foot, Ghostty).
2. Turn NumLock **on**.
3. Type `@` to open the mention picker, then press `Ctrl+N` — on `main` this closes the picker instead of moving the selection; on this branch it navigates correctly. Same for `Ctrl+P`, and for `#`/`:` pickers.
4. With some draft text in the compose box, press `Ctrl+U` — on `main` this only deletes to the start of the line; on this branch it fully clears the compose box (text + attachments).
5. Copy some text externally, then press `Ctrl+V` in the compose box, on `main` this falls through to the textarea's default paste; on this branch it goes through `smartPaste`.
6. Type a multi-line draft, put the cursor on the first line, and press `Up` — on `main` this just moves within the line instead of jumping to column 0 of the draft; on this branch it jumps to the true start. Same for `Down` on the last line jumping to the true end.

## Test plan

- [x] `TestIsCtrl_IgnoresLockStateBits` — unit coverage of the new helper across all three lock bits, alone and combined, plus a Ctrl+Shift negative case.
- [x] `TestMentionNavigateUpDown_WithNumLock` — regression test for the picker-closing bug.
- [x] `TestHandleInsertMode_CtrlUIgnoresNumLock` — regression test for Ctrl+U.
- [x] `TestHandleInsertMode_PasteIgnoresCapsLock` — regression test for Ctrl+V.
- [x] `TestInsertModeKeys/up_on_the_first_line_with_NumLock_still_jumps_to_the_start_of_the_textarea` and its CapsLock/Down counterpart — regression tests for the jump-to-edge bug.
