### PR TITLE
fix(rail): make the workspace unread dot agree with the sidebar

### DIFF
--- a/cmd/slk/event_handler_test.go
+++ b/cmd/slk/event_handler_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gammons/slk/internal/cache"
 	"github.com/gammons/slk/internal/config"
+	"github.com/gammons/slk/internal/ui"
 	"github.com/gammons/slk/internal/ui/channelfinder"
 	"github.com/gammons/slk/internal/ui/sidebar"
 	"github.com/slack-go/slack"
@@ -575,5 +576,35 @@ func TestOnThreadSubscriptionChanged_PersistsOnInactiveWorkspace(t *testing.T) {
 	}
 	if len(got) != 1 || got[0].ChannelID != "C1" || !got[0].Active {
 		t.Fatalf("inactive workspace must still persist thread_subscribed; got %+v, want 1 active row", got)
+	}
+}
+
+// TestMuteRefreshMsg pins which message a mute change posts: the active
+// workspace gets its sidebar list swapped, an inactive one gets the
+// read-state signal the rail, title and status hook re-derive from.
+// The inactive case is the one that used to post nothing.
+func TestMuteRefreshMsg(t *testing.T) {
+	channels := []sidebar.ChannelItem{{ID: "C1", IsMuted: true}}
+
+	msg := muteRefreshMsg(true, "T1", channels)
+	sr, ok := msg.(ui.SectionsRefreshedMsg)
+	if !ok {
+		t.Fatalf("active: got %T, want ui.SectionsRefreshedMsg", msg)
+	}
+	if sr.TeamID != "T1" || len(sr.Channels) != 1 || !sr.Channels[0].IsMuted {
+		t.Errorf("active: msg = %+v", sr)
+	}
+	sr.Channels[0].IsMuted = false
+	if !channels[0].IsMuted {
+		t.Error("active: the message shares the handler's slice; the App would be mutating wctx.Channels")
+	}
+
+	msg = muteRefreshMsg(false, "T1", channels)
+	rs, ok := msg.(ui.ReadStateChangedMsg)
+	if !ok {
+		t.Fatalf("inactive: got %T, want ui.ReadStateChangedMsg", msg)
+	}
+	if rs.WorkspaceID != "T1" {
+		t.Errorf("inactive: WorkspaceID = %q, want T1", rs.WorkspaceID)
 	}
 }

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -5102,14 +5102,10 @@ func (h *rtmEventHandler) refreshMutedForActive() {
 // Inactive: ReadStateChangedMsg. There is no sidebar on screen for
 // this workspace, but its rail dot, the title's "+N" and
 // $SLK_OTHER_UNREAD are all derived from these flags by
-// railUnreadWorkspaces, and nothing re-reads them until the next
-// read-state event. Before this branch existed the inactive case
-// posted nothing, so a channel muted or unmuted from another Slack
-// client left the rail stale -- an unmute left a workspace with
-// unreads dark, a mute kept one lit -- until an unrelated message or
-// mark happened to arrive. ReadStateChangedMsg is what
-// notifyReadStateChanged already answers to, and the App ignores its
-// fields, so no new message type is needed.
+// railUnreadWorkspaces, and nothing else re-reads them until the next
+// read-state event. ReadStateChangedMsg is what notifyReadStateChanged
+// already answers to, and the App ignores its fields, so no new
+// message type is needed.
 //
 // Pure so the choice is testable without a *tea.Program.
 func muteRefreshMsg(active bool, teamID string, channels []sidebar.ChannelItem) tea.Msg {

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -5065,12 +5065,10 @@ func (h *rtmEventHandler) OnMemberLeft(channelID, userID string) {
 }
 
 // refreshMutedForActive walks wctx.Channels, refreshes each item's
-// IsMuted flag from the current MuteStore, and posts a
-// SectionsRefreshedMsg so the App rebuilds the sidebar from the
-// updated list. Mirrors refreshSectionsForActive but for the mute
-// dimension; reuses the same message because the App treats it as a
-// "channel-list-attributes-changed" signal regardless of what
-// changed.
+// IsMuted flag from the current MuteStore, and posts the message
+// muteRefreshMsg chooses so the UI re-derives whatever it showed from
+// those flags. Mirrors refreshSectionsForActive but for the mute
+// dimension.
 func (h *rtmEventHandler) refreshMutedForActive() {
 	if h.wsCtx == nil || h.wsCtx.MuteStore == nil {
 		return
@@ -5089,15 +5087,38 @@ func (h *rtmEventHandler) refreshMutedForActive() {
 	if h.program == nil {
 		return
 	}
-	if h.isActive != nil && !h.isActive() {
-		return
+	active := h.isActive == nil || h.isActive()
+	h.program.Send(muteRefreshMsg(active, h.workspaceID, h.wsCtx.Channels))
+}
+
+// muteRefreshMsg is the message refreshMutedForActive posts after the
+// IsMuted flags change, chosen by whether the workspace is the active
+// one.
+//
+// Active: SectionsRefreshedMsg with a copy of the rebuilt list -- the
+// same "channel-list-attributes-changed" signal refreshSectionsForActive
+// uses -- so the App swaps the sidebar's items.
+//
+// Inactive: ReadStateChangedMsg. There is no sidebar on screen for
+// this workspace, but its rail dot, the title's "+N" and
+// $SLK_OTHER_UNREAD are all derived from these flags by
+// railUnreadWorkspaces, and nothing re-reads them until the next
+// read-state event. Before this branch existed the inactive case
+// posted nothing, so a channel muted or unmuted from another Slack
+// client left the rail stale -- an unmute left a workspace with
+// unreads dark, a mute kept one lit -- until an unrelated message or
+// mark happened to arrive. ReadStateChangedMsg is what
+// notifyReadStateChanged already answers to, and the App ignores its
+// fields, so no new message type is needed.
+//
+// Pure so the choice is testable without a *tea.Program.
+func muteRefreshMsg(active bool, teamID string, channels []sidebar.ChannelItem) tea.Msg {
+	if !active {
+		return ui.ReadStateChangedMsg{WorkspaceID: teamID}
 	}
-	channelsCopy := make([]sidebar.ChannelItem, len(h.wsCtx.Channels))
-	copy(channelsCopy, h.wsCtx.Channels)
-	h.program.Send(ui.SectionsRefreshedMsg{
-		TeamID:   h.workspaceID,
-		Channels: channelsCopy,
-	})
+	channelsCopy := make([]sidebar.ChannelItem, len(channels))
+	copy(channelsCopy, channels)
+	return ui.SectionsRefreshedMsg{TeamID: teamID, Channels: channelsCopy}
 }
 
 // listWorkspaces prints the configured workspaces with their TeamID and

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -1365,12 +1365,12 @@ func run() error {
 		})
 
 		app.SetWorkspaceUnreadReader(func() []string {
-			ids, err := db.WorkspacesWithUnreads()
+			unread, err := db.UnreadChannels()
 			if err != nil {
-				log.Printf("Warning: WorkspacesWithUnreads: %v", err)
+				log.Printf("Warning: UnreadChannels: %v", err)
 				return nil
 			}
-			return ids
+			return railUnreadWorkspaces(unread, router.ByID)
 		})
 
 		app.SetChannelService(ui.NewChannelService(ui.ChannelServiceFuncs{
@@ -4348,7 +4348,7 @@ func (h *rtmEventHandler) OnMessage(channelID, userID, ts, text, threadTS, subty
 		// Inactive workspace — durable read state is already settled
 		// above (written, or deliberately skipped). Fire a
 		// ReadStateChangedMsg so the workspace rail refreshes its dot
-		// from db.WorkspacesWithUnreads(). The sidebar's Invalidate is
+		// through railUnreadWorkspaces. The sidebar's Invalidate is
 		// a no-op here because the active workspace's sidebar isn't
 		// showing this channel anyway.
 		switch {

--- a/cmd/slk/main.go
+++ b/cmd/slk/main.go
@@ -268,17 +268,32 @@ func (w *WorkspaceContext) SetCustomEmoji(emojis map[string]string) {
 	w.customEmoji.Store(&emojis)
 }
 
-// workspaceRouter holds the program-wide "active workspace" pointer.
-// wireCallbacks(router) is invoked ONCE at startup. Every workspace-
-// scoped callback reads router.Active() at invocation time so the
-// effective workspace tracks the user's current Ctrl-N selection
-// without any closure rebinding.
+// workspaceRouter is the program-wide registry of connected
+// workspaces. active is the one the user is looking at:
+// wireCallbacks(router) is invoked ONCE at startup, and every
+// workspace-scoped callback reads router.Active() at invocation time
+// so the effective workspace tracks the user's current Ctrl-N
+// selection without any closure rebinding. all is every workspace
+// that has connected this session, keyed by team ID.
 //
-// The `all` map is populated only during the connect-workspaces phase
-// (before p.Run); subsequent reads from p.Send-invoked callbacks are
-// race-free without a mutex.
+// all is guarded by mu because its writers and readers are on
+// different goroutines. An earlier version of this comment said the
+// map "is populated only during the connect-workspaces phase (before
+// p.Run)" and so needed no mutex; that was wrong. run launches one
+// connect goroutine per workspace and then calls p.Run immediately,
+// so each goroutine's Add lands while the program is already handling
+// messages -- including the WorkspaceReadyMsg of whichever workspace
+// finished first, whose callbacks (EnsureSubscriptions, the rail's
+// unread reader on every read-state event, later the workspace
+// switcher) call ByID, and the wake watcher's All. Two workspaces
+// finishing together, or one finishing while another's ready message
+// is being handled, is a concurrent map write or read/write -- a
+// runtime fatal, not a data race the detector merely reports -- and
+// the window is exactly the boot phase, when every one of those
+// callbacks fires.
 type workspaceRouter struct {
 	active atomic.Pointer[WorkspaceContext]
+	mu     sync.RWMutex
 	all    map[string]*WorkspaceContext
 }
 
@@ -289,7 +304,30 @@ func newWorkspaceRouter() *workspaceRouter {
 func (r *workspaceRouter) Active() *WorkspaceContext  { return r.active.Load() }
 func (r *workspaceRouter) Set(wctx *WorkspaceContext) { r.active.Store(wctx) }
 func (r *workspaceRouter) ByID(teamID string) *WorkspaceContext {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	return r.all[teamID]
+}
+
+// Add registers a connected workspace. Called from its connect
+// goroutine; this is the write side of mu.
+func (r *workspaceRouter) Add(wctx *WorkspaceContext) {
+	r.mu.Lock()
+	r.all[wctx.TeamID] = wctx
+	r.mu.Unlock()
+}
+
+// All returns a snapshot of every connected workspace, as a slice
+// rather than the map so callers can iterate without holding mu
+// across whatever they do per workspace.
+func (r *workspaceRouter) All() []*WorkspaceContext {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]*WorkspaceContext, 0, len(r.all))
+	for _, wctx := range r.all {
+		out = append(out, wctx)
+	}
+	return out
 }
 
 // userResolverConcurrency caps how many users.info round trips the
@@ -1185,7 +1223,6 @@ func run() error {
 
 	// Declare p before wiring callbacks so closures can capture it
 	var p *tea.Program
-	workspaces := make(map[string]*WorkspaceContext)
 	var activeTeamID string
 
 	// router holds the program-wide active workspace pointer. All
@@ -1238,7 +1275,7 @@ func run() error {
 				return // shouldn't happen, but guard against it
 			}
 			teamName := activeTeamID
-			if wctx, ok := workspaces[activeTeamID]; ok && wctx.TeamName != "" {
+			if wctx := router.ByID(activeTeamID); wctx != nil && wctx.TeamName != "" {
 				teamName = wctx.TeamName
 			}
 			// Find the existing TOML key for this workspace, if any.
@@ -1278,7 +1315,7 @@ func run() error {
 			return
 		}
 		teamName := activeTeamID
-		if wctx, ok := workspaces[activeTeamID]; ok && wctx.TeamName != "" {
+		if wctx := router.ByID(activeTeamID); wctx != nil && wctx.TeamName != "" {
 			teamName = wctx.TeamName
 		}
 		tomlKey := activeTeamID
@@ -1300,11 +1337,11 @@ func run() error {
 		}
 	})
 
-	// Wire presence/DND status setter. Captured workspaces map and
-	// activeTeamID by reference so the closure always targets the
+	// Wire presence/DND status setter. Resolves activeTeamID through
+	// the router at invocation so the closure always targets the
 	// currently-active workspace context.
 	app.SetStatusSetter(func(action presencemenu.Action, snoozeMinutes int) {
-		wctx := workspaces[activeTeamID]
+		wctx := router.ByID(activeTeamID)
 		if wctx == nil || wctx.Client == nil {
 			return
 		}
@@ -2072,8 +2109,7 @@ func run() error {
 				return
 			}
 
-			workspaces[wctx.TeamID] = wctx
-			router.all[wctx.TeamID] = wctx
+			router.Add(wctx)
 			wsMgr.AddWorkspace(wctx.TeamID, wctx.TeamName, "")
 
 			// Decide whether this workspace becomes the active one.
@@ -2228,7 +2264,7 @@ func run() error {
 	defer wakeCancel()
 	go wake.New(10*time.Second, 5*time.Second, func(elapsed time.Duration) {
 		debuglog.Backfill("wake detected: elapsed=%v — triggering catch-up across all workspaces", elapsed)
-		for _, wctx := range router.all {
+		for _, wctx := range router.All() {
 			if wctx == nil || wctx.RTMHandler == nil {
 				continue
 			}
@@ -2255,7 +2291,7 @@ func run() error {
 	}
 
 	// Clean up connection managers
-	for _, wctx := range workspaces {
+	for _, wctx := range router.All() {
 		if wctx.ConnMgr != nil {
 			wctx.ConnMgr.Stop()
 		}

--- a/cmd/slk/rail_unread.go
+++ b/cmd/slk/rail_unread.go
@@ -4,62 +4,43 @@ import "github.com/gammons/slk/internal/cache"
 
 // railUnreadWorkspaces returns the workspace IDs whose rail dot should
 // be lit. It is the reader wireCallbacks installs through
-// App.SetWorkspaceUnreadReader, and OtherUnreadCount (the title's "+N"
-// and $SLK_OTHER_UNREAD) reads through the same installed reader, so
-// the three surfaces cannot disagree with each other.
+// App.SetWorkspaceUnreadReader; OtherUnreadCount (the title's "+N" and
+// $SLK_OTHER_UNREAD) reads through the same installed reader, so the
+// three surfaces cannot disagree.
 //
 // It answers the rail's question the way the sidebar answers its own:
 // a workspace is lit when at least one channel in its wctx.Channels is
-// ChannelItem.IsVisiblyUnread (internal/ui/sidebar/model.go) -- the one
-// predicate the sidebar dot, UnreadChannelCount and therefore
-// $SLK_UNREAD already share. Before this the reader lit every
-// workspace with any has_unread=1 row, so a single muted firehose
-// channel kept a workspace's dot on permanently while the sidebar,
-// correctly, showed nothing unread in it. That is the case
-// IsVisiblyUnread exists to prevent, applied one surface short.
+// ChannelItem.IsVisiblyUnread (internal/ui/sidebar/model.go), the one
+// predicate the sidebar dot, UnreadChannelCount and $SLK_UNREAD already
+// share. That is what keeps a muted channel from lighting the rail
+// while the sidebar shows nothing unread.
 //
 // unread is db.UnreadChannels; byID resolves a workspace to its live
 // context and is router.ByID in production. Both are parameters so
 // the predicate is pure and testable with neither a router nor a DB,
 // the same reason sidebar.IsStale takes its read state as arguments.
 //
-// One "unknown, so light it" case keeps the conservative default that
-// MuteStore.Ready documents (a dot we might have suppressed beats one
-// the user wanted to see and lost): byID returning nil, meaning the
-// workspace is still connecting or its connect failed. There is no
-// channel list to check against, so any unread row lights it, exactly
-// as before this change. This is also what keeps last session's cached
-// dots visible during boot, before any workspace has connected.
+// Two edge cases go opposite ways:
 //
-// A row whose channel is NOT in wctx.Channels is the opposite case and
-// never lights. The sidebar and the local channel finder are built
-// from the same loop that fills wctx.Channels (connectWorkspace), so
-// such a channel has no row on screen, no dot, and no keystroke that
-// can mark it read: a rail dot it lights can be neither explained nor
-// cleared from inside slk. The field case was an archived Slack
-// Connect channel. client.userBoot lists archived conversations the
-// user belongs to, with is_archived=true (verified 2026-09-11 against
-// a live response); bootConversations and users.conversations
-// (ExcludeArchived) keep them out of the sidebar, but hydrateFirstSight
-// caches every conversation userBoot names, archived or not, and
-// client.counts still reported the channel unread because its
-// last_read was Slack's never-opened sentinel. So a row the sidebar
-// could not show carried has_unread=1 from the first boot, and kept it
-// -- nothing deletes channel rows -- until the channel was opened in
-// the official client. Filtering archived conversations out of
-// hydrateFirstSight instead was rejected: the cache is allowed to know
-// more conversations than the sidebar shows (search results resolve
-// <#C…> mentions through those rows; see resolveChannel in main.go),
-// it would leave every existing cache lit, and it would close one way
-// a row can be unshowable rather than the property itself.
+//   - byID returns nil (the workspace is still connecting, or its
+//     connect failed): any unread row lights it. There is no channel
+//     list to check against, so MuteStore.Ready's conservative default
+//     applies -- a dot we might have suppressed beats one the user
+//     wanted and lost. This also keeps last session's cached dots
+//     visible during boot.
+//   - the row's channel is not in wctx.Channels: it never lights. The
+//     sidebar and the local channel finder are built from that list,
+//     so such a channel has no row on screen to explain a rail dot and
+//     no keystroke to clear it. (The field case was an archived
+//     channel: userBoot lists it, bootConversations drops it,
+//     hydrateFirstSight still caches it, client.counts still reports
+//     it unread.)
 //
 // wctx.Channels is read here on the UI goroutine without
 // synchronization, against writes from the WebSocket handler
 // (refreshMutedForActive, OnConversationOpened). That is how the
 // Lookup callback in wireCallbacks already reads it; this adds a
-// reader, not a convention. Likewise router.ByID: the
-// EnsureSubscriptions callback reads it from the UI goroutine while
-// connect goroutines are still populating it.
+// reader, not a convention.
 func railUnreadWorkspaces(unread []cache.UnreadChannel, byID func(teamID string) *WorkspaceContext) []string {
 	var out []string
 	lit := map[string]bool{}

--- a/cmd/slk/rail_unread.go
+++ b/cmd/slk/rail_unread.go
@@ -1,0 +1,73 @@
+package main
+
+import "github.com/gammons/slk/internal/cache"
+
+// railUnreadWorkspaces returns the workspace IDs whose rail dot should
+// be lit. It is the reader wireCallbacks installs through
+// App.SetWorkspaceUnreadReader, and OtherUnreadCount (the title's "+N"
+// and $SLK_OTHER_UNREAD) reads through the same installed reader, so
+// the three surfaces cannot disagree with each other.
+//
+// It answers the rail's question the way the sidebar answers its own:
+// a workspace is lit when at least one channel in its wctx.Channels is
+// ChannelItem.IsVisiblyUnread (internal/ui/sidebar/model.go) -- the one
+// predicate the sidebar dot, UnreadChannelCount and therefore
+// $SLK_UNREAD already share. Before this the reader lit every
+// workspace with any has_unread=1 row, so a single muted firehose
+// channel kept a workspace's dot on permanently while the sidebar,
+// correctly, showed nothing unread in it. That is the case
+// IsVisiblyUnread exists to prevent, applied one surface short.
+//
+// unread is db.UnreadChannels; byID resolves a workspace to its live
+// context and is router.ByID in production. Both are parameters so
+// the predicate is pure and testable with neither a router nor a DB,
+// the same reason sidebar.IsStale takes its read state as arguments.
+//
+// Two "unknown, so light it" cases keep the conservative default that
+// MuteStore.Ready documents (a dot we might have suppressed beats one
+// the user wanted to see and lost):
+//
+//   - byID returns nil: the workspace is still connecting, or its
+//     connect failed. There is no channel list to check against, so
+//     any unread row lights it, exactly as before this change. This is
+//     also what keeps last session's cached dots visible during boot,
+//     before any workspace has connected.
+//   - the row's channel is not in wctx.Channels: its mute state is
+//     unknown, so it is treated as unmuted.
+//
+// wctx.Channels is read here on the UI goroutine without
+// synchronization, against writes from the WebSocket handler
+// (refreshMutedForActive, OnConversationOpened). That is how the
+// Lookup callback in wireCallbacks already reads it; this adds a
+// reader, not a convention. Likewise router.ByID: the
+// EnsureSubscriptions callback reads it from the UI goroutine while
+// connect goroutines are still populating it.
+func railUnreadWorkspaces(unread []cache.UnreadChannel, byID func(teamID string) *WorkspaceContext) []string {
+	var out []string
+	lit := map[string]bool{}
+	for _, u := range unread {
+		if lit[u.WorkspaceID] {
+			continue
+		}
+		if railRowLights(u, byID(u.WorkspaceID)) {
+			lit[u.WorkspaceID] = true
+			out = append(out, u.WorkspaceID)
+		}
+	}
+	return out
+}
+
+// railRowLights reports whether one unread row lights its workspace's
+// dot. The two true-by-default branches are the "unknown, so light
+// it" cases railUnreadWorkspaces documents.
+func railRowLights(u cache.UnreadChannel, wctx *WorkspaceContext) bool {
+	if wctx == nil {
+		return true
+	}
+	for _, item := range wctx.Channels {
+		if item.ID == u.ChannelID {
+			return item.IsVisiblyUnread(u.State)
+		}
+	}
+	return true
+}

--- a/cmd/slk/rail_unread.go
+++ b/cmd/slk/rail_unread.go
@@ -23,17 +23,35 @@ import "github.com/gammons/slk/internal/cache"
 // the predicate is pure and testable with neither a router nor a DB,
 // the same reason sidebar.IsStale takes its read state as arguments.
 //
-// Two "unknown, so light it" cases keep the conservative default that
+// One "unknown, so light it" case keeps the conservative default that
 // MuteStore.Ready documents (a dot we might have suppressed beats one
-// the user wanted to see and lost):
+// the user wanted to see and lost): byID returning nil, meaning the
+// workspace is still connecting or its connect failed. There is no
+// channel list to check against, so any unread row lights it, exactly
+// as before this change. This is also what keeps last session's cached
+// dots visible during boot, before any workspace has connected.
 //
-//   - byID returns nil: the workspace is still connecting, or its
-//     connect failed. There is no channel list to check against, so
-//     any unread row lights it, exactly as before this change. This is
-//     also what keeps last session's cached dots visible during boot,
-//     before any workspace has connected.
-//   - the row's channel is not in wctx.Channels: its mute state is
-//     unknown, so it is treated as unmuted.
+// A row whose channel is NOT in wctx.Channels is the opposite case and
+// never lights. The sidebar and the local channel finder are built
+// from the same loop that fills wctx.Channels (connectWorkspace), so
+// such a channel has no row on screen, no dot, and no keystroke that
+// can mark it read: a rail dot it lights can be neither explained nor
+// cleared from inside slk. The field case was an archived Slack
+// Connect channel. client.userBoot lists archived conversations the
+// user belongs to, with is_archived=true (verified 2026-09-11 against
+// a live response); bootConversations and users.conversations
+// (ExcludeArchived) keep them out of the sidebar, but hydrateFirstSight
+// caches every conversation userBoot names, archived or not, and
+// client.counts still reported the channel unread because its
+// last_read was Slack's never-opened sentinel. So a row the sidebar
+// could not show carried has_unread=1 from the first boot, and kept it
+// -- nothing deletes channel rows -- until the channel was opened in
+// the official client. Filtering archived conversations out of
+// hydrateFirstSight instead was rejected: the cache is allowed to know
+// more conversations than the sidebar shows (search results resolve
+// <#C…> mentions through those rows; see resolveChannel in main.go),
+// it would leave every existing cache lit, and it would close one way
+// a row can be unshowable rather than the property itself.
 //
 // wctx.Channels is read here on the UI goroutine without
 // synchronization, against writes from the WebSocket handler
@@ -58,8 +76,9 @@ func railUnreadWorkspaces(unread []cache.UnreadChannel, byID func(teamID string)
 }
 
 // railRowLights reports whether one unread row lights its workspace's
-// dot. The two true-by-default branches are the "unknown, so light
-// it" cases railUnreadWorkspaces documents.
+// dot. The nil-wctx branch is the "unknown, so light it" case
+// railUnreadWorkspaces documents; a channel absent from wctx.Channels
+// is the "cannot be shown, so never light it" case.
 func railRowLights(u cache.UnreadChannel, wctx *WorkspaceContext) bool {
 	if wctx == nil {
 		return true
@@ -69,5 +88,5 @@ func railRowLights(u cache.UnreadChannel, wctx *WorkspaceContext) bool {
 			return item.IsVisiblyUnread(u.State)
 		}
 	}
-	return true
+	return false
 }

--- a/cmd/slk/rail_unread_test.go
+++ b/cmd/slk/rail_unread_test.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/gammons/slk/internal/cache"
+	"github.com/gammons/slk/internal/config"
+	"github.com/gammons/slk/internal/service"
+	"github.com/gammons/slk/internal/ui/sidebar"
+	"github.com/gammons/slk/internal/ui/workspace"
+	"github.com/slack-go/slack"
+)
+
+func unreadRow(workspaceID, channelID string) cache.UnreadChannel {
+	return cache.UnreadChannel{
+		WorkspaceID: workspaceID,
+		ChannelID:   channelID,
+		State:       cache.ReadState{LastReadTS: "1.0", HasUnread: true},
+	}
+}
+
+func railLookup(all map[string]*WorkspaceContext) func(string) *WorkspaceContext {
+	return func(teamID string) *WorkspaceContext { return all[teamID] }
+}
+
+func TestRailUnreadWorkspaces(t *testing.T) {
+	cases := []struct {
+		name   string
+		unread []cache.UnreadChannel
+		all    map[string]*WorkspaceContext
+		want   []string
+	}{
+		{
+			name:   "muted channel does not light the rail",
+			unread: []cache.UnreadChannel{unreadRow("T1", "C1")},
+			all: map[string]*WorkspaceContext{
+				"T1": {Channels: []sidebar.ChannelItem{{ID: "C1", IsMuted: true}}},
+			},
+			want: nil,
+		},
+		{
+			// Guards against over-filtering: one muted unread must not
+			// hide the unmuted one next to it.
+			name:   "muted and unmuted unread together still light",
+			unread: []cache.UnreadChannel{unreadRow("T1", "C1"), unreadRow("T1", "C2")},
+			all: map[string]*WorkspaceContext{
+				"T1": {Channels: []sidebar.ChannelItem{{ID: "C1", IsMuted: true}, {ID: "C2"}}},
+			},
+			want: []string{"T1"},
+		},
+		{
+			name:   "each workspace once, in row order",
+			unread: []cache.UnreadChannel{unreadRow("T1", "C1"), unreadRow("T1", "C2"), unreadRow("T2", "C3")},
+			all: map[string]*WorkspaceContext{
+				"T1": {Channels: []sidebar.ChannelItem{{ID: "C1"}, {ID: "C2"}}},
+				"T2": {Channels: []sidebar.ChannelItem{{ID: "C3"}}},
+			},
+			want: []string{"T1", "T2"},
+		},
+		{
+			// Still connecting, or failed to connect: no channel list
+			// to check against, so the pre-change behaviour holds.
+			name:   "workspace the router does not know keeps its dot",
+			unread: []cache.UnreadChannel{unreadRow("T1", "C1")},
+			all:    map[string]*WorkspaceContext{},
+			want:   []string{"T1"},
+		},
+		{
+			name:   "no unread rows",
+			unread: nil,
+			all:    map[string]*WorkspaceContext{"T1": {}},
+			want:   nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := railUnreadWorkspaces(tc.unread, railLookup(tc.all))
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("railUnreadWorkspaces = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRailUnreadWorkspaces_MuteStoreNotReady pins the conservative
+// default end to end through the production item builder: an item
+// built while the MuteStore has not bootstrapped carries
+// IsMuted=false, so the rail lights; once the store learns the channel
+// is muted and the item is refreshed (as refreshMutedForActive does on
+// pref_change), the same row goes dark.
+func TestRailUnreadWorkspaces_MuteStoreNotReady(t *testing.T) {
+	wctx := &WorkspaceContext{
+		MuteStore:         service.NewMuteStore(), // never bootstrapped: Ready() == false
+		UserNames:         map[string]string{},
+		UserNamesByHandle: map[string]string{},
+		BotUserIDs:        map[string]bool{},
+	}
+	ch := slack.Channel{
+		GroupConversation: slack.GroupConversation{
+			Conversation: slack.Conversation{ID: "C1"},
+			Name:         "firehose",
+		},
+	}
+	item, _ := buildChannelItem(ch, wctx, config.Config{}, "T1")
+	wctx.Channels = []sidebar.ChannelItem{item}
+	all := map[string]*WorkspaceContext{"T1": wctx}
+	unread := []cache.UnreadChannel{unreadRow("T1", "C1")}
+
+	if got := railUnreadWorkspaces(unread, railLookup(all)); !reflect.DeepEqual(got, []string{"T1"}) {
+		t.Fatalf("store not ready: got %v, want [T1] (assume nothing is muted)", got)
+	}
+
+	wctx.MuteStore.ApplyPrefChange("muted_channels", "C1")
+	wctx.Channels[0].IsMuted = wctx.MuteStore.IsMuted("C1")
+	if got := railUnreadWorkspaces(unread, railLookup(all)); got != nil {
+		t.Fatalf("store ready and C1 muted: got %v, want none", got)
+	}
+}
+
+// TestRailUnreadWorkspaces_RailAndTitleAgree wires the reader's output
+// into a workspace.Model the way App does and checks that the dots the
+// rail lights and the "+N" OtherUnreadCount reports are the same set,
+// which is the invariant OtherUnreadCount's doc comment promises.
+func TestRailUnreadWorkspaces_RailAndTitleAgree(t *testing.T) {
+	all := map[string]*WorkspaceContext{
+		"T1": {Channels: []sidebar.ChannelItem{{ID: "C1", IsMuted: true}}},
+		"T2": {Channels: []sidebar.ChannelItem{{ID: "C2"}}},
+		"T3": {Channels: []sidebar.ChannelItem{{ID: "C3", IsMuted: true}, {ID: "C4"}}},
+	}
+	unread := []cache.UnreadChannel{
+		unreadRow("T1", "C1"), unreadRow("T2", "C2"), unreadRow("T3", "C3"), unreadRow("T3", "C4"),
+	}
+	ids := railUnreadWorkspaces(unread, railLookup(all))
+
+	m := workspace.New([]workspace.WorkspaceItem{{ID: "T1"}, {ID: "T2"}, {ID: "T3"}}, 1)
+	m.SetUnreadReader(func() []string { return ids })
+	m.RefreshUnreads()
+
+	// Rows 1, 3, 5: see workspace.Model.ClickAt for the rail's row layout.
+	wantLit := map[string]bool{"T1": false, "T2": true, "T3": true}
+	for i, id := range []string{"T1", "T2", "T3"} {
+		item, ok := m.ClickAt(1 + 2*i)
+		if !ok || item.ID != id {
+			t.Fatalf("ClickAt(%d) = %+v, %v; want item %s", 1+2*i, item, ok, id)
+		}
+		if item.HasUnread != wantLit[id] {
+			t.Errorf("%s HasUnread = %v, want %v", id, item.HasUnread, wantLit[id])
+		}
+	}
+	// T2 is active, so only T3 counts toward "+N".
+	if got := m.OtherUnreadCount("T2"); got != 1 {
+		t.Errorf("OtherUnreadCount(T2) = %d, want 1", got)
+	}
+}

--- a/cmd/slk/rail_unread_test.go
+++ b/cmd/slk/rail_unread_test.go
@@ -4,9 +4,11 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/gammons/slk/internal/bootstrap"
 	"github.com/gammons/slk/internal/cache"
 	"github.com/gammons/slk/internal/config"
 	"github.com/gammons/slk/internal/service"
+	"github.com/gammons/slk/internal/slack/boot"
 	"github.com/gammons/slk/internal/ui/sidebar"
 	"github.com/gammons/slk/internal/ui/workspace"
 	"github.com/slack-go/slack"
@@ -71,6 +73,26 @@ func TestRailUnreadWorkspaces(t *testing.T) {
 			unread: nil,
 			all:    map[string]*WorkspaceContext{"T1": {}},
 			want:   nil,
+		},
+		{
+			// A channel the sidebar cannot show has no dot to explain
+			// this one and no keystroke to clear it, so it must not
+			// light the rail. The field case was an archived channel;
+			// see TestRailUnreadWorkspaces_ArchivedChannelInCache.
+			name:   "unread row for a channel not in the workspace list does not light",
+			unread: []cache.UnreadChannel{unreadRow("T1", "C9")},
+			all: map[string]*WorkspaceContext{
+				"T1": {Channels: []sidebar.ChannelItem{{ID: "C1"}}},
+			},
+			want: nil,
+		},
+		{
+			name:   "unlisted row next to a listed unread still lights",
+			unread: []cache.UnreadChannel{unreadRow("T1", "C1"), unreadRow("T1", "C9")},
+			all: map[string]*WorkspaceContext{
+				"T1": {Channels: []sidebar.ChannelItem{{ID: "C1"}}},
+			},
+			want: []string{"T1"},
 		},
 	}
 	for _, tc := range cases {
@@ -151,5 +173,63 @@ func TestRailUnreadWorkspaces_RailAndTitleAgree(t *testing.T) {
 	// T2 is active, so only T3 counts toward "+N".
 	if got := m.OtherUnreadCount("T2"); got != 1 {
 		t.Errorf("OtherUnreadCount(T2) = %d, want 1", got)
+	}
+}
+
+// TestRailUnreadWorkspaces_ArchivedChannelInCache is the synthetic
+// repro for the field case, built the way production builds it rather
+// than by hand: hydrateFirstSight caches every conversation userBoot
+// names, archived included; the sidebar list comes from
+// bootConversations, which drops the archived one; and the counts
+// snapshot then marks the archived channel unread with Slack's
+// never-opened last_read sentinel. Before the membership rule the
+// resulting row lit the rail with nothing visible to account for it.
+func TestRailUnreadWorkspaces_ArchivedChannelInCache(t *testing.T) {
+	db, err := cache.New(":memory:")
+	if err != nil {
+		t.Fatalf("cache.New: %v", err)
+	}
+	defer db.Close()
+
+	res := &bootstrap.Result{
+		Channels: []boot.Channel{
+			{ID: "C1", Name: "general", IsChannel: true},
+			{ID: "C2", Name: "amtrx-vendor-connect", IsChannel: true, IsPrivate: true, IsArchived: true},
+		},
+	}
+	hydrateFirstSight(db, "T1", res)
+	if _, err := db.GetChannel("C2"); err != nil {
+		t.Fatalf("archived channel was not cached; this test no longer exercises the repro: %v", err)
+	}
+
+	wctx := &WorkspaceContext{
+		UserNames:         map[string]string{},
+		UserNamesByHandle: map[string]string{},
+		BotUserIDs:        map[string]bool{},
+	}
+	for _, ch := range bootConversations(res) {
+		item, _ := buildChannelItem(ch, wctx, config.Config{}, "T1")
+		wctx.Channels = append(wctx.Channels, item)
+	}
+	if len(wctx.Channels) != 1 || wctx.Channels[0].ID != "C1" {
+		t.Fatalf("sidebar list = %+v; want only C1 (bootConversations drops archived)", wctx.Channels)
+	}
+
+	if err := db.ReplaceWorkspaceReadState("T1", []cache.ChannelReadStateUpdate{
+		{ChannelID: "C2", LastReadTS: "0000000000.000000", HasUnread: true},
+	}); err != nil {
+		t.Fatalf("ReplaceWorkspaceReadState: %v", err)
+	}
+	unread, err := db.UnreadChannels()
+	if err != nil {
+		t.Fatalf("UnreadChannels: %v", err)
+	}
+	if len(unread) != 1 || unread[0].ChannelID != "C2" {
+		t.Fatalf("UnreadChannels = %+v; want the archived row alone", unread)
+	}
+
+	all := map[string]*WorkspaceContext{"T1": wctx}
+	if got := railUnreadWorkspaces(unread, railLookup(all)); got != nil {
+		t.Errorf("archived channel lit the rail: got %v, want none", got)
 	}
 }

--- a/cmd/slk/workspace_router_test.go
+++ b/cmd/slk/workspace_router_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// TestWorkspaceRouter_ConcurrentAddAndByID is a race-detector test. It
+// reproduces the pattern boot produces -- connect goroutines calling
+// Add while UI-goroutine callbacks call ByID and All -- and fails under
+// -race if the router's map is ever touched unguarded. In production
+// the unguarded version is a runtime fatal ("concurrent map read and
+// map write"), not merely a report.
+func TestWorkspaceRouter_ConcurrentAddAndByID(t *testing.T) {
+	r := newWorkspaceRouter()
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		id := fmt.Sprintf("T%d", i)
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			r.Add(&WorkspaceContext{TeamID: id})
+		}()
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				_ = r.ByID(id)
+				_ = r.All()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := len(r.All()); got != 8 {
+		t.Fatalf("All() = %d workspaces, want 8", got)
+	}
+	for i := 0; i < 8; i++ {
+		id := fmt.Sprintf("T%d", i)
+		if w := r.ByID(id); w == nil || w.TeamID != id {
+			t.Errorf("ByID(%s) = %+v", id, w)
+		}
+	}
+}

--- a/internal/cache/channels_read_state.go
+++ b/internal/cache/channels_read_state.go
@@ -249,23 +249,50 @@ func (db *DB) GetWorkspaceReadState(workspaceID string) (map[string]ReadState, e
 	return out, rows.Err()
 }
 
-// WorkspacesWithUnreads returns the set of workspace IDs with at least
-// one has_unread=true channel. Used by the workspace rail.
-func (db *DB) WorkspacesWithUnreads() ([]string, error) {
+// UnreadChannel is one has_unread=1 row together with the workspace
+// that owns it. It is the workspace rail's raw input. The rail's
+// question is not "does any row in this workspace have has_unread=1"
+// but "would this workspace's sidebar show an unread dot", and the
+// second question needs the channel ID -- which the workspace-only
+// query this replaced (WorkspacesWithUnreads) discarded, leaving the
+// caller nothing to check mute or membership against.
+type UnreadChannel struct {
+	WorkspaceID string
+	ChannelID   string
+	State       ReadState
+}
+
+// UnreadChannels returns every channel row with has_unread=1 across
+// all workspaces, ordered by workspace then channel ID so the caller's
+// output is deterministic. Used by the workspace rail reader in
+// cmd/slk (railUnreadWorkspaces), which decides per row whether the
+// owning workspace's sidebar would actually show it as unread.
+//
+// Mute state is deliberately not filtered here. It lives only in
+// service.MuteStore -- in memory, hydrated from userBoot's prefs and
+// kept live by pref_change -- and is never written to this table, so a
+// query cannot see it. The same goes for "is this channel in the
+// sidebar at all": that is wctx.Channels, not a column. Both filters
+// belong in the caller, where both are in scope.
+func (db *DB) UnreadChannels() ([]UnreadChannel, error) {
 	rows, err := db.conn.Query(
-		`SELECT DISTINCT workspace_id FROM channels WHERE has_unread = 1`,
+		`SELECT workspace_id, id, last_read_ts, has_unread, mention_count
+		 FROM channels WHERE has_unread = 1
+		 ORDER BY workspace_id, id`,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("query workspaces with unreads: %w", err)
+		return nil, fmt.Errorf("query unread channels: %w", err)
 	}
 	defer rows.Close()
-	var out []string
+	var out []UnreadChannel
 	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err != nil {
-			return nil, fmt.Errorf("scan workspace id: %w", err)
+		var u UnreadChannel
+		var hasUnread int
+		if err := rows.Scan(&u.WorkspaceID, &u.ChannelID, &u.State.LastReadTS, &hasUnread, &u.State.MentionCount); err != nil {
+			return nil, fmt.Errorf("scan unread channel: %w", err)
 		}
-		out = append(out, id)
+		u.State.HasUnread = hasUnread == 1
+		out = append(out, u)
 	}
 	return out, rows.Err()
 }

--- a/internal/cache/channels_read_state_test.go
+++ b/internal/cache/channels_read_state_test.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -177,32 +178,34 @@ func TestGetWorkspaceReadState_ReturnsAllChannels(t *testing.T) {
 	}
 }
 
-func TestWorkspacesWithUnreads(t *testing.T) {
+func TestUnreadChannels(t *testing.T) {
 	db, err := New(":memory:")
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
 	defer db.Close()
+	newRSChannel(t, db, "C2", "T1")
 	newRSChannel(t, db, "C1", "T1")
-	newRSChannel(t, db, "C2", "T2")
-	newRSChannel(t, db, "C3", "T3")
+	newRSChannel(t, db, "C3", "T2")
+	newRSChannel(t, db, "C4", "T3")
 
 	_ = db.UpdateChannelReadState("C1", "1.0", true)
-	_ = db.UpdateChannelReadState("C3", "1.0", true)
-	// C2/T2 has no unreads
+	_ = db.UpdateChannelReadState("C2", "2.0", true)
+	_ = db.SetChannelMentionCount("C2", 3)
+	_ = db.UpdateChannelReadState("C4", "4.0", true)
+	// C3/T2 has no unreads and must not appear at all.
 
-	got, err := db.WorkspacesWithUnreads()
+	got, err := db.UnreadChannels()
 	if err != nil {
-		t.Fatalf("WorkspacesWithUnreads: %v", err)
+		t.Fatalf("UnreadChannels: %v", err)
 	}
-	want := map[string]bool{"T1": true, "T3": true}
-	if len(got) != 2 {
-		t.Fatalf("got %d ids, want 2: %v", len(got), got)
+	want := []UnreadChannel{
+		{WorkspaceID: "T1", ChannelID: "C1", State: ReadState{LastReadTS: "1.0", HasUnread: true}},
+		{WorkspaceID: "T1", ChannelID: "C2", State: ReadState{LastReadTS: "2.0", HasUnread: true, MentionCount: 3}},
+		{WorkspaceID: "T3", ChannelID: "C4", State: ReadState{LastReadTS: "4.0", HasUnread: true}},
 	}
-	for _, id := range got {
-		if !want[id] {
-			t.Errorf("unexpected workspace %q", id)
-		}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("UnreadChannels =\n%+v\nwant\n%+v", got, want)
 	}
 }
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2480,7 +2480,7 @@ func (a *App) SetReadStateReader(f func() map[string]cache.ReadState) {
 
 // SetWorkspaceUnreadReader installs the callback the workspace rail
 // uses on RefreshUnreads to learn which workspaces have at least one
-// channel with has_unread=true.
+// channel their sidebar would show as unread.
 func (a *App) SetWorkspaceUnreadReader(f func() []string) {
 	a.workspaceRail.SetUnreadReader(f)
 }

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -4493,7 +4493,9 @@ func setupAppForTitleTest(
 // wiring test. It verifies that notifyReadStateChanged actually plumbs
 // each input from the collaborator the architecture assigns to it:
 //   - active count comes from the sidebar (mute-filtered)
-//   - other-workspace count comes from the rail (not mute-filtered)
+//   - other-workspace count comes from the rail, whose installed reader
+//     applies the sidebar's mute rule per workspace (railUnreadWorkspaces
+//     in cmd/slk); this test's stub reader stands in for it
 //   - workspace name comes from the rail for the active team
 //
 // If a future refactor reroutes any of these sources, the assertions

--- a/internal/ui/reducer_workspace.go
+++ b/internal/ui/reducer_workspace.go
@@ -83,6 +83,13 @@ var reduceWorkspace reducerFunc = func(a *App, msg tea.Msg) (tea.Cmd, bool) {
 	case SectionsRefreshedMsg:
 		if m.TeamID == a.activeTeamID {
 			a.SetChannels(m.Channels)
+			// The new list carries new IsMuted flags, and "(N)",
+			// $SLK_UNREAD and the rail derive from those, not just
+			// the sidebar's dots. SetChannels only swaps the items;
+			// without this a channel muted while unread lost its
+			// sidebar dot but stayed counted in the title until the
+			// next read-state event.
+			a.notifyReadStateChanged()
 		}
 		// Inactive-workspace events have already updated the
 		// WorkspaceContext.Channels in cmd/slk; App.Update only
@@ -250,6 +257,15 @@ func reduceWorkspaceReady(a *App, m WorkspaceReadyMsg) tea.Cmd {
 		threads.EnsureSubscriptions(team)
 		return nil
 	})
+	// The rail reader keeps a workspace's cached dot until the router
+	// knows the workspace, so last session's dots survive boot. Now
+	// that this one is connected the answer can change -- a cached dot
+	// held up only by muted or unlisted channels should go dark -- and
+	// nothing else recomputes it until some read-state event happens
+	// to arrive. connectWorkspace has already written the workspace's
+	// authoritative counts, so recompute here, for every workspace
+	// that becomes ready, not only the initial active one.
+	a.notifyReadStateChanged()
 	return tea.Batch(batch...)
 }
 

--- a/internal/ui/reducer_workspace_unread_refresh_test.go
+++ b/internal/ui/reducer_workspace_unread_refresh_test.go
@@ -1,0 +1,74 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/gammons/slk/internal/cache"
+	"github.com/gammons/slk/internal/ui/sidebar"
+	"github.com/gammons/slk/internal/ui/workspace"
+)
+
+// TestWorkspaceReady_RefreshesRailAndTitle pins that a workspace
+// finishing its connect recomputes the rail and the title. The rail
+// reader keeps a workspace's cached dot until the router knows the
+// workspace; once connected the answer can change (the cached dot was
+// held up by a muted or unlisted channel), and before this nothing
+// recomputed it until an unrelated read-state event.
+func TestWorkspaceReady_RefreshesRailAndTitle(t *testing.T) {
+	app := setupAppForTitleTest(t,
+		[]sidebar.ChannelItem{{ID: "C1", Name: "general", Type: "channel"}},
+		[]workspace.WorkspaceItem{
+			{ID: "T1", Name: "SWAP", Initials: "SW"},
+			{ID: "T2", Name: "Other", Initials: "OT"},
+		},
+		map[string]cache.ReadState{"C1": {HasUnread: true}},
+		nil,
+	)
+	workspaceUnreads := []string{"T1", "T2"}
+	app.SetWorkspaceUnreadReader(func() []string { return workspaceUnreads })
+	app.activeTeamID = "T1"
+	app.notifyReadStateChanged()
+	if got, want := app.windowTitle, "slk SW (1) +1"; got != want {
+		t.Fatalf("before T2 connects: windowTitle = %q want %q", got, want)
+	}
+
+	// T2 connects. With its channel list known, the reader no longer
+	// counts it: its only unread channel turns out to be muted.
+	workspaceUnreads = []string{"T1"}
+	app.Update(WorkspaceReadyMsg{TeamID: "T2", TeamName: "Other"})
+
+	if got, want := app.windowTitle, "slk SW (1)"; got != want {
+		t.Errorf("after T2 connects: windowTitle = %q want %q", got, want)
+	}
+	// Rail rows are 1, 3, 5, ...; see workspace.Model.ClickAt.
+	if item, ok := app.workspaceRail.ClickAt(3); !ok || item.ID != "T2" || item.HasUnread {
+		t.Errorf("rail T2 after ready = %+v, %v; want dark", item, ok)
+	}
+}
+
+// TestSectionsRefreshed_ActiveWorkspace_RefreshesTitle pins the active
+// twin of muteRefreshMsg's inactive case: a SectionsRefreshedMsg that
+// mutes an unread channel must drop it from "(N)" and $SLK_UNREAD, not
+// only from the sidebar's dots.
+func TestSectionsRefreshed_ActiveWorkspace_RefreshesTitle(t *testing.T) {
+	app := setupAppForTitleTest(t,
+		[]sidebar.ChannelItem{{ID: "C1", Name: "general", Type: "channel"}},
+		[]workspace.WorkspaceItem{{ID: "T1", Name: "SWAP", Initials: "SW"}},
+		map[string]cache.ReadState{"C1": {HasUnread: true}},
+		[]string{"T1"},
+	)
+	app.activeTeamID = "T1"
+	app.notifyReadStateChanged()
+	if got, want := app.windowTitle, "slk SW (1)"; got != want {
+		t.Fatalf("before mute: windowTitle = %q want %q", got, want)
+	}
+
+	app.Update(SectionsRefreshedMsg{
+		TeamID:   "T1",
+		Channels: []sidebar.ChannelItem{{ID: "C1", Name: "general", Type: "channel", IsMuted: true}},
+	})
+
+	if got, want := app.windowTitle, "slk SW"; got != want {
+		t.Errorf("after mute: windowTitle = %q want %q", got, want)
+	}
+}

--- a/internal/ui/workspace/model.go
+++ b/internal/ui/workspace/model.go
@@ -19,9 +19,11 @@ type Model struct {
 	items    []WorkspaceItem
 	selected int
 	version  int64
-	// unreadReader returns the set of workspace IDs that currently
-	// have at least one channel with has_unread=true. Set by App via
-	// SetUnreadReader; called by RefreshUnreads.
+	// unreadReader returns the set of workspace IDs whose dot should
+	// be lit: those with at least one channel their own sidebar would
+	// show as unread (mute-filtered; see railUnreadWorkspaces in
+	// cmd/slk). Set by App via SetUnreadReader; called by
+	// RefreshUnreads and OtherUnreadCount.
 	unreadReader func() []string
 }
 
@@ -56,8 +58,10 @@ func (m *Model) NameByID(id string) string {
 
 // OtherUnreadCount returns the number of workspaces with unreads,
 // excluding activeID. Reads through the installed unreadReader; returns
-// 0 when no reader is set. Does not filter mute -- matches the rail
-// dot's existing semantics so the title's "+N" and the rail dots agree.
+// 0 when no reader is set. Mute filtering is the reader's job, not
+// this method's: the reader applies the sidebar's IsVisiblyUnread
+// predicate per workspace, so the title's "+N", the rail dots and the
+// active workspace's "(N)" all agree on what counts as unread.
 func (m *Model) OtherUnreadCount(activeID string) int {
 	if m.unreadReader == nil {
 		return 0

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -44,7 +44,7 @@ quiet_hours = "22:00-08:00"   # planned
 # state always runs last, so the surface converges on the current state.
 # Executed via `sh -c` with:
 #   $SLK_UNREAD        unread channels in the active workspace (mute-filtered)
-#   $SLK_OTHER_UNREAD  unread count across other workspaces
+#   $SLK_OTHER_UNREAD  other workspaces with unread channels (mute-filtered)
 #   $SLK_WORKSPACE     active workspace name
 #   $SLK_TITLE         the window-title string, e.g. "slk SW (3) +1"
 # status_command = 'my-statusbar --slack-unread "$SLK_UNREAD"'


### PR DESCRIPTION
## Problem

The green dot next to a workspace in the left rail lit up for any channel with `has_unread=1` in the cache. Every other unread indicator in slk (the sidebar dot, the `(N)` in the window title, `$SLK_UNREAD`) ignores muted channels. The rail didn't. So a single muted firehose channel kept a workspace's dot on permanently, with nothing visibly unread inside it.

Worse, one workspace was lit by a channel that wasn't in the sidebar or Ctrl+t at all, so there was no way to clear it from inside slk. That one turned out to be an archived Slack Connect channel.

I hit both within an hour of first use, on 4 of 5 workspaces. Once the dot is always on, you stop looking at it.

## Cause

Two things, verified against live `client.userBoot` and `client.counts` responses on 2026-09-11:

1. **Mutes aren't in the database.** `WorkspacesWithUnreads` was a plain SQL query. Mute state lives only in `service.MuteStore`, in memory, so no query can filter it.
2. **The cache knows about channels the sidebar hides.** `client.userBoot` lists archived channels the user belongs to with `is_archived: true`. `bootConversations` correctly drops them from the sidebar, but `hydrateFirstSight` caches every channel userBoot returns, archived or not. `client.counts` still reported the archived channel as unread (its `last_read` was Slack's never-opened sentinel), so the row got `has_unread=1` and nothing could ever show or clear it. Channel rows are never deleted, so the dot was permanent.

## Fix

The rail now asks the same question the sidebar asks: *does this workspace have a channel in its list that `IsVisiblyUnread`?*

- `cache.UnreadChannels()` returns unread rows **with their channel IDs** (replaces `WorkspacesWithUnreads`).
- `railUnreadWorkspaces` (`cmd/slk/rail_unread.go`) is a pure function: for each unread row, find the channel in the workspace's `wctx.Channels` and apply `IsVisiblyUnread`. Muted → no dot. Not in the list → no dot. Workspace still connecting → keep the dot (the conservative default `MuteStore.Ready` documents, and what keeps cached dots visible during boot).
- The title's `+N` and `$SLK_OTHER_UNREAD` read through the same function, so they stay in sync with the dots.

Review of the diff turned up three more gaps, each its own commit:

- **`workspaceRouter` gets a mutex.** Its map was written by connect goroutines and read by UI callbacks with no lock; the comment saying it was populated before `p.Run` was wrong, since connects run alongside it. That's a runtime fatal waiting to happen, and the rail reader made it more likely. The duplicate `workspaces` map in `run` is removed too.
- **Inactive-workspace mute changes refresh the rail.** Muting a channel from another client in a workspace you're not looking at updates the dot immediately instead of waiting for the next unrelated event.
- **Channel-list changes fan out to the rail and title.** `SectionsRefreshedMsg` for the active workspace and `WorkspaceReadyMsg` both changed what the unread surfaces derive from without calling `notifyReadStateChanged`. Muting an unread channel in the active workspace left `(N)` stale, and a workspace finishing its connect kept a cached dot its now-known channel list no longer justified.

Six commits, one per change (the fifth only trims a comment), each with its own tests.

## Why not fix it elsewhere

- **Filter archived channels out of `hydrateFirstSight`?** The cache is allowed to know more than the sidebar shows (search results resolve `<#C…>` mentions through those rows), and it wouldn't fix existing caches since rows are never deleted. Happy to add it as a follow-up if you'd like the rows gone too.
- **Add an `is_archived` column?** A migration for a display bug. Not needed once the rail checks the live list.
- **Filter at the counts write path?** Three writers to keep in sync instead of one reader.

## Tests

All new tests are plain `testing.T`, white-box. The rail tests add two unexported helpers local to their file (`unreadRow`, `railLookup`); nothing shared.

- Cache: `TestUnreadChannels`.
- Rail predicate: muted → dark, muted + unmuted → lit, absent from list → dark, unknown workspace → lit, and `MuteStore` not ready → lit (through the real `buildChannelItem`).
- `TestRailUnreadWorkspaces_ArchivedChannelInCache`: the archived-channel repro built the way production builds it (`hydrateFirstSight` → `bootConversations` → `ReplaceWorkspaceReadState`).
- `TestRailUnreadWorkspaces_RailAndTitleAgree`: dots and `OtherUnreadCount` are the same set.
- `TestWorkspaceRouter_ConcurrentAddAndByID`: fails under `-race` with the mutex removed.
- `TestMuteRefreshMsg`: active vs inactive message choice.
- `TestWorkspaceReady_RefreshesRailAndTitle` and `TestSectionsRefreshed_ActiveWorkspace_RefreshesTitle`: through `App.Update`; the title and rail recompute when a workspace connects and when an active-workspace channel is muted.

Each commit's tests were confirmed red with its change reverted. `go build`, `go vet`, `go test ./... -race`, `gofmt -l`, and `golangci-lint run` (v2.13.1) are all clean.

**Field check (macOS, five live workspaces):** with the patched build sitting on one workspace, marking a message unread in a *different* workspace from the official client lit that workspace's dot; muting the channel there cleared the dot immediately, without touching slk; unmuting lit it again; opening the channel cleared it. That is the mute rule and the inactive-workspace refresh end to end. The archived-channel case was consumed before the fix (opening it in the official client is the only way out today), so it is covered by the production-shaped test above rather than a live re-run.

## Noted but not changed

- `wctx.Channels` is read on the UI goroutine while the WebSocket handler mutates it. That predates this PR (the `Lookup` callback does the same) and needs a lock or snapshot on `WorkspaceContext`, which is bigger than this change.
- `OtherUnreadCount` will count a workspace that's in the cache but no longer configured. Pre-existing.

## AI assistance

Written with Claude (Fable 5.1, extra-high thinking effort) driving the investigation, code, and tests from a brief I wrote after reproducing both bugs. The cause was confirmed against live API responses, not inferred from the code, and Codex reviewed the diff; its findings are commits 3, 4 and 6. I've read the diff and will defend it in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
