### PR TITLE
fix(messages): keep fenced code blocks intact through the message body wrap

### DIFF
--- a/internal/ui/messages/codeblock_wrap_test.go
+++ b/internal/ui/messages/codeblock_wrap_test.go
@@ -1,0 +1,95 @@
+// Fenced code blocks must retain their whitespace and full-width surface
+// background when the message body is wrapped.
+package messages
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// renderBody runs the same two steps the message panes run: render the
+// markdown, then wrap the result to the content width.
+func renderBody(t *testing.T, src string, width int) []string {
+	t.Helper()
+	out := RenderSlackMarkdownWith(src, RenderSlackMarkdownOpts{Width: width})
+	return strings.Split(WordWrap(out, width), "\n")
+}
+
+func TestCodeBlock_EveryLineFillsTheFullWidth(t *testing.T) {
+	const width = 40
+	lines := renderBody(t, "```\nshort\nalso short\n```", width)
+
+	var body []string
+	for _, l := range lines {
+		if ansi.Strip(l) != "" {
+			body = append(body, l)
+		}
+	}
+	if len(body) != 2 {
+		t.Fatalf("got %d content lines, want 2:\n%q", len(body), lines)
+	}
+	for i, l := range body {
+		if w := ansi.StringWidth(l); w != width {
+			t.Errorf("line %d width = %d, want %d (background must reach the right edge): %q",
+				i, w, width, ansi.Strip(l))
+		}
+	}
+}
+
+func TestCodeBlock_PreservesIndentation(t *testing.T) {
+	lines := renderBody(t, "```\n    four spaces\nno indent\n```", 40)
+
+	var found bool
+	for _, l := range lines {
+		if strings.Contains(ansi.Strip(l), "four spaces") {
+			found = true
+			// One column of style padding, then the source's own four.
+			if !strings.HasPrefix(ansi.Strip(l), "     four spaces") {
+				t.Errorf("indentation collapsed: %q", ansi.Strip(l))
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("indented line missing entirely:\n%q", lines)
+	}
+}
+
+// A long line inside a block is hard-wrapped at the column, not
+// re-flowed at word boundaries, and never exceeds the width.
+func TestCodeBlock_LongLineHardWrapsWithinWidth(t *testing.T) {
+	const width = 24
+	lines := renderBody(t, "```\n"+strings.Repeat("x", 60)+"\n```", width)
+	for i, l := range lines {
+		if w := ansi.StringWidth(l); w > width {
+			t.Errorf("line %d width = %d, exceeds %d: %q", i, w, width, ansi.Strip(l))
+		}
+	}
+}
+
+// Guard the prose side of the wrapLine change: a line that already fits
+// is now emitted verbatim, so its internal spacing survives too.
+func TestWordWrap_FittingLineIsUntouched(t *testing.T) {
+	const in = "  leading and   internal   spaces"
+	if got := WordWrap(in, 80); got != in {
+		t.Errorf("WordWrap(%q) = %q, want it returned verbatim", in, got)
+	}
+}
+
+// Lines that exceed the limit still reflow at word boundaries.
+func TestWordWrap_OverlongLineStillReflows(t *testing.T) {
+	const want = "aaa bbb\nccc ddd"
+	if got := WordWrap("aaa bbb ccc ddd", 7); got != want {
+		t.Errorf("WordWrap = %q, want %q", got, want)
+	}
+}
+
+// Width: 0 keeps the pre-existing behaviour for callers that don't know
+// their width (previews, tests), rather than failing.
+func TestCodeBlock_ZeroWidthFallsBackToOldBehaviour(t *testing.T) {
+	out := RenderSlackMarkdownWith("```\nhello\n```", RenderSlackMarkdownOpts{})
+	if !strings.Contains(ansi.Strip(out), "hello") {
+		t.Errorf("zero-width render lost the content: %q", ansi.Strip(out))
+	}
+}

--- a/internal/ui/messages/model.go
+++ b/internal/ui/messages/model.go
@@ -1963,6 +1963,7 @@ func (m *Model) renderMessagePlain(msg MessageItem, width int, avatarStr string,
 		EmojiCells:   m.emojiCtx.Cells,
 		Customs:      m.emojiCtx.Customs,
 		EmojiFlushes: &flushes,
+		Width:        contentWidth,
 	}
 	rendered := RenderSlackMarkdownWith(MessageTextSource(msg), bodyOpts)
 	if len(m.searchTerms) > 0 {

--- a/internal/ui/messages/render.go
+++ b/internal/ui/messages/render.go
@@ -209,6 +209,14 @@ func WordWrap(s string, limit int) string {
 // can't see and which would push downstream layout (e.g. the thread
 // compose box) over content above it.
 func wrapLine(buf *strings.Builder, line string, limit int) {
+	// Keep fitting lines byte-for-byte. The reflow below intentionally
+	// normalizes overlong prose with strings.Fields; applying it here
+	// would destroy code indentation and fragment ANSI-styled runs.
+	if lipgloss.Width(line) <= limit {
+		buf.WriteString(line)
+		return
+	}
+
 	words := strings.Fields(line)
 	if len(words) == 0 {
 		return
@@ -627,6 +635,14 @@ type RenderSlackMarkdownOpts struct {
 	EmojiCells   int                      // 0 falls back to 2
 	Customs      map[string]string        // workspace custom emoji map; may be nil
 	EmojiFlushes *[]func(io.Writer) error // append-only; may be nil
+
+	// Width is the content width the result will be wrapped to, and is
+	// used only by the code-block path: a fenced block is hard-wrapped
+	// and padded to exactly this width so every one of its lines
+	// carries the surface background edge to edge, the way Slack draws
+	// one. 0 leaves the old behaviour (block as wide as its longest
+	// line, ragged right edge).
+	Width int
 }
 
 // RenderSlackMarkdown converts Slack-flavored markdown and emoji shortcodes
@@ -654,7 +670,27 @@ func RenderSlackMarkdownWith(text string, opts RenderSlackMarkdownOpts) string {
 	// Handle code blocks first (before other formatting to avoid conflicts)
 	text = codeBlockRe.ReplaceAllStringFunc(text, func(match string) string {
 		inner := codeBlockRe.FindStringSubmatch(match)[1]
-		inner = strings.TrimSpace(inner)
+		// Remove the line break that separates a fenced block from its
+		// content, not the content's whitespace. strings.TrimSpace would
+		// erase indentation from the first and last code lines.
+		if trimmed, ok := strings.CutPrefix(inner, "\r\n"); ok {
+			inner = trimmed
+		} else {
+			inner = strings.TrimPrefix(inner, "\n")
+		}
+		if trimmed, ok := strings.CutSuffix(inner, "\r\n"); ok {
+			inner = trimmed
+		} else {
+			inner = strings.TrimSuffix(inner, "\n")
+		}
+		// Hard-wrap before styling so WordWrap never reflows code as
+		// prose. Width includes one padding column on each side; setting
+		// it on the style extends the surface background across the line.
+		// Breaking at word boundaries would move code tokens.
+		if w := opts.Width; w > 2 {
+			inner = ansi.Hardwrap(inner, w-2, false)
+			return "\n" + codeBlockStyle().Width(w).Render(inner) + "\n"
+		}
 		return "\n" + codeBlockStyle().Render(inner) + "\n"
 	})
 

--- a/internal/ui/thread/model.go
+++ b/internal/ui/thread/model.go
@@ -1849,6 +1849,7 @@ func (m *Model) renderThreadMessage(msg messages.MessageItem, width int, userNam
 		EmojiCells:   m.emojiCtx.Cells,
 		Customs:      m.emojiCtx.Customs,
 		EmojiFlushes: &flushes,
+		Width:        contentWidth,
 	}
 	text := styles.MessageText.Render(messages.WordWrap(messages.RenderSlackMarkdownWith(messages.MessageTextSource(msg), bodyOpts), contentWidth))
 


### PR DESCRIPTION
## Problem

Fenced code blocks rendered as ragged fragments instead of a solid surface. Leading indentation disappeared, internal spacing could collapse, and each line's background stopped at its last character.

Two independent behaviors caused it:

1. `codeBlockStyle` had no width, so short lines were not padded to the message width.
2. `WordWrap` passed every line through `strings.Fields`, even when the line already fitted. That reflow removes indentation and collapses whitespace.

The second change affects every message line, not only code blocks. The new behavior is deliberately narrow: fitting lines are preserved byte-for-byte, while overlong prose still reflows at word boundaries.

## Fix

The message and thread panes now pass their content width through `RenderSlackMarkdownOpts`.

For fenced code blocks, the renderer:

- removes only the line break next to each fence, preserving indentation and trailing whitespace in the code itself;
- hard-wraps code to `Width-2`, leaving one padding column on each side;
- renders the block at the full content width so its surface background reaches the right edge.

Code is hard-wrapped rather than word-wrapped because moving a token to the next line changes the pasted content.

`WordWrap` now returns any fitting line unchanged. Its existing `strings.Fields` path remains in place for lines that actually exceed the limit.

`Width: 0` preserves the previous rendering path for callers such as compact previews that do not provide a content width.

## Tests

`internal/ui/messages/codeblock_wrap_test.go` covers the observable contracts:

- every code-block line fills the available width;
- indentation on the first code line survives;
- an unbroken long line stays within the width;
- fitting prose retains its exact whitespace;
- overlong prose still wraps at word boundaries;
- a zero-width options value still renders the code block.

The regression checks were run against each production change separately:

- removing the fitting-line guard fails the full-width, indentation, and fitting-line tests;
- removing the code-block width branch fails the full-width test;
- restoring the old `strings.TrimSpace` call fails the first-line indentation test.

Golden snapshots are unchanged.

## Test plan

- `gofmt -l .`
- `go build -ldflags="-s -w" -trimpath ./...`
- `go vet ./...`
- `go test -count=1 ./...`
- `go test -race ./...`
- `golangci-lint run ./...` with v2.13.1
- `git diff --check`
- Rebased onto current `main`.
