### PR TITLE
feat(compose): support external editors using ctrl + e

### DIFF
--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -1174,6 +1174,9 @@ func run() error {
 	app.SetSidebarStaleThreshold(time.Duration(cfg.Sidebar.HideInactiveAfterDays) * 24 * time.Hour)
 	app.SetMouseWheelLines(cfg.Appearance.MouseWheelLines)
 	app.SetColoredUsernames(cfg.Appearance.ColoredUsernames)
+	if editor, ok := ui.ResolveEditor(cfg.Compose.Editor); ok {
+		app.SetComposeEditor(editor)
+	}
 
 	// Wire theme switcher
 	app.SetThemeItems(styles.ThemeNames())

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,9 +19,15 @@ type Config struct {
 	Notifications Notifications         `toml:"notifications"`
 	Cache         CacheConfig           `toml:"cache"`
 	Sidebar       Sidebar               `toml:"sidebar"`
+	Compose       Compose               `toml:"compose"`
 	Sections      map[string]SectionDef `toml:"sections"`
 	Theme         Theme                 `toml:"theme"`
 	Workspaces    map[string]Workspace  `toml:"workspaces"`
+}
+
+type Compose struct {
+	// Editor is the Ctrl+E fallback when $VISUAL/$EDITOR are unset.
+	Editor string `toml:"editor"`
 }
 
 // SectionDef defines a sidebar section with channel name patterns.

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -212,6 +212,10 @@ type App struct {
 	// native clipboard initialization.
 	clipboardAvailable bool
 
+	// composeEditor is Ctrl+E's editor argv, resolved once at startup
+	// by ui.ResolveEditor (editor.go). Nil means unconfigured.
+	composeEditor []string
+
 	// clipboardRead is the function used by smartPaste to read OS clipboard
 	// contents. Tests inject fakes via SetClipboardReader.
 	clipboardRead clipboardReader
@@ -2438,6 +2442,11 @@ func (a *App) SetUploader(fn UploadFunc) {
 // available in headless and CGO-free environments.
 func (a *App) SetClipboardAvailable(ok bool) {
 	a.clipboardAvailable = ok
+}
+
+// SetComposeEditor sets Ctrl+E's resolved editor argv (see editor.go).
+func (a *App) SetComposeEditor(editor []string) {
+	a.composeEditor = editor
 }
 
 // SetClipboardReader replaces the clipboard read function. Used by

--- a/internal/ui/compose/model.go
+++ b/internal/ui/compose/model.go
@@ -99,6 +99,10 @@ type Model struct {
 	// opens, so a high-visibility broadcast never silently repeats.
 	broadcast bool
 
+	// editingExternally is true while Ctrl+E's editor is open. Update()
+	// refuses all key input while set.
+	editingExternally bool
+
 	// version increments on every Update / state mutation. Used by App's
 	// panel-cache layer so the wrapped compose panel only re-renders when
 	// the compose has actually changed.
@@ -284,6 +288,19 @@ func (m *Model) SetUploading(on bool) {
 	m.dirty()
 }
 
+// SetEditingExternally sets whether Ctrl+E's editor is open, which
+// causes Update() to refuse key input.
+func (m *Model) SetEditingExternally(on bool) {
+	if m.editingExternally == on {
+		return
+	}
+	m.editingExternally = on
+	m.dirty()
+}
+
+// EditingExternally reports whether Ctrl+E's editor is open.
+func (m *Model) EditingExternally() bool { return m.editingExternally }
+
 // Uploading reports whether an upload is currently in flight.
 func (m *Model) Uploading() bool { return m.uploading }
 
@@ -429,6 +446,10 @@ func (m *Model) SetWidth(width int) {
 
 func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	keyMsg, isKey := msg.(tea.KeyMsg)
+
+	if isKey && m.editingExternally {
+		return m, nil
+	}
 
 	// Backspace at column 0 of an empty textarea removes the last
 	// pending attachment instead of forwarding to the textarea.

--- a/internal/ui/editor.go
+++ b/internal/ui/editor.go
@@ -1,0 +1,130 @@
+// internal/ui/editor.go
+//
+// Ctrl+E edits the compose box in an external editor ($VISUAL /
+// $EDITOR / compose.editor), resolved once at startup by
+// ResolveEditor (see cmd/slk/main.go) and stored on App — never
+// re-read per keypress.
+package ui
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/gammons/slk/internal/debuglog"
+)
+
+// getenv returns os.Getenv(key), or def if unset/empty.
+func getenv(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+// ResolveEditor picks $VISUAL, then $EDITOR, then configEditor. No
+// fallback beyond that (e.g. "vi") — it isn't installed by default on
+// Windows.
+func ResolveEditor(configEditor string) (parts []string, ok bool) {
+	parts = strings.Fields(getenv("VISUAL", getenv("EDITOR", configEditor)))
+	return parts, len(parts) > 0
+}
+
+func editorCommand(parts []string, path string) *exec.Cmd {
+	args := append(append([]string{}, parts[1:]...), path)
+	cmd := exec.Command(parts[0], args...)
+	// tea.ExecProcess only fills in Stdin/Stdout/Stderr when unset, and
+	// otherwise falls back to the Program's own output (a non-*os.File
+	// io.Writer wrapping sixel frame correlation) — which forces Go's
+	// exec package to pipe the child through a copy goroutine instead
+	// of a real fd. The editor's own terminal-capability negotiation
+	// (and mouse parsing) breaks without a genuine tty here, same as it
+	// would for any program handed a pipe instead of its real stdout.
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd
+}
+
+// EditorFinishedMsg reports an external-editor session ending. Path is
+// read back and removed regardless of Err — the file's contents are
+// trusted over the editor's exit code.
+type EditorFinishedMsg struct {
+	Panel Panel
+	Path  string
+	Err   error
+}
+
+func (a *App) openComposeInEditor() tea.Cmd {
+	if len(a.composeEditor) == 0 {
+		return toastWithClear(a,
+			"No editor configured — set $VISUAL, $EDITOR, or compose.editor in config.toml",
+			4*time.Second)
+	}
+
+	panel := PanelMessages
+	target := &a.compose
+	if a.focusedPanel == PanelThread && a.threadVisible {
+		panel = PanelThread
+		target = &a.threadCompose
+	}
+
+	f, err := os.CreateTemp("", "slk-compose-*.md")
+	if err != nil {
+		return toastWithClear(a, "Could not open editor: "+err.Error(), 3*time.Second)
+	}
+	path := f.Name()
+	if _, err := f.WriteString(target.Value()); err != nil {
+		f.Close()
+		os.Remove(path)
+		return toastWithClear(a, "Could not open editor: "+err.Error(), 3*time.Second)
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(path)
+		return toastWithClear(a, "Could not open editor: "+err.Error(), 3*time.Second)
+	}
+
+	target.SetEditingExternally(true)
+	target.SetPlaceholderOverride("Editing in $EDITOR — waiting for it to exit...")
+	debuglog.General("editor: opening %v for %s", a.composeEditor, path)
+
+	cmd := editorCommand(a.composeEditor, path)
+	return tea.ExecProcess(cmd, func(err error) tea.Msg {
+		return EditorFinishedMsg{Panel: panel, Path: path, Err: err}
+	})
+}
+
+func reduceEditorFinished(a *App, m EditorFinishedMsg) tea.Cmd {
+	defer os.Remove(m.Path)
+
+	target := &a.compose
+	if m.Panel == PanelThread {
+		target = &a.threadCompose
+	}
+	target.SetEditingExternally(false)
+	target.SetPlaceholderOverride("")
+
+	// A non-nil *exec.ExitError means the editor ran and exited
+	// non-zero — trust the file over that (some editors exit non-zero
+	// on things that still leave a saved draft). Any other error means
+	// it never ran at all (e.g. not found), which the user should hear
+	// about.
+	var exitErr *exec.ExitError
+	launchFailed := m.Err != nil && !errors.As(m.Err, &exitErr)
+	debuglog.General("editor: finished path=%s err=%v launchFailed=%v", m.Path, m.Err, launchFailed)
+
+	content, readErr := os.ReadFile(m.Path)
+	if readErr != nil {
+		return toastWithClear(a, "Editor: could not read draft back: "+readErr.Error(), 3*time.Second)
+	}
+	target.SetValue(strings.TrimRight(string(content), "\n"))
+
+	if launchFailed {
+		return toastWithClear(a, "Could not open editor: "+m.Err.Error(), 4*time.Second)
+	}
+	return nil
+}

--- a/internal/ui/editor_test.go
+++ b/internal/ui/editor_test.go
@@ -1,0 +1,282 @@
+package ui
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestResolveEditor_PrefersVisualOverEditorOverConfig(t *testing.T) {
+	t.Setenv("VISUAL", "myvisual --flag")
+	t.Setenv("EDITOR", "myeditor")
+
+	parts, ok := ResolveEditor("configeditor")
+	if !ok {
+		t.Fatal("want ok=true")
+	}
+	want := []string{"myvisual", "--flag"}
+	if len(parts) != len(want) || parts[0] != want[0] || parts[1] != want[1] {
+		t.Fatalf("want VISUAL to win with %v, got %v", want, parts)
+	}
+
+	cmd := editorCommand(parts, "/tmp/draft.md")
+	wantArgs := []string{"myvisual", "--flag", "/tmp/draft.md"}
+	for i, w := range wantArgs {
+		if cmd.Args[i] != w {
+			t.Fatalf("want args %v, got %v", wantArgs, cmd.Args)
+		}
+	}
+}
+
+func TestResolveEditor_EditorBeatsConfigWhenVisualUnset(t *testing.T) {
+	t.Setenv("VISUAL", "")
+	os.Unsetenv("VISUAL")
+	t.Setenv("EDITOR", "nano")
+
+	parts, ok := ResolveEditor("configeditor")
+	if !ok || len(parts) != 1 || parts[0] != "nano" {
+		t.Fatalf("want [nano] beating config, got %v ok=%v", parts, ok)
+	}
+}
+
+func TestResolveEditor_FallsBackToConfigWhenNeitherEnvVarSet(t *testing.T) {
+	os.Unsetenv("VISUAL")
+	os.Unsetenv("EDITOR")
+
+	parts, ok := ResolveEditor("myconfigeditor --wait")
+	if !ok {
+		t.Fatal("want ok=true from the config value")
+	}
+	want := []string{"myconfigeditor", "--wait"}
+	if len(parts) != len(want) || parts[0] != want[0] || parts[1] != want[1] {
+		t.Fatalf("want %v, got %v", want, parts)
+	}
+}
+
+func TestResolveEditor_NoneConfiguredReturnsNotOk(t *testing.T) {
+	os.Unsetenv("VISUAL")
+	os.Unsetenv("EDITOR")
+
+	if parts, ok := ResolveEditor(""); ok {
+		t.Fatalf("want ok=false when nothing is configured, got %v", parts)
+	}
+}
+
+func TestReduceEditorFinished_LoadsContentIntoChannelCompose(t *testing.T) {
+	a := newTestAppWithMessages(t)
+	f, err := os.CreateTemp(t.TempDir(), "slk-compose-*.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := f.Name()
+	if _, err := f.WriteString("edited in vim\n\n"); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	reduceEditorFinished(a, EditorFinishedMsg{Panel: PanelMessages, Path: path})
+
+	if got := a.compose.Value(); got != "edited in vim" {
+		t.Fatalf("want channel compose %q, got %q", "edited in vim", got)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("want temp file removed, stat err = %v", err)
+	}
+}
+
+func TestReduceEditorFinished_RoutesToThreadCompose(t *testing.T) {
+	a := newTestAppWithMessages(t)
+	f, err := os.CreateTemp(t.TempDir(), "slk-compose-*.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := f.Name()
+	if _, err := f.WriteString("thread reply text"); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	reduceEditorFinished(a, EditorFinishedMsg{Panel: PanelThread, Path: path})
+
+	if got := a.threadCompose.Value(); got != "thread reply text" {
+		t.Fatalf("want thread compose %q, got %q", "thread reply text", got)
+	}
+	if a.compose.Value() != "" {
+		t.Fatalf("editor result leaked into channel compose: %q", a.compose.Value())
+	}
+}
+
+func TestReduceEditorFinished_MissingFileLeavesComposeUntouched(t *testing.T) {
+	a := newTestAppWithMessages(t)
+	a.compose.SetValue("original draft")
+
+	reduceEditorFinished(a, EditorFinishedMsg{Panel: PanelMessages, Path: "/nonexistent/slk-compose-does-not-exist.md"})
+
+	if got := a.compose.Value(); got != "original draft" {
+		t.Fatalf("want original draft preserved on read failure, got %q", got)
+	}
+}
+
+func TestApp_CtrlEOpensEditorFromInsertMode(t *testing.T) {
+	a := newTestAppWithMessages(t)
+	a.SetMode(ModeInsert)
+	a.focusedPanel = PanelMessages
+	a.composeEditor = []string{"true"} // Cmd is never invoked, so this never actually runs
+	_ = a.compose.Focus()
+	a.compose.SetValue("draft before editor")
+
+	cmd := a.handleKey(tea.KeyPressMsg{Code: 'e', Mod: tea.ModCtrl})
+	if cmd == nil {
+		t.Fatal("want a non-nil Cmd from Ctrl+E in insert mode")
+	}
+	if !a.compose.EditingExternally() {
+		t.Fatal("want compose locked while the editor is open")
+	}
+}
+
+func TestComposeModel_UpdateIgnoresKeysWhileEditingExternally(t *testing.T) {
+	a := newTestAppWithMessages(t)
+	a.SetMode(ModeInsert)
+	a.focusedPanel = PanelMessages
+	_ = a.compose.Focus()
+	a.compose.SetValue("draft")
+	a.compose.SetEditingExternally(true)
+
+	_, _ = a.Update(tea.KeyPressMsg{Code: 'x', Text: "x"})
+
+	if a.compose.Value() != "draft" {
+		t.Fatalf("want compose locked, got %q", a.compose.Value())
+	}
+}
+
+func TestReduceEditorFinished_ClearsLockAndPlaceholder(t *testing.T) {
+	a := newTestAppWithMessages(t)
+	a.compose.SetEditingExternally(true)
+	a.compose.SetPlaceholderOverride("Editing in $EDITOR — waiting for it to exit...")
+	f, err := os.CreateTemp(t.TempDir(), "slk-compose-*.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := f.Name()
+	f.Close()
+
+	reduceEditorFinished(a, EditorFinishedMsg{Panel: PanelMessages, Path: path})
+
+	if a.compose.EditingExternally() {
+		t.Fatal("want compose unlocked after the editor exits")
+	}
+}
+
+func TestReduceEditorFinished_LaunchFailureShowsToast(t *testing.T) {
+	a := newTestAppWithMessages(t)
+	f, err := os.CreateTemp(t.TempDir(), "slk-compose-*.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := f.Name()
+	f.Close()
+
+	launchErr := &exec.Error{Name: "no-such-editor", Err: exec.ErrNotFound}
+	cmd := reduceEditorFinished(a, EditorFinishedMsg{Panel: PanelMessages, Path: path, Err: launchErr})
+	if cmd == nil {
+		t.Fatal("want a toast Cmd when the editor could not be launched")
+	}
+}
+
+func TestReduceEditorFinished_NonZeroExitDoesNotToast(t *testing.T) {
+	a := newTestAppWithMessages(t)
+	f, err := os.CreateTemp(t.TempDir(), "slk-compose-*.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := f.Name()
+	f.Close()
+
+	exitErr := exec.Command("false").Run() // a real *exec.ExitError
+	if exitErr == nil {
+		t.Skip("\"false\" did not produce a non-zero exit on this system")
+	}
+	cmd := reduceEditorFinished(a, EditorFinishedMsg{Panel: PanelMessages, Path: path, Err: exitErr})
+	if cmd != nil {
+		t.Fatal("want no toast for a plain non-zero exit — trust the file over the exit code")
+	}
+}
+
+func TestApp_CtrlEWithNoEditorConfiguredShowsToast(t *testing.T) {
+	a := newTestAppWithMessages(t)
+	a.SetMode(ModeInsert)
+	a.focusedPanel = PanelMessages
+	a.composeEditor = nil
+	_ = a.compose.Focus()
+	a.compose.SetValue("draft before editor")
+
+	cmd := a.handleKey(tea.KeyPressMsg{Code: 'e', Mod: tea.ModCtrl})
+	if cmd == nil {
+		t.Fatal("want a non-nil Cmd (the toast) even with no editor configured")
+	}
+	if a.compose.Value() != "draft before editor" {
+		t.Fatalf("draft must be untouched when no editor is configured, got %q", a.compose.Value())
+	}
+}
+
+// TestApp_UpdateRoutesCtrlEThroughFullDispatch exercises the real
+// tea.Program entry point (Update, not handleKey directly) — the
+// reducer chain in Update runs before handleKey and could swallow a
+// KeyPressMsg before it ever reaches the Ctrl+E check.
+func TestApp_UpdateRoutesCtrlEThroughFullDispatch(t *testing.T) {
+	a := newTestAppWithMessages(t)
+	a.SetMode(ModeInsert)
+	a.focusedPanel = PanelMessages
+	a.composeEditor = []string{"true"}
+	_ = a.compose.Focus()
+
+	_, cmd := a.Update(tea.KeyPressMsg{Code: 'e', Mod: tea.ModCtrl})
+	if cmd == nil {
+		t.Fatal("want a non-nil Cmd from a.Update for Ctrl+E in insert mode")
+	}
+	if !a.compose.EditingExternally() {
+		t.Fatal("want compose locked — something upstream of handleKey may be swallowing the key")
+	}
+}
+
+// TestApp_CtrlEWorksWithNumLockModifierBit guards the actual bug:
+// some terminals (e.g. Ghostty) report a NumLock/CapsLock bit
+// alongside Mod even when irrelevant to the binding, which broke a
+// bare `mod == tea.ModCtrl` comparison.
+func TestApp_CtrlEWorksWithNumLockModifierBit(t *testing.T) {
+	a := newTestAppWithMessages(t)
+	a.SetMode(ModeInsert)
+	a.focusedPanel = PanelMessages
+	a.composeEditor = []string{"true"}
+	_ = a.compose.Focus()
+
+	cmd := a.handleKey(tea.KeyPressMsg{Code: 'e', Mod: tea.ModCtrl | tea.ModNumLock})
+	if cmd == nil {
+		t.Fatal("want Ctrl+E to still register with NumLock's Mod bit set")
+	}
+	if !a.compose.EditingExternally() {
+		t.Fatal("want compose locked — the NumLock bit must not defeat the ctrl+e check")
+	}
+}
+
+// TestEditorCommand_UsesRealStdio pins the actual fix for garbled
+// input inside the external editor: Stdin/Stdout/Stderr must be the
+// real *os.File descriptors, not left for tea.ExecProcess to fall back
+// to the Program's own output (a non-*os.File io.Writer, which forces
+// Go's exec package to pipe the child through a copy goroutine instead
+// of a real tty — breaking the editor's own terminal-capability
+// negotiation and mouse parsing).
+func TestEditorCommand_UsesRealStdio(t *testing.T) {
+	cmd := editorCommand([]string{"true"}, "/tmp/draft.md")
+	if cmd.Stdin != os.Stdin {
+		t.Error("want cmd.Stdin == os.Stdin")
+	}
+	if cmd.Stdout != os.Stdout {
+		t.Error("want cmd.Stdout == os.Stdout")
+	}
+	if cmd.Stderr != os.Stderr {
+		t.Error("want cmd.Stderr == os.Stderr")
+	}
+}

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -64,6 +64,7 @@ type KeyMap struct {
 	WinClose            key.Binding
 	WinOnly             key.Binding
 	ToggleBroadcast     key.Binding
+	OpenInEditor        key.Binding
 }
 
 func DefaultKeyMap() KeyMap {
@@ -139,5 +140,7 @@ func DefaultKeyMap() KeyMap {
 		// "Also send to #channel" checkbox for the next reply.
 		// Alt+Enter sends and broadcasts in a single keystroke.
 		ToggleBroadcast: key.NewBinding(key.WithKeys("ctrl+o"), key.WithHelp("ctrl+o / alt+enter", "also send reply to channel")),
+		// Shadows the textarea's own ctrl+e (LineEnd); "End" still works.
+		OpenInEditor: key.NewBinding(key.WithKeys("ctrl+e"), key.WithHelp("ctrl+e", "edit message in $EDITOR")),
 	}
 }

--- a/internal/ui/mode_insert.go
+++ b/internal/ui/mode_insert.go
@@ -19,6 +19,8 @@
 //     attachments + uploading flag).
 //   - Ctrl+O (thread compose)    -> toggle "also send to channel" for
 //     the next thread reply.
+//   - Ctrl+E                     -> edit the draft in $VISUAL/$EDITOR
+//     (suspends the TUI; see editor.go).
 //   - Up / Down on first/last line -> jump to start/end of textarea.
 //   - Plain Enter                -> send (or commit edit, or upload-
 //     then-send if attachments present).
@@ -119,6 +121,9 @@ func handleInsertMode(a *App, msg tea.KeyMsg) tea.Cmd {
 	isPaste := code == 'v' && mod == tea.ModCtrl
 	if isPaste {
 		return a.smartPaste()
+	}
+	if code == 'e' && mod == tea.ModCtrl {
+		return a.openComposeInEditor()
 	}
 
 	// Insert-mode shortcuts that operate on the active compose:

--- a/internal/ui/reducer_io.go
+++ b/internal/ui/reducer_io.go
@@ -11,6 +11,9 @@
 //	UploadProgressMsg         - in-flight upload progress toast.
 //	UploadResultMsg           - upload finished: clear compose
 //	                            attachments + Sent/Failed toast.
+//	EditorFinishedMsg         - Ctrl+E external-editor session ended:
+//	                            read the temp file back into the
+//	                            compose it came from, then remove it.
 //	ConnectionStateMsg        - WS connection state changed:
 //	                            push to status bar.
 //	ToastMsg                  - generic toast (3s auto-clear).
@@ -149,6 +152,9 @@ var reduceIO reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
 	case UploadProgressMsg:
 		a.statusbar.SetToast(fmt.Sprintf("Uploading %d/%d…", m.Done, m.Total))
 		return nil, true
+
+	case EditorFinishedMsg:
+		return reduceEditorFinished(a, m), true
 
 	case UploadResultMsg:
 		a.compose.SetUploading(false)

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -58,6 +58,9 @@ quiet_hours = "22:00-08:00"   # planned
 # matching Slack. (This is a behavior change: previously a mention or keyword
 # in a muted channel would still notify.)
 
+[compose]
+editor = "nvim"   # Ctrl+E editor, used when $VISUAL and $EDITOR are unset
+
 [cache]
 message_retention_days = 30
 max_db_size_mb = 500

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -21,6 +21,7 @@
 ## Compose
 
 - Multi-line input, `Shift+Enter` for newlines
+- External editor (`Ctrl+E`) — opens the draft in `$VISUAL`, then `$EDITOR`, then `[compose] editor` from config; the edited text replaces the draft when the editor exits
 - Inline `@mention` autocomplete (resolves to `<@UserID>` on send)
 - Special mentions: `@here`, `@channel`, `@everyone`
 - Bracketed paste — paste multi-line text from the system clipboard without it being interpreted as keystrokes

--- a/wiki/Keybindings.md
+++ b/wiki/Keybindings.md
@@ -14,6 +14,7 @@
 | `Shift+Enter` | Insert | Newline |
 | `Ctrl+V` | Insert | Smart paste — image / file path / text (use `Ctrl+V`, not the terminal's `Ctrl+Shift+V`) |
 | `Ctrl+U` | Insert | Clear compose (text + pending attachments) |
+| `Ctrl+E` | Insert | Edit the draft in `$VISUAL` / `$EDITOR` (or `compose.editor`) |
 | `Ctrl+O` | Insert (thread) | Toggle "also send to channel" for the next thread reply |
 | `Alt+Enter` | Insert (thread) | Send thread reply and broadcast to channel (one-shot) |
 | `Ctrl+U` / `Ctrl+D` | Normal | Half-page up / down |


### PR DESCRIPTION
Writes the compose box to a temp file and suspends the TUI to edit it externally, reloading the result on exit. Editor is resolved once at startup ($VISUAL, then $EDITOR, then compose.editor in config.toml) and stored on App rather than re-read per keypress. Compose locks read-only while the editor is open. when there is some issue opening buffer externally, there is toast shown to the user rather than silent skip.

closes #200 